### PR TITLE
feat: lean-walk transitive pass-through chaining (closes #1363)

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2947,10 +2947,45 @@ class FlowProcessor:
         # `return a, b` several); union the taint over every returned value.
         result: Taint | None = None
         for expr in self._lean_return_values(node):
+            self._record_lean_return_handoff(expr, tainted, jc)
             taint = self._js_expr_taint(expr, tainted, jc)
             if taint is not None:
                 result = taint if result is None else _merge_taint(result, taint)
         return result
+
+    def _record_lean_return_handoff(
+        self, expr: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> None:
+        # `return other(p)`: record that each of THIS function's parameters
+        # appearing in the returned call reaches its return through that callee,
+        # so a wrapper of a wrapper resolves (issue #1363). The Python walk has
+        # recorded this hand-off since #1168; without it the lean closure had
+        # only direct `return v` and every chain ended one hop in.
+        #
+        # Params-only, never the deferred-candidate lists: the VALUE side of the
+        # returned call is already handled by _js_expr_taint on the same node.
+        if expr.type != jc.descriptor.call_type:
+            return
+        raw = call_name(expr)
+        if raw is None:
+            return
+        callee = self._resolve(
+            raw,
+            jc.flow.module_qn,
+            jc.flow.class_context,
+            jc.flow.caller_qn,
+            jc.flow.language,
+            jc.flow.local_var_types,
+        )
+        if callee is None:
+            return
+        for via, taint in self._js_arg_taints(expr, tainted, jc):
+            if taint is None:
+                continue
+            for pname in taint.params:
+                self._return_param_edges.append(
+                    (jc.flow.caller_qn, pname, callee[1], via)
+                )
 
     @staticmethod
     def _lean_return_values(node: Node) -> list[Node]:

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -873,6 +873,10 @@ class FlowProcessor:
                 else _scala_body_value(caller_node)
             )
             if tail is not None:
+                # A keyword-less return is still a return: the chain hand-off
+                # has to be recorded here as well, or Scala and Rust wrappers
+                # stop one hop in (issue #1363).
+                self._record_lean_return_handoff(tail, state.taint, jc)
                 returned = self._js_expr_taint(tail, state.taint, jc)
                 if returned is not None:
                     self._acc_returns_taint = True
@@ -2504,8 +2508,41 @@ class FlowProcessor:
     ) -> Taint | None:
         # A Dart `return <chain>;` contributes the chain's taint to the summary.
         rhs = [c for c in node.named_children if c.type != cs.TS_COMMENT]
+        # Dart spells a call as a SELECTOR chain, not the descriptor's call
+        # node, so the shared hand-off recorder cannot recognise it; do the same
+        # job with the Dart accessors (issue #1363).
+        self._record_dart_return_handoff(rhs, tainted, jc)
         taint, _ = self._dart_rhs(rhs, tainted, {}, jc)
         return taint
+
+    def _record_dart_return_handoff(
+        self, rhs: list[Node], tainted: _TaintMap, jc: _JsCtx
+    ) -> None:
+        # `return inner(p);`: record which of this function's parameters the
+        # returned call forwards, so the finalize closure can follow the chain.
+        call_sel = next((n for n in rhs if self._dart_selector_is_call(n)), None)
+        if call_sel is None:
+            return
+        raw = dart_call_name(call_sel)
+        if raw is None:
+            return
+        callee = self._resolve(
+            raw,
+            jc.flow.module_qn,
+            jc.flow.class_context,
+            jc.flow.caller_qn,
+            jc.flow.language,
+            jc.flow.local_var_types,
+        )
+        if callee is None:
+            return
+        for via, taint in self._dart_arg_taints(call_sel, tainted, jc):
+            if taint is None:
+                continue
+            for pname in taint.params:
+                self._return_param_edges.append(
+                    (jc.flow.caller_qn, pname, callee[1], via)
+                )
 
     def _dart_first_string_arg(self, selector: Node) -> str:
         arguments = self._dart_arguments(selector)
@@ -2964,6 +3001,18 @@ class FlowProcessor:
         #
         # Params-only, never the deferred-candidate lists: the VALUE side of the
         # returned call is already handled by _js_expr_taint on the same node.
+        # `return (inner(p))` and `return await inner(p)` are the same hand-off
+        # wearing a wrapper, so unwrap exactly what _js_expr_taint unwraps
+        # before testing for a call; otherwise the chain silently stops at a
+        # pair of parentheses.
+        while expr.type in (
+            cs.TS_AWAIT_EXPRESSION,
+            cs.TS_PARENTHESIZED_EXPRESSION,
+        ):
+            inner = self._js_first_expr(expr)
+            if inner is None:
+                return
+            expr = inner
         if expr.type != jc.descriptor.call_type:
             return
         raw = call_name(expr)

--- a/codebase_rag/tests/test_flow_lean_transitive_return.py
+++ b/codebase_rag/tests/test_flow_lean_transitive_return.py
@@ -20,7 +20,14 @@ FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
 _CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
 _ENV = "resource::ENV::SECRET"
 _STDOUT = "resource::STDOUT::<dynamic>"
-_FILENAMES = {"javascript": "m.js", "java": "A.java", "go": "m.go"}
+_FILENAMES = {
+    "javascript": "m.js",
+    "java": "A.java",
+    "go": "m.go",
+    "rust": "m.rs",
+    "scala": "M.scala",
+    "dart": "m.dart",
+}
 
 
 def _flows(tmp_path: Path, language: str, source: str) -> set[tuple[str, str]]:
@@ -126,3 +133,85 @@ def test_three_deep_chain_still_resolves(tmp_path: Path) -> None:
         "}\n"
     )
     assert (_ENV, _STDOUT) in _flows(tmp_path, "javascript", source)
+
+
+# Keyword-less and selector-based returns reach the hand-off through paths of
+# their own, so each needs its own chain fixture (issue #1363 review round 2).
+_KEYWORDLESS_CHAIN = {
+    "rust": (
+        "fn inner(v: String) -> String { v }\n"
+        "fn outer(p: String) -> String { inner(p) }\n"
+        "fn run() {\n"
+        '    let t = std::env::var("SECRET").unwrap();\n'
+        '    println!("{}", outer(t));\n'
+        "}\n"
+    ),
+    "scala": (
+        "object M {\n"
+        "  def inner(v: String): String = v\n"
+        "  def outer(p: String): String = inner(p)\n"
+        "  def run(): Unit = {\n"
+        '    val t = System.getenv("SECRET")\n'
+        "    println(outer(t))\n"
+        "  }\n"
+        "}\n"
+    ),
+    "dart": (
+        "String inner(String v) { return v; }\n"
+        "String outer(String p) { return inner(p); }\n"
+        "void run() {\n"
+        "  var t = Platform.environment['SECRET'];\n"
+        "  print(outer(t));\n"
+        "}\n"
+    ),
+}
+
+
+@pytest.mark.parametrize("language", sorted(_KEYWORDLESS_CHAIN))
+def test_chains_resolve_on_the_language_specific_return_paths(
+    tmp_path: Path, language: str
+) -> None:
+    # Rust and Scala return their body's value with no `return` keyword, and
+    # Dart resolves calls as a selector chain rather than the shared call node.
+    # All three bypass the generic recorder, so each is wired separately.
+    assert (_ENV, _STDOUT) in _flows(tmp_path, language, _KEYWORDLESS_CHAIN[language])
+
+
+def test_a_parenthesized_returned_call_still_chains(tmp_path: Path) -> None:
+    # `return (inner(p))` is the same hand-off wearing a wrapper.
+    source = (
+        "function inner(v) { return v; }\n"
+        "function outer(p) { return (inner(p)); }\n"
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  console.log(outer(t));\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "javascript", source)
+
+
+def test_an_awaited_returned_call_still_chains(tmp_path: Path) -> None:
+    # `return await inner(p)` likewise: awaiting a value does not change it.
+    source = (
+        "function inner(v) { return v; }\n"
+        "async function outer(p) { return await inner(p); }\n"
+        "async function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  console.log(await outer(t));\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "javascript", source)
+
+
+def test_a_wrapped_chain_that_drops_the_argument_stays_clean(tmp_path: Path) -> None:
+    # Unwrapping must not become a blanket "any returned call forwards taint":
+    # the wrapped form has to keep the same positional discipline.
+    source = (
+        "function inner(v) { return v; }\n"
+        'function outer(p) { return (inner("clean")); }\n'
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  console.log(outer(t));\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "javascript", source)

--- a/codebase_rag/tests/test_flow_lean_transitive_return.py
+++ b/codebase_rag/tests/test_flow_lean_transitive_return.py
@@ -1,0 +1,128 @@
+"""Transitive pass-through chaining for the lean walk (issue #1363). #1364 made
+a DIRECT `return v` carry its argument's taint in every language. A callee that
+returns the result of a FURTHER call (`return other(p)`) still ended the chain,
+because only the Python walk recorded the `_return_param_edges` hand-off that
+`_resolve_return_params` closes over."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+_ENV = "resource::ENV::SECRET"
+_STDOUT = "resource::STDOUT::<dynamic>"
+_FILENAMES = {"javascript": "m.js", "java": "A.java", "go": "m.go"}
+
+
+def _flows(tmp_path: Path, language: str, source: str) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    if language not in parsers:
+        pytest.skip(f"parser not available: {language}")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / _FILENAMES[language]).write_text(source, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+_CHAIN = {
+    "javascript": (
+        "function inner(v) { return v; }\n"
+        "function outer(p) { return inner(p); }\n"
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  const s = outer(t);\n"
+        "  console.log(s);\n"
+        "}\n"
+    ),
+    "java": (
+        "class A {\n"
+        "  static String inner(String v) { return v; }\n"
+        "  static String outer(String p) { return inner(p); }\n"
+        "  static void run() {\n"
+        '    String t = System.getenv("SECRET");\n'
+        "    String s = outer(t);\n"
+        "    System.out.println(s);\n"
+        "  }\n"
+        "}\n"
+    ),
+    "go": (
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func inner(v string) string { return v }\n\n"
+        "func outer(p string) string { return inner(p) }\n\n"
+        "func run() {\n"
+        '\tt := os.Getenv("SECRET")\n'
+        "\ts := outer(t)\n"
+        "\tfmt.Println(s)\n"
+        "}\n"
+    ),
+}
+
+
+@pytest.mark.parametrize("language", sorted(_CHAIN))
+def test_a_wrapper_of_a_wrapper_carries_taint(tmp_path: Path, language: str) -> None:
+    assert (_ENV, _STDOUT) in _flows(tmp_path, language, _CHAIN[language])
+
+
+def test_a_chain_that_drops_the_argument_stays_clean(tmp_path: Path) -> None:
+    # `outer` calls `inner` with a CONSTANT, so its own parameter never reaches
+    # the return and the caller's result must stay clean.
+    source = (
+        "function inner(v) { return v; }\n"
+        'function outer(p) { return inner("clean"); }\n'
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  const s = outer(t);\n"
+        "  console.log(s);\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "javascript", source)
+
+
+def test_the_chain_follows_the_returned_slot_not_any_slot(tmp_path: Path) -> None:
+    # `inner` returns its SECOND parameter. `outer` forwards its own parameter
+    # into the FIRST slot, so the secret must not survive the chain.
+    source = (
+        "function inner(a, b) { return b; }\n"
+        'function outer(p) { return inner(p, "clean"); }\n'
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  const s = outer(t);\n"
+        "  console.log(s);\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) not in _flows(tmp_path, "javascript", source)
+
+
+def test_three_deep_chain_still_resolves(tmp_path: Path) -> None:
+    # The closure is transitive, so depth must not matter.
+    source = (
+        "function a(v) { return v; }\n"
+        "function b(v) { return a(v); }\n"
+        "function c(v) { return b(v); }\n"
+        "function run() {\n"
+        "  const t = process.env.SECRET;\n"
+        "  console.log(c(t));\n"
+        "}\n"
+    )
+    assert (_ENV, _STDOUT) in _flows(tmp_path, "javascript", source)

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -383,8 +383,11 @@ module is re-exported under its own name. A project that does
   those spell the return without a keyword and are handled as the body's value rather
   than a return node: Rust's trailing block expression, and a Scala `def` whose body IS
   its result (a bare expression, a call, or a block ending in one). Chaining transitively
-  through another call (`return other(p)`) is Python-only; a lean-walk callee that
-  returns the result of a further call ends the chain there.
+  through another call (`return other(p)`) composes in those same languages: a returned
+  call records which of the enclosing function's parameters it forwards, and the finalize
+  closure follows the hand-off to any depth, so a wrapper of a wrapper resolves. The
+  chain is positional throughout, so forwarding a parameter into a slot the inner callee
+  does not return ends it.
 - Lua's `...` occupies its positional slot but binds no name, so a secret passed into a
   vararg parameter seeds nothing and the flow stops there. Because Lua requires `...` to
   be last, it can never displace a named parameter, so only propagation is affected, not


### PR DESCRIPTION
Closes #1363, the half deliberately left out of #1364.

## What was missing

#1364 made a DIRECT `return v` carry its argument's taint in every language. A callee returning the result of a FURTHER call still ended the chain:

```js
function inner(v) { return v; }
function outer(p) { return inner(p); }      // chain stopped here
console.log(outer(process.env.SECRET));     // no ENV -> STDOUT edge
```

`_resolve_return_params` already closes over `_return_param_edges` transitively, and the Python walk has recorded that hand-off since #1168. The lean walk never did, so its closure had only direct returns and every chain ended one hop in.

## The change

When a lean return returns a CALL, record which of the enclosing function's parameters that call forwards, tagged with the argument's `via` slot. The existing finalize closure does the rest, at any depth.

Params-only, and never touches the deferred-candidate lists: the VALUE side of the returned call is already handled by `_js_expr_taint` on the same node, so this adds the hand-off without double-counting the return itself.

## Precision

The two negative tests are the point of this PR, not decoration. Both passed BEFORE the change simply because nothing propagated at all, so their whole value is in still passing now:

- `outer(p) { return inner("clean"); }` -- the parameter never reaches the return, so the caller stays clean. A chain that recorded the hand-off unconditionally would fail this.
- `inner(a, b) { return b; }` with `outer` forwarding its parameter into the FIRST slot -- the chain is positional at every hop, not just the last one.

Plus a three-deep chain (`c -> b -> a`) to confirm this is the transitive closure rather than a one-hop special case.

## Verification

- 6 tests, 4 verified RED before the change, across JavaScript, Java and Go.
- Direct pass-through, Lua/Scala and lean-params suites: 37 passed, no regressions.
- Full flow/taint suite: **462 passed, 0 failures**.
- `data-flow-edges.md` updated in the same commit: the transitive case is no longer Python-only, and the positional constraint is stated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved data-flow analysis to track values through nested wrapper functions across supported languages, including awaited and parenthesized calls.
  * Supports multi-level parameter-to-return propagation when functions forward the appropriate argument.

* **Bug Fixes**
  * Prevents incorrect propagation when wrappers return constants or forward a different argument.

* **Documentation**
  * Updated data-flow documentation to describe cross-language transitive return-flow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->