### PR TITLE
chore: remove stale suspension note and disabled badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,6 @@
   </p>
 
   <p>
-  <!-- Badges below are commented out while the GitHub account is suspended. Restore them when the account is reinstated.
-       Stars/Forks: shields.io hits GitHub's API (returns "repo not found" for suspended accounts).
-       gitcgr: indexes from GitHub (shows "not indexed" while unavailable).
-       MseeP.ai: badge PNG ignores inline height on Bitbucket and renders as a full-size tile.
-  <a href="https://github.com/vitali87/code-graph-rag/stargazers">
-    <img src="https://img.shields.io/github/stars/vitali87/code-graph-rag?style=social" alt="GitHub stars" />
-  </a>
-  <a href="https://github.com/vitali87/code-graph-rag/network/members">
-    <img src="https://img.shields.io/github/forks/vitali87/code-graph-rag?style=social" alt="GitHub forks" />
-  </a>
-  -->
   <a href="https://github.com/vitali87/code-graph-rag/actions/workflows/ci.yml">
     <img src="https://img.shields.io/github/actions/workflow/status/vitali87/code-graph-rag/ci.yml?branch=main" alt="CI" />
   </a>
@@ -30,11 +19,6 @@
   <a href="https://sonarcloud.io/summary/overall?id=vitali87_code-graph-rag">
     <img src="https://sonarcloud.io/api/project_badges/measure?project=vitali87_code-graph-rag&metric=alert_status" alt="Quality Gate Status" />
   </a>
-  <!--
-  <a href="https://mseep.ai/app/vitali87-code-graph-rag">
-    <img src="https://mseep.net/pr/vitali87-code-graph-rag-badge.png" alt="MseeP.ai Security Assessment" height="20" />
-  </a>
-  -->
   <a href="https://code-graph-rag.com">
     <img src="https://img.shields.io/badge/Enterprise-Support%20%26%20Services-6366f1" alt="Enterprise Support" />
   </a>
@@ -53,11 +37,6 @@
   <a href="https://www.bestpractices.dev/projects/13757">
     <img src="https://www.bestpractices.dev/projects/13757/badge" alt="OpenSSF Best Practices" />
   </a>
-  <!--
-  <a href="https://gitcgr.com/vitali87/code-graph-rag">
-    <img src="https://gitcgr.com/badge/vitali87/code-graph-rag.svg" alt="gitcgr" />
-  </a>
-  -->
 </p>
 </div>
 


### PR DESCRIPTION
## Summary

The README carried a note saying the stars/forks, MseeP.ai and gitcgr badges were commented out because the GitHub account was suspended. Removes the note and the disabled badge markup.

## Changes

Deleted from the badge block in `README.md`:

- The four-line suspension note
- GitHub stars and forks badges (shields.io)
- MseeP.ai Security Assessment badge
- gitcgr badge

Pure deletions — 22 lines, no active badge touched. Trendshift, CI, Codecov, SonarCloud, Enterprise Support, PyPI Version/Downloads, SkillsLLM, OpenSSF Scorecard and OpenSSF Best Practices all render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ge73MShRDNCLANmsrvZkss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated commented-out badge sections from the README.
  * No changes to product functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->