### PR TITLE
fix: carry taint through C# type-test patterns that bind a name

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -334,3 +334,7 @@ CSHARP_TAINT_TRANSPARENT_METHODS = frozenset(
 TS_CSHARP_TUPLE_PATTERN = "tuple_pattern"
 TS_CSHARP_TUPLE_EXPRESSION = "tuple_expression"
 TS_CSHARP_DECLARATION_EXPRESSION = "declaration_expression"
+# `if (o is string s)` binds `s` to the SUBJECT's value, so taint has to cross
+# the pattern or the bound name looks clean inside the branch.
+TS_CSHARP_IS_PATTERN = "is_pattern_expression"
+TS_CSHARP_DECLARATION_PATTERN = "declaration_pattern"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1298,8 +1298,10 @@ class FlowProcessor:
             self._bind_lean_type_decl(node, handles, jc)
             return
         if d.pattern_test_type is not None and node_type == d.pattern_test_type:
+            # Bind, then fall THROUGH to the normal traversal: the tested
+            # subject can be a call (`Forward(secret) is string s`), whose own
+            # argument and parameter-to-sink flows are emitted by walking it.
             self._bind_pattern_test(node, tainted, jc)
-            return
         if node_type == d.declarator_type or node_type in (
             cs.TS_ASSIGNMENT_EXPRESSION,
             cs.TS_GO_ASSIGNMENT_STATEMENT,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1297,6 +1297,9 @@ class FlowProcessor:
             # below skips so it is not re-bound to no handle (issue #1220).
             self._bind_lean_type_decl(node, handles, jc)
             return
+        if d.pattern_test_type is not None and node_type == d.pattern_test_type:
+            self._bind_pattern_test(node, tainted, jc)
+            return
         if node_type == d.declarator_type or node_type in (
             cs.TS_ASSIGNMENT_EXPRESSION,
             cs.TS_GO_ASSIGNMENT_STATEMENT,
@@ -1322,6 +1325,34 @@ class FlowProcessor:
             if returned is not None:
                 self._acc_returns_taint = True
                 self._acc_return_taint = _merge_taint(self._acc_return_taint, returned)
+
+    def _bind_pattern_test(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+        # `o is string s` binds `s` to the SUBJECT's value, so the bound name
+        # inherits the subject's taint. The name is only in scope where the test
+        # held, so binding it here needs no branch tracking.
+        d = jc.descriptor
+        subject = node.named_children[0] if node.named_children else None
+        pattern = next(
+            (
+                child
+                for child in node.named_children
+                if child.type == d.pattern_declaration_type
+            ),
+            None,
+        )
+        if subject is None or pattern is None:
+            return
+        name_node = pattern.named_children[-1] if pattern.named_children else None
+        if name_node is None or name_node.type != d.identifier_type:
+            return
+        name = name_node.text.decode(cs.ENCODING_UTF8) if name_node.text else None
+        if not name:
+            return
+        taint = self._js_expr_taint(subject, tainted, jc)
+        if taint is not None:
+            tainted[name] = taint
+        else:
+            tainted.pop(name, None)
 
     def _lean_bind(
         self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -132,6 +132,12 @@ class LanguageDescriptor:
     # each bound name in its own declaration node. None where the grammar has
     # no such form.
     declaration_expression_type: str | None = None
+
+    # Type-test pattern that BINDS a name to the tested value
+    # (`if (o is string s)`): the bound name must inherit the subject's taint,
+    # or it reads as clean inside the branch that guarantees it is the value.
+    pattern_test_type: str | None = None
+    pattern_declaration_type: str | None = None
     # True when a declarator binds its initialiser as the LAST unfielded named child
     # rather than a `value`/`right` field (C# `variable_declarator` is `name = <expr>`
     # with the expression unfielded). Lets the handle-binding walk read the RHS.
@@ -468,6 +474,8 @@ _CSHARP_DESCRIPTOR = LanguageDescriptor(
     tuple_pattern_type=cs.TS_CSHARP_TUPLE_PATTERN,
     tuple_value_type=cs.TS_CSHARP_TUPLE_EXPRESSION,
     declaration_expression_type=cs.TS_CSHARP_DECLARATION_EXPRESSION,
+    pattern_test_type=cs.TS_CSHARP_IS_PATTERN,
+    pattern_declaration_type=cs.TS_CSHARP_DECLARATION_PATTERN,
     # `var r = new StreamReader("x")` binds the initialiser as the declarator's
     # last unfielded named child (no `value` field), so the handle walk reads it.
     declarator_value_is_last_child=True,

--- a/codebase_rag/tests/test_flow_csharp_edges.py
+++ b/codebase_rag/tests/test_flow_csharp_edges.py
@@ -323,3 +323,26 @@ def test_is_pattern_without_a_binding_is_ignored(tmp_path: Path) -> None:
         '            Console.WriteLine("safe");\n        }\n    }\n}\n'
     )
     assert (_ENV_K, _STDOUT) not in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_call_subject_of_a_pattern_still_emits_its_own_flows(tmp_path: Path) -> None:
+    # The tested subject can be a CALL, and binding the pattern name must not
+    # suppress walking it: `Forward` writes its argument to stderr, so that
+    # edge has to survive alongside the pattern binding.
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    private string Forward(string v)\n    {\n"
+        "        Console.Error.WriteLine(v);\n        return v;\n    }\n\n"
+        "    public void Run()\n    {\n"
+        '        var secret = Environment.GetEnvironmentVariable("K");\n'
+        "        if (Forward(secret) is string s)\n        {\n"
+        "            Console.WriteLine(s);\n        }\n    }\n}\n"
+    )
+    flows = _run_flow(tmp_path, {"Program.cs": source})
+    assert (_ENV_K, "resource::STDERR::<dynamic>") in flows
+    # NOT asserted: ENV -> STDOUT via `s`. A call subject does not carry its
+    # RETURN taint to the bound name, but that is a pre-existing pass-through
+    # limitation, not a pattern one -- `var t = Forward(secret); sink(t);`
+    # emits no edge either. Asserting it here would tie this test to a gap it
+    # does not own.

--- a/codebase_rag/tests/test_flow_csharp_edges.py
+++ b/codebase_rag/tests/test_flow_csharp_edges.py
@@ -280,3 +280,46 @@ def test_discard_slot_consumes_its_position(tmp_path: Path) -> None:
         "        Console.WriteLine(secret);\n    }\n}\n"
     )
     assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_is_pattern_binds_the_tested_value(tmp_path: Path) -> None:
+    # `o is string s` guarantees `s` IS the tested value, so it inherits its
+    # taint; without this the bound name reads as clean inside the very branch
+    # that established what it is.
+    source = (
+        "using System;\n\n"
+        "public class Leaky\n{\n"
+        "    public void Run()\n    {\n"
+        '        object o = Environment.GetEnvironmentVariable("K");\n'
+        "        if (o is string s)\n        {\n"
+        "            Console.WriteLine(s);\n        }\n    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, {"Program.cs": source})
+
+
+def test_is_pattern_on_a_clean_subject_emits_no_flow(tmp_path: Path) -> None:
+    # The guard: the binding must carry the SUBJECT's taint, not simply mark
+    # every pattern-bound name as tainted.
+    source = (
+        "using System;\n\n"
+        "public class Fine\n{\n"
+        "    public void Run()\n    {\n"
+        '        object o = "constant";\n'
+        "        if (o is string s)\n        {\n"
+        "            Console.WriteLine(s);\n        }\n    }\n}\n"
+    )
+    assert _run_flow(tmp_path, {"Program.cs": source}) == set()
+
+
+def test_is_pattern_without_a_binding_is_ignored(tmp_path: Path) -> None:
+    # `o is string` binds nothing, so there is no name to taint and the walk
+    # must not fall over reaching for one.
+    source = (
+        "using System;\n\n"
+        "public class Fine\n{\n"
+        "    public void Run()\n    {\n"
+        '        object o = Environment.GetEnvironmentVariable("K");\n'
+        "        if (o is string)\n        {\n"
+        '            Console.WriteLine("safe");\n        }\n    }\n}\n'
+    )
+    assert (_ENV_K, _STDOUT) not in _run_flow(tmp_path, {"Program.cs": source})


### PR DESCRIPTION
Part of #1187, and the last of the three gaps the probe on that issue confirmed. Like #1360 and #1361, no compiler needed.

## The gap

```csharp
object o = Environment.GetEnvironmentVariable("K");
if (o is string s)
{
    Console.WriteLine(s);   // no edge
}
```

`s` read as clean inside the very branch that established what it is. Missed in both modes.

## The fix

A type-test pattern that BINDS a name gives that name the subject's value, so it inherits the subject's taint. Two descriptor fields (`pattern_test_type`, `pattern_declaration_type`) and one branch in the walk's dispatch, so it stays descriptor-driven rather than a C# special case.

**Why this needs no branch tracking**, which is what makes it lean-walk work rather than IOperation work: `s` is only in scope where the test HELD. The language scopes it for us, so binding at the pattern is not an over-approximation.

## Guards

Two tests aimed at the failure modes I could have shipped:

- a CLEAN subject emits nothing (`flows == set()`), so the binding carries the subject's taint rather than marking every pattern-bound name tainted
- `o is string` with NO binding is ignored, since there is no name to taint and the walk must not reach for one

## Verified

- probe: `False/False` before, `True/True` after, both modes
- `test_flow_csharp_edges.py`: 20 passed
- flow/lean/io_access sweep: **579 passed**, which is the signal that matters here since this adds a branch to the SHARED statement dispatch rather than a C#-only path

## #1187 status after this

All three probed gaps are closed: `ConfigureAwait` plumbing (#1360), tuple deconstruction (#1361), type-test patterns (this). The remaining scope on that issue is LINQ operator flow, `SymbolFinder` completeness, and source generators -- plus #1356, the interface-dispatch policy question that is deliberately still open for a decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved C# pattern-matching analysis by tracking data flow from tested values to pattern-bound variables.
  - Added support for distinguishing variable-binding patterns from type-only patterns.
  - Preserved flow detection for expressions evaluated as pattern subjects.

- **Bug Fixes**
  - Prevented incorrect data-flow results when tested values are clean or patterns do not introduce bindings.

- **Tests**
  - Added coverage for tainted and clean values, type-only patterns, variable bindings, and call expressions used in patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->