### PR TITLE
test: cover the expression-bodied and read-only local-function ref shapes (#1353)

### DIFF
--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -565,3 +565,59 @@ def test_cross_project_ref_emits_the_write_fact_itself(
     facts = run_csharp_frontend(repo)
     writes = {key[3]: value for key, value in facts.out_writes.items()}
     assert writes.get("Fill") == {1: "sink"}
+
+
+# The block-bodied local function is already covered above. These two add the
+# shapes it does not reach: the EXPRESSION-bodied local function, and the
+# read-only negative that keeps the branch from writing back unconditionally
+# (issue #1353 item 1).
+_LOCAL_FUNCTION_EXPRESSION_REF = (
+    "using System;\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    "        void Fill(string src, ref string dst) => dst = src;\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    '        var sink = "";\n'
+    "        Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+_LOCAL_FUNCTION_READ_ONLY_REF = (
+    "using System;\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    "        void Inspect(string src, ref string other)\n        {\n"
+    "            Console.Error.WriteLine(src.Length + other.Length);\n        }\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    '        var sink = "";\n'
+    "        Inspect(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_expression_bodied_local_function_ref_callee_writes_back(
+    tmp_path: Path,
+) -> None:
+    # `CallableBody` reaches for `local.ExpressionBody?.Expression` on this
+    # shape; nothing exercised that fallback before.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "lf2", _LOCAL_FUNCTION_EXPRESSION_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_read_only_ref_local_function_never_gains_a_flow(tmp_path: Path) -> None:
+    # The local-function branch must keep the same discipline as the method one:
+    # a `ref` parameter that is only READ does not write back, so treating every
+    # ref argument as written would invent an edge. The callee reports to STDERR
+    # deliberately: writing to STDOUT there would leak the token through the
+    # callee's OWN sink and the test would pass or fail for the wrong reason.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "lf3", _LOCAL_FUNCTION_READ_ONLY_REF, cs.CSharpFrontend.HYBRID
+    )


### PR DESCRIPTION
Addresses item 1 of #1353, minus the part that turned out to be done already.

## Context

#1353 records that `CallableBody` handles `LocalFunctionStatementSyntax` with no test behind it, and that I declined CodeRabbit's request for one during the #1351 review as unrealistic. That judgement was wrong: local functions taking `ref` are ordinary in parsing and `TryX` helpers.

## What was already covered

While writing this I found `test_local_function_ref_callee_writes_back` already on main, added by another session with the same #1353 reference. The BLOCK-bodied shape is proven. I dropped my duplicate rather than land a second copy of it.

## What this adds

Two shapes main does not reach:

- **Expression-bodied local function** (`void Fill(string src, ref string dst) => dst = src;`). `CallableBody` falls back to `local.ExpressionBody?.Expression` for this, and nothing exercised that fallback.
- **Read-only `ref` local function.** `ref` PERMITS a write, it does not promise one, so the local-function branch has to keep the same discipline as the method branch or it invents an edge through a variable the callee only reads.

## A fixture bug worth naming

My first version of the negative test FAILED, and the cause was my fixture, not the code: the callee reported via `Console.WriteLine`, which leaks the token through the callee's OWN sink and produces a real ENV -> STDOUT flow regardless of write-back. The existing `_READ_ONLY_REF` fixture uses `Console.Error.WriteLine` for exactly this reason. I matched it and recorded why in a comment, so the next person does not "simplify" it back to STDOUT and get a test that passes for the wrong reason.

## Verification

- 3 local-function tests pass (the pre-existing one plus these two).
- Full C# frontend suites: **45 passed** (`test_csharp_semantic_flow.py`, `test_csharp_semantic_facts.py`, `test_csharp_frontend_wiring.py`).

## Remaining on #1353

Items 2 (cross-project `ref` callees) and 3 (`IArgumentOperation` vs syntax binding) still need owner decisions and are untouched here. **#1353 stays open.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for C# local functions with expression-bodied implementations.
  * Verified taint propagation through write-back reference arguments.
  * Confirmed read-only reference parameters do not create unintended data flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->