### PR TITLE
fix: treat C# await plumbing methods as taint transparent

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -312,3 +312,18 @@ CSHARP_RESERVED_KEYWORDS = frozenset(
         "while",
     }
 )
+
+
+# Await plumbing that returns the SAME value in a different wrapper: the flow
+# walk recurses a method-call receiver only through these, so without them
+# `await FetchAsync().ConfigureAwait(false)` loses the receiver's taint and a
+# sink fed from it has no edge. `ConfigureAwait` is near-universal in library
+# code, so this shape is common rather than exotic (issue #1187).
+CSHARP_TAINT_TRANSPARENT_METHODS = frozenset(
+    {
+        "ConfigureAwait",
+        "GetAwaiter",
+        "GetResult",
+        "AsTask",
+    }
+)

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -406,6 +406,7 @@ _CPP_DESCRIPTOR = LanguageDescriptor(
 )
 
 _CSHARP_DESCRIPTOR = LanguageDescriptor(
+    taint_transparent_methods=cs.CSHARP_TAINT_TRANSPARENT_METHODS,
     call_type=cs.TS_CSHARP_INVOCATION_EXPRESSION,
     string_type=cs.TS_CSHARP_STRING_LITERAL,
     string_content_type=cs.TS_CSHARP_STRING_LITERAL_CONTENT,

--- a/codebase_rag/tests/test_flow_csharp_edges.py
+++ b/codebase_rag/tests/test_flow_csharp_edges.py
@@ -118,3 +118,49 @@ def test_csharp_untainted_value_emits_no_flow(tmp_path: Path) -> None:
     }
     flows = _run_flow(tmp_path, files)
     assert flows == set(), flows
+
+
+_ENV_K = "resource::ENV::K"
+_STDOUT = "resource::STDOUT::<dynamic>"
+_AWAIT_PLUMBING = (
+    "using System;\nusing System.Threading.Tasks;\n\n"
+    "public class Leaky\n{\n"
+    "    private async Task<string> FetchAsync()\n    {\n"
+    "        await Task.Delay(1);\n"
+    '        return Environment.GetEnvironmentVariable("K");\n    }\n\n'
+    "    public async Task Run()\n    {\n"
+    "        var token = await FetchAsync().ConfigureAwait(false);\n"
+    "        Console.WriteLine(token);\n    }\n}\n"
+)
+
+
+def test_configure_await_preserves_taint(tmp_path: Path) -> None:
+    # `ConfigureAwait` returns the SAME value in a different wrapper. Without it
+    # in the transparent set the walk stops at the receiver and a very common
+    # library-code shape loses its edge entirely (issue #1187).
+    flows = _run_flow(tmp_path, {"Program.cs": _AWAIT_PLUMBING})
+    assert (_ENV_K, _STDOUT) in flows
+
+
+def test_await_plumbing_chain_preserves_taint(tmp_path: Path) -> None:
+    # The blocking form of the same plumbing: GetAwaiter().GetResult().
+    source = _AWAIT_PLUMBING.replace(
+        "var token = await FetchAsync().ConfigureAwait(false);",
+        "var token = FetchAsync().GetAwaiter().GetResult();",
+    ).replace("public async Task Run()", "public void Run()")
+    flows = _run_flow(tmp_path, {"Program.cs": source})
+    assert (_ENV_K, _STDOUT) in flows
+
+
+def test_terminal_method_on_a_tainted_receiver_emits_no_flow(tmp_path: Path) -> None:
+    # The guard on the other side: a method that does NOT return the receiver's
+    # value must not propagate taint, or the transparent set becomes a blanket
+    # "any method preserves taint" rule.
+    source = (
+        "using System;\n\n"
+        "public class Fine\n{\n"
+        "    public void Run()\n    {\n"
+        '        var token = Environment.GetEnvironmentVariable("K");\n'
+        "        Console.WriteLine(token.Length);\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) not in _run_flow(tmp_path, {"Program.cs": source})

--- a/codebase_rag/tests/test_flow_csharp_edges.py
+++ b/codebase_rag/tests/test_flow_csharp_edges.py
@@ -164,3 +164,19 @@ def test_terminal_method_on_a_tainted_receiver_emits_no_flow(tmp_path: Path) -> 
         "        Console.WriteLine(token.Length);\n    }\n}\n"
     )
     assert (_ENV_K, _STDOUT) not in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_value_task_as_task_preserves_taint(tmp_path: Path) -> None:
+    # `AsTask` converts a ValueTask to a Task without changing the value, so it
+    # belongs in the transparent set for the same reason as ConfigureAwait.
+    source = (
+        "using System;\nusing System.Threading.Tasks;\n\n"
+        "public class Leaky\n{\n"
+        "    private async ValueTask<string> FetchAsync()\n    {\n"
+        "        await Task.Delay(1);\n"
+        '        return Environment.GetEnvironmentVariable("K");\n    }\n\n'
+        "    public async Task Run()\n    {\n"
+        "        var token = await FetchAsync().AsTask();\n"
+        "        Console.WriteLine(token);\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})


### PR DESCRIPTION
Part of #1187, but NOT the IOperation work that issue anticipates -- this one needed no compiler at all.

## The gap

`await FetchAsync().ConfigureAwait(false)` lost its taint entirely. A tainted value returned from an async method, awaited through `ConfigureAwait`, reached a sink with **no FLOWS_TO edge** in EITHER mode -- lexical walk and Roslyn frontend alike.

That matters because `ConfigureAwait(false)` is near-universal in C# library code, so this is a common shape rather than an exotic one.

## How it was found, and what else the probe said

Before writing anything I probed four candidate shapes in both modes, because #1187 lists async/await as remaining scope and I wanted to know which parts were actually missing rather than assume:

| shape | before |
|---|---|
| `await FetchAsync()` | already worked (return-taint summaries cover it) |
| `var t = FetchAsync(); await t;` | already worked |
| `await FetchAsync().ConfigureAwait(false)` | **missed in both modes** |
| tuple deconstruction `var (a, b) = (tainted, clean)` | **missed in both modes** |
| `if (o is string s)` pattern | **missed in both modes** |

So two thirds of what I assumed was an async gap already worked. Only the plumbing shape was broken.

## The fix

The descriptor already has a language-agnostic `taint_transparent_methods` set -- Rust uses it for `.unwrap()`, `.clone()`, methods that return the same value in a different wrapper. `ConfigureAwait` is exactly that shape, as are `GetAwaiter`, `GetResult` and `AsTask`. Giving the C# descriptor that set fixes it with existing machinery.

Because this is the LEAN walk, the fix lands in both modes: users without a dotnet toolchain get it too.

## Guard against the obvious over-correction

A transparent-method set is one careless entry away from "every method preserves taint". `test_terminal_method_on_a_tainted_receiver_emits_no_flow` pins the other side: `Console.WriteLine(token.Length)` must emit NO edge, because `.Length` does not return the receiver's value.

## Verified

- `configureawait` probe: `False/False` before, `True/True` after
- 8 tests in `test_flow_csharp_edges.py`, including the blocking `GetAwaiter().GetResult()` chain and the guard
- flow + csharp battery: **601 passed** (the two C# oracle files that fail on `main` in this environment stay deselected)

## Still open

Tuple deconstruction and `is`-pattern flow remain missed in both modes. Both are named in #1187 and both need real work in the walk (or IOperation), not a descriptor entry -- I am not smuggling them in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved C# data-flow analysis across common asynchronous and call-wrapper methods.
  - Environment-variable taint is now preserved through `ConfigureAwait`, `GetAwaiter`, `GetResult`, and `AsTask` chains.
  - Prevented taint from incorrectly propagating through terminal property access such as `token.Length`.

- **Tests**
  - Added coverage for asynchronous wrapper chains and terminal method behavior in C# analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->