### PR TITLE
ci: configure pre-commit.ci to auto-fix lint and format on PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,16 @@
+# pre-commit.ci runs these hooks on every PR and pushes the fixes back to the
+# branch, so lint/format drift from clones without `pre-commit install` (cloud
+# sessions, fork contributors) is corrected server-side instead of failing CI.
+ci:
+  autofix_prs: true
+  autofix_commit_msg: "style: pre-commit.ci auto-fixes"
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  # ty and generate-readme are `language: system` hooks that need uv and the
+  # project venv; pre-commit.ci's isolated runners cannot run them. CI's Type
+  # Check job still covers ty on every PR.
+  skip: [ty, generate-readme]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/docs/guide/interactive-querying.md
+++ b/docs/guide/interactive-querying.md
@@ -77,7 +77,7 @@ The interactive agent has access to these tools:
 <!-- SECTION:agentic_tools -->
 | Tool | Description |
 |----|-----------|
-| `query_graph` | Query the codebase knowledge graph using natural language questions. Ask in plain English about classes, functions, methods, dependencies, or code structure. Examples: 'Find all functions that call each other', 'What classes are in the user module', 'Show me functions with the longest call chains'. |
+| `query_graph` | Query the codebase knowledge graph using natural language questions. Ask in plain English about classes, functions, methods, dependencies, or code structure. Examples: 'Find all functions that call each other', 'What classes are in the user module', 'Show me functions with the longest call chains'. Results come from a machine-generated Cypher query (returned as query_used) that may be narrower than your question, so treat rows as candidates, not answers. Check the relationship column when present: a file that defines or imports a symbol is NOT a caller of it. Before reporting call sites, verify them in the source (read the file or fetch the function source), and cross-check suspiciously short result lists with a text search. |
 | `read_file` | Reads the content of text-based files. Images and PDFs the user references are attached inline; read them directly. |
 | `create_file` | Creates a new file with content. IMPORTANT: Check file existence first! Overwrites completely WITHOUT showing diff. Use only for new files, not existing file modifications. |
 | `replace_code` | Surgically replaces specific code blocks in files. Requires exact target code and replacement. Only modifies the specified block, leaving rest of file unchanged. True surgical patching. |


### PR DESCRIPTION
## Summary

Lint/format failures keep reaching CI because pre-commit hooks live in .git/hooks per clone: commits made from cloud sessions, other clones, or fork contributors (recent examples: #1325, #1384, #1386) bypass them, and the Lint & Format job only detects the drift instead of fixing it.

This adds a `ci:` block to .pre-commit-config.yaml so pre-commit.ci runs the same hooks on every PR and pushes the fixes back to the branch. Its pushes come from the app's own identity, so they re-trigger CI (a GITHUB_TOKEN push from a homegrown autofix workflow would not).

- `autofix_prs: true` with a single-line conventional commit message
- `skip: [ty, generate-readme]`: these are `language: system` hooks needing uv and the project venv, which pre-commit.ci's isolated runners cannot run; the Type Check CI job still covers ty
- monthly hook autoupdate

Also regenerates the agentic tools table in docs/guide/interactive-querying.md, drift left by #1387 (authored in a hookless environment, proving the point).

## Activation

Config alone does nothing: the pre-commit.ci GitHub App must be installed for this repo at https://github.com/apps/pre-commit-ci (repo owner action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Bgmvsf9hj6GPgaXsEN2BH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified interactive query guidance: generated queries may be narrower than the original question.
  * Advised treating results as candidates, checking relationship columns, and verifying call sites against source and text search.

* **Chores**
  * Added automated pull request fixes and scheduled configuration updates.
  * Configured specific system hooks to be skipped in isolated automation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->