### PR TITLE
fix(tests): make the well-known-symbols dead-code e2e observable and passing

### DIFF
--- a/codebase_rag/tests/test_dead_code_well_known_symbols.py
+++ b/codebase_rag/tests/test_dead_code_well_known_symbols.py
@@ -1,4 +1,3 @@
-import socket
 from pathlib import Path
 
 import pytest
@@ -10,19 +9,6 @@ from codebase_rag.dead_code import (
     is_well_known_symbol_member,
 )
 from evals.dead_code import cgr_dead_code, default_dead_code_config
-
-
-def is_memgraph_up() -> bool:
-    try:
-        with socket.create_connection(("127.0.0.1", 7687), timeout=0.1):
-            return True
-    except OSError:
-        return False
-
-
-skip_if_no_memgraph = pytest.mark.skipif(
-    not is_memgraph_up(), reason="Memgraph is unreachable"
-)
 
 
 def test_is_well_known_symbol_member() -> None:
@@ -70,9 +56,9 @@ def test_method_symbol_root_predicate_is_allowlisted() -> None:
     assert _is_js_well_known_symbol_root("[mySym]", True, "a.ts") is False
 
 
-@skip_if_no_memgraph
 def test_javascript_well_known_symbols_liveness_roots(tmp_path: Path) -> None:
-    # 4b + 4c: Parser/graph-shape test & DB-backed e2e test
+    # 4b + 4c: Parser/graph-shape test & in-memory e2e test (the eval capture
+    # harness replays the updater into a capturing ingestor; no database).
     # Copy fixtures to temp repo
     fixtures_dir = Path("fixtures/well_known_symbols")
     if not fixtures_dir.exists():

--- a/fixtures/well_known_symbols/iterables.ts
+++ b/fixtures/well_known_symbols/iterables.ts
@@ -7,12 +7,25 @@ export class Collection<T> {
   async *[Symbol.asyncIterator]() { for (const i of this.items) yield i }  // runtime → NOT dead
   static [Symbol.hasInstance](x: unknown) { return Array.isArray(x) }      // runtime → NOT dead
 
+  add(item: T) { this.items.push(item); return this }  // referenced below → live
+}
+
+// Non-exported on purpose: every public member of an `export class` is API
+// surface and therefore a liveness root, which would mask the symbol
+// allowlist. Here only the well-known-symbol rule can keep a member alive.
+class Bag<T> {
+  private items: T[] = [];
+
+  [Symbol.iterator]() { return this.items[Symbol.iterator]() }             // runtime → NOT dead
+  async *[Symbol.asyncIterator]() { for (const i of this.items) yield i }  // runtime → NOT dead
+  static [Symbol.hasInstance](x: unknown) { return Array.isArray(x) }      // runtime → NOT dead
+
   iterator() { return this.items }              // plain name, unused → SHOULD be reported (control)
   [Symbol.for('app.tag')]() { return 'x' }      // registry symbol, not well-known → SHOULD be reported
   [local]() { return 'y' }                      // local symbol, not Symbol.<name> → SHOULD be reported
-
-  add(item: T) { this.items.push(item); return this }  // referenced below → live
 }
 
 const c = new Collection<number>()
 c.add(1)
+const bag = new Bag<number>()
+void bag


### PR DESCRIPTION
## Summary

`test_javascript_well_known_symbols_liveness_roots` has never passed — and never ran in CI. Two compounding problems:

1. **Vestigial skip gate.** The test was skipped unless Memgraph was reachable on `127.0.0.1:7687`, but the harness it uses (`evals.dead_code.cgr_dead_code` → `_capture`) replays the graph updater into an **in-memory** capturing ingestor and never touches a database. CI has no Memgraph, so the test silently skipped everywhere; on a machine with Memgraph up, it fails.

2. **Fixture contradiction.** The "should be reported" control members — plain `iterator()`, `[Symbol.for('app.tag')]`, `[local]` — lived inside `export class Collection`. The parser marks every public member of an exported class `is_exported`, and exported symbols are documented liveness roots (docs/guide/dead-code.md: *"Roots: exported/public symbols"*). The export root therefore suppressed the controls unconditionally, and the well-known-symbol allowlist the test exists to verify was unobservable.

## Fix

- Move the control members (plus copies of the well-known-symbol members) into a **non-exported** class `Bag`, where only the allowlist can keep a member alive: `[Symbol.iterator]`/`[Symbol.asyncIterator]`/`[Symbol.hasInstance]` stay live purely through the allowlist, while the plain method, the application registry symbol, and the local symbol land in the dead-code report — exactly the distinctions the allowlist (from `fix: allowlist well-known and runtime registry symbols`, c0b3b1d4) draws.
- Keep `export class Collection` with its well-known members so the exported surface stays covered.
- Remove the Memgraph skip so the test actually runs in CI from now on.

No production code changes — the engine and parser behave as documented; the fixture asserted against that contract.

## Test plan

- [x] `pytest codebase_rag/tests/test_dead_code_well_known_symbols.py` — 4 passed (previously 1 perma-skipped/failing)
- [x] Related suites green: dead-code collect/command/eval, JS symbol roots, symbol-keyed member dispatch, structural-tier notice (100 passed)
- [x] ruff check + format clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the well-known-symbol liveness test to run with an in-memory harness, without requiring a database connection.
  * Removed environment-dependent test skipping, improving test reliability and consistency.

* **Bug Fixes**
  * Corrected fixture class usage so exported collection behavior and runtime-referenced symbol methods are accurately covered by dead-code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->