### PR TITLE
fix: lean-walk pass-through helpers keep their argument's taint (#1363)

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -351,3 +351,6 @@ RS_ITER_MAP = "map"
 RS_ITER_COLLECT = "collect"
 TS_RS_ARRAY_TYPE = "array_type"
 RS_FIELD_ELEMENT = "element"
+# Rust spells a `return x;` node return_expression, NOT return_statement:
+# the shared TS_RETURN_STATEMENT never matches it (issue #1365).
+TS_RS_RETURN_EXPRESSION = "return_expression"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2065,7 +2065,14 @@ class FlowProcessor:
                     self._return_edge_candidates.append(
                         (callee[0], callee[1], jc.flow.caller_spec)
                     )
-                    return Taint(frozenset(), frozenset({callee[1]})), frozenset()
+                    # Dart resolves a call's value here rather than through
+                    # _js_expr_taint, so it needs the same per-call pass-through
+                    # token to compose a helper's returned parameter (#1363).
+                    token = _passthrough_result_token(jc.flow.caller_qn, call_sel)
+                    return (
+                        Taint(frozenset(), frozenset({callee[1], token})),
+                        frozenset(),
+                    )
             return None, frozenset()
         if len(rhs) == 1 and rhs[0].type == cs.TS_DART_IDENTIFIER and rhs[0].text:
             alias = rhs[0].text.decode(cs.ENCODING_UTF8)

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -196,6 +196,25 @@ def _lean_parameter_slots(
     return [], None
 
 
+# A Rust block's final child is the function's value only when it is an
+# expression: a statement or declaration yields `()` and returns nothing.
+_RUST_NON_VALUE_TAIL = frozenset({cs.TS_EXPRESSION_STATEMENT, cs.TS_RS_LET_DECLARATION})
+
+
+def _rust_tail_expression(func_node: Node) -> Node | None:
+    # The value a Rust body yields with no `return` keyword and no trailing
+    # semicolon -- the idiomatic form, which carries no return node at all and
+    # so reaches none of the return branches in the walk (issue #1365).
+    body = func_node.child_by_field_name(cs.FIELD_BODY)
+    if body is None or body.type != cs.TS_RS_BLOCK:
+        return None
+    children = [c for c in body.named_children if c.type != cs.TS_COMMENT]
+    if not children:
+        return None
+    tail = children[-1]
+    return None if tail.type in _RUST_NON_VALUE_TAIL else tail
+
+
 class Taint(NamedTuple):
     # What is tainting a variable: resolved resource origins plus the set of
     # callee QNs whose (possibly not-yet-processed) return value it carries. A
@@ -799,6 +818,15 @@ class FlowProcessor:
             # not leak its shadow past the join.
             for node in statements:
                 state = self._walk_flat_stmt(node, state, jc)
+        if ctx.language == cs.SupportedLanguage.RUST:
+            tail = _rust_tail_expression(caller_node)
+            if tail is not None:
+                returned = self._js_expr_taint(tail, state.taint, jc)
+                if returned is not None:
+                    self._acc_returns_taint = True
+                    self._acc_return_taint = _merge_taint(
+                        self._acc_return_taint, returned
+                    )
         if self._acc_returns_taint:
             self._summaries[ctx.caller_qn] = self._acc_return_taint
 
@@ -1322,7 +1350,9 @@ class FlowProcessor:
             self._flow_stream(node, tainted, handles, jc)
         elif d.keyword_stdout_write_types and node_type in d.keyword_stdout_write_types:
             self._flow_keyword_write(node, tainted, jc)
-        elif node_type == cs.TS_RETURN_STATEMENT:
+        elif node_type in (cs.TS_RETURN_STATEMENT, cs.TS_RS_RETURN_EXPRESSION):
+            # Rust names this node return_expression, so matching only
+            # return_statement dropped every Rust return summary (issue #1365).
             returned = self._js_return_taint(node, tainted, jc)
             if returned is not None:
                 self._acc_returns_taint = True

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1508,7 +1508,13 @@ class FlowProcessor:
                 self._return_edge_candidates.append(
                     (callee[0], callee[1], jc.flow.caller_spec)
                 )
-                return Taint(frozenset(), frozenset({callee[1]}))
+                # The result also carries a per-call-site pass-through token so a
+                # tainted argument to a return-parameter reaches THIS call's
+                # consumers only (issue #1363, mirroring the Python path from
+                # #1168); it resolves to nothing when the callee is not a
+                # pass-through, so non-pass-through calls are unaffected.
+                token = _passthrough_result_token(jc.flow.caller_qn, node)
+                return Taint(frozenset(), frozenset({callee[1], token}))
             # A method chain: recurse the receiver ONLY through a taint-transparent
             # method -- Rust Result unwrapping (`std::env::var("X").unwrap()`) or a
             # value-preserving conversion (`s.as_bytes()`). A terminal method that

--- a/codebase_rag/tests/test_flow_edges_lean_params.py
+++ b/codebase_rag/tests/test_flow_edges_lean_params.py
@@ -1,9 +1,9 @@
 """Forward parameter-taint composition for the lean walk in Java, C#, Rust, and C
 (issue #1195, following #1169's Go/JS/TS/C++). A secret handed to a wrapper whose
 parameter reaches a sink must connect the source resource to the sink resource,
-and the argument must map to the RIGHT positional parameter. Return composition
-stays Python-only (a lean callee's return does not forward taint), so only the
-parameter-to-sink direction is asserted here."""
+and the argument must map to the RIGHT positional parameter. Only the
+parameter-to-sink direction is asserted here; the return direction is covered by
+test_flow_lean_passthrough_return.py (issue #1363)."""
 
 from __future__ import annotations
 

--- a/codebase_rag/tests/test_flow_lean_passthrough_return.py
+++ b/codebase_rag/tests/test_flow_lean_passthrough_return.py
@@ -3,8 +3,14 @@ Python a callee's return summary keyed by a per-call token, so a tainted
 argument entering a parameter that reaches the return carries through to the
 caller's use of the result. The lean walk built every part of that -- parameter
 seeding, the token on the call-site record, the return-param closure -- but its
-call-result Taint omitted the token, so the composition never joined and every
-lean language silently lost pass-through taint."""
+call-result Taint omitted the token, so the composition never joined and the
+lean languages silently lost pass-through taint. Dart resolves a call's value on
+its own `_dart_rhs` path and needed the same token there.
+
+Lua and Scala are NOT covered: neither has a lean parameter-slot extractor
+(`_lean_parameter_slots` returns no slots for them), so no parameter is ever
+seeded and there is nothing for the token to compose against. Rust has an
+extractor but still does not compose; both gaps are tracked separately."""
 
 from __future__ import annotations
 
@@ -28,6 +34,7 @@ _FILENAMES = {
     "c_sharp": "A.cs",
     "go": "m.go",
     "rust": "m.rs",
+    "dart": "m.dart",
 }
 
 
@@ -80,6 +87,14 @@ _PASSTHROUGH = {
         "    var s = Forward(t);\n"
         "    Console.WriteLine(s);\n"
         "  }\n"
+        "}\n"
+    ),
+    "dart": (
+        "String forward(String v) { return v; }\n"
+        "void run() {\n"
+        "  var t = Platform.environment['SECRET'];\n"
+        "  var s = forward(t);\n"
+        "  print(s);\n"
         "}\n"
     ),
     "go": (

--- a/codebase_rag/tests/test_flow_lean_passthrough_return.py
+++ b/codebase_rag/tests/test_flow_lean_passthrough_return.py
@@ -9,8 +9,8 @@ its own `_dart_rhs` path and needed the same token there.
 
 Lua and Scala are NOT covered: neither has a lean parameter-slot extractor
 (`_lean_parameter_slots` returns no slots for them), so no parameter is ever
-seeded and there is nothing for the token to compose against. Rust has an
-extractor, so no parameter is ever seeded. Both are tracked in #1365.
+seeded and there is nothing for the token to compose against. Both are tracked
+in #1365.
 
 Rust needed two further fixes: it spells a `return x;` node `return_expression`
 (so the shared `TS_RETURN_STATEMENT` never matched and NO Rust return summary

--- a/codebase_rag/tests/test_flow_lean_passthrough_return.py
+++ b/codebase_rag/tests/test_flow_lean_passthrough_return.py
@@ -1,0 +1,156 @@
+"""Pass-through return composition for the lean walk (issue #1363). #1168 gave
+Python a callee's return summary keyed by a per-call token, so a tainted
+argument entering a parameter that reaches the return carries through to the
+caller's use of the result. The lean walk built every part of that -- parameter
+seeding, the token on the call-site record, the return-param closure -- but its
+call-result Taint omitted the token, so the composition never joined and every
+lean language silently lost pass-through taint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+_ENV = "resource::ENV::SECRET"
+_STDOUT = "resource::STDOUT::<dynamic>"
+_FILENAMES = {
+    "javascript": "m.js",
+    "java": "A.java",
+    "c_sharp": "A.cs",
+    "go": "m.go",
+    "rust": "m.rs",
+}
+
+
+def _flows(tmp_path: Path, language: str, source: str) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    if language not in parsers:
+        pytest.skip(f"parser not available: {language}")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / _FILENAMES[language]).write_text(source, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+_PASSTHROUGH = {
+    "javascript": (
+        "function forward(v) { return v; }\n"
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  const s = forward(t);\n"
+        "  console.log(s);\n"
+        "}\n"
+    ),
+    "java": (
+        "class A {\n"
+        "  static String forward(String v) { return v; }\n"
+        "  static void run() {\n"
+        '    String t = System.getenv("SECRET");\n'
+        "    String s = forward(t);\n"
+        "    System.out.println(s);\n"
+        "  }\n"
+        "}\n"
+    ),
+    "c_sharp": (
+        "using System;\n"
+        "class A {\n"
+        "  static string Forward(string v) { return v; }\n"
+        "  static void Run() {\n"
+        '    var t = Environment.GetEnvironmentVariable("SECRET");\n'
+        "    var s = Forward(t);\n"
+        "    Console.WriteLine(s);\n"
+        "  }\n"
+        "}\n"
+    ),
+    "go": (
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func forward(v string) string { return v }\n\n"
+        "func run() {\n"
+        '\tt := os.Getenv("SECRET")\n'
+        "\ts := forward(t)\n"
+        "\tfmt.Println(s)\n"
+        "}\n"
+    ),
+}
+
+
+@pytest.mark.parametrize("language", sorted(_PASSTHROUGH))
+def test_passthrough_helper_carries_taint_to_the_caller(
+    tmp_path: Path, language: str
+) -> None:
+    assert (_ENV, _STDOUT) in _flows(tmp_path, language, _PASSTHROUGH[language])
+
+
+def test_a_callee_that_discards_its_argument_stays_clean(tmp_path: Path) -> None:
+    # The token must resolve to nothing when the parameter never reaches the
+    # return, or every call would launder taint into its result.
+    source = (
+        'function drop(v) { return "constant"; }\n'
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  const s = drop(t);\n"
+        "  console.log(s);\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "javascript", source)
+
+
+def test_taint_follows_the_returned_parameter_not_any_parameter(
+    tmp_path: Path,
+) -> None:
+    # `pick` returns its SECOND parameter, so a secret handed to the first must
+    # not reach the sink: the composition is positional, not per-callee.
+    clean = (
+        "function pick(a, b) { return b; }\n"
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        '  const s = pick(t, "clean");\n'
+        "  console.log(s);\n"
+        "}\n"
+    )
+    tainted = (
+        "function pick(a, b) { return b; }\n"
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        '  const s = pick("clean", t);\n'
+        "  console.log(s);\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path / "a", "javascript", clean)
+    assert (_ENV, _STDOUT) in _flows(tmp_path / "b", "javascript", tainted)
+
+
+def test_one_call_site_taint_does_not_leak_into_another(tmp_path: Path) -> None:
+    # Both calls share a callee, so a summary keyed by the CALLEE would taint the
+    # clean call's result too. The per-call token is what keeps them apart.
+    source = (
+        "function fwd(v) { return v; }\n"
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  fwd(t);\n"
+        '  const s = fwd("clean");\n'
+        "  console.log(s);\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "javascript", source)

--- a/codebase_rag/tests/test_flow_lean_passthrough_return.py
+++ b/codebase_rag/tests/test_flow_lean_passthrough_return.py
@@ -10,7 +10,12 @@ its own `_dart_rhs` path and needed the same token there.
 Lua and Scala are NOT covered: neither has a lean parameter-slot extractor
 (`_lean_parameter_slots` returns no slots for them), so no parameter is ever
 seeded and there is nothing for the token to compose against. Rust has an
-extractor but still does not compose; both gaps are tracked separately."""
+extractor, so no parameter is ever seeded. Both are tracked in #1365.
+
+Rust needed two further fixes: it spells a `return x;` node `return_expression`
+(so the shared `TS_RETURN_STATEMENT` never matched and NO Rust return summary
+was recorded at all), and its idiomatic return is a block's trailing expression
+with no return node whatsoever."""
 
 from __future__ import annotations
 
@@ -97,6 +102,14 @@ _PASSTHROUGH = {
         "  print(s);\n"
         "}\n"
     ),
+    "rust": (
+        "fn forward(v: String) -> String { return v; }\n"
+        "fn run() {\n"
+        '    let t = std::env::var("SECRET").unwrap();\n'
+        "    let s = forward(t);\n"
+        '    println!("{}", s);\n'
+        "}\n"
+    ),
     "go": (
         "package main\n\n"
         'import (\n\t"fmt"\n\t"os"\n)\n\n'
@@ -169,3 +182,62 @@ def test_one_call_site_taint_does_not_leak_into_another(tmp_path: Path) -> None:
         "}\n"
     )
     assert (_ENV, _STDOUT) not in _flows(tmp_path, "javascript", source)
+
+
+def test_rust_tail_expression_is_a_return(tmp_path: Path) -> None:
+    # `fn f(v: T) -> T { v }` is the idiomatic Rust return and carries no return
+    # node at all, so the walk has to read the block's trailing expression.
+    source = (
+        "fn forward(v: String) -> String { v }\n"
+        "fn run() {\n"
+        '    let t = std::env::var("SECRET").unwrap();\n'
+        "    let s = forward(t);\n"
+        '    println!("{}", s);\n'
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "rust", source)
+
+
+def test_rust_own_read_return_reaches_the_caller(tmp_path: Path) -> None:
+    # No parameter is involved: this is the plain return summary that was lost
+    # for every Rust function while return_expression went unrecognised.
+    source = (
+        'fn fetch() -> String { return std::env::var("SECRET").unwrap(); }\n'
+        "fn run() {\n"
+        "    let s = fetch();\n"
+        '    println!("{}", s);\n'
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "rust", source)
+
+
+def test_a_rust_tail_expression_that_derives_an_unrelated_value_stays_clean(
+    tmp_path: Path,
+) -> None:
+    # The tail expression is the function's value, but `v.len()` is a LENGTH, not
+    # the secret. Treating any trailing expression mentioning a parameter as a
+    # pass-through is the false positive this mechanism could introduce.
+    source = (
+        "fn size(v: String) -> usize { v.len() }\n"
+        "fn run() {\n"
+        '    let t = std::env::var("SECRET").unwrap();\n'
+        "    let s = size(t);\n"
+        '    println!("{}", s);\n'
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "rust", source)
+
+
+def test_a_rust_body_ending_in_a_statement_returns_nothing(tmp_path: Path) -> None:
+    # A trailing SEMICOLON makes the block yield `()`. The helper never writes
+    # anywhere, so a bogus return summary is the only thing that could produce an
+    # edge here: this pins the statement-versus-expression distinction itself.
+    source = (
+        "fn discard(v: String) { let _x = v; }\n"
+        "fn run() {\n"
+        '    let t = std::env::var("SECRET").unwrap();\n'
+        "    let s = discard(t);\n"
+        '    println!("{:?}", s);\n'
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "rust", source)

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -369,17 +369,17 @@ module is re-exported under its own name. A project that does
   `resource -> resource` flow even when the source and the sink live in different
   bodies — the logging-wrapper case `secret = getenv('K'); log_it(secret)` with
   `log_it(m): logger.info(m)` connects ENV to STDOUT. Only resolved callees participate;
-  there are still no `Parameter` nodes and no SSA-level precision. Java and C# parse
-  into the graph but have no parameter-name extractor yet, so their positional
-  composition stays inert until one is added.
-- Forward argument taint also composes through a callee's **return** value for Python
+  there are still no `Parameter` nodes and no SSA-level precision.
+- Forward argument taint also composes through a callee's **return** value
   (pass-through helpers such as `def redact(v): return v`): a parameter that reaches the
-  function's return — directly or transitively through `return other(p)` and pass-through
-  chains — is closed over by the same finalize fixpoint, and a call site passing a tainted
-  argument into such a parameter folds that argument's origins into the callee's return
-  summary, so a caller consuming the return (`y = redact(secret); print(y)`) resolves the
-  secret to the sink. This return composition is Python-only; the lean walks forward
-  taint into callee sinks (above) but not yet through a callee's return.
+  function's return is closed over by the same finalize fixpoint, and a call site passing
+  a tainted argument into such a parameter folds that argument's origins into the callee's
+  return summary, so a caller consuming the return (`y = redact(secret); print(y)`)
+  resolves the secret to the sink. The composition is keyed by the individual call site,
+  so a second call to the same helper with a clean argument keeps a clean result. Every
+  language composes a DIRECT pass-through (`return v`). Chaining it transitively through
+  another call (`return other(p)`) is Python-only; a lean-walk callee that returns the
+  result of a further call ends the chain there.
 - The `kind = arg` edge itself is still recorded one level deep — it marks that a
   tainted value reached a call — and is emitted alongside the forward composition above.
   Sources and sinks are direct I/O calls from the registry.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -376,10 +376,13 @@ module is re-exported under its own name. A project that does
   a tainted argument into such a parameter folds that argument's origins into the callee's
   return summary, so a caller consuming the return (`y = redact(secret); print(y)`)
   resolves the secret to the sink. The composition is keyed by the individual call site,
-  so a second call to the same helper with a clean argument keeps a clean result. Every
-  language composes a DIRECT pass-through (`return v`). Chaining it transitively through
-  another call (`return other(p)`) is Python-only; a lean-walk callee that returns the
-  result of a further call ends the chain there.
+  so a second call to the same helper with a clean argument keeps a clean result. A DIRECT
+  pass-through (`return v`) composes in Python, JavaScript, TypeScript, Java, C#, Go, PHP,
+  C, C++ and Dart. It does NOT compose in Lua or Scala, which have no lean parameter-slot
+  extractor, so no parameter is seeded for the composition to match; Rust has an extractor
+  but does not compose either. Chaining transitively through another call
+  (`return other(p)`) is Python-only; a lean-walk callee that returns the result of a
+  further call ends the chain there.
 - The `kind = arg` edge itself is still recorded one level deep — it marks that a
   tainted value reached a call — and is emitted alongside the forward composition above.
   Sources and sinks are direct I/O calls from the registry.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -378,9 +378,10 @@ module is re-exported under its own name. A project that does
   resolves the secret to the sink. The composition is keyed by the individual call site,
   so a second call to the same helper with a clean argument keeps a clean result. A DIRECT
   pass-through (`return v`) composes in Python, JavaScript, TypeScript, Java, C#, Go, PHP,
-  C, C++ and Dart. It does NOT compose in Lua or Scala, which have no lean parameter-slot
-  extractor, so no parameter is seeded for the composition to match; Rust has an extractor
-  but does not compose either. Chaining transitively through another call
+  C, C++, Dart and Rust, including Rust's idiomatic trailing-expression return with no
+  `return` keyword. It does NOT compose in Lua or Scala, which have no lean parameter-slot
+  extractor, so no parameter is seeded for the composition to match. Chaining transitively
+  through another call
   (`return other(p)`) is Python-only; a lean-walk callee that returns the result of a
   further call ends the chain there.
 - The `kind = arg` edge itself is still recorded one level deep — it marks that a


### PR DESCRIPTION
Addresses #1363 for the direct pass-through case.

## The defect

A helper that returns its parameter unchanged laundered taint in every lean-walk language:

```js
function forward(v) { return v; }
const t = process.env.SECRET;
console.log(forward(t));      // no ENV -> STDOUT edge
```

Python emitted this edge; C#, JS, Java and Go did not. I filed the issue as C#-specific and that was wrong: it affects all twelve lean-walk languages.

## Cause

#1168 built the composition generically and `finalize()` is language-agnostic. The lean walk already had every part of it:

- parameters seeded as `Taint(params={name})`
- `_param_call_sites` recorded WITH a per-call token
- `_resolve_return_params` closing over the callee summaries

The one break was the join. `_js_expr_taint` returned a call's result as `Taint(pending={callee_qn})` while the Python path returns `{callee_qn, token}`. The origins injected under `token` in `finalize()` were therefore unreachable from any caller, so the composition silently resolved to nothing. The fix adds the token to the lean call result.

## Why this does not fabricate edges

The token is the precision mechanism, not a shortcut, and the tests pin each way it could go wrong:

- callee discards its parameter (`return "constant"`) gives no edge
- callee returns its SECOND parameter: secret passed first gives no edge, passed second gives the edge
- two calls to the same helper, one tainted and one clean: the clean call's result stays clean. A callee-keyed summary would fail this; the per-call token is what makes it pass.

A token for a non-pass-through callee resolves to nothing, so calls that were not pass-throughs are unaffected.

## Scope

Direct pass-through (`return v`) now composes in every language. Chaining transitively through a further call (`return other(p)`) still needs the `_return_param_edges` recording that only the Python walk does; that stays Python-only and #1363 stays open for it rather than widening this change.

## Verification

- 7 new tests in `codebase_rag/tests/test_flow_lean_passthrough_return.py`, parameterised over JavaScript, Java, C# and Go, verified RED before the fix and GREEN after.
- Full flow/taint suite: 433 passed, no regressions.
- Docs corrected: `data-flow-edges.md` claimed the return composition was Python-only, and separately still claimed Java and C# have no parameter-name extractor (#1195 added those).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data-flow tracking for pass-through return values across supported languages, including Rust.
  * Recognized Rust explicit returns and trailing expressions as function return values.
  * Prevented taint from leaking between separate call sites.
  * Ensured discarded and non-returned arguments remain clean.
  * Preserved correct positional parameter selection.

* **Documentation**
  * Clarified language-specific return propagation behavior and parser limitations.

* **Tests**
  * Added regression coverage for JavaScript, Java, C#, Go, Dart, and Rust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->