### PR TITLE
docs: explain why the newest tag runs ahead of the newest release (#1373)

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -49,6 +49,19 @@ instead of locally, set `CGR_EMBEDDING_PROVIDER=openai` with
 `OPENAI_EMBEDDING_BASE_URL` and `OPENAI_EMBEDDING_MODEL`; torch and
 transformers are then not required locally.
 
+### Which version am I getting?
+
+`pip install code-graph-rag` gives you the newest PyPI release, which is deliberately
+not the newest commit. Git tags exist for every version (one per merge), while PyPI
+uploads and GitHub Release binaries land on an every-50 cadence, so the tag on `main`
+runs ahead of the published version.
+
+To run code newer than the latest release, install from git:
+
+```bash
+pip install "git+https://github.com/vitali87/code-graph-rag@main#egg=code-graph-rag[treesitter-full]"
+```
+
 ### Prerequisites
 
 - Python 3.12+

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -54,12 +54,13 @@ transformers are then not required locally.
 `pip install code-graph-rag` gives you the newest PyPI release, which is deliberately
 not the newest commit. Git tags exist for every version (one per merge), while PyPI
 uploads and GitHub Release binaries land on an every-50 cadence, so the tag on `main`
-runs ahead of the published version.
+usually runs ahead of the published version. A security fix is the exception: it
+ships immediately rather than waiting for the cadence.
 
 To run code newer than the latest release, install from git:
 
 ```bash
-pip install "git+https://github.com/vitali87/code-graph-rag@main#egg=code-graph-rag[treesitter-full]"
+pip install "code-graph-rag[treesitter-full] @ git+https://github.com/vitali87/code-graph-rag@main"
 ```
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -108,20 +108,22 @@ Three version lines exist and they intentionally differ:
 | where | what it tracks |
 |---|---|
 | git tags | every version, one per merge |
-| GitHub Releases (binaries, signatures) | every 50th version |
-| PyPI | every 50th version |
+| GitHub Releases (binaries, signatures) | every 50th version, plus any security fix |
+| PyPI | every 50th version, plus any security fix |
 
-So the newest tag on `main` always runs ahead of the newest release, often by
-tens of patch versions. Nothing is stuck; the cadences differ by design.
+So the newest tag on `main` usually runs ahead of the newest release, often by
+tens of patch versions; they coincide only just after a release. Nothing is
+stuck, the cadences differ by design. A security fix does NOT wait for the
+cadence: it ships a release and a PyPI upload immediately.
 
 `uv tool install` and `pipx install` give you the newest PyPI version, which is the
-newest RELEASE, not the newest tag. That is deliberate: interim tags exist so every
-merge is addressable, while binaries and PyPI uploads land on the every-50 cadence.
+newest RELEASE, not the newest tag. Interim tags exist so every merge is
+addressable; binaries and PyPI uploads follow the cadence above.
 
 To run code newer than the latest release, install from git:
 
 ```bash
-uv tool install "git+https://github.com/vitali87/code-graph-rag@main#egg=code-graph-rag[treesitter-full,semantic]"
+uv tool install "code-graph-rag[treesitter-full,semantic] @ git+https://github.com/vitali87/code-graph-rag@main"
 ```
 
 You also need Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites, source installs, and environment setup are in the [Installation](docs/getting-started/installation.md) guide.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ uv tool install "code-graph-rag[treesitter-full,semantic]"
 pipx install "code-graph-rag[treesitter-full,semantic]"
 ```
 
+### Which version am I getting?
+
+Three version lines exist and they intentionally differ:
+
+| where | what it tracks |
+|---|---|
+| git tags | every version, one per merge |
+| GitHub Releases (binaries, signatures) | every 50th version |
+| PyPI | every 50th version |
+
+So the newest tag on `main` always runs ahead of the newest release, often by
+tens of patch versions. Nothing is stuck; the cadences differ by design.
+
+`uv tool install` and `pipx install` give you the newest PyPI version, which is the
+newest RELEASE, not the newest tag. That is deliberate: interim tags exist so every
+merge is addressable, while binaries and PyPI uploads land on the every-50 cadence.
+
+To run code newer than the latest release, install from git:
+
+```bash
+uv tool install "git+https://github.com/vitali87/code-graph-rag@main#egg=code-graph-rag[treesitter-full,semantic]"
+```
+
 You also need Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites, source installs, and environment setup are in the [Installation](docs/getting-started/installation.md) guide.
 
 ## Quick Start

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,6 +71,34 @@ All pull requests are validated by CI, which runs in parallel:
 4. **Integration Tests**: Full stack testing with Memgraph
 5. **PR Title Validation**: Conventional Commits format check
 
+### Release cadence and why tags outrun releases
+
+`version-bump.yml` tags every merge, but only some of those tags publish. The
+difference is the CREDENTIAL used to push the tag, which is easy to miss when
+reading the workflows:
+
+```bash
+git tag "v${NEW}"
+if [ release == "true" ]; then
+  git push origin "v${NEW}"                                   # SSH deploy key
+else
+  git push "https://x-access-token:${GITHUB_TOKEN}@..." "v${NEW}"
+fi
+```
+
+`publish.yml` triggers on `push: tags: ["v*"]`, so it looks like every tag should
+publish. It does not, because GitHub deliberately does not run workflows for
+events pushed with `GITHUB_TOKEN`. Interim tags therefore land on the remote and
+publish nothing, while release tags go out over the SSH deploy key and do trigger
+the publish.
+
+A release happens on the every-50 cadence, or immediately when the `decide` step
+sees a security fix (a GHSA id in the commit message, an explicit `[security]`
+marker, or an associated PR labelled `security`).
+
+If you are ever debugging "the tag exists but PyPI did not update", this is why,
+and the tag not publishing is the intended behaviour rather than a failure.
+
 ### Automated Code Review
 
 This project uses automated code review bots (**Greptile** and **Gemini Code Assist**). Before requesting a human review, address all bot comments by either implementing suggestions or replying with a clear justification for why a suggestion doesn't apply.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -77,12 +77,13 @@ All pull requests are validated by CI, which runs in parallel:
 difference is the CREDENTIAL used to push the tag, which is easy to miss when
 reading the workflows:
 
-```bash
-git tag "v${NEW}"
-if [ release == "true" ]; then
-  git push origin "v${NEW}"                                   # SSH deploy key
+```yaml
+git tag "v${{ steps.bump_version.outputs.new }}"
+if [ "${{ steps.decide.outputs.release }}" = "true" ]; then
+  git push origin "v${{ steps.bump_version.outputs.new }}"          # SSH deploy key
 else
-  git push "https://x-access-token:${GITHUB_TOKEN}@..." "v${NEW}"
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+    "v${{ steps.bump_version.outputs.new }}"
 fi
 ```
 
@@ -92,12 +93,15 @@ events pushed with `GITHUB_TOKEN`. Interim tags therefore land on the remote and
 publish nothing, while release tags go out over the SSH deploy key and do trigger
 the publish.
 
-A release happens on the every-50 cadence, or immediately when the `decide` step
+A release happens every 50 versions, or immediately when the `decide` step
 sees a security fix (a GHSA id in the commit message, an explicit `[security]`
 marker, or an associated PR labelled `security`).
 
-If you are ever debugging "the tag exists but PyPI did not update", this is why,
-and the tag not publishing is the intended behaviour rather than a failure.
+If you are ever debugging "the tag exists but PyPI did not update", check WHICH
+kind of tag it is first. For an interim tag this is the intended behaviour and
+there is nothing to fix. For a release tag it is a real failure: that one is
+pushed over the SSH deploy key and must trigger `publish.yml`, so investigate
+the workflow run rather than assuming the cadence explains it.
 
 ### Automated Code Review
 


### PR DESCRIPTION
Closes the documentation half of #1373. The cadence-change half (publish every version, or on version-changed push) is left alone: that is a release-policy decision, not a docs fix.

## Verified the mechanism before writing it

The issue says interim tags never trigger `publish.yml`. `publish.yml` triggers on `push: tags: ["v*"]`, which looks like it should fire for every tag, so I traced why it does not.

`version-bump.yml` chooses the CREDENTIAL based on whether the version is a release:

```yaml
git tag "v${NEW}"
if [ release == "true" ]; then
  git push origin "v${NEW}"                                    # SSH deploy key
else
  git push "https://x-access-token:${GITHUB_TOKEN}@..." "v${NEW}"
fi
```

GitHub does not trigger workflows for events pushed with `GITHUB_TOKEN`. So interim tags land on the remote and publish nothing, while every-50 release tags go out over the SSH key and do trigger the publish. The every-50 cadence is implemented by that credential choice.

Confirmed against reality: tags `v0.0.709` through `v0.0.716` all exist on the remote, and `publish.yml` last ran on 2026-08-18 for `v0.0.670`, which is also what PyPI serves. The behaviour is deliberate, not a stuck pipeline.

## What the docs now say

A short section in README and PYPI_README: three version lines exist, git tags move per merge while Releases and PyPI move every 50, the newest tag therefore runs ahead by design, and here is the git install command for running newer code.

## One thing I removed from my own draft

My first version included a "today" column with `v0.0.716` and `v0.0.670` in it. That is drift by construction: hardcoded version numbers in a README are exactly the staleness this issue is about, and they would be wrong within a day. The table now describes only the RELATIONSHIP, which stays true. The live PyPI version is already on the badge at the top of the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how Git tags, GitHub Releases, and PyPI versions differ, including when they may be published together.
  * Documented that security fixes may be released immediately outside the regular 50-version cadence.
  * Clarified which version package installers provide.
  * Simplified instructions for installing the latest code directly from the `main` branch.
  * Added guidance on release timing, publishing triggers, release cadence, and expected interim-tag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->