### PR TITLE
fix: index the name property for graph read-path lookups

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -557,6 +557,16 @@ NODE_UNIQUE_CONSTRAINTS: dict[str, str] = {
     label.value: key.value for label, key in _NODE_LABEL_UNIQUE_KEYS.items()
 }
 
+# Generated Cypher overwhelmingly filters on bare `name` ("who calls X" →
+# WHERE f.name = 'X'); without a label+name index every such query is a full
+# label scan. Labels whose unique key already IS `name` are covered by the
+# constraint indexes derived from NODE_UNIQUE_CONSTRAINTS.
+NODE_NAME_INDEXES: tuple[str, ...] = tuple(
+    label.value
+    for label, key in _NODE_LABEL_UNIQUE_KEYS.items()
+    if key is not UniqueKeyType.NAME
+)
+
 # Superseded unique constraints that must be dropped from existing shared
 # databases; a leftover Folder/File path constraint would keep rejecting the
 # second same-relative-path node the fix now creates (issue #897).

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -34,6 +34,7 @@ from ..constants import (
     KEY_TO_VAL,
     LEGACY_NODE_CONSTRAINTS,
     MERGE_KEY_PROPS_BY_REL,
+    NODE_NAME_INDEXES,
     NODE_UNIQUE_CONSTRAINTS,
     REL_TYPE_CALLS,
 )
@@ -352,6 +353,14 @@ class MemgraphIngestor:
         for label, prop in NODE_UNIQUE_CONSTRAINTS.items():
             try:
                 self._execute_query(build_index_query(label, prop))
+            except Exception:
+                pass
+        # The unique-key indexes serve MERGE at write time; generated Cypher
+        # reads filter on bare `name`, which needs its own label+name index
+        # or every lookup is a full label scan.
+        for label in NODE_NAME_INDEXES:
+            try:
+                self._execute_query(build_index_query(label, KEY_NAME))
             except Exception:
                 pass
         logger.info(ls.MG_INDEXES_DONE)

--- a/codebase_rag/tests/test_graph_service.py
+++ b/codebase_rag/tests/test_graph_service.py
@@ -369,10 +369,28 @@ class TestEnsureConstraints:
 
         # One SHOW, two damage probes, a create-constraint and a
         # create-index per label, plus a name index per non-name-keyed label.
-        expected_queries = (
-            3 + len(NODE_UNIQUE_CONSTRAINTS) * 2 + len(NODE_NAME_INDEXES)
-        )
+        expected_queries = 3 + len(NODE_UNIQUE_CONSTRAINTS) * 2 + len(NODE_NAME_INDEXES)
         assert call_count == expected_queries
+
+    def test_continues_on_name_index_error(self) -> None:
+        # A failing name-index CREATE (e.g. the index already exists) must not
+        # abort the loop: every remaining name index is still attempted.
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        executed_queries: list[str] = []
+
+        def fail_first_name_index(query: str) -> list[dict]:
+            executed_queries.append(query)
+            if query == f"CREATE INDEX ON :{NODE_NAME_INDEXES[0]}(name);":
+                raise RuntimeError("Index already exists")
+            return []
+
+        with patch.object(
+            MemgraphIngestor, "_execute_query", side_effect=fail_first_name_index
+        ):
+            ingestor.ensure_constraints()
+
+        for label in NODE_NAME_INDEXES:
+            assert f"CREATE INDEX ON :{label}(name);" in executed_queries
 
 
 class TestLegacyPathKeyMigration:

--- a/codebase_rag/tests/test_graph_service.py
+++ b/codebase_rag/tests/test_graph_service.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from codebase_rag.constants import NODE_UNIQUE_CONSTRAINTS
+from codebase_rag.constants import NODE_NAME_INDEXES, NODE_UNIQUE_CONSTRAINTS
 from codebase_rag.cypher_queries import (
     build_create_node_query,
     build_create_relationship_query,
@@ -367,9 +367,11 @@ class TestEnsureConstraints:
         ):
             ingestor.ensure_constraints()
 
-        # One SHOW, two damage probes, then a create-constraint and a
-        # create-index per label.
-        expected_queries = 3 + len(NODE_UNIQUE_CONSTRAINTS) * 2
+        # One SHOW, two damage probes, a create-constraint and a
+        # create-index per label, plus a name index per non-name-keyed label.
+        expected_queries = (
+            3 + len(NODE_UNIQUE_CONSTRAINTS) * 2 + len(NODE_NAME_INDEXES)
+        )
         assert call_count == expected_queries
 
 

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -9,6 +9,7 @@ from codebase_rag.constants import (
     KEY_NAME,
     KEY_PATH,
     KEY_QUALIFIED_NAME,
+    NODE_NAME_INDEXES,
     NODE_UNIQUE_CONSTRAINTS,
     NodeLabel,
     RelationshipType,
@@ -264,6 +265,13 @@ class TestEnsureConstraintsForAllLabels:
             assert expected_index in executed_queries, (
                 f"Missing index for {label.value}. Expected query: {expected_index}. "
                 "Indexes are required for efficient MERGE operations in Memgraph."
+            )
+        for label in NODE_NAME_INDEXES:
+            expected_index = f"CREATE INDEX ON :{label}({KEY_NAME});"
+            assert expected_index in executed_queries, (
+                f"Missing name index for {label}. Expected query: {expected_index}. "
+                "Generated Cypher filters on bare `name`; without a label+name "
+                "index every lookup is a full label scan."
             )
 
 


### PR DESCRIPTION
## Problem

`_ensure_indexes` only indexes each label's unique key (`qualified_name`/`path`) — the write-path MERGE optimization from #283. But the Cypher that `query_graph` generates overwhelmingly filters on bare `name` (`WHERE f.name = 'X'`), and no label had a `name` index, so every such lookup was a full label scan. On a 54k-node graph with an agent firing ~5 concurrent queries, scans stack into multi-minute stalls and 300 s timeouts.

## Fix

New `NODE_NAME_INDEXES` constant: every label whose unique key is not already `name` (18 labels) gets a `CREATE INDEX ON :Label(name)` in `_ensure_indexes`. `Project`/`ExternalPackage` are already covered by their constraint indexes. 38 indexes total after `ensure_constraints()`.

## Measured impact (live agentic A/B, django @ `9e7cc2b62`, Haiku 4.5, identical 40 questions)

| graph condition | mean s | p95 s | worst | hard failures |
|---|---|---|---|---|
| unindexed | 39.4 | 107 | 300 s timeout | 2 |
| indexed | **25.7** | **68** | 96 s | **0** |

Previously-stalling query shapes return in 0.008–0.042 s. Accuracy unchanged (paired F1 within run variance). Parse-path indexing bench unaffected (68 s / 0.7 GiB, same as baseline).

Part of #1383 (read-path checklist item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTZezth6v6Tc5KJkRHuc2h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic indexes for node labels queried by their `name` property, improving graph query performance.
  * Index setup now continues for remaining labels if an individual index cannot be created.

* **Tests**
  * Expanded coverage to verify name indexes are created for all applicable node labels.
  * Updated service tests to account for additional index creation operations and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->