### PR TITLE
feat: Lua and Scala parameter slots complete the lean taint composition (#1365)

### DIFF
--- a/codebase_rag/constants/ast_lua.py
+++ b/codebase_rag/constants/ast_lua.py
@@ -33,3 +33,7 @@ TS_LUA_FUNCTION_DEFINITION = "function_definition"
 IMPORT_REQUIRE = "require"
 IMPORT_PCALL = "pcall"
 IMPORT_IMPORT = "import"
+
+# Lua `...` in a parameter list: occupies the trailing variadic slot and
+# binds no simple name (issue #1365).
+TS_LUA_VARARG_EXPRESSION = "vararg_expression"

--- a/codebase_rag/constants/ast_scala.py
+++ b/codebase_rag/constants/ast_scala.py
@@ -32,3 +32,6 @@ TS_SCALA_REPEATED_PARAMETER_TYPE = "repeated_parameter_type"
 TS_SCALA_INDENTED_BLOCK = "indented_block"
 # A def declared `Unit` discards its body's value, so no return summary.
 SCALA_UNIT_TYPE = "Unit"
+# Every spelling of scala.Unit. A user-defined type merely ENDING in Unit
+# (`example.Unit`) is a real type whose return value must still compose.
+SCALA_UNIT_TYPES = frozenset({"Unit", "scala.Unit", "_root_.scala.Unit"})

--- a/codebase_rag/constants/ast_scala.py
+++ b/codebase_rag/constants/ast_scala.py
@@ -29,3 +29,6 @@ TS_SCALA_TYPE_IDENTIFIER = "type_identifier"
 # parameter (`xs: String*`) is spelled as the parameter's TYPE node.
 TS_SCALA_PARAMETER = "parameter"
 TS_SCALA_REPEATED_PARAMETER_TYPE = "repeated_parameter_type"
+TS_SCALA_INDENTED_BLOCK = "indented_block"
+# A def declared `Unit` discards its body's value, so no return summary.
+SCALA_UNIT_TYPE = "Unit"

--- a/codebase_rag/constants/ast_scala.py
+++ b/codebase_rag/constants/ast_scala.py
@@ -24,3 +24,8 @@ TS_SCALA_LAMBDA_EXPRESSION = "lambda_expression"
 TS_SCALA_IDENTIFIER = "identifier"
 TS_SCALA_INSTANCE_EXPRESSION = "instance_expression"
 TS_SCALA_TYPE_IDENTIFIER = "type_identifier"
+
+# Scala parameter shapes for lean slot extraction (issue #1365). A repeated
+# parameter (`xs: String*`) is spelled as the parameter's TYPE node.
+TS_SCALA_PARAMETER = "parameter"
+TS_SCALA_REPEATED_PARAMETER_TYPE = "repeated_parameter_type"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -214,16 +214,14 @@ _SCALA_NON_VALUE_TAIL = frozenset(
 
 
 def _scala_returns_unit(func_node: Node) -> bool:
-    # `Unit` and the qualified `scala.Unit` (and `_root_.scala.Unit`) name the
-    # same type, so compare the LAST dotted segment rather than the whole
-    # annotation. A user-defined type that happens to end in `Unit` would also
-    # match; that direction only SUPPRESSES a summary, so the cost is a missed
-    # flow rather than a fabricated one, which is the safer way to be wrong.
+    # The spellings of scala.Unit are enumerable, so match them exactly rather
+    # than by trailing segment: a user-defined `example.Unit` is an ordinary
+    # type whose returned value DOES matter, and suppressing it would drop a
+    # real flow.
     return_type = func_node.child_by_field_name(cs.FIELD_RETURN_TYPE)
     if return_type is None or return_type.text is None:
         return False
-    spelled = return_type.text.decode(cs.ENCODING_UTF8).strip()
-    return spelled.rpartition(cs.SEPARATOR_DOT)[2] == cs.SCALA_UNIT_TYPE
+    return return_type.text.decode(cs.ENCODING_UTF8).strip() in cs.SCALA_UNIT_TYPES
 
 
 def _scala_body_value(func_node: Node) -> Node | None:

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -72,11 +72,13 @@ from ..utils import (
     go_positional_parameter_slots,
     java_positional_parameter_slots,
     js_ts_positional_parameter_slots,
+    lua_positional_parameter_slots,
     php_positional_parameter_slots,
     python_free_variable_names,
     python_parameter_names,
     rust_positional_parameter_slots,
     safe_decode_text,
+    scala_positional_parameter_slots,
 )
 from .constants import (
     KEY_KIND,
@@ -193,12 +195,38 @@ def _lean_parameter_slots(
         return php_positional_parameter_slots(func_node)
     if language == cs.SupportedLanguage.DART:
         return dart_positional_parameter_slots(func_node)
+    if language == cs.SupportedLanguage.LUA:
+        return lua_positional_parameter_slots(func_node)
+    if language == cs.SupportedLanguage.SCALA:
+        return scala_positional_parameter_slots(func_node)
     return [], None
 
 
 # A Rust block's final child is the function's value only when it is an
 # expression: a statement or declaration yields `()` and returns nothing.
 _RUST_NON_VALUE_TAIL = frozenset({cs.TS_EXPRESSION_STATEMENT, cs.TS_RS_LET_DECLARATION})
+
+
+# A Scala block yields its final expression; a definition yields Unit.
+_SCALA_NON_VALUE_TAIL = frozenset(
+    {cs.TS_SCALA_VAL_DEFINITION, cs.TS_SCALA_VAR_DEFINITION}
+)
+
+
+def _scala_body_value(func_node: Node) -> Node | None:
+    # Scala has no return keyword in idiomatic code: a def's BODY is its value,
+    # whether that is a bare expression (`def f(v: String) = v`), a call, or a
+    # block whose final expression is the result (issue #1365).
+    body = func_node.child_by_field_name(cs.FIELD_BODY)
+    if body is None:
+        return None
+    if body.type != cs.TS_SCALA_BLOCK:
+        return body
+    children = [c for c in body.named_children if c.type != cs.TS_COMMENT]
+    if not children:
+        return None
+    tail = children[-1]
+    return None if tail.type in _SCALA_NON_VALUE_TAIL else tail
 
 
 def _rust_tail_expression(func_node: Node) -> Node | None:
@@ -818,8 +846,12 @@ class FlowProcessor:
             # not leak its shadow past the join.
             for node in statements:
                 state = self._walk_flat_stmt(node, state, jc)
-        if ctx.language == cs.SupportedLanguage.RUST:
-            tail = _rust_tail_expression(caller_node)
+        if ctx.language in (cs.SupportedLanguage.RUST, cs.SupportedLanguage.SCALA):
+            tail = (
+                _rust_tail_expression(caller_node)
+                if ctx.language == cs.SupportedLanguage.RUST
+                else _scala_body_value(caller_node)
+            )
             if tail is not None:
                 returned = self._js_expr_taint(tail, state.taint, jc)
                 if returned is not None:

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -217,10 +217,24 @@ def _scala_body_value(func_node: Node) -> Node | None:
     # Scala has no return keyword in idiomatic code: a def's BODY is its value,
     # whether that is a bare expression (`def f(v: String) = v`), a call, or a
     # block whose final expression is the result (issue #1365).
+    #
+    # A def DECLARED `Unit` is the exception: its body's value is discarded, so
+    # summarising it would invent a return the caller can never observe and a
+    # sink consuming `f()` would report a flow that does not exist. Only an
+    # explicit annotation is trusted here; an inferred type is unknown to the
+    # walk and left alone.
+    return_type = func_node.child_by_field_name(cs.FIELD_RETURN_TYPE)
+    if (
+        return_type is not None
+        and return_type.text is not None
+        and return_type.text.decode(cs.ENCODING_UTF8) == cs.SCALA_UNIT_TYPE
+    ):
+        return None
     body = func_node.child_by_field_name(cs.FIELD_BODY)
     if body is None:
         return None
-    if body.type != cs.TS_SCALA_BLOCK:
+    # Scala 3 significant indentation spells the same block `indented_block`.
+    if body.type not in (cs.TS_SCALA_BLOCK, cs.TS_SCALA_INDENTED_BLOCK):
         return body
     children = [c for c in body.named_children if c.type != cs.TS_COMMENT]
     if not children:

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -213,6 +213,19 @@ _SCALA_NON_VALUE_TAIL = frozenset(
 )
 
 
+def _scala_returns_unit(func_node: Node) -> bool:
+    # `Unit` and the qualified `scala.Unit` (and `_root_.scala.Unit`) name the
+    # same type, so compare the LAST dotted segment rather than the whole
+    # annotation. A user-defined type that happens to end in `Unit` would also
+    # match; that direction only SUPPRESSES a summary, so the cost is a missed
+    # flow rather than a fabricated one, which is the safer way to be wrong.
+    return_type = func_node.child_by_field_name(cs.FIELD_RETURN_TYPE)
+    if return_type is None or return_type.text is None:
+        return False
+    spelled = return_type.text.decode(cs.ENCODING_UTF8).strip()
+    return spelled.rpartition(cs.SEPARATOR_DOT)[2] == cs.SCALA_UNIT_TYPE
+
+
 def _scala_body_value(func_node: Node) -> Node | None:
     # Scala has no return keyword in idiomatic code: a def's BODY is its value,
     # whether that is a bare expression (`def f(v: String) = v`), a call, or a
@@ -223,12 +236,7 @@ def _scala_body_value(func_node: Node) -> Node | None:
     # sink consuming `f()` would report a flow that does not exist. Only an
     # explicit annotation is trusted here; an inferred type is unknown to the
     # walk and left alone.
-    return_type = func_node.child_by_field_name(cs.FIELD_RETURN_TYPE)
-    if (
-        return_type is not None
-        and return_type.text is not None
-        and return_type.text.decode(cs.ENCODING_UTF8) == cs.SCALA_UNIT_TYPE
-    ):
+    if _scala_returns_unit(func_node):
         return None
     body = func_node.child_by_field_name(cs.FIELD_BODY)
     if body is None:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -973,6 +973,59 @@ def _rust_parameter_name(pattern: Node | None) -> str | None:
     return None
 
 
+def lua_positional_parameter_slots(
+    func_node: Node,
+) -> tuple[list[str | None], int | None]:
+    # Lua `parameters` holds bare `identifier` children plus a trailing `...`
+    # spelled `vararg_expression`, which takes the variadic slot and binds no
+    # name. A `function obj:method(a)` receiver is implicit (never a parameter
+    # node), and a `:` call passes it implicitly too, so the explicit arguments
+    # still line up with these slots and nothing has to be dropped.
+    params = func_node.child_by_field_name(cs.FIELD_PARAMETERS)
+    if params is None:
+        return [], None
+    names: list[str | None] = []
+    variadic_index: int | None = None
+    for param in params.named_children:
+        if param.type == cs.TS_LUA_VARARG_EXPRESSION:
+            if variadic_index is None:
+                variadic_index = len(names)
+            names.append(None)
+            continue
+        if param.type == cs.TS_LUA_IDENTIFIER:
+            names.append(safe_decode_text(param))
+    return names, variadic_index
+
+
+def scala_positional_parameter_slots(
+    func_node: Node,
+) -> tuple[list[str | None], int | None]:
+    # Scala `parameters` -> `parameter` (name field). A repeated parameter
+    # (`xs: String*`) carries a `repeated_parameter_type` as its TYPE, which is
+    # the only marker distinguishing it from a normal one. Curried definitions
+    # (`def f(a: Int)(b: Int)`) have SEVERAL sibling `parameters` lists; the
+    # field yields the first, and only that one maps to arg:<index> at a call
+    # site, so the later lists are deliberately left alone.
+    params = func_node.child_by_field_name(cs.FIELD_PARAMETERS)
+    if params is None:
+        return [], None
+    names: list[str | None] = []
+    variadic_index: int | None = None
+    for param in params.named_children:
+        if param.type != cs.TS_SCALA_PARAMETER:
+            continue
+        type_node = param.child_by_field_name(cs.FIELD_TYPE)
+        if (
+            type_node is not None
+            and type_node.type == cs.TS_SCALA_REPEATED_PARAMETER_TYPE
+            and variadic_index is None
+        ):
+            variadic_index = len(names)
+        name = param.child_by_field_name(cs.FIELD_NAME)
+        names.append(safe_decode_text(name) if name is not None else None)
+    return names, variadic_index
+
+
 def rust_positional_parameter_slots(
     func_node: Node,
 ) -> tuple[list[str | None], int | None]:

--- a/codebase_rag/tests/test_flow_lua_scala_param_slots.py
+++ b/codebase_rag/tests/test_flow_lua_scala_param_slots.py
@@ -1,0 +1,182 @@
+"""Lean parameter-slot extraction for Lua and Scala (issue #1365). Every other
+lean language got slots in #1195/#1169; these two fell through to an empty list,
+so no parameter was ever seeded and BOTH composition directions stayed inert:
+argument-into-callee-sink (#1169) and the pass-through return (#1363)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+_ENV = "resource::ENV::SECRET"
+_STDOUT = "resource::STDOUT::<dynamic>"
+_FILENAMES = {"lua": "m.lua", "scala": "M.scala"}
+
+
+def _flows(tmp_path: Path, language: str, source: str) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    if language not in parsers:
+        pytest.skip(f"parser not available: {language}")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / _FILENAMES[language]).write_text(source, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+def test_lua_argument_reaches_a_sink_inside_the_callee(tmp_path: Path) -> None:
+    source = (
+        "local function logIt(msg) print(msg) end\n"
+        'local function caller() local s = os.getenv("SECRET") logIt(s) end\n'
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "lua", source)
+
+
+def test_lua_maps_the_argument_to_the_right_slot(tmp_path: Path) -> None:
+    # The secret is the SECOND argument, and only the second parameter is
+    # printed: a compacting or shifted slot list would fabricate the edge.
+    leaks = (
+        "local function logIt(tag, msg) print(msg) end\n"
+        'local function caller() local s = os.getenv("SECRET") logIt("app", s) end\n'
+    )
+    clean = (
+        "local function logIt(tag, msg) print(tag) end\n"
+        'local function caller() local s = os.getenv("SECRET") logIt("app", s) end\n'
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path / "a", "lua", leaks)
+    assert (_ENV, _STDOUT) not in _flows(tmp_path / "b", "lua", clean)
+
+
+def test_lua_passthrough_return_carries_taint(tmp_path: Path) -> None:
+    source = (
+        "local function forward(v) return v end\n"
+        'local function caller() local s = os.getenv("SECRET") print(forward(s)) end\n'
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "lua", source)
+
+
+def test_scala_argument_reaches_a_sink_inside_the_callee(tmp_path: Path) -> None:
+    source = (
+        "object M {\n"
+        "  def logIt(msg: String): Unit = println(msg)\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        "    logIt(s)\n"
+        "  }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)
+
+
+def test_scala_maps_the_argument_to_the_right_slot(tmp_path: Path) -> None:
+    leaks = (
+        "object M {\n"
+        "  def logIt(tag: String, msg: String): Unit = println(msg)\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        '    logIt("app", s)\n'
+        "  }\n"
+        "}\n"
+    )
+    clean = (
+        "object M {\n"
+        "  def logIt(tag: String, msg: String): Unit = println(tag)\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        '    logIt("app", s)\n'
+        "  }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path / "a", "scala", leaks)
+    assert (_ENV, _STDOUT) not in _flows(tmp_path / "b", "scala", clean)
+
+
+def test_scala_passthrough_return_carries_taint(tmp_path: Path) -> None:
+    source = (
+        "object M {\n"
+        "  def forward(v: String): String = v\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        "    println(forward(s))\n"
+        "  }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)
+
+
+def test_a_scala_body_that_derives_an_unrelated_value_stays_clean(
+    tmp_path: Path,
+) -> None:
+    # A def's body IS its value, but `v.length` is a LENGTH, not the secret.
+    # Treating any body mentioning a parameter as a pass-through is the false
+    # positive this rule could introduce.
+    source = (
+        "object M {\n"
+        "  def size(v: String): Int = v.length\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        "    println(size(s))\n"
+        "  }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "scala", source)
+
+
+def test_a_scala_block_ending_in_a_definition_returns_nothing(tmp_path: Path) -> None:
+    # A block whose last child is a `val` yields Unit, so the caller's binding
+    # must not inherit the secret. The helper writes nowhere, so a bogus return
+    # value is the only thing that could produce an edge.
+    source = (
+        "object M {\n"
+        "  def hold(v: String): Unit = { val kept = v }\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        "    println(hold(s))\n"
+        "  }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "scala", source)
+
+
+def test_lua_taint_passed_into_the_vararg_slot_does_not_propagate(
+    tmp_path: Path,
+) -> None:
+    # `...` takes a slot but binds no name, so a secret landing in it seeds
+    # nothing and the flow stops. Asserting the real behaviour rather than the
+    # behaviour I first assumed: Lua's vararg is always LAST, so it can never
+    # displace a named parameter, and the shift this slot guards against in
+    # other languages is unreachable here. The limitation is the propagation,
+    # not the mapping.
+    source = (
+        "local function logIt(tag, ...) print(...) end\n"
+        'local function caller() local s = os.getenv("SECRET") logIt("app", s) end\n'
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "lua", source)
+
+
+def test_lua_named_parameter_before_a_vararg_still_maps(tmp_path: Path) -> None:
+    # The named parameters preceding `...` must still resolve by position.
+    source = (
+        "local function logIt(msg, ...) print(msg) end\n"
+        'local function caller() local s = os.getenv("SECRET") logIt(s) end\n'
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "lua", source)

--- a/codebase_rag/tests/test_flow_lua_scala_param_slots.py
+++ b/codebase_rag/tests/test_flow_lua_scala_param_slots.py
@@ -180,3 +180,47 @@ def test_lua_named_parameter_before_a_vararg_still_maps(tmp_path: Path) -> None:
         'local function caller() local s = os.getenv("SECRET") logIt(s) end\n'
     )
     assert (_ENV, _STDOUT) in _flows(tmp_path, "lua", source)
+
+
+def test_a_scala_unit_method_does_not_return_its_last_expression(
+    tmp_path: Path,
+) -> None:
+    # `Unit` DISCARDS the body's value, so summarising the trailing expression
+    # would invent a return the caller can never observe and report a flow that
+    # does not exist. The read still happens; it just does not reach the sink
+    # through the call's result.
+    source = (
+        "object M {\n"
+        '  def hold(): Unit = { System.getenv("SECRET") }\n'
+        "  def caller(): Unit = { println(hold()) }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "scala", source)
+
+
+def test_a_scala_method_returning_a_value_still_composes(tmp_path: Path) -> None:
+    # The control for the Unit rule: the same body under a String return type
+    # MUST still reach the sink, or the exclusion would be silently swallowing
+    # real flows.
+    source = (
+        "object M {\n"
+        '  def fetch(): String = { System.getenv("SECRET") }\n'
+        "  def caller(): Unit = { println(fetch()) }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)
+
+
+def test_scala_3_indented_body_composes(tmp_path: Path) -> None:
+    # Scala 3 significant indentation spells the body `indented_block` rather
+    # than `block`; matching only the braced form would silently miss every
+    # Scala 3 helper.
+    source = (
+        "object M:\n"
+        "  def forward(v: String): String =\n"
+        "    v\n"
+        "  def caller(): Unit =\n"
+        '    val s = System.getenv("SECRET")\n'
+        "    println(forward(s))\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)

--- a/codebase_rag/tests/test_flow_lua_scala_param_slots.py
+++ b/codebase_rag/tests/test_flow_lua_scala_param_slots.py
@@ -270,3 +270,16 @@ def test_a_unit_method_that_writes_its_parameter_still_reaches_the_sink(
         "}\n"
     )
     assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)
+
+
+def test_a_user_defined_type_ending_in_unit_still_composes(tmp_path: Path) -> None:
+    # `example.Unit` is an ordinary type, not scala.Unit: its returned value is
+    # observable, so suppressing it would drop a real flow. Matching the Unit
+    # spellings exactly rather than by trailing segment is what keeps this edge.
+    source = (
+        "object M {\n"
+        '  def fetch(): example.Unit = { System.getenv("SECRET") }\n'
+        "  def caller(): Unit = { println(fetch()) }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)

--- a/codebase_rag/tests/test_flow_lua_scala_param_slots.py
+++ b/codebase_rag/tests/test_flow_lua_scala_param_slots.py
@@ -224,3 +224,49 @@ def test_scala_3_indented_body_composes(tmp_path: Path) -> None:
         "    println(forward(s))\n"
     )
     assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)
+
+
+def test_a_qualified_scala_unit_also_returns_nothing(tmp_path: Path) -> None:
+    # `scala.Unit` names the same type as `Unit`, so an exact-string check on
+    # the annotation lets the qualified spelling through and re-opens the leak.
+    source = (
+        "object M {\n"
+        '  def fetch(): scala.Unit = { System.getenv("SECRET") }\n'
+        "  def caller(): Unit = { println(fetch()) }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "scala", source)
+
+
+def test_a_unit_method_discarding_a_non_unit_expression_stays_clean(
+    tmp_path: Path,
+) -> None:
+    # A `Unit` def whose trailing expression HAS a value still discards it.
+    source = (
+        "object M {\n"
+        "  def leak(v: String): Unit = { v.toUpperCase }\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        "    println(leak(s))\n"
+        "  }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "scala", source)
+
+
+def test_a_unit_method_that_writes_its_parameter_still_reaches_the_sink(
+    tmp_path: Path,
+) -> None:
+    # The Unit exclusion must not suppress the parameter-to-SINK direction: the
+    # helper prints the secret itself, which is a real flow regardless of what
+    # the method returns.
+    source = (
+        "object M {\n"
+        "  def show(v: String): Unit = { println(v) }\n"
+        "  def caller(): Unit = {\n"
+        '    val s = System.getenv("SECRET")\n'
+        "    show(s)\n"
+        "  }\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "scala", source)

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -377,13 +377,17 @@ module is re-exported under its own name. A project that does
   return summary, so a caller consuming the return (`y = redact(secret); print(y)`)
   resolves the secret to the sink. The composition is keyed by the individual call site,
   so a second call to the same helper with a clean argument keeps a clean result. A DIRECT
-  pass-through (`return v`) composes in Python, JavaScript, TypeScript, Java, C#, Go, PHP,
-  C, C++, Dart and Rust, including Rust's idiomatic trailing-expression return with no
-  `return` keyword. It does NOT compose in Lua or Scala, which have no lean parameter-slot
-  extractor, so no parameter is seeded for the composition to match. Chaining transitively
-  through another call
-  (`return other(p)`) is Python-only; a lean-walk callee that returns the result of a
-  further call ends the chain there.
+  pass-through (`return v`) composes in every language the walk covers: Python,
+  JavaScript, TypeScript, Java, C#, Go, PHP, C, C++, Dart, Rust, Lua and Scala. Two of
+  those spell the return without a keyword and are handled as the body's value rather
+  than a return node: Rust's trailing block expression, and a Scala `def` whose body IS
+  its result (a bare expression, a call, or a block ending in one). Chaining transitively
+  through another call (`return other(p)`) is Python-only; a lean-walk callee that
+  returns the result of a further call ends the chain there.
+- Lua's `...` occupies its positional slot but binds no name, so a secret passed into a
+  vararg parameter seeds nothing and the flow stops there. Because Lua requires `...` to
+  be last, it can never displace a named parameter, so only propagation is affected, not
+  the positional mapping.
 - The `kind = arg` edge itself is still recorded one level deep — it marks that a
   tainted value reached a call — and is emitted alongside the forward composition above.
   Sources and sinks are direct I/O calls from the registry.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -361,8 +361,9 @@ module is re-exported under its own name. A project that does
   summaries are resolved by a worklist fixpoint once every file has been walked, so
   a callee defined after (or in a different file from) its caller is still known to
   return a tainted value at the caller's site.
-- Forward argument taint composes into callee **sinks** for Python and the lean-walk
-  languages with a parameter-name extractor (Go, JavaScript, TypeScript/TSX, C++): a
+- Forward argument taint composes into callee **sinks** for Python and every lean-walk
+  language with a parameter-name extractor, which is now all of them: Go, JavaScript,
+  TypeScript/TSX, C++, Java, C#, Rust, C, PHP, Dart, Lua and Scala. A
   parameter that reaches a write sink inside its body is recorded as a per-function
   parameter-sink summary (closed over transitive parameter hand-offs by the same
   finalize fixpoint), so a tainted argument passed at a call site emits the full


### PR DESCRIPTION
Closes #1365.

## What was missing

`_lean_parameter_slots` dispatched per language and fell through to `return [], None` for Lua and Scala. With no slots, no parameter was ever seeded as `Taint(params={name})`, so BOTH composition directions were inert for those two languages, not just the return one:

- argument into a callee sink (#1169)
- pass-through return (#1363)

Every other lean language got its extractor in #1195/#1169. These two were simply never added.

## Two pieces

**Slot extractors** (`utils.py`), following the #1195 precedent:

- Lua: `parameters` holds bare `identifier` children plus a trailing `...` (`vararg_expression`) which takes the variadic slot and binds no name.
- Scala: `parameters` -> `parameter` with a `name` field; a repeated parameter (`xs: String*`) is identified by its TYPE node being `repeated_parameter_type`. Curried definitions have several sibling `parameters` lists and only the first maps to `arg:<index>`, so the rest are deliberately left alone.

**Scala body-as-value.** `def forward(v: String): String = v` has no return node at all: a def's BODY is its value. This is the same shape as Rust's trailing block expression, so the existing hook is generalised to cover both. A block body resolves to its final expression; a block ending in a `val`/`var` definition yields Unit and returns nothing.

## Precision

The body-as-value rule is the risky half, so it is pinned in both directions:

- `def size(v: String): Int = v.length` yields a LENGTH, not the secret. No edge.
- `def hold(v: String): Unit = { val kept = v }` ends in a definition, writes nowhere. No edge.
- Positional mapping for both languages: the secret as the second argument reaches the sink only when the callee uses its second parameter.

## A correction to my own test

I first wrote a Lua test asserting that `...` prevents a positional shift. Measuring instead of assuming showed the premise was wrong: **Lua requires `...` to be last**, so it can never displace a named parameter and that shift is unreachable. The real, narrower limitation is that taint landing in `...` binds no name and stops there. The test now asserts that measured behaviour, and the documentation states it.

## Verification

- 10 tests, all verified RED before the change.
- Flow/taint/Lua/Scala suite: 729 passed, 5 skipped, no regressions.
- `data-flow-edges.md` updated: direct pass-through now composes in all thirteen covered languages, with the two keyword-less return forms and the Lua vararg limitation called out explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved data-flow analysis for Lua and Scala function parameters, including variadic and repeated parameters.
  * Added support for tracking Scala expression-, block-, and indented-body return values.
  * Improved propagation of values through Lua and Scala function calls.

* **Bug Fixes**
  * Prevented incorrect propagation through Lua varargs and Scala methods returning `Unit`, including qualified `Unit` types.
  * Preserved correct handling of user-defined types ending in `Unit`.

* **Documentation**
  * Updated data-flow documentation with Scala return handling and Lua vararg behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->