### PR TITLE
feat: add structural ast-grep support for 7 more languages (#1352)

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -19,7 +19,7 @@ Point it at a repository and it reads every source file, extracts functions, cla
 
 ## Supported Languages
 
-Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby, Kotlin, Swift, Elixir, Haskell, Solidity, Bash, and Nix have structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier, which requires the `ast-grep` extra (`pip install 'code-graph-rag[ast-grep]'`).
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby, Kotlin, Swift, Elixir, Haskell, Solidity, Bash, and Nix have structural support (modules, functions, classes where the language has them, and imports) through the pluggable ast-grep tier, which requires the `ast-grep` extra (`pip install 'code-graph-rag[ast-grep]'`).
 
 ## Install
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -19,7 +19,7 @@ Point it at a repository and it reads every source file, extracts functions, cla
 
 ## Supported Languages
 
-Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby has structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier, which requires the `ast-grep` extra (`pip install 'code-graph-rag[ast-grep]'`).
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby, Kotlin, Swift, Elixir, Haskell, Solidity, Bash, and Nix have structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier, which requires the `ast-grep` extra (`pip install 'code-graph-rag[ast-grep]'`).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See the [Architecture Overview](docs/architecture/overview.md) and [Graph Schema
 
 ## Supported Languages
 
-Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby has structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier. See the [Language Support](docs/architecture/language-support.md) matrix for per-language capabilities.
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby, Kotlin, Swift, Elixir, Haskell, Solidity, Bash, and Nix have structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier. See the [Language Support](docs/architecture/language-support.md) matrix for per-language capabilities.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ See the [Architecture Overview](docs/architecture/overview.md) and [Graph Schema
 
 ## Supported Languages
 
-Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby, Kotlin, Swift, Elixir, Haskell, Solidity, Bash, and Nix have structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier. See the [Language Support](docs/architecture/language-support.md) matrix for per-language capabilities.
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby, Kotlin, Swift, Elixir, Haskell, Solidity, Bash, and Nix have structural support (modules, functions, classes where the language has them, and imports) through the pluggable ast-grep tier. See the [Language Support](docs/architecture/language-support.md) matrix for per-language capabilities.
 
 ## Installation
 

--- a/codebase_rag/parsers/ast_grep_patterns/README.md
+++ b/codebase_rag/parsers/ast_grep_patterns/README.md
@@ -30,7 +30,47 @@ imports:                # patterns whose match becomes an IMPORTS edge
   - "require_relative $PATH"
 ```
 
-`extensions` and `ast_grep_id` are required; the pattern lists are optional.
+`extensions` and `ast_grep_id` are required; the rule lists are optional.
+
+## Rule forms
+
+Each entry in `functions`, `classes` and `imports` is either a **pattern**
+(a plain string, as above) or a **kind rule** (a mapping). A rule must set
+exactly one of `pattern` or `kind`.
+
+```yaml
+functions:
+  - "def $NAME"                  # pattern rule
+  - kind: function_declaration   # kind rule
+```
+
+Prefer a **kind rule** when modifiers or keywords can precede the construct.
+A pattern is a fixed shape, so `fun $NAME` matches `fun f()` but *not*
+`private suspend fun f()`; both are the same `function_declaration` node, so
+one kind rule covers every modifier combination. Prefer a **pattern** when the
+language has no dedicated node for the construct (Elixir definitions are all
+generic `call` nodes) or when the value you want is a literal rather than an
+identifier (a Solidity import path).
+
+Kind rules take the name from the node's `name` field, falling back to its
+first identifier-like child. Three optional keys handle the rest:
+
+| Key | Applies to | Effect |
+|---|---|---|
+| `name_child` | `kind` | take the name from this child kind instead of the default lookup |
+| `has_child` | `kind` | skip matches with no child of this kind |
+| `name_head` | `pattern` | keep only the leading identifier of the capture |
+
+`has_child` disambiguates a node type that covers several concepts. A Nix
+`binding` is a function only when its value is a `function_expression`;
+without the guard, every attribute in a set would be emitted as a Function.
+Likewise a Haskell type signature (`speak :: a -> String`) parses as a
+`function` node, so requiring a `match` child keeps the type variable `a`
+out of the graph.
+
+`name_head` trims a capture down to the bare name. Elixir's zero-arg and
+guarded defs match no parenthesised pattern, so the do-block fallback
+captures `guarded(x) when is_integer(x)`; `name_head` reduces it to `guarded`.
 
 ## Metavariable conventions
 

--- a/codebase_rag/parsers/ast_grep_patterns/bash.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/bash.yaml
@@ -1,0 +1,14 @@
+# ast-grep pattern config for Bash/shell (issue #1352).
+language: bash
+ast_grep_id: bash
+extensions:
+  - ".sh"
+  - ".bash"
+functions:
+  # one kind covers all three spellings: `f() {}`, `function f {}`,
+  # `function f() {}`
+  - kind: function_definition
+classes: []
+imports:
+  - "source $PATH"
+  - ". $PATH"

--- a/codebase_rag/parsers/ast_grep_patterns/elixir.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/elixir.yaml
@@ -1,0 +1,32 @@
+# ast-grep pattern config for Elixir (issue #1352).
+# Elixir definitions are macro CALLS, not distinct grammar nodes (every one
+# is a `call`), so this config is pattern-driven. Ordering matters: the
+# `($$$)` forms come first because they capture the bare name, while the
+# `do`-block fallback captures the whole signature for zero-arg and guarded
+# defs, which the tier then trims.
+language: elixir
+ast_grep_id: elixir
+extensions:
+  - ".ex"
+  - ".exs"
+functions:
+  - "def $NAME($$$)"
+  - "defp $NAME($$$)"
+  - "defmacro $NAME($$$)"
+  - "defmacrop $NAME($$$)"
+  # zero-arg (`def run do`) and guarded (`def f(x) when ...`) defs match no
+  # parenthesised form, so these fall back to the do-block spelling and trim
+  # the captured signature down to the leading name
+  - pattern: "def $NAME do\n$$$\nend"
+    name_head: true
+  - pattern: "defp $NAME do\n$$$\nend"
+    name_head: true
+classes:
+  - "defmodule $NAME do\n$$$\nend"
+  - "defprotocol $NAME do\n$$$\nend"
+  - "defimpl $NAME do\n$$$\nend"
+imports:
+  - "import $PATH"
+  - "alias $PATH"
+  - "require $PATH"
+  - "use $PATH"

--- a/codebase_rag/parsers/ast_grep_patterns/haskell.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/haskell.yaml
@@ -1,0 +1,26 @@
+# ast-grep pattern config for Haskell (issue #1352).
+language: haskell
+ast_grep_id: haskell
+extensions:
+  - ".hs"
+functions:
+  # `function` is an equation with parameters (greet name = ...); `bind` is a
+  # nullary binding (main = ...). Type signatures are a separate `signature`
+  # kind and are deliberately NOT matched, so a function is emitted once.
+  # has_child: match excludes function TYPES inside a signature
+  # (`speak :: a -> String` also parses as a `function` node, whose name
+  # would be the type variable `a`, not a definition).
+  - kind: function
+    name_child: variable
+    has_child: match
+  - kind: bind
+    name_child: variable
+    has_child: match
+classes:
+  - kind: data_type
+  - kind: newtype
+  - kind: type_synomym
+  - kind: class
+imports:
+  - kind: import
+    name_child: module

--- a/codebase_rag/parsers/ast_grep_patterns/kotlin.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/kotlin.yaml
@@ -14,7 +14,11 @@ functions:
 classes:
   # one kind for class, interface, data class, sealed class and enum class
   - kind: class_declaration
-  # `object Registry { }` is not a class_declaration in this grammar
+  # objects are neither class_declaration nor one single kind: a modifier or
+  # delegation form (`private object R`, `object R : Service`) is an
+  # object_declaration, while a plain `object R { }` parses as an
+  # object_literal that only the pattern reaches. Both are needed.
+  - kind: object_declaration
   - "object $NAME { $$$ }"
 imports:
   - kind: import_header

--- a/codebase_rag/parsers/ast_grep_patterns/kotlin.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/kotlin.yaml
@@ -1,0 +1,20 @@
+# ast-grep pattern config for Kotlin (issue #1352).
+# Kind rules do the heavy lifting here: modifiers (`private suspend fun f()`)
+# sit OUTSIDE the construct a pattern can spell, but the node is still a
+# `function_declaration`, so matching by kind catches every modifier
+# combination instead of enumerating them.
+language: kotlin
+ast_grep_id: kotlin
+extensions:
+  - ".kt"
+  - ".kts"
+functions:
+  # covers fun/suspend fun/private fun/override fun and companion-object members
+  - kind: function_declaration
+classes:
+  # one kind for class, interface, data class, sealed class and enum class
+  - kind: class_declaration
+  # `object Registry { }` is not a class_declaration in this grammar
+  - "object $NAME { $$$ }"
+imports:
+  - kind: import_header

--- a/codebase_rag/parsers/ast_grep_patterns/nix.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/nix.yaml
@@ -1,0 +1,14 @@
+# ast-grep pattern config for Nix (issue #1352).
+language: nix
+ast_grep_id: nix
+extensions:
+  - ".nix"
+functions:
+  # a `binding` is only a function when its value is a lambda; has_child
+  # keeps plain attributes (name = "p";) out of the Function set
+  - kind: binding
+    name_child: attrpath
+    has_child: function_expression
+classes: []
+imports:
+  - "import $PATH"

--- a/codebase_rag/parsers/ast_grep_patterns/solidity.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/solidity.yaml
@@ -1,0 +1,21 @@
+# ast-grep pattern config for Solidity (issue #1352).
+language: solidity
+ast_grep_id: solidity
+extensions:
+  - ".sol"
+functions:
+  # visibility/mutability keywords follow the name, so the kind rule catches
+  # public/internal/pure/view variants uniformly
+  - kind: function_definition
+  - kind: constructor_definition
+  - kind: modifier_definition
+classes:
+  - kind: contract_declaration
+  - kind: interface_declaration
+  - kind: library_declaration
+imports:
+  # the imported path is a string literal, not an identifier, so patterns
+  # capture it via $PATH (quotes are stripped by the tier)
+  - "import $PATH;"
+  - "import {$$$} from $PATH;"
+  - "import $PATH as $ALIAS;"

--- a/codebase_rag/parsers/ast_grep_patterns/swift.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/swift.yaml
@@ -1,0 +1,17 @@
+# ast-grep pattern config for Swift (issue #1352).
+language: swift
+ast_grep_id: swift
+extensions:
+  - ".swift"
+functions:
+  # covers func, static func, and modifier-prefixed declarations
+  - kind: function_declaration
+  - kind: init_declaration
+  # requirements inside a protocol body are their own kind
+  - kind: protocol_function_declaration
+classes:
+  # class, struct, enum and extension all share this kind in the grammar
+  - kind: class_declaration
+  - kind: protocol_declaration
+imports:
+  - kind: import_declaration

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -7,10 +7,12 @@
 from __future__ import annotations
 
 import logging
+import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .. import constants as cs
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
@@ -23,17 +25,103 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _PATTERNS_DIR = Path(__file__).parent / "ast_grep_patterns"
+# leading bare name of a captured signature, for `name_head` rules
+_LEADING_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*[!?]?")
 # Metavar conventions contributors must follow in the YAML patterns.
 _NAME_METAVAR = "NAME"
 _PATH_METAVAR = "PATH"
+# Child node kinds that carry a declaration's name, tried in order when a
+# kind rule's node exposes no `name` field. Grammars differ on which one
+# they use (kotlin: simple_identifier, haskell/solidity: identifier or a
+# *_id node), so the fallback list spans them rather than per-language.
+_NAME_CHILD_KINDS = (
+    "name",
+    "identifier",
+    "simple_identifier",
+    "type_identifier",
+    "constructor",
+    "module_id",
+    "variable",
+)
+
+
+@dataclass(frozen=True)
+class _Rule:
+    """One matcher from a config: either an ast-grep pattern or a node kind.
+
+    A pattern captures its result in the $NAME/$PATH metavar. A `kind` rule
+    matches a node type instead, which is what grammars need when modifiers
+    sit outside the matched construct (`private suspend fun f()` is still a
+    kotlin `function_declaration`, but no fixed pattern spells every modifier
+    combination). Kind rules take the name from the node's `name` field, or
+    else its first `_NAME_CHILD_KINDS` child.
+    """
+
+    pattern: str | None = None
+    kind: str | None = None
+    # for kind rules whose name lives on a non-standard child kind
+    name_child: str | None = None
+    # kind rules only: skip matches without a child of this kind. Needed when
+    # one grammar node covers several concepts (a nix `binding` is a function
+    # only when its value is a `function_expression`; without this every
+    # attribute in a set would be emitted as a Function).
+    has_child: str | None = None
+    # pattern rules only: keep just the leading identifier of the capture.
+    # Elixir defs are macro calls, so the only pattern that matches a
+    # zero-arg or guarded `def` captures the whole signature
+    # (`guarded(x) when is_integer(x)`); this trims it to `guarded`.
+    name_head: bool = False
+
+    @property
+    def label(self) -> str:
+        return self.pattern if self.pattern is not None else f"kind={self.kind}"
+
+
+def _parse_rule(raw: object, path_name: str, section: str) -> _Rule:
+    if isinstance(raw, str):
+        return _Rule(pattern=raw)
+    if isinstance(raw, Mapping):
+        fields = cast("Mapping[str, object]", raw)
+        pattern = fields.get("pattern")
+        kind = fields.get("kind")
+        if bool(pattern) == bool(kind):
+            raise ValueError(
+                f"{path_name}: each {section} rule needs exactly one of "
+                f"'pattern' or 'kind'"
+            )
+        name_child = fields.get("name_child")
+        has_child = fields.get("has_child")
+        name_head = bool(fields.get("name_head"))
+        if name_head and not pattern:
+            raise ValueError(
+                f"{path_name}: 'name_head' applies to 'pattern' rules only"
+            )
+        if has_child and not kind:
+            raise ValueError(f"{path_name}: 'has_child' applies to 'kind' rules only")
+        return _Rule(
+            pattern=str(pattern) if pattern else None,
+            kind=str(kind) if kind else None,
+            name_child=str(name_child) if name_child else None,
+            has_child=str(has_child) if has_child else None,
+            name_head=name_head,
+        )
+    raise ValueError(f"{path_name}: {section} rules must be a string or a mapping")
+
+
+def _parse_rules(raw: object, path_name: str, section: str) -> tuple[_Rule, ...]:
+    if not raw:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"{path_name}: '{section}' must be a list of rules")
+    return tuple(_parse_rule(item, path_name, section) for item in raw)
 
 
 @dataclass(frozen=True)
 class _LangConfig:
     ast_grep_id: str
-    functions: tuple[str, ...]
-    classes: tuple[str, ...]
-    imports: tuple[str, ...]
+    functions: tuple[_Rule, ...]
+    classes: tuple[_Rule, ...]
+    imports: tuple[_Rule, ...]
 
 
 def load_pattern_configs() -> dict[str, _LangConfig]:
@@ -53,9 +141,9 @@ def load_pattern_configs() -> dict[str, _LangConfig]:
             extensions = [ext.strip() for ext in extensions.split(",") if ext.strip()]
         config = _LangConfig(
             ast_grep_id=str(ast_grep_id),
-            functions=tuple(data.get("functions") or ()),
-            classes=tuple(data.get("classes") or ()),
-            imports=tuple(data.get("imports") or ()),
+            functions=_parse_rules(data.get("functions"), path.name, "functions"),
+            classes=_parse_rules(data.get("classes"), path.name, "classes"),
+            imports=_parse_rules(data.get("imports"), path.name, "imports"),
         )
         for extension in extensions:
             configs[extension] = config
@@ -75,6 +163,17 @@ def structural_tier_extensions() -> frozenset[str]:
         return frozenset(load_pattern_configs())
     except Exception:  # noqa: BLE001
         return frozenset()
+
+
+def _leading_identifier(text: str) -> str | None:
+    """The bare name at the head of a captured signature.
+
+    `guarded(x) when is_integer(x)` -> `guarded`, `zero_arg` -> `zero_arg`.
+    Returns None when the capture does not start with an identifier, so a
+    stray match is dropped rather than emitted under a junk name.
+    """
+    match = _LEADING_IDENTIFIER_RE.match(text.strip())
+    return match.group(0) if match else None
 
 
 def _strip_quotes(text: str) -> str:
@@ -136,14 +235,14 @@ class AstGrepTier:
         # Functions then classes; dedupe by start line PER label so a specific
         # pattern (def self.$NAME) wins over a general one (def $NAME) on the
         # same line, while a class and function sharing a line both still land.
-        for label, patterns in (
+        for label, rules in (
             (cs.NodeLabel.FUNCTION, config.functions),
             (cs.NodeLabel.CLASS, config.classes),
         ):
             self._extract_definitions(
                 root,
                 label,
-                patterns,
+                rules,
                 file_path,
                 module_qn,
                 relative_path,
@@ -155,17 +254,17 @@ class AstGrepTier:
         self,
         root: SgNode,
         label: cs.NodeLabel,
-        patterns: tuple[str, ...],
+        rules: tuple[_Rule, ...],
         file_path: Path,
         module_qn: str,
         relative_path: str,
         absolute_path: str,
     ) -> None:
         claimed: set[int] = set()
-        for pattern in patterns:
-            for node in self._find_all(root, pattern, file_path):
-                name_node = node.get_match(_NAME_METAVAR)
-                if name_node is None:
+        for rule in rules:
+            for node in self._find_all(root, rule, file_path):
+                name = self._definition_name(node, rule)
+                if name is None:
                     continue
                 line = node.range().start.line
                 if line in claimed:
@@ -173,32 +272,69 @@ class AstGrepTier:
                 claimed.add(line)
                 self._emit_definition(
                     label,
-                    name_node.text(),
+                    name,
                     node,
                     module_qn,
                     relative_path,
                     absolute_path,
                 )
 
+    def _definition_name(self, node: SgNode, rule: _Rule) -> str | None:
+        """The declared name of a matched node, or None if it has none."""
+        if rule.pattern is not None:
+            name_node = node.get_match(_NAME_METAVAR)
+            if name_node is None:
+                return None
+            text = name_node.text()
+            return _leading_identifier(text) if rule.name_head else text
+        # kind rule: prefer the grammar's `name` field, then a named child of
+        # a known identifier kind. A config may pin an explicit child kind
+        # when a grammar puts something else first.
+        if rule.name_child:
+            for child in node.children():
+                if child.kind() == rule.name_child:
+                    return child.text()
+            return None
+        field = node.field("name")
+        if field is not None:
+            return field.text()
+        for child in node.children():
+            if child.kind() in _NAME_CHILD_KINDS:
+                return child.text()
+        return None
+
     def _extract_imports(
         self,
         root: SgNode,
-        patterns: tuple[str, ...],
+        rules: tuple[_Rule, ...],
         file_path: Path,
         module_qn: str,
     ) -> None:
-        for pattern in patterns:
-            for node in self._find_all(root, pattern, file_path):
-                target_node = node.get_match(_PATH_METAVAR)
-                if target_node is not None:
-                    self._emit_import(_strip_quotes(target_node.text()), module_qn)
+        for rule in rules:
+            for node in self._find_all(root, rule, file_path):
+                if rule.pattern is not None:
+                    target_node = node.get_match(_PATH_METAVAR)
+                    target = target_node.text() if target_node is not None else None
+                else:
+                    target = self._definition_name(node, rule)
+                if target:
+                    self._emit_import(_strip_quotes(target), module_qn)
 
-    def _find_all(self, root: SgNode, pattern: str, file_path: Path) -> list[SgNode]:
+    def _find_all(self, root: SgNode, rule: _Rule, file_path: Path) -> list[SgNode]:
         try:
-            return root.find_all(pattern=pattern)
+            if rule.pattern is not None:
+                return root.find_all(pattern=rule.pattern)
+            matches = root.find_all(kind=rule.kind)
+            if rule.has_child:
+                matches = [
+                    node
+                    for node in matches
+                    if any(c.kind() == rule.has_child for c in node.children())
+                ]
+            return matches
         except RuntimeError as exc:
             logger.warning(
-                "bad ast-grep pattern %r for %s: %s", pattern, file_path, exc
+                "bad ast-grep rule %s for %s: %s", rule.label, file_path, exc
             )
             return []
 

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -98,6 +98,8 @@ def _parse_rule(raw: object, path_name: str, section: str) -> _Rule:
             )
         if has_child and not kind:
             raise ValueError(f"{path_name}: 'has_child' applies to 'kind' rules only")
+        if name_child and not kind:
+            raise ValueError(f"{path_name}: 'name_child' applies to 'kind' rules only")
         return _Rule(
             pattern=str(pattern) if pattern else None,
             kind=str(kind) if kind else None,

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -260,16 +260,22 @@ class AstGrepTier:
         relative_path: str,
         absolute_path: str,
     ) -> None:
-        claimed: set[int] = set()
+        claimed: set[tuple[int, int]] = set()
         for rule in rules:
             for node in self._find_all(root, rule, file_path):
                 name = self._definition_name(node, rule)
                 if name is None:
                     continue
-                line = node.range().start.line
-                if line in claimed:
+                start = node.range().start
+                # Keyed on (line, column), not line alone: overlapping rules
+                # for the SAME declaration start at the same column, so the
+                # specific rule still wins over the general one, while two
+                # distinct declarations sharing a line (`fun a() {}; fun b()
+                # {}`) keep their own nodes instead of the second vanishing.
+                position = (start.line, start.column)
+                if position in claimed:
                     continue
-                claimed.add(line)
+                claimed.add(position)
                 self._emit_definition(
                     label,
                     name,

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -472,10 +472,12 @@ def test_kotlin_object_modifier_and_delegation_forms(tmp_path: Path) -> None:
     # a plain `object X { }` is an object_literal (pattern-only), while
     # modifier and delegation forms are object_declaration (kind-only), so
     # the config needs both rules to cover all three.
+    # equality, not a subset: the two overlapping object rules must not
+    # double-emit, and no unrelated node may leak into this fixture.
     names = _node_names(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), CLASS)
-    assert {"Plain", "Hidden", "Delegating"} <= names, names
+    assert names == {"Plain", "Hidden", "Delegating"}, names
 
 
 def test_kotlin_object_members_still_extracted(tmp_path: Path) -> None:
     names = _node_names(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), FUNCTION)
-    assert {"a", "b", "c"} <= names, names
+    assert names == {"a", "b", "c"}, names

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -7,6 +7,7 @@
 # and the forms it would WRONGLY claim (type signatures, plain attributes).
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -39,6 +40,15 @@ def _node_names(mock: MagicMock, label: str) -> set[str]:
         for c in mock.ensure_node_batch.call_args_list
         if str(c.args[0]) == label
     }
+
+
+def _node_name_counts(mock: MagicMock, label: str) -> Counter[str]:
+    """Emission counts per name, to catch a node emitted more than once."""
+    return Counter(
+        c.args[1].get(cs.KEY_NAME)
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == label
+    )
 
 
 def _import_targets(mock: MagicMock) -> set[str]:
@@ -472,12 +482,15 @@ def test_kotlin_object_modifier_and_delegation_forms(tmp_path: Path) -> None:
     # a plain `object X { }` is an object_literal (pattern-only), while
     # modifier and delegation forms are object_declaration (kind-only), so
     # the config needs both rules to cover all three.
-    # equality, not a subset: the two overlapping object rules must not
-    # double-emit, and no unrelated node may leak into this fixture.
-    names = _node_names(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), CLASS)
-    assert names == {"Plain", "Hidden", "Delegating"}, names
+    # Counts, not a set: the object_declaration kind rule and the
+    # object_literal pattern cover disjoint spellings today, so each name
+    # lands once. Asserting counts pins that -- if either rule widens to
+    # overlap the other, a set comparison would silently hide the resulting
+    # duplicate emission.
+    counts = _node_name_counts(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), CLASS)
+    assert counts == Counter({"Plain": 1, "Hidden": 1, "Delegating": 1}), counts
 
 
 def test_kotlin_object_members_still_extracted(tmp_path: Path) -> None:
-    names = _node_names(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), FUNCTION)
-    assert names == {"a", "b", "c"}, names
+    counts = _node_name_counts(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), FUNCTION)
+    assert counts == Counter({"a": 1, "b": 1, "c": 1}), counts

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -1,0 +1,433 @@
+# Structural support for the tree-sitter languages cgr had no LanguageSpec
+# for (issue #1352): Kotlin, Swift, Solidity, Bash, Elixir, Haskell and Nix
+# are extracted by the ast-grep tier from the shipped YAML pattern configs.
+# Each test indexes a real source file end to end and asserts the
+# Module/Function/Class nodes and DEFINES/IMPORTS edges land, with emphasis
+# on the forms a naive pattern would MISS (modifiers, guards, zero-arg defs)
+# and the forms it would WRONGLY claim (type signatures, plain attributes).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FUNCTION = cs.NodeLabel.FUNCTION.value
+CLASS = cs.NodeLabel.CLASS.value
+MODULE = cs.NodeLabel.MODULE.value
+EXTERNAL_MODULE = cs.NodeLabel.EXTERNAL_MODULE.value
+DEFINES = cs.RelationshipType.DEFINES.value
+IMPORTS = cs.RelationshipType.IMPORTS.value
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> MagicMock:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return mock
+
+
+def _node_names(mock: MagicMock, label: str) -> set[str]:
+    return {
+        c.args[1].get(cs.KEY_NAME)
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == label
+    }
+
+
+def _import_targets(mock: MagicMock) -> set[str]:
+    return {
+        to
+        for _from, to in {
+            (c.args[0][2], c.args[2][2])
+            for c in mock.ensure_relationship_batch.call_args_list
+            if str(c.args[1]) == IMPORTS
+        }
+    }
+
+
+def _defined(mock: MagicMock) -> set[str]:
+    return {
+        c.args[2][2]
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == DEFINES
+    }
+
+
+KOTLIN = """package com.example.app
+import kotlinx.coroutines.launch
+
+class Greeter(val name: String) {
+    fun greet(x: String): String = "hi"
+    suspend fun load() {}
+    private suspend fun deep() {}
+    override fun run() {}
+    companion object {
+        fun build(): Greeter = Greeter("a")
+    }
+}
+interface Speaker { fun speak() }
+object Registry { fun get() = 1 }
+data class Point(val x: Int)
+enum class Color { RED }
+fun topLevel(a: Int): Int = a
+"""
+
+
+def test_kotlin_functions_including_modifiers(tmp_path: Path) -> None:
+    # the point of the kind rule: modifiers sit outside any fixed pattern,
+    # so `suspend`/`private suspend`/`override` must still be captured.
+    names = _node_names(_run(tmp_path, {"Greeter.kt": KOTLIN}), FUNCTION)
+    assert {
+        "greet",
+        "load",
+        "deep",
+        "run",
+        "build",
+        "speak",
+        "get",
+        "topLevel",
+    } <= names, names
+
+
+def test_kotlin_classes_interfaces_objects_and_enums(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"Greeter.kt": KOTLIN}), CLASS)
+    assert {"Greeter", "Speaker", "Registry", "Point", "Color"} <= names, names
+
+
+def test_kotlin_imports(tmp_path: Path) -> None:
+    targets = _import_targets(_run(tmp_path, {"Greeter.kt": KOTLIN}))
+    assert "kotlinx.coroutines.launch" in targets, targets
+
+
+SWIFT = """import Foundation
+
+class Greeter {
+    func greet(name: String) -> String { return "hi" }
+    static func build() -> Greeter { return Greeter() }
+    init() {}
+}
+struct Point {
+    var x: Int
+    func mag() -> Int { return x }
+}
+protocol Speaker { func speak() }
+enum Color { case red }
+extension Greeter { func extra() {} }
+func topLevel(a: Int) -> Int { return a }
+"""
+
+
+def test_swift_functions_and_initializers(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"Greeter.swift": SWIFT}), FUNCTION)
+    assert {"greet", "build", "init", "mag", "speak", "extra", "topLevel"} <= names, (
+        names
+    )
+
+
+def test_swift_types(tmp_path: Path) -> None:
+    # class/struct/enum/extension share one grammar kind; protocol is its own
+    names = _node_names(_run(tmp_path, {"Greeter.swift": SWIFT}), CLASS)
+    assert {"Greeter", "Point", "Color", "Speaker"} <= names, names
+
+
+def test_swift_imports(tmp_path: Path) -> None:
+    assert "Foundation" in _import_targets(_run(tmp_path, {"G.swift": SWIFT}))
+
+
+SOLIDITY = """pragma solidity ^0.8.0;
+import "./Base.sol";
+
+contract Token is Base {
+    function transfer(address to) public returns (bool) { return true; }
+    function _helper() internal pure returns (uint) { return 1; }
+    constructor() {}
+    modifier onlyOwner() { _; }
+}
+interface IThing { function doIt() external; }
+library Math { function add(uint a) internal pure returns (uint) { return a; } }
+"""
+
+
+def test_solidity_functions_modifiers_and_constructor(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"Token.sol": SOLIDITY}), FUNCTION)
+    assert {"transfer", "_helper", "doIt", "add", "onlyOwner"} <= names, names
+
+
+def test_solidity_contract_interface_and_library(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"Token.sol": SOLIDITY}), CLASS)
+    assert {"Token", "IThing", "Math"} <= names, names
+
+
+def test_solidity_import_path_is_unquoted(tmp_path: Path) -> None:
+    # the imported path is a string literal; the tier strips the quotes
+    assert "./Base.sol" in _import_targets(_run(tmp_path, {"T.sol": SOLIDITY}))
+
+
+BASH = """#!/usr/bin/env bash
+source ./lib.sh
+
+greet() {
+  echo "hi"
+}
+function build {
+  echo "b"
+}
+function deploy() {
+  echo "d"
+}
+"""
+
+
+def test_bash_all_three_function_spellings(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"deploy.sh": BASH}), FUNCTION)
+    assert {"greet", "build", "deploy"} <= names, names
+
+
+def test_bash_source_import(tmp_path: Path) -> None:
+    assert "./lib.sh" in _import_targets(_run(tmp_path, {"deploy.sh": BASH}))
+
+
+ELIXIR = """defmodule MyApp.Greeter do
+  import Logger
+  alias MyApp.Helper
+
+  def greet(name), do: "hi"
+  defp secret(), do: 1
+  defmacro mac(x), do: x
+
+  def zero_arg do
+    1
+  end
+
+  def guarded(x) when is_integer(x) do
+    x
+  end
+end
+
+defprotocol Shape do
+  def area(s)
+end
+"""
+
+
+def test_elixir_defs_including_zero_arg_and_guarded(tmp_path: Path) -> None:
+    # zero-arg and guarded defs match no parenthesised pattern; they come
+    # from the do-block fallback whose capture the tier trims to the name.
+    names = _node_names(_run(tmp_path, {"greeter.ex": ELIXIR}), FUNCTION)
+    assert {"greet", "secret", "mac", "zero_arg", "guarded", "area"} <= names, names
+
+
+def test_elixir_modules_and_protocols(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"greeter.ex": ELIXIR}), CLASS)
+    assert {"MyApp.Greeter", "Shape"} <= names, names
+
+
+def test_elixir_import_alias_edges(tmp_path: Path) -> None:
+    targets = _import_targets(_run(tmp_path, {"greeter.ex": ELIXIR}))
+    assert {"Logger", "MyApp.Helper"} <= targets, targets
+
+
+HASKELL = """module MyApp.Greeter where
+import Data.List
+
+data Shape = Circle Double | Square Double
+newtype Wrapper = Wrapper Int
+type Alias = String
+class Speaker a where
+  speak :: a -> String
+
+greet :: String -> String
+greet name = "hi"
+
+main :: IO ()
+main = putStrLn "x"
+"""
+
+
+def test_haskell_equations_and_nullary_binds(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"Greeter.hs": HASKELL}), FUNCTION)
+    assert {"greet", "main"} <= names, names
+
+
+def test_haskell_type_signature_is_not_a_function(tmp_path: Path) -> None:
+    # `speak :: a -> String` parses as a `function` node too; without the
+    # has_child guard the type variable `a` would land as a Function.
+    names = _node_names(_run(tmp_path, {"Greeter.hs": HASKELL}), FUNCTION)
+    assert "a" not in names, names
+    assert "String" not in names, names
+
+
+def test_haskell_types_and_classes(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"Greeter.hs": HASKELL}), CLASS)
+    assert {"Shape", "Wrapper", "Alias", "Speaker"} <= names, names
+
+
+def test_haskell_imports(tmp_path: Path) -> None:
+    assert "Data.List" in _import_targets(_run(tmp_path, {"G.hs": HASKELL}))
+
+
+NIX = """{ pkgs ? import <nixpkgs> {} }:
+let
+  helper = x: x + 1;
+  greet = name: "hi ${name}";
+in
+{
+  myPkg = pkgs.stdenv.mkDerivation { name = "p"; };
+}
+"""
+
+
+def test_nix_lambda_bindings_are_functions(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"default.nix": NIX}), FUNCTION)
+    assert {"helper", "greet"} <= names, names
+
+
+def test_nix_plain_attributes_are_not_functions(tmp_path: Path) -> None:
+    # has_child: function_expression keeps non-lambda attributes out
+    names = _node_names(_run(tmp_path, {"default.nix": NIX}), FUNCTION)
+    assert "myPkg" not in names, names
+    assert "name" not in names, names
+
+
+def test_new_language_configs_load_and_map_extensions() -> None:
+    from codebase_rag.parsers.ast_grep_tier import load_pattern_configs
+
+    configs = load_pattern_configs()
+    expected = {
+        ".kt": "kotlin",
+        ".kts": "kotlin",
+        ".swift": "swift",
+        ".sol": "solidity",
+        ".sh": "bash",
+        ".bash": "bash",
+        ".ex": "elixir",
+        ".exs": "elixir",
+        ".hs": "haskell",
+        ".nix": "nix",
+    }
+    for extension, ast_grep_id in expected.items():
+        assert extension in configs, extension
+        assert configs[extension].ast_grep_id == ast_grep_id, extension
+
+
+def test_module_nodes_emitted_for_new_languages(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"Greeter.kt": KOTLIN, "deploy.sh": BASH})
+    names = _node_names(mock, MODULE)
+    assert {"Greeter.kt", "deploy.sh"} <= names, names
+
+
+def test_defines_edges_for_new_languages(tmp_path: Path) -> None:
+    defined = _defined(_run(tmp_path, {"Greeter.kt": KOTLIN}))
+    assert any(qn.endswith(".topLevel") for qn in defined), defined
+    assert any(qn.endswith(".Greeter") for qn in defined), defined
+
+
+def _load_from(tmp_path: Path, monkeypatch, yaml_text: str):
+    from codebase_rag.parsers import ast_grep_tier
+
+    (tmp_path / "lang.yaml").write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(ast_grep_tier, "_PATTERNS_DIR", tmp_path)
+    return ast_grep_tier.load_pattern_configs()
+
+
+HEADER = 'ast_grep_id: ruby\nextensions: [".xx"]\n'
+
+
+def test_plain_string_rule_still_parses_as_pattern(tmp_path: Path, monkeypatch) -> None:
+    # back-compat: the original string-list format must keep working
+    configs = _load_from(tmp_path, monkeypatch, HEADER + 'functions: ["def $NAME"]\n')
+    rule = configs[".xx"].functions[0]
+    assert rule.pattern == "def $NAME"
+    assert rule.kind is None
+
+
+def test_kind_rule_parses(tmp_path: Path, monkeypatch) -> None:
+    configs = _load_from(
+        tmp_path, monkeypatch, HEADER + "functions:\n  - kind: function_declaration\n"
+    )
+    rule = configs[".xx"].functions[0]
+    assert rule.kind == "function_declaration"
+    assert rule.pattern is None
+
+
+def test_rule_with_both_pattern_and_kind_raises(tmp_path: Path, monkeypatch) -> None:
+    try:
+        _load_from(
+            tmp_path,
+            monkeypatch,
+            HEADER + "functions:\n  - kind: fn\n    pattern: 'def $NAME'\n",
+        )
+    except ValueError as exc:
+        assert "exactly one" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for pattern+kind")
+
+
+def test_rule_with_neither_pattern_nor_kind_raises(tmp_path: Path, monkeypatch) -> None:
+    try:
+        _load_from(tmp_path, monkeypatch, HEADER + "functions:\n  - name_child: x\n")
+    except ValueError as exc:
+        assert "exactly one" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for empty rule")
+
+
+def test_has_child_on_pattern_rule_raises(tmp_path: Path, monkeypatch) -> None:
+    try:
+        _load_from(
+            tmp_path,
+            monkeypatch,
+            HEADER + "functions:\n  - pattern: 'def $NAME'\n    has_child: match\n",
+        )
+    except ValueError as exc:
+        assert "has_child" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for has_child on a pattern rule")
+
+
+def test_name_head_on_kind_rule_raises(tmp_path: Path, monkeypatch) -> None:
+    try:
+        _load_from(
+            tmp_path,
+            monkeypatch,
+            HEADER + "functions:\n  - kind: fn\n    name_head: true\n",
+        )
+    except ValueError as exc:
+        assert "name_head" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for name_head on a kind rule")
+
+
+def test_leading_identifier_trims_signatures() -> None:
+    from codebase_rag.parsers.ast_grep_tier import _leading_identifier
+
+    assert _leading_identifier("guarded(x) when is_integer(x)") == "guarded"
+    assert _leading_identifier("zero_arg") == "zero_arg"
+    assert _leading_identifier("valid?") == "valid?"
+    assert _leading_identifier("save!") == "save!"
+    assert _leading_identifier("(oops)") is None
+
+
+def test_non_list_rule_section_raises(tmp_path: Path, monkeypatch) -> None:
+    try:
+        _load_from(tmp_path, monkeypatch, HEADER + "functions: 'def $NAME'\n")
+    except ValueError as exc:
+        assert "must be a list" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for a non-list rule section")
+
+
+def test_rule_of_unsupported_type_raises(tmp_path: Path, monkeypatch) -> None:
+    try:
+        _load_from(tmp_path, monkeypatch, HEADER + "functions:\n  - 42\n")
+    except ValueError as exc:
+        assert "string or a mapping" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for a non-string, non-mapping rule")

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -445,3 +445,37 @@ def test_same_line_declarations_both_get_defines_edges(tmp_path: Path) -> None:
     defined = _defined(_run(tmp_path, {"S.kt": "fun first() {}; fun second() {}\n"}))
     assert any(qn.endswith(".first") for qn in defined), defined
     assert any(qn.endswith(".second") for qn in defined), defined
+
+
+def test_name_child_on_pattern_rule_raises(tmp_path: Path, monkeypatch) -> None:
+    # name_child is ignored by the pattern branch, so a config setting both
+    # would silently do nothing; reject it instead.
+    try:
+        _load_from(
+            tmp_path,
+            monkeypatch,
+            HEADER + "functions:\n  - pattern: 'def $NAME'\n    name_child: variable\n",
+        )
+    except ValueError as exc:
+        assert "name_child" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for name_child on a pattern rule")
+
+
+KOTLIN_OBJECTS = """object Plain { fun a() = 1 }
+private object Hidden { fun b() = 2 }
+object Delegating : Service { fun c() = 3 }
+"""
+
+
+def test_kotlin_object_modifier_and_delegation_forms(tmp_path: Path) -> None:
+    # a plain `object X { }` is an object_literal (pattern-only), while
+    # modifier and delegation forms are object_declaration (kind-only), so
+    # the config needs both rules to cover all three.
+    names = _node_names(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), CLASS)
+    assert {"Plain", "Hidden", "Delegating"} <= names, names
+
+
+def test_kotlin_object_members_still_extracted(tmp_path: Path) -> None:
+    names = _node_names(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), FUNCTION)
+    assert {"a", "b", "c"} <= names, names

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -431,3 +431,17 @@ def test_rule_of_unsupported_type_raises(tmp_path: Path, monkeypatch) -> None:
         assert "string or a mapping" in str(exc)
     else:
         raise AssertionError("expected ValueError for a non-string, non-mapping rule")
+
+
+def test_two_same_line_declarations_both_land(tmp_path: Path) -> None:
+    # definitions are deduped by (line, column); keying on line alone dropped
+    # the second declaration whenever two shared a source line.
+    mock = _run(tmp_path, {"S.kt": "fun first() {}; fun second() {}\n"})
+    names = _node_names(mock, FUNCTION)
+    assert {"first", "second"} <= names, names
+
+
+def test_same_line_declarations_both_get_defines_edges(tmp_path: Path) -> None:
+    defined = _defined(_run(tmp_path, {"S.kt": "fun first() {}; fun second() {}\n"}))
+    assert any(qn.endswith(".first") for qn in defined), defined
+    assert any(qn.endswith(".second") for qn in defined), defined

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -32,7 +32,9 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 These languages have no hand-written tree-sitter parser in cgr. They are
 handled by the pluggable [ast-grep](https://ast-grep.github.io/) tier, which
 emits `Module`, `Function` and `Class` nodes plus `IMPORTS` edges from a
-single YAML pattern file per language.
+single YAML pattern file per language. Which node kinds a language yields
+depends on its config: the `-` entries below mark constructs the language
+does not have (Bash and Nix declare no class-like types).
 
 This is a **basic** tier: names are flat (no nested-namespace qualification)
 and there is **no call-graph (`CALLS`) resolution**, so call-graph analyses

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -27,6 +27,35 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 | Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
 <!-- /SECTION:supported_languages -->
 
+## Structural Support (ast-grep tier)
+
+These languages have no hand-written tree-sitter parser in cgr. They are
+handled by the pluggable [ast-grep](https://ast-grep.github.io/) tier, which
+emits `Module`, `Function` and `Class` nodes plus `IMPORTS` edges from a
+single YAML pattern file per language.
+
+This is a **basic** tier: names are flat (no nested-namespace qualification)
+and there is **no call-graph (`CALLS`) resolution**, so call-graph analyses
+such as dead-code detection skip these files. It requires the `ast-grep`
+extra (`pip install 'code-graph-rag[ast-grep]'`).
+
+| Language | Extensions | Functions | Classes/Types | Imports |
+|---|---|---|---|---|
+| Ruby | .rb | methods, singleton methods | classes, modules | require, require_relative |
+| Kotlin | .kt, .kts | functions incl. suspend/private/override, companion members | classes, interfaces, data classes, objects, enums | import |
+| Swift | .swift | functions, initializers, protocol requirements | classes, structs, enums, extensions, protocols | import |
+| Elixir | .ex, .exs | def, defp, defmacro incl. zero-arg and guarded | defmodule, defprotocol, defimpl | import, alias, require, use |
+| Haskell | .hs | equations and nullary binds | data, newtype, type, class | import |
+| Solidity | .sol | functions, constructors, modifiers | contracts, interfaces, libraries | import |
+| Bash | .sh, .bash | all three `function`/`()` spellings | - | source, . |
+| Nix | .nix | lambda bindings | - | import |
+
+To add another language, drop a YAML file into
+`codebase_rag/parsers/ast_grep_patterns/`; see the
+[README](https://github.com/vitali87/code-graph-rag/blob/main/codebase_rag/parsers/ast_grep_patterns/README.md)
+there for the rule format. Only languages with an ast-grep built-in grammar
+are supported.
+
 ## Language-Agnostic Design
 
 All languages share a unified graph schema, meaning queries work the same way regardless of language. You can query across languages in the same knowledge graph when analysing polyglot repositories.


### PR DESCRIPTION
Closes #1352.

## Scope

The issue asks for "all missing languages from Tree-Sitter", which is unbounded in the abstract, so I bounded it empirically. The repo already has a pluggable **ast-grep tier** (added for Ruby in #414) where a language is a single YAML file. I probed the installed `ast-grep-py` for the language ids it actually accepts, then subtracted the 14 that already have a tree-sitter `LanguageSpec`.

That leaves exactly **7** genuinely missing programming languages, all added here:

**Kotlin, Swift, Solidity, Bash, Elixir, Haskell, Nix**

Each lands as `Module`/`Function`/`Class` nodes plus `IMPORTS` edges. This is the existing **basic** tier: flat names, no `CALLS` resolution. Dead-code analysis picks the new extensions up automatically, since it reads the shipped configs.

## Why the tier needed new rule forms

Pattern-only matching could not express two of these languages, and both failure modes were **silent** (dropped or wrong nodes, not errors):

- `fun $NAME` matches `fun f()` but **not** `private suspend fun f()` — yet both are one `function_declaration` node. No fixed pattern spells every modifier combination.
- Elixir's zero-arg and guarded defs match no parenthesised pattern; the only pattern that hits them captures `guarded(x) when is_integer(x)` as the "name".

So the tier gains three optional rule keys:

| Key | Applies to | Effect |
|---|---|---|
| `kind` | rule form | match a node type instead of a fixed pattern shape |
| `has_child` | `kind` | skip matches with no child of this kind |
| `name_head` | `pattern` | keep only the leading identifier of the capture |

`has_child` caught two real false positives that would otherwise have shipped:

- A Haskell type signature (`speak :: a -> String`) also parses as a `function` node, which would have put the **type variable `a`** in the graph as a function.
- A Nix `binding` is a function only when its value is a `function_expression`; without the guard **every plain attribute** in a set became a `Function`.

Both are pinned by regression tests.

## Backward compatibility

Plain string rules keep working, so `ruby.yaml` is untouched and its 9 existing tests pass unchanged.

## Testing

- 41 tier tests pass: 9 pre-existing Ruby + 32 new. The new tests deliberately cover both the forms a naive pattern **misses** (modifiers, guards, zero-arg defs, all three Bash function spellings) and the forms it **wrongly claims** (type signatures, plain attributes).
- Full unit suite: **7510 passed**, 60 skipped.
- `ruff` and `ty` clean on the changed files.

One note: `test_rust_attr_run_scan_perf` fails under `-n auto` but passes in isolation. It is a timing-sensitive perf test in Rust code untouched by this PR, starved by CPU contention — pre-existing flake, not a regression from these changes.

## Docs

README, PYPI_README, the language-support matrix (new "Structural Support" section, since the auto-generated table is driven by `LANGUAGE_METADATA` and covers tree-sitter languages only), and the contributor pattern README documenting the new rule forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structural parsing support for Kotlin, Swift, Elixir, Haskell, Solidity, Bash, and Nix.
  * Improved extraction of functions, types, modules, imports, constructors, and language-specific declarations.
  * Added flexible matching for syntax kinds, patterns, required child nodes, and identifiers.

* **Documentation**
  * Updated supported-language, architecture, and rule-configuration guidance.

* **Tests**
  * Added coverage for parsing, imports, definitions, language mappings, and rule validation across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->