### PR TITLE
feat: return relationship context from generated caller queries

### DIFF
--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -129,6 +129,12 @@ WHERE c.name = 'UserService'
 RETURN c.name AS className, m.name AS methodName, m.qualified_name AS qualified_name, labels(m) AS type
 LIMIT {CYPHER_DEFAULT_LIMIT}"""
 
+CYPHER_EXAMPLE_FUNCTION_CALLERS = f"""MATCH (caller)-[r:CALLS]->(callee:Function|Method)
+WHERE callee.name = 'process_payment'
+RETURN caller.qualified_name AS caller_qualified_name, caller.path AS path,
+       type(r) AS relationship, labels(caller) AS caller_type
+LIMIT {CYPHER_DEFAULT_LIMIT}"""
+
 # ast-grep findings (issue #413): Pattern/CodeSmell/SecurityIssue nodes hang
 # off a Module via IMPLEMENTS_PATTERN/HAS_SMELL/HAS_VULNERABILITY. The finding
 # node's name is the rule id; start_line locates the site.

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -130,8 +130,9 @@ RETURN c.name AS className, m.name AS methodName, m.qualified_name AS qualified_
 LIMIT {CYPHER_DEFAULT_LIMIT}"""
 
 CYPHER_EXAMPLE_FUNCTION_CALLERS = f"""MATCH (caller)-[r:CALLS]->(callee:Function|Method)
-WHERE callee.name = 'process_payment'
+WHERE callee.qualified_name ENDS WITH '.process_payment'
 RETURN caller.qualified_name AS caller_qualified_name, caller.path AS path,
+       callee.qualified_name AS callee_qualified_name,
        type(r) AS relationship, labels(caller) AS caller_type
 LIMIT {CYPHER_DEFAULT_LIMIT}"""
 

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -4,13 +4,13 @@ from loguru import logger
 
 from .cypher_queries import (
     CYPHER_EXAMPLE_CLASS_METHODS,
-    CYPHER_EXAMPLE_FUNCTION_CALLERS,
     CYPHER_EXAMPLE_CODE_SMELLS,
     CYPHER_EXAMPLE_CONTENT_BY_PATH,
     CYPHER_EXAMPLE_DECORATED_FUNCTIONS,
     CYPHER_EXAMPLE_FILES_IN_FOLDER,
     CYPHER_EXAMPLE_FIND_FILE,
     CYPHER_EXAMPLE_FIND_PATTERN,
+    CYPHER_EXAMPLE_FUNCTION_CALLERS,
     CYPHER_EXAMPLE_KEYWORD_SEARCH,
     CYPHER_EXAMPLE_LIMIT_ONE,
     CYPHER_EXAMPLE_PROJECT_SCOPED,
@@ -302,6 +302,8 @@ cypher// "What methods does UserService have?" or "Show me methods in UserServic
 cypher// "Which functions call process_payment?" or "Who uses process_payment?" or "Find call sites of process_payment"
 // Match the CALLS edge explicitly and return `type(r)` so definers/importers can't be mistaken for callers.
 // The caller end stays unlabeled: modules, functions, and methods can all hold call sites.
+// Filter by qualified_name suffix (rule 2) and return the callee's qualified_name: several
+// same-named callables can exist, and each row must say whose caller it is.
 {CYPHER_EXAMPLE_FUNCTION_CALLERS}
 
 **Pattern: Scoping Results to a Single Project**
@@ -401,7 +403,7 @@ You are a Neo4j Cypher query generator. You ONLY respond with a valid Cypher que
     ```
 
 *   **Natural Language:** "Which functions call process_payment?" or "Who uses process_payment?"
-*   **Cypher Query (Note: match the `CALLS` edge and return `type(r)`; leave the caller unlabeled):**
+*   **Cypher Query (Note: match the `CALLS` edge and return `type(r)`; leave the caller unlabeled; filter by qualified_name suffix and return the callee identity):**
     ```cypher
     {CYPHER_EXAMPLE_FUNCTION_CALLERS}
     ```

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -352,9 +352,9 @@ You are a Neo4j Cypher query generator. You ONLY respond with a valid Cypher que
 
 **VALUE PATTERN RULES (CRITICAL FOR NAME MATCHING):**
 - The `qualified_name` property contains FULL paths like: `'Project.folder.subfolder.ClassName'`
-- When users mention a class or function by SHORT NAME (e.g., "VatManager", "UserService"), you MUST match using the `name` property, NOT `qualified_name`.
-- CORRECT: `WHERE c.name = 'VatManager'`
-- WRONG: `WHERE c.qualified_name = 'VatManager'` (will never match!)
+- When users mention a class or function by SHORT NAME (e.g., "VatManager", "UserService"), match `name` equality for exact lookups (`WHERE c.name = 'VatManager'`) or a `qualified_name` suffix (`WHERE c.qualified_name ENDS WITH '.VatManager'`).
+- For caller/callee relationship queries, PREFER the `qualified_name` suffix and return the matched `qualified_name`: several same-named definitions can exist, and each row must say which one it refers to.
+- WRONG: `WHERE c.qualified_name = 'VatManager'` (equality against a short name will never match!)
 - Use `DEFINES_METHOD` relationship to find methods of a class.
 - Use `DEFINES` relationship to find functions/classes defined in a module.
 

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -4,6 +4,7 @@ from loguru import logger
 
 from .cypher_queries import (
     CYPHER_EXAMPLE_CLASS_METHODS,
+    CYPHER_EXAMPLE_FUNCTION_CALLERS,
     CYPHER_EXAMPLE_CODE_SMELLS,
     CYPHER_EXAMPLE_CONTENT_BY_PATH,
     CYPHER_EXAMPLE_DECORATED_FUNCTIONS,
@@ -54,6 +55,8 @@ CYPHER_QUERY_RULES = """**2. Critical Cypher Query Rules**
 - **Use `ENDS WITH` for qualified_name**: The `qualified_name` property contains full paths like `'Project.folder.subfolder.ClassName'`. When users mention a class, function, or method by its short name (e.g., "VatManager"), use `ENDS WITH` to match: `WHERE c.qualified_name ENDS WITH '.VatManager'`. Do NOT use `{name: 'VatManager'}` equality matching.
 - **Use `toLower()` for Searches**: For case-insensitive searching on string properties, use `toLower()`.
 - **Querying Lists**: To check if a list property (like `decorators`) contains an item, use the `ANY` or `IN` clause (e.g., `WHERE 'flow' IN n.decorators`).
+- **Match the asked-about relationship explicitly and RETURN it**: For questions about callers, callees, usage, or dependencies, match the specific edge (e.g., `(caller)-[r:CALLS]->(callee)`) and include `type(r) AS relationship` in the RETURN clause. A bare node list is ambiguous — the file that *defines* or *imports* a function is not a *caller* of it, and the consumer can only tell them apart if the relationship type is in the results.
+- **Prefer multi-label matches over guessing one label**: When the node kind is uncertain, match `(n:Function|Method)` (or `(n:Function|Method|Class)`) instead of a single label — a wrong single label silently returns nothing. Leave the *other* end of a relationship pattern unlabeled when any node kind is a valid answer (e.g., module-level code also has `CALLS` edges).
 - **NEVER use unbounded variable-length paths**: Patterns like `[:CALLS*]`, `[*]`, `[:CALLS*1..]` enumerate every path in the graph and exhaust memory. Always cap with an upper bound, e.g. `[:CALLS*1..6]`. If you genuinely need unbounded reachability, use a MAGE procedure (see Section 2b) instead of variable-length Cypher.
 
 **2b. Graph Algorithm Procedures (MAGE)**
@@ -295,6 +298,12 @@ cypher// "What methods does UserService have?" or "Show me methods in UserServic
 // Use `ENDS WITH` to match the class by short name since qualified_name contains full path.
 {CYPHER_EXAMPLE_CLASS_METHODS}
 
+**Pattern: Finding Callers of a Function/Method**
+cypher// "Which functions call process_payment?" or "Who uses process_payment?" or "Find call sites of process_payment"
+// Match the CALLS edge explicitly and return `type(r)` so definers/importers can't be mistaken for callers.
+// The caller end stays unlabeled: modules, functions, and methods can all hold call sites.
+{CYPHER_EXAMPLE_FUNCTION_CALLERS}
+
 **Pattern: Scoping Results to a Single Project**
 cypher// "show all classes in myproject" (multi-project database)
 // Filter on the qualified_name prefix to keep results within one project.
@@ -337,6 +346,7 @@ You are a Neo4j Cypher query generator. You ONLY respond with a valid Cypher que
 7.  **AGGREGATION QUERIES**: When asked "how many" or "count", return ONLY the count:
     - CORRECT: `MATCH (c:Class) RETURN count(c) AS total`
     - WRONG: `MATCH (c:Class) RETURN c.name, count(c) AS total` (returns all items!)
+8.  **RETURN THE RELATIONSHIP TYPE**: For questions about callers, callees, or usage, match the edge explicitly (e.g., `(caller)-[r:CALLS]->(callee)`) and include `type(r) AS relationship` in the RETURN clause. Defining or importing a function is NOT calling it; without the relationship type in the results the consumer cannot tell the difference.
 
 **VALUE PATTERN RULES (CRITICAL FOR NAME MATCHING):**
 - The `qualified_name` property contains FULL paths like: `'Project.folder.subfolder.ClassName'`
@@ -388,6 +398,12 @@ You are a Neo4j Cypher query generator. You ONLY respond with a valid Cypher que
 *   **Cypher Query (Note: match by `name` property, use `DEFINES_METHOD` relationship):**
     ```cypher
     {CYPHER_EXAMPLE_CLASS_METHODS}
+    ```
+
+*   **Natural Language:** "Which functions call process_payment?" or "Who uses process_payment?"
+*   **Cypher Query (Note: match the `CALLS` edge and return `type(r)`; leave the caller unlabeled):**
+    ```cypher
+    {CYPHER_EXAMPLE_FUNCTION_CALLERS}
     ```
 
 *   **Natural Language:** "show all classes in myproject"

--- a/codebase_rag/tests/test_cypher_relationship_context.py
+++ b/codebase_rag/tests/test_cypher_relationship_context.py
@@ -1,0 +1,44 @@
+from codebase_rag.constants import CYPHER_DEFAULT_LIMIT
+from codebase_rag.cypher_queries import CYPHER_EXAMPLE_FUNCTION_CALLERS
+from codebase_rag.prompts import (
+    build_cypher_system_prompt,
+    build_local_cypher_system_prompt,
+)
+
+
+class TestCallerExampleQuery:
+    def test_matches_calls_edge_explicitly(self) -> None:
+        assert "-[r:CALLS]->" in CYPHER_EXAMPLE_FUNCTION_CALLERS
+
+    def test_returns_relationship_type(self) -> None:
+        assert "type(r) AS relationship" in CYPHER_EXAMPLE_FUNCTION_CALLERS
+
+    def test_caller_end_is_unlabeled(self) -> None:
+        # Module-level code also holds call sites; labeling the caller end
+        # would silently drop those rows.
+        assert "MATCH (caller)-" in CYPHER_EXAMPLE_FUNCTION_CALLERS
+
+    def test_callee_uses_multi_label_match(self) -> None:
+        assert "callee:Function|Method" in CYPHER_EXAMPLE_FUNCTION_CALLERS
+
+    def test_result_rows_are_bounded(self) -> None:
+        assert f"LIMIT {CYPHER_DEFAULT_LIMIT}" in CYPHER_EXAMPLE_FUNCTION_CALLERS
+
+
+class TestCypherPromptRelationshipGuidance:
+    def test_main_prompt_contains_caller_pattern_example(self) -> None:
+        assert CYPHER_EXAMPLE_FUNCTION_CALLERS in build_cypher_system_prompt()
+
+    def test_main_prompt_requires_relationship_in_return(self) -> None:
+        prompt = build_cypher_system_prompt()
+        assert "Match the asked-about relationship explicitly and RETURN it" in prompt
+        assert "type(r) AS relationship" in prompt
+
+    def test_main_prompt_prefers_multi_label_matches(self) -> None:
+        assert "Prefer multi-label matches" in build_cypher_system_prompt()
+
+    def test_local_prompt_contains_caller_pattern_example(self) -> None:
+        assert CYPHER_EXAMPLE_FUNCTION_CALLERS in build_local_cypher_system_prompt()
+
+    def test_local_prompt_requires_relationship_in_return(self) -> None:
+        assert "RETURN THE RELATIONSHIP TYPE" in build_local_cypher_system_prompt()

--- a/codebase_rag/tests/test_cypher_relationship_context.py
+++ b/codebase_rag/tests/test_cypher_relationship_context.py
@@ -24,6 +24,23 @@ class TestCallerExampleQuery:
     def test_result_rows_are_bounded(self) -> None:
         assert f"LIMIT {CYPHER_DEFAULT_LIMIT}" in CYPHER_EXAMPLE_FUNCTION_CALLERS
 
+    def test_callee_filter_uses_qualified_name_suffix(self) -> None:
+        # Bare `name` equality both breaks the prompt's own ENDS-WITH rule and
+        # conflates every same-named symbol (Greptile review on PR #1386).
+        assert (
+            "callee.qualified_name ENDS WITH '.process_payment'"
+            in CYPHER_EXAMPLE_FUNCTION_CALLERS
+        )
+        assert "callee.name" not in CYPHER_EXAMPLE_FUNCTION_CALLERS
+
+    def test_returns_callee_identity(self) -> None:
+        # With several same-named callables, each caller row must say WHOSE
+        # caller it is (Greptile review on PR #1386).
+        assert (
+            "callee.qualified_name AS callee_qualified_name"
+            in CYPHER_EXAMPLE_FUNCTION_CALLERS
+        )
+
 
 class TestCypherPromptRelationshipGuidance:
     def test_main_prompt_contains_caller_pattern_example(self) -> None:

--- a/codebase_rag/tests/test_cypher_relationship_context.py
+++ b/codebase_rag/tests/test_cypher_relationship_context.py
@@ -59,3 +59,12 @@ class TestCypherPromptRelationshipGuidance:
 
     def test_local_prompt_requires_relationship_in_return(self) -> None:
         assert "RETURN THE RELATIONSHIP TYPE" in build_local_cypher_system_prompt()
+
+    def test_local_prompt_short_name_rule_allows_qualified_suffix(self) -> None:
+        # The local prompt must not contradict the caller example: a flat
+        # "never qualified_name for short names" rule invites name-equality
+        # caller queries that conflate same-named symbols (CodeRabbit review
+        # on PR #1386).
+        prompt = build_local_cypher_system_prompt()
+        assert "ENDS WITH '.VatManager'" in prompt
+        assert "NOT `qualified_name`" not in prompt


### PR DESCRIPTION
Implements checklist items 2–3 of #1383.

## Problem

The agentic A/B benchmark (#1383) showed that with the graph toolset a weak orchestrator (Haiku 4.5) scores **worse** than plain grep (mean F1 0.854 vs 0.913) on "which files call X" questions. Root cause: `query_graph` returns node/file lists without saying **which edge** connected them, and the generated Cypher often doesn't match a `CALLS` edge at all — so the model reports the file that *defines* or *imports* a function as a *caller* (e.g. `RowNumber` → `functions/window.py`, its definition site), and single-label matches silently truncate answers.

## Changes

- **New `CYPHER_EXAMPLE_FUNCTION_CALLERS`** — the canonical caller pattern: matches `-[r:CALLS]->` explicitly, returns `type(r) AS relationship`, leaves the caller end unlabeled (module-level call sites are real callers), and multi-label-matches the callee (`Function|Method`).
- **New Cypher rule (main + local prompts):** for caller/callee/usage questions, match the specific edge and include `type(r) AS relationship` in `RETURN` — a bare node list can't distinguish CALLS from DEFINES/IMPORTS.
- **New Cypher rule:** prefer multi-label matches over guessing one label; a wrong single label returns nothing without any error signal.
- Tests asserting the example's shape and that both system prompts carry the example and rules.

## Testing

`pytest codebase_rag/tests/test_cypher_relationship_context.py codebase_rag/tests/test_cypher_project_scope.py` — 18 passed.

Companion to #1384 (read-path name indexes). Refs #1383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTZezth6v6Tc5KJkRHuc2h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved caller searches to identify functions by qualified-name suffixes, including namespaced and similarly named functions.
  * Results now include the called function’s qualified identity, relationship types, paths, labels, and result limits.
  * Enhanced query guidance for explicit caller relationships, multi-label matching, and uncertain node types.

* **Tests**
  * Added coverage for qualified-name filtering, callee identity, relationship details, label matching, result limits, and prompt guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->