### PR TITLE
feat: make query_graph description demand verification of candidates

### DIFF
--- a/codebase_rag/tools/tool_descriptions.py
+++ b/codebase_rag/tools/tool_descriptions.py
@@ -25,7 +25,13 @@ CODEBASE_QUERY = (
     "Ask in plain English about classes, functions, methods, dependencies, or code structure. "
     "Examples: 'Find all functions that call each other', "
     "'What classes are in the user module', "
-    "'Show me functions with the longest call chains'."
+    "'Show me functions with the longest call chains'. "
+    "Results come from a machine-generated Cypher query (returned as query_used) "
+    "that may be narrower than your question, so treat rows as candidates, not "
+    "answers. Check the relationship column when present: a file that defines or "
+    "imports a symbol is NOT a caller of it. Before reporting call sites, verify "
+    "them in the source (read the file or fetch the function source), and "
+    "cross-check suspiciously short result lists with a text search."
 )
 
 DIRECTORY_LISTER = "Lists the contents of a directory to explore the codebase."


### PR DESCRIPTION
Implements checklist item 4 of #1383.

## Problem

In the agentic A/B benchmark, a weak orchestrator (Haiku 4.5) took `query_graph` output at face value: it reported definition and import sites as callers and accepted silently-truncated result lists without cross-checking, scoring **below** plain grep (mean F1 0.854 vs 0.913). Opus 5 tied grep only because it verified graph results in the source before answering. The tool description should demand that discipline rather than assume the orchestrator brings it.

## Change

Extend `CODEBASE_QUERY` to state that results come from a machine-generated Cypher query (`query_used`) that may be narrower than the question, that rows are candidates rather than answers, that defining/importing a symbol is not calling it, and that call sites must be verified in source (with a text-search cross-check for suspiciously short lists).

## Testing

`pytest -k tool` — same pass/fail set as origin/main (the 3 failures are pre-existing environmental issues: missing `ast-grep-py`, unregistered asyncio marks); 167 passed.

Companion to #1384 and #1386. Refs #1383.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTZezth6v6Tc5KJkRHuc2h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved guidance for interpreting codebase query results.
  * Clarified that generated query results are candidate matches and may not fully answer the original question.
  * Added recommendations to verify relationships, inspect source code, and cross-check unexpectedly small result sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->