### PR TITLE
test: skip instead of aborting collection when an optional grammar is absent (#1371)

### DIFF
--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import tree_sitter_java as tsjava
+import pytest
 from tree_sitter import Language, Node, Parser
 
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.parsers.java.utils import extract_class_info
 from codebase_rag.tests.conftest import get_relationships
+
+# Optional grammar: a base install ships only tree-sitter-python, so this
+# module must SKIP rather than abort collection (issue #1371).
+tsjava = pytest.importorskip("tree_sitter_java")
 
 
 def _call_targets(mock_ingestor: MagicMock) -> set[str]:

--- a/codebase_rag/tests/test_js_class_body_cache_ownership.py
+++ b/codebase_rag/tests/test_js_class_body_cache_ownership.py
@@ -8,10 +8,14 @@
 # unequal and clears it.
 from __future__ import annotations
 
-import tree_sitter_javascript as tsj
+import pytest
 from tree_sitter import Language, Parser
 
 from codebase_rag.parsers.js_ts import utils as js_utils
+
+# Optional grammar: a base install ships only tree-sitter-python, so this
+# module must SKIP rather than abort collection (issue #1371).
+tsj = pytest.importorskip("tree_sitter_javascript")
 
 
 def _parse(src: str):

--- a/codebase_rag/tests/test_rust_iter_closure_param_typing.py
+++ b/codebase_rag/tests/test_rust_iter_closure_param_typing.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock
 
 import pytest
 import tree_sitter
-import tree_sitter_rust
 
 from codebase_rag.parsers.rs.type_inference import RustTypeInferenceEngine
 from codebase_rag.tests.test_rust_crate_path_trait_linking import (
@@ -21,6 +20,10 @@ from codebase_rag.tests.test_rust_crate_path_trait_linking import (
     _write,
     create_and_run_updater,
 )
+
+# Optional grammar: a base install ships only tree-sitter-python, so this
+# module must SKIP rather than abort collection (issue #1371).
+tree_sitter_rust = pytest.importorskip("tree_sitter_rust")
 
 
 @pytest.fixture


### PR DESCRIPTION
Part of #1371. This PR fixes ONLY the collection errors, which are separable from the larger skip audit and worth landing on their own.

## The defect

A base install ships `tree-sitter-python` and nothing else; the other twelve grammars live in the `treesitter-full` extra. Three test modules import an optional grammar at MODULE level:

| module | grammar |
|---|---|
| `test_java_field_access_chains.py` | `tree_sitter_java` |
| `test_js_class_body_cache_ownership.py` | `tree_sitter_javascript` |
| `test_rust_iter_closure_param_typing.py` | `tree_sitter_rust` |

So they do not fail as tests, they abort collection:

```
!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
```

A base install therefore cannot run the suite at all. The issue reports "184 passed, 2 failed" because that reviewer's focused selection happened to route around these three modules.

## The fix

Route each through `pytest.importorskip`, matching the existing precedent in `test_ast_grep_service.py` and `test_python_frontend.py`. The call sits AFTER the module's imports so it does not trip `E402`, which is also where the existing precedent puts it.

## Verification

Reproduced without uninstalling anything: a `sitecustomize.py` on `PYTHONPATH` hides the optional grammar modules. Getting that harness right mattered more than it sounds -- my first version raised `ImportError` from `find_spec`, which is NOT what a missing module does (it returns `None`), and it wrongly flagged two modules that already guard correctly with `find_spec(...) is not None`. The corrected harness returns `None` and lets `import` raise `ModuleNotFoundError`.

Both directions checked:

- with grammars installed: **40 passed**
- base-install simulation: **3 skipped**, collection completes

## Not in this PR

The audit found **1184 test-level failures across 237 modules** on a base install, which is a much larger problem than the two the issue describes. That needs a mechanism decision (the existing `skip_if_missing` is opt-in and 237 modules did not opt in), so it is being discussed on #1371 with measurements rather than bundled here. **#1371 stays open.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test collection when optional Java, JavaScript, or Rust parsing grammars are unavailable.
  * Affected tests now skip gracefully instead of causing collection failures in base installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->