### PR TITLE
feat: grade Java inheritance in the eval harness against the javac oracle

### DIFF
--- a/codebase_rag/tests/test_eval_java_inheritance.py
+++ b/codebase_rag/tests/test_eval_java_inheritance.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import typer
 
 from evals import constants as ec
+from evals import inheritance as inh
 from evals.inheritance import (
     java_cgr_inheritance,
     java_oracle_inheritance,
@@ -81,3 +83,24 @@ def test_no_overrides_row_is_emitted_for_java(tmp_path: Path) -> None:
 def test_the_java_label_differs_from_the_python_one() -> None:
     # A Java 1.0 must not be readable as the Python 1.0: different unit.
     assert ec.JAVA_SUPERTYPES_LABEL != ec.INHERITS_LABEL
+
+
+def test_missing_java_toolchain_exits_instead_of_scoring_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Without a JDK the oracle yields no edges. Scoring that would write a
+    # header-only CSV and an empty diff and exit 0, which reads as "this repo
+    # has no inheritance" rather than "the grader never ran" -- a measurement
+    # that silently means nothing is worse than no measurement.
+    repo = tmp_path / "proj"
+    _write(repo)
+    monkeypatch.setattr(inh, "java_available", lambda: False)
+    with pytest.raises(typer.Exit) as exit_info:
+        inh.main(
+            target=repo,
+            project_name="proj",
+            out_dir=tmp_path / "out",
+            language=ec.InheritanceLanguage.JAVA,
+        )
+    assert exit_info.value.exit_code == 1
+    assert not (tmp_path / "out").exists()

--- a/codebase_rag/tests/test_eval_java_inheritance.py
+++ b/codebase_rag/tests/test_eval_java_inheritance.py
@@ -1,0 +1,83 @@
+# Java inheritance grading for the eval harness (issue #1190). The javac oracle
+# already emits extends/implements as name_edges, so this grades CGR's resolved
+# INHERITS/IMPLEMENTS against it. The comparison unit is deliberately asymmetric
+# and the label says so: the SUBCLASS is matched by location (exact), the
+# supertype by simple name, because that is all the oracle names.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evals import constants as ec
+from evals.inheritance import (
+    java_cgr_inheritance,
+    java_oracle_inheritance,
+    score_inheritance,
+)
+from evals.oracles.java_oracle import java_available
+
+_BASE = 'package com.app;\n\npublic class Base {\n    public String describe() {\n        return "base";\n    }\n}\n'
+_SPEAKS = "package com.app;\n\npublic interface Speaks {\n    String speak();\n}\n"
+_CHILD = (
+    "package com.app;\n\n"
+    "public class Child extends Base implements Speaks {\n"
+    "    @Override\n"
+    '    public String describe() {\n        return "child";\n    }\n\n'
+    '    public String speak() {\n        return "hi";\n    }\n}\n'
+)
+
+
+def _write(repo: Path) -> None:
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    (package / "Base.java").write_text(_BASE, encoding="utf-8")
+    (package / "Speaks.java").write_text(_SPEAKS, encoding="utf-8")
+    (package / "Child.java").write_text(_CHILD, encoding="utf-8")
+
+
+@pytest.mark.skipif(not java_available(), reason="java oracle needs a working JDK")
+def test_oracle_reads_extends_and_implements(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    _write(repo)
+    oracle = java_oracle_inheritance(repo)
+    targets = {edge[1] for edge in oracle.inherits}
+    assert targets == {"Base", "Speaks"}
+    # The oracle emits no OVERRIDES, so the category stays empty rather than
+    # being guessed at; score_inheritance then omits the row entirely.
+    assert oracle.overrides == set()
+
+
+@pytest.mark.skipif(not java_available(), reason="java oracle needs a working JDK")
+def test_cgr_and_oracle_agree_on_the_fixture(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    _write(repo)
+    result = score_inheritance(
+        java_cgr_inheritance(repo, "proj"),
+        java_oracle_inheritance(repo),
+        inherits_label=ec.JAVA_SUPERTYPES_LABEL,
+    )
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row["label"] == ec.JAVA_SUPERTYPES_LABEL
+    assert (row["tp"], row["fp"], row["fn"]) == (2, 0, 0)
+
+
+@pytest.mark.skipif(not java_available(), reason="java oracle needs a working JDK")
+def test_no_overrides_row_is_emitted_for_java(tmp_path: Path) -> None:
+    # CGR *does* resolve Java OVERRIDES, but the oracle cannot adjudicate them,
+    # so reporting a score would be measuring nothing. Absence is the honest
+    # result, and it must not silently become a 0.0 or a 1.0.
+    repo = tmp_path / "proj"
+    _write(repo)
+    result = score_inheritance(
+        java_cgr_inheritance(repo, "proj"),
+        java_oracle_inheritance(repo),
+        inherits_label=ec.JAVA_SUPERTYPES_LABEL,
+    )
+    assert [row["label"] for row in result.rows] == [ec.JAVA_SUPERTYPES_LABEL]
+
+
+def test_the_java_label_differs_from_the_python_one() -> None:
+    # A Java 1.0 must not be readable as the Python 1.0: different unit.
+    assert ec.JAVA_SUPERTYPES_LABEL != ec.INHERITS_LABEL

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -112,6 +112,8 @@ ROUND_DIGITS = 4
 # Go structure eval: cgr nodes graded against the go/ast oracle
 # (evals/oracles/go_ast.go), joined on (kind, file, start_line).
 GO_SUFFIX = ".go"
+JAVA_SUFFIX = ".java"
+LOCATION_KEY_SEPARATOR = ":"
 GO_SCORED_NODE_KINDS: tuple[cs.NodeLabel, ...] = (
     cs.NodeLabel.FUNCTION,
     cs.NodeLabel.METHOD,
@@ -392,6 +394,7 @@ JS_DIFF_FILENAME = "js_diff.json"
 # Java structure eval: cgr nodes graded against the JDK Compiler Tree API
 # oracle (evals/oracles/java_oracle/Oracle.java), joined on (kind, file, line).
 JAVA_SUFFIX = ".java"
+LOCATION_KEY_SEPARATOR = ":"
 JAVA_SCORED_NODE_KINDS: tuple[cs.NodeLabel, ...] = (
     cs.NodeLabel.FUNCTION,
     cs.NodeLabel.METHOD,
@@ -650,3 +653,18 @@ INSTANTIATION_DIFF_PREFIX = "instantiation:"
 INSTANTIATES_LABEL = "instantiates"
 INSTANTIATION_EDGE_REPR = "{file} -> {cls}"
 INSTANTIATION_TITLE = "cgr instantiation eval: file-level INSTANTIATES vs ast oracle"
+
+# Java inheritance grading (issue #1190). The oracle names supertypes by SIMPLE
+# name, so the row is labelled to say what it measures rather than borrowing the
+# Python row's label.
+JAVA_SUPERTYPES_LABEL = "supertypes(simple-name)"
+
+
+class InheritanceLanguage(StrEnum):
+    PYTHON = "python"
+    JAVA = "java"
+
+
+INHERITANCE_LANGUAGE_HELP = (
+    "Language to grade: python (ast oracle) or java (javac oracle)."
+)

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -112,8 +112,6 @@ ROUND_DIGITS = 4
 # Go structure eval: cgr nodes graded against the go/ast oracle
 # (evals/oracles/go_ast.go), joined on (kind, file, start_line).
 GO_SUFFIX = ".go"
-JAVA_SUFFIX = ".java"
-LOCATION_KEY_SEPARATOR = ":"
 GO_SCORED_NODE_KINDS: tuple[cs.NodeLabel, ...] = (
     cs.NodeLabel.FUNCTION,
     cs.NodeLabel.METHOD,

--- a/evals/inheritance.py
+++ b/evals/inheritance.py
@@ -18,6 +18,7 @@ from . import constants as ec
 from . import logs as ls
 from .ast_oracle import _from_base_parts, _iter_py_files, _module_dotted
 from .cgr_graph import _capture
+from .oracles.java_oracle import run_java_oracle
 from .score import _prf
 from .structure_report import render, write_outputs
 from .types_defs import DiffBucket, LocationStats, ScoreResult, ScoreRow
@@ -27,6 +28,7 @@ console_target = Path(ec.INHERITANCE_DEFAULT_TARGET)
 _CLASS = cs.NodeLabel.CLASS.value
 _METHOD = cs.NodeLabel.METHOD.value
 _INHERITS = cs.RelationshipType.INHERITS.value
+_IMPLEMENTS = cs.RelationshipType.IMPLEMENTS.value
 _OVERRIDES = cs.RelationshipType.OVERRIDES.value
 _EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
 
@@ -202,7 +204,66 @@ def _override_repr(edge: OverrideEdge) -> str:
     return ec.OVERRIDES_EDGE_REPR.format(sub=edge[0], base=edge[1], method=edge[2])
 
 
-def score_inheritance(cgr: CgrResult, oracle: OracleResult) -> ScoreResult:
+def _location_key(file: str, line: int) -> str:
+    # Subclass identity by LOCATION, not by name: the javac oracle names a
+    # supertype by simple name but pins the subclass to a file and line, and
+    # matching the subclass exactly keeps the looseness confined to one side of
+    # the comparison.
+    return f"{file}{ec.LOCATION_KEY_SEPARATOR}{line}"
+
+
+def java_oracle_inheritance(target: Path) -> OracleResult:
+    # The javac oracle already emits extends/implements as `name_edges`; no
+    # oracle-side work is needed (issue #1190). It emits no OVERRIDES, so that
+    # category stays empty and _prf omits the row rather than scoring a
+    # category the oracle cannot adjudicate.
+    graph = run_java_oracle(target)
+    inherits: set[InheritEdge] = set()
+    subclasses: set[str] = set()
+    for edge in graph.name_edges:
+        if edge.rel_type not in (_INHERITS, _IMPLEMENTS):
+            continue
+        key = _location_key(edge.source.file, edge.source.start_line)
+        subclasses.add(key)
+        inherits.add((key, edge.target_name))
+    return OracleResult(
+        inherits=inherits,
+        overrides=set(),
+        top_classes=frozenset(subclasses),
+        override_scope=frozenset(),
+    )
+
+
+def java_cgr_inheritance(target: Path, project: str) -> CgrResult:
+    ingestor = _capture(target, project)
+    props_by_node = {
+        (label, str(uid)): props for (label, uid), props in ingestor.nodes.items()
+    }
+    inherits: set[InheritEdge] = set()
+    for from_label, from_val, rel_type, _to_label, to_val in ingestor.rels:
+        if rel_type not in (_INHERITS, _IMPLEMENTS):
+            continue
+        props = props_by_node.get((from_label, str(from_val)))
+        path = str(props.get(cs.KEY_PATH, "")) if props else ""
+        if not path.endswith(ec.JAVA_SUFFIX):
+            continue
+        line = props.get(cs.KEY_START_LINE) if props else None
+        # Node properties are a heterogeneous union; a non-integer start_line
+        # is unusable as a location key, so skip rather than coerce it.
+        if not isinstance(line, int):
+            continue
+        # The oracle names the supertype simply, so the qn is reduced to its
+        # last segment to compare like with like.
+        base = str(to_val).rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        inherits.add((_location_key(path, line), base))
+    return CgrResult(inherits=inherits, overrides=set())
+
+
+def score_inheritance(
+    cgr: CgrResult,
+    oracle: OracleResult,
+    inherits_label: str = ec.INHERITS_LABEL,
+) -> ScoreResult:
     # Restrict cgr to the oracle's gradeable universe: top-level subclasses for
     # INHERITS, single-base subclasses for OVERRIDES. This drops nested-class
     # and multi-base-MRO edges the oracle cannot adjudicate, rather than scoring
@@ -214,10 +275,10 @@ def score_inheritance(cgr: CgrResult, oracle: OracleResult) -> ScoreResult:
     rows: list[ScoreRow] = []
     diff: dict[str, DiffBucket] = {}
 
-    inh_row = _prf(ec.Category.EDGE.value, ec.INHERITS_LABEL, cgr_inh, oracle_inh)
+    inh_row = _prf(ec.Category.EDGE.value, inherits_label, cgr_inh, oracle_inh)
     if inh_row is not None:
         rows.append(inh_row)
-        diff[ec.INHERITANCE_DIFF_PREFIX + ec.INHERITS_LABEL] = DiffBucket(
+        diff[ec.INHERITANCE_DIFF_PREFIX + inherits_label] = DiffBucket(
             missing=[_inherit_repr(e) for e in sorted(oracle_inh - cgr_inh)],
             extra=[_inherit_repr(e) for e in sorted(cgr_inh - oracle_inh)],
         )
@@ -243,10 +304,31 @@ def main(
     out_dir: Annotated[
         Path, typer.Option(help="Directory for inheritance_scores.csv and diff json.")
     ] = Path(ec.DEFAULT_OUT_DIR),
+    language: Annotated[
+        ec.InheritanceLanguage, typer.Option(help=ec.INHERITANCE_LANGUAGE_HELP)
+    ] = ec.InheritanceLanguage.PYTHON,
 ) -> None:
     target = target.resolve()
     project = project_name or target.name
     logger.info(ls.INHERITANCE_TARGET.format(target=target, project=project))
+
+    if language == ec.InheritanceLanguage.JAVA:
+        # The javac oracle names supertypes by SIMPLE name while it pins the
+        # subclass to a location, so the row carries its own label: a Java 1.0
+        # is not measuring the same unit as the Python one (issue #1190).
+        result = score_inheritance(
+            java_cgr_inheritance(target, project),
+            java_oracle_inheritance(target),
+            inherits_label=ec.JAVA_SUPERTYPES_LABEL,
+        )
+        write_outputs(
+            result,
+            out_dir,
+            ec.INHERITANCE_SCORES_FILENAME,
+            ec.INHERITANCE_DIFF_FILENAME,
+        )
+        render(result, ec.INHERITANCE_TITLE)
+        return
 
     oracle = oracle_inheritance(target, project)
     logger.success(

--- a/evals/inheritance.py
+++ b/evals/inheritance.py
@@ -18,7 +18,7 @@ from . import constants as ec
 from . import logs as ls
 from .ast_oracle import _from_base_parts, _iter_py_files, _module_dotted
 from .cgr_graph import _capture
-from .oracles.java_oracle import run_java_oracle
+from .oracles.java_oracle import java_available, run_java_oracle
 from .score import _prf
 from .structure_report import render, write_outputs
 from .types_defs import DiffBucket, LocationStats, ScoreResult, ScoreRow
@@ -313,6 +313,12 @@ def main(
     logger.info(ls.INHERITANCE_TARGET.format(target=target, project=project))
 
     if language == ec.InheritanceLanguage.JAVA:
+        # Without a JDK the oracle yields nothing, and scoring that would write
+        # a header-only CSV and an empty diff while exiting 0 -- reporting "no
+        # gradeable edges" when the truth is "the grader never ran".
+        if not java_available():
+            logger.error(ls.JAVA_ORACLE_MISSING)
+            raise typer.Exit(code=1)
         # The javac oracle names supertypes by SIMPLE name while it pins the
         # subclass to a location, so the row carries its own label: a Java 1.0
         # is not measuring the same unit as the Python one (issue #1190).


### PR DESCRIPTION
Part of #1190: the first non-Python row for resolved-edge grading. `evals/inheritance.py` gains `--language java`.

## Why this was cheap

The javac oracle already emits the ground truth. `Oracle.java` builds extends/implements edges and ships them in `name_edges`; no oracle-side work was needed. The only Python-side blockers were `_iter_py_files` and a single `.endswith(PY_SUFFIX)` filter.

I had originally written on the issue that the edges live in the payload's `edges` array. That was wrong -- `edges` holds DEFINES/DEFINES_METHOD, and the inheritance edges are in `name_edges`. I found that by dumping the oracle payload on a fixture before writing any wiring, which is the habit this repo keeps rewarding.

## The comparison unit, stated rather than buried

The oracle names a supertype by SIMPLE name but pins the subclass to a file and line. So the grading is deliberately asymmetric:

- **subclass: matched by LOCATION** -- exact, no name collisions
- **supertype: matched by simple name** -- all the oracle offers

That is a weaker unit than the Python row, which resolves both ends to qualified names. So the row carries its own label, `supertypes(simple-name)`, instead of borrowing Python's `inherits-resolved`. #1190 makes this an acceptance criterion ("a 1.0 is never read wider than it was measured"), and a shared label would have quietly violated it.

## OVERRIDES is not graded for Java, on purpose

CGR *does* resolve Java OVERRIDES -- the indexer logs `Child.speak() OVERRIDES Speaks.speak()` on the fixture. The oracle emits none, so there is no ground truth to grade against. Rather than invent one, the category stays empty and `_prf` omits the row entirely: no score beats a score of something that was not measured. `test_no_overrides_row_is_emitted_for_java` locks that in, because the failure mode would be a silent 0.0 or 1.0 appearing in a results table.

## Verified

On a three-file fixture (`Child extends Base implements Speaks`) the oracle and CGR agree exactly: tp=2, fp=0, fn=0, and exactly one row emitted.

Four tests. Eval-adjacent battery: 303 passed, 12 skipped (the two C# oracle files that fail on `main` in this environment stay deselected).

## Not in this PR

`import_resolution.py` has the same Python-only shape and would follow the same pattern; I kept this to one eval so the comparison-unit decision can be reviewed on a small diff before it is repeated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Java inheritance evaluation for `extends` and `implements` relationships.
  * Added language selection for Python and Java inheritance evaluations.
  * Added Java-specific scoring labels and simple-name supertype matching.
  * Java evaluations now require a working JDK and report configuration failures clearly.

* **Tests**
  * Added coverage for Java inheritance extraction, scoring agreement, override handling, language-specific labels, and missing Java toolchains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->