### PR TITLE
feat: prove ref writes for callee bodies in referenced projects

### DIFF
--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -56,17 +56,36 @@ public static class Frontend
             .Select(p => p.AssemblyName)
             .Where(n => !string.IsNullOrEmpty(n))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var collector = new FactCollector(rootFull, IgnoredDirs(), firstPartyAssemblies);
+        // Materialize every compilation FIRST and index each syntax tree by its
+        // owner. A callee body can live in a REFERENCED project, and asking the
+        // caller's compilation for a model of a tree it does not own throws, so
+        // without this index a cross-project `ref` write cannot be proven and
+        // the fact is silently dropped (issue #1353). The workspace already
+        // caches these compilations behind its solution snapshot, so holding
+        // the list adds little over building them one at a time.
+        // GetCompilationAsync runs source generators, so symbols that resolve
+        // only through generated members still bind; the generated trees
+        // themselves have no first-party path and never become facts.
+        var compilations = new List<Compilation>();
         foreach (var project in projects)
         {
-            // GetCompilationAsync runs source generators, so symbols that resolve
-            // only through generated members still bind; the generated trees
-            // themselves have no first-party path and never become facts.
-            var compilation = await project.GetCompilationAsync();
-            if (compilation is null)
+            if (await project.GetCompilationAsync() is { } built)
             {
-                continue;
+                compilations.Add(built);
             }
+        }
+        var treeOwners = new Dictionary<SyntaxTree, Compilation>();
+        foreach (var built in compilations)
+        {
+            foreach (var tree in built.SyntaxTrees)
+            {
+                treeOwners.TryAdd(tree, built);
+            }
+        }
+        var collector = new FactCollector(
+            rootFull, IgnoredDirs(), firstPartyAssemblies, treeOwners);
+        foreach (var compilation in compilations)
+        {
             foreach (var tree in compilation.SyntaxTrees)
             {
                 var path = tree.FilePath;
@@ -107,12 +126,18 @@ public static class Frontend
         private readonly HashSet<(string, int, int, string, int, string)> _seenQueries = new();
 
         private readonly HashSet<string> _firstPartyAssemblies;
+        private readonly IReadOnlyDictionary<SyntaxTree, Compilation> _treeOwners;
 
-        public FactCollector(string rootFull, HashSet<string> ignoredDirs, HashSet<string> firstPartyAssemblies)
+        public FactCollector(
+            string rootFull,
+            HashSet<string> ignoredDirs,
+            HashSet<string> firstPartyAssemblies,
+            IReadOnlyDictionary<SyntaxTree, Compilation> treeOwners)
         {
             _rootFull = rootFull;
             _ignoredDirs = ignoredDirs;
             _firstPartyAssemblies = firstPartyAssemblies;
+            _treeOwners = treeOwners;
         }
 
         public bool IsFirstParty(string path)
@@ -432,7 +457,7 @@ public static class Frontend
         // Does the callee actually assign this `ref` parameter? Answerable only
         // for a first-party body: an external ref callee cannot be inspected,
         // so it is treated as read-only rather than assumed to write.
-        private static bool RefParameterIsWritten(
+        private bool RefParameterIsWritten(
             SemanticModel model,
             InvocationExpressionSyntax invocation,
             ArgumentSyntax argument,
@@ -471,15 +496,16 @@ public static class Frontend
             {
                 return false;
             }
-            // A body in a REFERENCED project belongs to another compilation;
-            // asking this one for its model throws. The collector holds no
-            // workspace, so that call cannot be proven here -- treat it as
-            // read-only, the same conservative answer as an external callee.
-            if (!model.Compilation.ContainsSyntaxTree(body.SyntaxTree))
+            // A body in a REFERENCED project belongs to ANOTHER compilation, and
+            // asking this one for a model of a tree it does not own throws. The
+            // owner index covers every loaded project, so a cross-project callee
+            // is now provable instead of silently treated as read-only. A tree
+            // from outside the solution has no owner and stays unprovable.
+            if (ResolveOwner(model.Compilation, body.SyntaxTree) is not { } owner)
             {
                 return false;
             }
-            var calleeModel = model.Compilation.GetSemanticModel(body.SyntaxTree);
+            var calleeModel = owner.GetSemanticModel(body.SyntaxTree);
             if (calleeModel.AnalyzeDataFlow(body) is not { Succeeded: true } flow)
             {
                 return false;
@@ -511,6 +537,17 @@ public static class Frontend
                 (SyntaxNode?)local.Body ?? local.ExpressionBody?.Expression,
             _ => null,
         };
+
+        // The compilation that owns a tree: the caller's own when it contains
+        // the tree, otherwise the project the index attributes it to.
+        private Compilation? ResolveOwner(Compilation caller, SyntaxTree tree)
+        {
+            if (caller.ContainsSyntaxTree(tree))
+            {
+                return caller;
+            }
+            return _treeOwners.TryGetValue(tree, out var owner) ? owner : null;
+        }
 
         // `out var n` declares the variable inline, so the symbol comes from the
         // declaration rather than from a reference; a plain `out n` is an

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -553,17 +553,15 @@ def test_ref_write_back_across_a_project_reference(tmp_path: Path) -> None:
 @pytest.mark.skipif(
     not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
 )
-def test_cross_project_ref_emits_the_write_fact_itself(tmp_path: Path) -> None:
+def test_cross_project_ref_emits_the_write_fact_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # The sibling test asserts the downstream EDGE, which could in principle
     # survive for an unrelated reason. This one pins the fact the frontend
     # actually produces: argument index 1 of `Fill` writes `sink`.
     repo = tmp_path / "facts"
     _write_cross_project_repo(repo)
-    previous = settings.CSHARP_FRONTEND
-    settings.CSHARP_FRONTEND = cs.CSharpFrontend.HYBRID
-    try:
-        facts = run_csharp_frontend(repo)
-    finally:
-        settings.CSHARP_FRONTEND = previous
+    monkeypatch.setattr(settings, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)
+    facts = run_csharp_frontend(repo)
     writes = {key[3]: value for key, value in facts.out_writes.items()}
     assert writes.get("Fill") == {1: "sink"}

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -473,3 +473,73 @@ def test_local_function_ref_callee_writes_back(tmp_path: Path) -> None:
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "lf1", _LOCAL_FUNCTION_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_LIB_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n"
+    "</Project>\n"
+)
+_APP_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n"
+    "  <ItemGroup>\n"
+    '    <ProjectReference Include="../Lib/Lib.csproj" />\n'
+    "  </ItemGroup>\n"
+    "</Project>\n"
+)
+_LIB_HELPER = (
+    "namespace Lib;\n\n"
+    "public class Helper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n"
+)
+_APP_PROGRAM = (
+    "using System;\nusing Lib;\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+def _cross_project_flows(repo: Path) -> set[tuple[str, str]]:
+    (repo / "Lib").mkdir(parents=True)
+    (repo / "App").mkdir(parents=True)
+    (repo / "Lib" / "Lib.csproj").write_text(_LIB_CSPROJ, encoding="utf-8")
+    (repo / "Lib" / "Helper.cs").write_text(_LIB_HELPER, encoding="utf-8")
+    (repo / "App" / "App.csproj").write_text(_APP_CSPROJ, encoding="utf-8")
+    (repo / "App" / "Program.cs").write_text(_APP_PROGRAM, encoding="utf-8")
+    parsers, queries = load_parsers()
+    previous = settings.CSHARP_FRONTEND
+    settings.CSHARP_FRONTEND = cs.CSharpFrontend.HYBRID
+    try:
+        mock = MagicMock()
+        GraphUpdater(
+            ingestor=mock,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+            capture=_CAPTURE_IO,
+        ).run()
+    finally:
+        settings.CSHARP_FRONTEND = previous
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_ref_write_back_across_a_project_reference(tmp_path: Path) -> None:
+    # The callee body lives in a REFERENCED project, so it belongs to another
+    # compilation; asking the caller's for a model of that tree throws, and the
+    # write was previously unprovable and silently dropped (issue #1353).
+    assert (_ENV_K, _STDOUT) in _cross_project_flows(tmp_path / "sln")

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -16,6 +16,7 @@ from codebase_rag.capture import resolve_capture
 from codebase_rag.config import settings
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.csharp_frontend import run_csharp_frontend
 from codebase_rag.parsers.csharp_frontend.frontend import (
     _arg_flows,
     _out_writes,
@@ -507,13 +508,17 @@ _APP_PROGRAM = (
 )
 
 
-def _cross_project_flows(repo: Path) -> set[tuple[str, str]]:
+def _write_cross_project_repo(repo: Path) -> None:
     (repo / "Lib").mkdir(parents=True)
     (repo / "App").mkdir(parents=True)
     (repo / "Lib" / "Lib.csproj").write_text(_LIB_CSPROJ, encoding="utf-8")
     (repo / "Lib" / "Helper.cs").write_text(_LIB_HELPER, encoding="utf-8")
     (repo / "App" / "App.csproj").write_text(_APP_CSPROJ, encoding="utf-8")
     (repo / "App" / "Program.cs").write_text(_APP_PROGRAM, encoding="utf-8")
+
+
+def _cross_project_flows(repo: Path) -> set[tuple[str, str]]:
+    _write_cross_project_repo(repo)
     parsers, queries = load_parsers()
     previous = settings.CSHARP_FRONTEND
     settings.CSHARP_FRONTEND = cs.CSharpFrontend.HYBRID
@@ -543,3 +548,22 @@ def test_ref_write_back_across_a_project_reference(tmp_path: Path) -> None:
     # compilation; asking the caller's for a model of that tree throws, and the
     # write was previously unprovable and silently dropped (issue #1353).
     assert (_ENV_K, _STDOUT) in _cross_project_flows(tmp_path / "sln")
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_cross_project_ref_emits_the_write_fact_itself(tmp_path: Path) -> None:
+    # The sibling test asserts the downstream EDGE, which could in principle
+    # survive for an unrelated reason. This one pins the fact the frontend
+    # actually produces: argument index 1 of `Fill` writes `sink`.
+    repo = tmp_path / "facts"
+    _write_cross_project_repo(repo)
+    previous = settings.CSHARP_FRONTEND
+    settings.CSHARP_FRONTEND = cs.CSharpFrontend.HYBRID
+    try:
+        facts = run_csharp_frontend(repo)
+    finally:
+        settings.CSHARP_FRONTEND = previous
+    writes = {key[3]: value for key, value in facts.out_writes.items()}
+    assert writes.get("Fill") == {1: "sink"}


### PR DESCRIPTION
Part of #1353, item 2. Closes the cross-project gap that #1351 left guarded rather than solved.

## The gap

A `ref` parameter written by a callee in a REFERENCED project could not be proven. `RefParameterIsWritten` needs a semantic model for the callee body, that body belongs to another compilation, and asking the caller's compilation for a model of a tree it does not own THROWS. #1351 guarded it with `ContainsSyntaxTree` and treated such a callee as read-only -- safe, but it means multi-project solutions, which is most real C#, lost `ref` write-back across every project boundary.

## The change

`Main` now materializes every project's `Compilation` first and indexes each syntax tree by its owner, then hands that index to `FactCollector`. `ResolveOwner` returns the caller's own compilation when it contains the tree and the owning one otherwise, so a cross-project callee is provable. A tree from outside the solution has no owner and stays unprovable, which keeps the conservative answer for genuinely external callees.

On memory: the workspace already caches compilations behind its solution snapshot, so holding the list adds little over building them one at a time. Worth a second opinion if you disagree -- it is the one judgement call in this diff.

## Verified in both directions

A two-project fixture (`App` with a `ProjectReference` to `Lib`, the `ref` callee in `Lib`):

- with the old `ContainsSyntaxTree` guard: `out_writes` is `{}` -- the fact is dropped
- with the owner index: `{('App/Program.cs', 11, 15, 'Fill'): {1: 'sink'}}`

`test_ref_write_back_across_a_project_reference` builds that fixture and asserts the ENV -> STDOUT edge end to end. 18 passed in `test_csharp_semantic_flow.py`.

## Remaining on #1353

Item 3, `IArgumentOperation` vs syntax-level argument binding, is a reviewer preference rather than a correctness question and I am deliberately not deciding it alone. Item 4 is a full adversarial pass over the helper, which commits 2-6 of #1351 never received.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C# analysis across referenced projects, allowing `ref` parameter write-back flows to be tracked correctly.
  * Fixed cases where data flow between project boundaries was incorrectly omitted when the relevant method was defined in another project.

* **Tests**
  * Added coverage for cross-project C# data flow, including flows from environment values to standard output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->