### PR TITLE
fix: bind C# tuple deconstruction so each name takes its own element's taint

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -333,3 +333,4 @@ CSHARP_TAINT_TRANSPARENT_METHODS = frozenset(
 # child and a tuple child rather than the usual name/value fields.
 TS_CSHARP_TUPLE_PATTERN = "tuple_pattern"
 TS_CSHARP_TUPLE_EXPRESSION = "tuple_expression"
+TS_CSHARP_DECLARATION_EXPRESSION = "declaration_expression"

--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -327,3 +327,9 @@ CSHARP_TAINT_TRANSPARENT_METHODS = frozenset(
         "AsTask",
     }
 )
+
+
+# Deconstructing declaration: `var (a, b) = (x, y)` binds through a pattern
+# child and a tuple child rather than the usual name/value fields.
+TS_CSHARP_TUPLE_PATTERN = "tuple_pattern"
+TS_CSHARP_TUPLE_EXPRESSION = "tuple_expression"

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -127,6 +127,11 @@ class LanguageDescriptor:
     # form (issue #1187).
     tuple_pattern_type: str | None = None
     tuple_value_type: str | None = None
+
+    # An explicitly typed deconstruction slot (`(string a, int b) = t`) wraps
+    # each bound name in its own declaration node. None where the grammar has
+    # no such form.
+    declaration_expression_type: str | None = None
     # True when a declarator binds its initialiser as the LAST unfielded named child
     # rather than a `value`/`right` field (C# `variable_declarator` is `name = <expr>`
     # with the expression unfielded). Lets the handle-binding walk read the RHS.
@@ -462,6 +467,7 @@ _CSHARP_DESCRIPTOR = LanguageDescriptor(
     argument_wrapper_type=cs.TS_CSHARP_ARGUMENT,
     tuple_pattern_type=cs.TS_CSHARP_TUPLE_PATTERN,
     tuple_value_type=cs.TS_CSHARP_TUPLE_EXPRESSION,
+    declaration_expression_type=cs.TS_CSHARP_DECLARATION_EXPRESSION,
     # `var r = new StreamReader("x")` binds the initialiser as the declarator's
     # last unfielded named child (no `value` field), so the handle walk reads it.
     declarator_value_is_last_child=True,

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -118,6 +118,15 @@ class LanguageDescriptor:
     # the expression. When set, the positional-arg picker unwraps it to reach the
     # string literal / nested handle. None where args are bare expressions.
     argument_wrapper_type: str | None = None
+
+    # Deconstructing declaration shapes: a declarator that binds SEVERAL names
+    # from a tuple carries neither a `name` nor a `value` field, only a pattern
+    # child and a value child (C# `var (a, b) = (x, y)`). Naming both lets the
+    # shared extractor pair them positionally, which is what the taint walk
+    # already does for Go's multi-assign. None where the grammar has no such
+    # form (issue #1187).
+    tuple_pattern_type: str | None = None
+    tuple_value_type: str | None = None
     # True when a declarator binds its initialiser as the LAST unfielded named child
     # rather than a `value`/`right` field (C# `variable_declarator` is `name = <expr>`
     # with the expression unfielded). Lets the handle-binding walk read the RHS.
@@ -451,6 +460,8 @@ _CSHARP_DESCRIPTOR = LanguageDescriptor(
     new_expression_type=cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION,
     # C# wraps every call argument in an `argument` node.
     argument_wrapper_type=cs.TS_CSHARP_ARGUMENT,
+    tuple_pattern_type=cs.TS_CSHARP_TUPLE_PATTERN,
+    tuple_value_type=cs.TS_CSHARP_TUPLE_EXPRESSION,
     # `var r = new StreamReader("x")` binds the initialiser as the declarator's
     # last unfielded named child (no `value` field), so the handle walk reads it.
     declarator_value_is_last_child=True,

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -475,6 +475,49 @@ def lean_binding_values(
     return [node]
 
 
+def _deconstruction_pairs(
+    pattern: Node, value: Node, descriptor: LanguageDescriptor
+) -> tuple[list[str | None], list[Node]]:
+    # Walk the pattern and the tuple in LOCKSTEP so each name is paired with the
+    # element at its own position, descending together where both sides nest
+    # (`var (a, (b, c)) = (x, (y, z))`). A discard or an unrecognised position
+    # yields None, which consumes the slot without binding anything -- the miss
+    # direction, never a wrong binding.
+    names: list[str | None] = []
+    values: list[Node] = []
+    targets = list(pattern.named_children)
+    elements = [
+        unwrap_argument(child, descriptor.argument_wrapper_type)
+        for child in value.named_children
+    ]
+    for index, target in enumerate(targets):
+        element = elements[index] if index < len(elements) else None
+        if element is None:
+            continue
+        # Both SIDES wrap their elements: a C# tuple wraps each slot in an
+        # `argument`, on the pattern side as well as the value side.
+        target = unwrap_argument(target, descriptor.argument_wrapper_type)
+        # An explicitly typed slot (`string a`) wraps its name one level deeper.
+        if (
+            descriptor.declaration_expression_type is not None
+            and target.type == descriptor.declaration_expression_type
+        ):
+            target = target.named_children[-1] if target.named_children else target
+        nested_pattern = target.type in (
+            descriptor.tuple_pattern_type,
+            descriptor.tuple_value_type,
+        )
+        if nested_pattern and element.type == descriptor.tuple_value_type:
+            sub_names, sub_values = _deconstruction_pairs(target, element, descriptor)
+            names.extend(sub_names)
+            values.extend(sub_values)
+            continue
+        bound = lean_binding_targets(target, descriptor)
+        names.append(bound[0] if bound else None)
+        values.append(element)
+    return names, values
+
+
 def binding_targets_values(
     node: Node, descriptor: LanguageDescriptor
 ) -> tuple[list[str | None], list[Node]]:
@@ -485,6 +528,16 @@ def binding_targets_values(
     # (unwrapped through pointer/reference declarators).
     left = node.child_by_field_name(cs.FIELD_LEFT)
     if left is not None:
+        right = node.child_by_field_name(cs.FIELD_RIGHT)
+        # `(string a, int b) = (x, y)` is an ASSIGNMENT whose left is a tuple,
+        # not a declarator, so it never reaches the deconstruction branch below.
+        if (
+            descriptor.tuple_value_type is not None
+            and left.type == descriptor.tuple_value_type
+            and right is not None
+            and right.type == descriptor.tuple_value_type
+        ):
+            return _deconstruction_pairs(left, right, descriptor)
         return (
             lean_binding_targets(left, descriptor),
             lean_binding_values(node.child_by_field_name(cs.FIELD_RIGHT), descriptor),
@@ -522,14 +575,7 @@ def binding_targets_values(
             None,
         )
         if pattern is not None and tuple_value is not None:
-            names: list[str | None] = []
-            for child in pattern.named_children:
-                names.extend(lean_binding_targets(child, descriptor))
-            elements = [
-                unwrap_argument(child, descriptor.argument_wrapper_type)
-                for child in tuple_value.named_children
-            ]
-            return names, [e for e in elements if e is not None]
+            return _deconstruction_pairs(pattern, tuple_value, descriptor)
 
     if (
         descriptor.binding_target_container_type is not None

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -504,6 +504,34 @@ def binding_targets_values(
             node.child_by_field_name(cs.FIELD_VALUE), descriptor
         )
     if (
+        descriptor.tuple_pattern_type is not None
+        and descriptor.tuple_value_type is not None
+        and node.type == descriptor.declarator_type
+    ):
+        # A deconstructing declarator (`var (a, b) = (x, y)`) has neither a
+        # `name` nor a `value` field, so the branches above find nothing and the
+        # binding is skipped entirely -- every deconstructed name stays untainted.
+        # Pattern names and tuple elements pair BY POSITION, which is exactly
+        # what the caller already does for a multi-target binding.
+        pattern = next(
+            (c for c in node.named_children if c.type == descriptor.tuple_pattern_type),
+            None,
+        )
+        tuple_value = next(
+            (c for c in node.named_children if c.type == descriptor.tuple_value_type),
+            None,
+        )
+        if pattern is not None and tuple_value is not None:
+            names: list[str | None] = []
+            for child in pattern.named_children:
+                names.extend(lean_binding_targets(child, descriptor))
+            elements = [
+                unwrap_argument(child, descriptor.argument_wrapper_type)
+                for child in tuple_value.named_children
+            ]
+            return names, [e for e in elements if e is not None]
+
+    if (
         descriptor.binding_target_container_type is not None
         and node.type == descriptor.declarator_type
     ):

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -475,6 +475,51 @@ def lean_binding_values(
     return [node]
 
 
+def _deconstruction_children(
+    node: Node, descriptor: LanguageDescriptor
+) -> tuple[Node, Node] | None:
+    # A deconstructing declarator (`var (a, b) = (x, y)`) carries neither a
+    # `name` nor a `value` field, only a pattern child and a tuple child.
+    pattern = next(
+        (c for c in node.named_children if c.type == descriptor.tuple_pattern_type),
+        None,
+    )
+    value = next(
+        (c for c in node.named_children if c.type == descriptor.tuple_value_type),
+        None,
+    )
+    return None if pattern is None or value is None else (pattern, value)
+
+
+def _is_tuple_assignment(
+    left: Node, right: Node | None, descriptor: LanguageDescriptor
+) -> bool:
+    # `(string a, int b) = (x, y)` is an ASSIGNMENT whose left is a tuple rather
+    # than a declarator, so it never reaches the deconstruction branch that
+    # handles `var (a, b) = ...`.
+    return (
+        descriptor.tuple_value_type is not None
+        and left.type == descriptor.tuple_value_type
+        and right is not None
+        and right.type == descriptor.tuple_value_type
+    )
+
+
+def _deconstruction_slot(target: Node, descriptor: LanguageDescriptor) -> Node:
+    # One pattern slot, unwrapped to the node that actually names the binding:
+    # both SIDES wrap their elements (a C# tuple wraps each slot in an
+    # `argument`, pattern side as well as value side), and an explicitly typed
+    # slot (`string a`) wraps its name one level deeper again.
+    target = unwrap_argument(target, descriptor.argument_wrapper_type)
+    if (
+        descriptor.declaration_expression_type is not None
+        and target.type == descriptor.declaration_expression_type
+        and target.named_children
+    ):
+        return target.named_children[-1]
+    return target
+
+
 def _deconstruction_pairs(
     pattern: Node, value: Node, descriptor: LanguageDescriptor
 ) -> tuple[list[str | None], list[Node]]:
@@ -494,15 +539,7 @@ def _deconstruction_pairs(
         element = elements[index] if index < len(elements) else None
         if element is None:
             continue
-        # Both SIDES wrap their elements: a C# tuple wraps each slot in an
-        # `argument`, on the pattern side as well as the value side.
-        target = unwrap_argument(target, descriptor.argument_wrapper_type)
-        # An explicitly typed slot (`string a`) wraps its name one level deeper.
-        if (
-            descriptor.declaration_expression_type is not None
-            and target.type == descriptor.declaration_expression_type
-        ):
-            target = target.named_children[-1] if target.named_children else target
+        target = _deconstruction_slot(target, descriptor)
         nested_pattern = target.type in (
             descriptor.tuple_pattern_type,
             descriptor.tuple_value_type,
@@ -529,15 +566,8 @@ def binding_targets_values(
     left = node.child_by_field_name(cs.FIELD_LEFT)
     if left is not None:
         right = node.child_by_field_name(cs.FIELD_RIGHT)
-        # `(string a, int b) = (x, y)` is an ASSIGNMENT whose left is a tuple,
-        # not a declarator, so it never reaches the deconstruction branch below.
-        if (
-            descriptor.tuple_value_type is not None
-            and left.type == descriptor.tuple_value_type
-            and right is not None
-            and right.type == descriptor.tuple_value_type
-        ):
-            return _deconstruction_pairs(left, right, descriptor)
+        if _is_tuple_assignment(left, right, descriptor):
+            return _deconstruction_pairs(left, right, descriptor)  # type: ignore[arg-type]
         return (
             lean_binding_targets(left, descriptor),
             lean_binding_values(node.child_by_field_name(cs.FIELD_RIGHT), descriptor),
@@ -566,16 +596,9 @@ def binding_targets_values(
         # binding is skipped entirely -- every deconstructed name stays untainted.
         # Pattern names and tuple elements pair BY POSITION, which is exactly
         # what the caller already does for a multi-target binding.
-        pattern = next(
-            (c for c in node.named_children if c.type == descriptor.tuple_pattern_type),
-            None,
-        )
-        tuple_value = next(
-            (c for c in node.named_children if c.type == descriptor.tuple_value_type),
-            None,
-        )
-        if pattern is not None and tuple_value is not None:
-            return _deconstruction_pairs(pattern, tuple_value, descriptor)
+        pair = _deconstruction_children(node, descriptor)
+        if pair is not None:
+            return _deconstruction_pairs(pair[0], pair[1], descriptor)
 
     if (
         descriptor.binding_target_container_type is not None

--- a/codebase_rag/tests/test_flow_csharp_edges.py
+++ b/codebase_rag/tests/test_flow_csharp_edges.py
@@ -180,3 +180,41 @@ def test_value_task_as_task_preserves_taint(tmp_path: Path) -> None:
         "        Console.WriteLine(token);\n    }\n}\n"
     )
     assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})
+
+
+_TUPLE_SRC = (
+    "using System;\n\n"
+    "public class Leaky\n{{\n"
+    "    public void Run()\n    {{\n"
+    '        var (secret, plain) = (Environment.GetEnvironmentVariable("K"), "clean");\n'
+    "        Console.WriteLine({read});\n    }}\n}}\n"
+)
+
+
+def test_tuple_deconstruction_binds_the_tainted_element(tmp_path: Path) -> None:
+    # A deconstructing declarator carries no name/value field, so the binding
+    # was skipped entirely and every deconstructed name stayed untainted.
+    flows = _run_flow(tmp_path, {"Program.cs": _TUPLE_SRC.format(read="secret")})
+    assert (_ENV_K, _STDOUT) in flows
+
+
+def test_tuple_deconstruction_leaves_the_clean_element_clean(tmp_path: Path) -> None:
+    # The precision half: pattern names and tuple elements pair BY POSITION, so
+    # reading the untainted element must emit nothing. Without this the fix
+    # would be an over-approximation that taints every deconstructed name.
+    flows = _run_flow(tmp_path, {"Program.cs": _TUPLE_SRC.format(read="plain")})
+    assert (_ENV_K, _STDOUT) not in flows
+
+
+def test_tuple_deconstruction_taints_only_the_matching_position(tmp_path: Path) -> None:
+    # Mirror of the above with the taint in the SECOND slot, so a fix that
+    # simply spread the first value across all names would fail here.
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    public void Run()\n    {\n"
+        '        var (plain, secret) = ("clean", Environment.GetEnvironmentVariable("K"));\n'
+        "        Console.WriteLine(secret);\n"
+        "        Console.Error.WriteLine(plain);\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})

--- a/codebase_rag/tests/test_flow_csharp_edges.py
+++ b/codebase_rag/tests/test_flow_csharp_edges.py
@@ -200,10 +200,10 @@ def test_tuple_deconstruction_binds_the_tainted_element(tmp_path: Path) -> None:
 
 def test_tuple_deconstruction_leaves_the_clean_element_clean(tmp_path: Path) -> None:
     # The precision half: pattern names and tuple elements pair BY POSITION, so
-    # reading the untainted element must emit nothing. Without this the fix
-    # would be an over-approximation that taints every deconstructed name.
+    # reading the untainted element must emit nothing. Asserted as the EXACT set
+    # rather than one absent pair, so no other fabricated edge can hide either.
     flows = _run_flow(tmp_path, {"Program.cs": _TUPLE_SRC.format(read="plain")})
-    assert (_ENV_K, _STDOUT) not in flows
+    assert flows == set()
 
 
 def test_tuple_deconstruction_taints_only_the_matching_position(tmp_path: Path) -> None:
@@ -216,5 +216,67 @@ def test_tuple_deconstruction_taints_only_the_matching_position(tmp_path: Path) 
         '        var (plain, secret) = ("clean", Environment.GetEnvironmentVariable("K"));\n'
         "        Console.WriteLine(secret);\n"
         "        Console.Error.WriteLine(plain);\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_nested_deconstruction_binds_the_inner_name(tmp_path: Path) -> None:
+    # `tuple_pattern` nests, and the value nests with it; the pair walk descends
+    # both together so an inner name still takes its own element.
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    public void Run()\n    {\n"
+        '        var (a, (b, c)) = ("clean", (Environment.GetEnvironmentVariable("K"), 1));\n'
+        "        Console.WriteLine(b);\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_nested_deconstruction_keeps_the_outer_clean_name_clean(tmp_path: Path) -> None:
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    public void Run()\n    {\n"
+        '        var (a, (b, c)) = ("clean", (Environment.GetEnvironmentVariable("K"), 1));\n'
+        "        Console.WriteLine(a);\n    }\n}\n"
+    )
+    assert _run_flow(tmp_path, {"Program.cs": source}) == set()
+
+
+def test_typed_deconstruction_assignment_binds(tmp_path: Path) -> None:
+    # `(string a, int b) = (x, y)` is an ASSIGNMENT whose left is a tuple, not a
+    # declarator, so it reaches the pair walk by a different route entirely.
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    public void Run()\n    {\n"
+        '        (string a, int b) = (Environment.GetEnvironmentVariable("K"), 1);\n'
+        "        Console.WriteLine(a);\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_predeclared_deconstruction_assignment_binds(tmp_path: Path) -> None:
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    public void Run()\n    {\n"
+        "        string a; int b;\n"
+        '        (a, b) = (Environment.GetEnvironmentVariable("K"), 1);\n'
+        "        Console.WriteLine(a);\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_discard_slot_consumes_its_position(tmp_path: Path) -> None:
+    # `_` binds nothing, but it must still CONSUME its slot or every later name
+    # would pair with the wrong element.
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    public void Run()\n    {\n"
+        '        var (_, secret) = ("clean", Environment.GetEnvironmentVariable("K"));\n'
+        "        Console.WriteLine(secret);\n    }\n}\n"
     )
     assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})


### PR DESCRIPTION
Part of #1187: the second of the three gaps my probe on that issue confirmed. Like #1360, this needed no compiler.

## The gap

`var (secret, plain) = (Environment.GetEnvironmentVariable("K"), "clean");` bound NOTHING. Every deconstructed name stayed untainted, in both modes, so a sink fed from `secret` had no edge.

## Root cause

A deconstructing `variable_declarator` carries neither a `name` nor a `value` field -- it has two named children, `tuple_pattern` and `tuple_expression`. `binding_targets_values` looks for `left`/`right`, then `name`/`value`, then a container type, finds none of them, and returns nothing, so the walk skips the binding entirely.

I confirmed that against the real tree rather than inferring it:

```
variable_declarator  |(a, b) = (o, 1)
  tuple_pattern      |(a, b)
  tuple_expression   |(o, 1)
```

`child_by_field_name("name")` and `("value")` both return None.

## The fix

Two new descriptor fields, `tuple_pattern_type` and `tuple_value_type`, and one branch in the shared extractor that pairs pattern names with tuple elements. It is descriptor-driven rather than a C# special case, so any grammar with the same shape can opt in by naming its two node types.

The positional pairing itself is NOT new code: `_lean_bind` already pairs multiple targets with multiple values by index (it does this for Go multi-assign). Giving the extractor the right lists is all that was missing.

## Precision, not just propagation

The obvious wrong fix here is to spread the tuple's taint across every bound name, which would "pass" a naive test while tainting `plain`. Three tests pin the actual behaviour:

- reading `secret` emits the edge
- reading `plain` emits **nothing**
- the mirror case with the taint in the SECOND slot, which a first-value-spread implementation would fail

## Verified

- probe: `False/False` before, `True/True` after, both modes
- `test_flow_csharp_edges.py`: 12 passed
- shared-extractor regression sweep across flow/lean/dart/handle/callable suites: 330 passed

Two tests fail in that sweep, `test_csharp_retrieval_eval.py` and `test_csharp_structure_oracle.py`. I verified by stashing this branch that both fail identically on `main` in this environment, so they are pre-existing and unrelated -- I checked rather than assuming, because this change does touch C#.

## Still open on #1187

`is`-pattern flow (`if (o is string s)`) remains missed in both modes. That one is not a declarator at all, so it needs separate handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added C# tuple deconstruction support for nested, typed, and predeclared assignments.
  - Taint tracking now maps tuple elements to corresponding variables, including positional and discard slots.

- **Bug Fixes**
  - Fixed missing or incorrect bindings in complex tuple deconstruction scenarios.
  - Ensured clean elements remain untainted when other tuple values contain tainted data.

- **Tests**
  - Added coverage for nested patterns, typed assignments, predeclared variables, and discard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->