### PR TITLE
fix(readme): render every latest-release highlight in Latest News

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,18 +3,20 @@
 Newest first. Entries are the project's headline **features and capabilities**
 for users: new language support, analysis, querying, graph, and integrations.
 They are NOT for CI, developer tooling, release or build automation, refactors,
-documentation, tests, or bug fixes; leave that kind out. The top three entries
-are rendered into the README's "Latest News" section by
-`scripts/generate_readme.py`, so edit them here rather than in the README. The
-release workflow also prepends feature entries via `scripts/update_news.py`,
-derived from the release's generated Highlights (dropping non-feature themes);
-hand edits remain welcome between releases.
+documentation, tests, or bug fixes; leave that kind out. Every entry above the
+`latest-release-end` marker is rendered into the README's "Latest News"
+section by `scripts/generate_readme.py`, so edit entries here rather than in
+the README. The release workflow prepends feature entries via
+`scripts/update_news.py`, derived from the release's generated Highlights
+(dropping non-feature themes), and moves the marker below the block it
+inserted; hand edits remain welcome between releases and render too.
 
 - **Java Taint Improvements**: Enhanced taint tracking in Java, including handling JDK shims, chained call receivers, literal arguments, and type-test patterns.
 - **C# Taint Propagation**: Improved taint propagation in C# with refinements to argument binding, tuple deconstruction, and await plumbing methods.
 - **Semantic Frontend Enhancements**: Added in-process Jedi semantic frontend for Python and re-run semantic frontends on the watch path for more accurate analysis.
 - **Protocol Buffer Indexing**: Introduced a canonical protobuf index with provenance manifest and a verify command for improved data integrity.
 - **Structural Analysis**: Added structural snapshot diffs between protobuf indexes and structural ast-grep support for seven additional languages.
+<!-- latest-release-end -->
 - **Runtime Call Tracing**: A dynamic tracer runs your code (typically the test suite) and merges the calls that actually happened into the graph as `CALLS` edges (flagged where static analysis missed them), so dispatch through interfaces, virtual methods, function pointers, reflection, and framework routing becomes visible. Convert a run from Python, the JVM, Node.js, .NET, PHP, Lua, Dart, Go, Rust, or C/C++ with `cgr trace`, or ingest production pprof profiles from an eBPF continuous profiler (Parca, Pyroscope, OpenTelemetry) with `cgr trace convert --format ebpf`.
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 - **Java Taint Improvements**: Enhanced taint tracking in Java, including handling JDK shims, chained call receivers, literal arguments, and type-test patterns.
 - **C# Taint Propagation**: Improved taint propagation in C# with refinements to argument binding, tuple deconstruction, and await plumbing methods.
 - **Semantic Frontend Enhancements**: Added in-process Jedi semantic frontend for Python and re-run semantic frontends on the watch path for more accurate analysis.
+- **Protocol Buffer Indexing**: Introduced a canonical protobuf index with provenance manifest and a verify command for improved data integrity.
+- **Structural Analysis**: Added structural snapshot diffs between protobuf indexes and structural ast-grep support for seven additional languages.
 <!-- /SECTION:latest_news -->
 
 See [NEWS.md](NEWS.md) for the full history.

--- a/codebase_rag/readme_sections.py
+++ b/codebase_rag/readme_sections.py
@@ -229,12 +229,21 @@ def format_dependencies(deps: list[str]) -> str:
         _save_pypi_cache(cache)
 
 
+# Duplicated from scripts/update_news.py, which must stay stdlib-only and
+# cannot depend on this package; a test asserts the two literals never drift.
+LATEST_RELEASE_MARKER = "<!-- latest-release-end -->"
+
+
 def format_latest_news(news_path: Path, limit: int = 3) -> str:
-    # Render the top `limit` bullet entries from NEWS.md into the README's
-    # "Latest News" section. NEWS.md is the source of truth (newest first):
-    # the release workflow prepends entries via scripts/update_news.py and
-    # hand edits remain welcome between releases (issue #1146); the generator
-    # only syncs it into the README.
+    # Render the latest release's bullet entries from NEWS.md into the
+    # README's "Latest News" section. NEWS.md is the source of truth (newest
+    # first): the release workflow prepends entries via scripts/update_news.py
+    # and leaves the latest-release marker below the block it inserted, so
+    # every highlight of the latest release is rendered, however many there
+    # are (a fixed top three once hid two of the five v0.0.720 highlights).
+    # Hand edits remain welcome between releases (issue #1146) and land above
+    # the marker, so they render too. Without a marker, or with no entries
+    # above it, fall back to the top `limit` entries.
     try:
         content = news_path.read_text(encoding=ENCODING_UTF8)
     except OSError:
@@ -242,10 +251,19 @@ def format_latest_news(news_path: Path, limit: int = 3) -> str:
     # Group each "- " entry with its wrapped continuation lines; a blank line
     # closes the entry (Markdown list-item semantics), so trailing prose or a
     # header list elsewhere in the file is not swept into the news bullets.
+    # The marker also closes the entry above it, and records how many entries
+    # belong to the latest release.
     bullets: list[str] = []
     current: list[str] = []
+    marker_count: int | None = None
     for line in content.splitlines():
-        if line.startswith("- "):
+        if line.strip() == LATEST_RELEASE_MARKER:
+            if current:
+                bullets.append("\n".join(current))
+                current = []
+            if marker_count is None:
+                marker_count = len(bullets)
+        elif line.startswith("- "):
             if current:
                 bullets.append("\n".join(current))
             current = [line]
@@ -256,7 +274,8 @@ def format_latest_news(news_path: Path, limit: int = 3) -> str:
             current = []
     if current:
         bullets.append("\n".join(current))
-    return "\n".join(bullets[:limit])
+    count = marker_count if marker_count else limit
+    return "\n".join(bullets[:count])
 
 
 def generate_all_sections(project_root: Path) -> dict[str, str]:

--- a/codebase_rag/tests/test_generate_readme.py
+++ b/codebase_rag/tests/test_generate_readme.py
@@ -93,6 +93,61 @@ class TestLatestNews:
     def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
         assert format_latest_news(tmp_path / "nope.md") == ""
 
+    def test_marker_renders_every_latest_release_entry(self, tmp_path: Path) -> None:
+        # v0.0.720 shipped five highlights but the README showed only three;
+        # the latest-release marker must lift the cap for the marked block.
+        news = tmp_path / "NEWS.md"
+        news.write_text(
+            "# News\n\n"
+            "- **A**: first.\n"
+            "- **B**: second.\n"
+            "- **C**: third.\n"
+            "- **D**: fourth.\n"
+            "- **E**: fifth.\n"
+            "<!-- latest-release-end -->\n"
+            "- **F**: older release.\n",
+            encoding="utf-8",
+        )
+        result = format_latest_news(news, limit=3)
+        assert result == (
+            "- **A**: first.\n"
+            "- **B**: second.\n"
+            "- **C**: third.\n"
+            "- **D**: fourth.\n"
+            "- **E**: fifth."
+        )
+        assert "latest-release-end" not in result
+
+    def test_marker_is_not_swallowed_as_continuation_line(self, tmp_path: Path) -> None:
+        # The marker follows a bullet with no blank line between them; it must
+        # terminate that bullet, not be absorbed as wrapped continuation text.
+        news = tmp_path / "NEWS.md"
+        news.write_text(
+            "- **A**: line one\n  wrapped line two.\n"
+            "<!-- latest-release-end -->\n"
+            "- **B**: older.\n",
+            encoding="utf-8",
+        )
+        assert format_latest_news(news, limit=3) == (
+            "- **A**: line one\n  wrapped line two."
+        )
+
+    def test_marker_without_entries_above_falls_back_to_limit(
+        self, tmp_path: Path
+    ) -> None:
+        news = tmp_path / "NEWS.md"
+        news.write_text(
+            "# News\n\n"
+            "<!-- latest-release-end -->\n"
+            "- **A**: first.\n"
+            "- **B**: second.\n"
+            "- **C**: third.\n"
+            "- **D**: fourth.\n",
+            encoding="utf-8",
+        )
+        result = format_latest_news(news, limit=3)
+        assert result == "- **A**: first.\n- **B**: second.\n- **C**: third."
+
 
 def test_cli_command_table_has_one_markdown_row_per_command() -> None:
     lines = format_cli_commands_table().splitlines()

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from scripts.update_news import (
+    LATEST_RELEASE_MARKER,
     existing_themes,
     extract_bullets,
     is_feature_theme,
@@ -9,9 +10,9 @@ from scripts.update_news import (
 
 NEWS = """# Latest News
 
-Newest first. The top three entries are rendered into the README's "Latest News"
-section automatically by `scripts/generate_readme.py`, so edit them here rather
-than in the README.
+Newest first. Every entry above the latest-release marker is rendered into the
+README's "Latest News" section automatically by `scripts/generate_readme.py`,
+so edit entries here rather than in the README.
 
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier.
 - **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments.
@@ -135,7 +136,9 @@ class TestPrependNews:
         fragment = "- **First Feature**: The very first entry.\n"
         updated, inserted = prepend_news(header_only, fragment)
         assert inserted == ["- **First Feature**: The very first entry."]
-        assert updated.endswith("- **First Feature**: The very first entry.\n")
+        assert updated.endswith(
+            f"- **First Feature**: The very first entry.\n{LATEST_RELEASE_MARKER}\n"
+        )
 
     def test_duplicate_theme_within_one_fragment_inserted_once(self) -> None:
         fragment = (
@@ -159,6 +162,46 @@ class TestPrependNews:
         updated, inserted = prepend_news(NEWS, fragment)
         assert len(inserted) == 4
         assert "- **Four**" in updated
+
+    def test_marker_placed_after_inserted_release_block(self) -> None:
+        # The README renders every entry above the marker as the latest
+        # release's news, so the marker must sit directly below the block
+        # this release inserted.
+        fragment = (
+            "- **Web Search**: The agent can now search the web.\n"
+            "- **Static Binaries**: Intel macOS builds link OpenSSL statically.\n"
+        )
+        updated, inserted = prepend_news(NEWS, fragment)
+        assert len(inserted) == 2
+        lines = updated.splitlines()
+        marker_at = lines.index(LATEST_RELEASE_MARKER)
+        assert lines[marker_at - 1].startswith("- **Static Binaries**")
+        assert lines[marker_at + 1].startswith("- **Ruby Support**")
+
+    def test_marker_moves_to_newest_release_block(self) -> None:
+        first, _ = prepend_news(NEWS, "- **Web Search**: search the web.\n")
+        second, inserted = prepend_news(first, "- **Voice Input**: speak to it.\n")
+        assert len(inserted) == 1
+        lines = second.splitlines()
+        assert lines.count(LATEST_RELEASE_MARKER) == 1
+        marker_at = lines.index(LATEST_RELEASE_MARKER)
+        assert lines[marker_at - 1].startswith("- **Voice Input**")
+        assert lines[marker_at + 1].startswith("- **Web Search**")
+
+    def test_no_fresh_bullets_leaves_marker_untouched(self) -> None:
+        first, _ = prepend_news(NEWS, "- **Web Search**: search the web.\n")
+        second, inserted = prepend_news(first, "- **web search**: same theme.\n")
+        assert inserted == []
+        assert second == first
+
+    def test_marker_matches_readme_renderer(self) -> None:
+        # scripts/update_news.py must stay stdlib-only, so the marker literal
+        # is duplicated in codebase_rag.readme_sections; they must never drift.
+        from codebase_rag.readme_sections import (
+            LATEST_RELEASE_MARKER as RENDER_MARKER,
+        )
+
+        assert LATEST_RELEASE_MARKER == RENDER_MARKER
 
     def test_mixed_fragment_inserts_only_fresh_themes(self) -> None:
         fragment = (

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -28,6 +28,13 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)\*\*: \S.*$")
 
+# Placed directly below the block of entries the latest release inserted, so
+# the README's "Latest News" can render that whole block instead of a fixed
+# top-N (a fixed three once hid two of the five v0.0.720 highlights). This
+# script must stay stdlib-only, so the literal is duplicated in
+# codebase_rag.readme_sections; a test asserts the two never drift.
+LATEST_RELEASE_MARKER = "<!-- latest-release-end -->"
+
 # Latest News is for user-facing features, never CI, developer tooling,
 # release/build automation, refactors, docs, tests, or bug fixes. Any bullet
 # whose theme names that kind of work is dropped so it can never reach the
@@ -100,7 +107,9 @@ def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
     Bullets whose theme already appears anywhere in NEWS.md or earlier in the
     same fragment are dropped, which makes a rerun of the same release
     idempotent. Every remaining Highlights bullet is accepted: the fragment is
-    the release's curated Highlights section, so all of it is news.
+    the release's curated Highlights section, so all of it is news. The
+    latest-release marker is moved below the inserted block so the README can
+    render the whole block; when nothing is inserted the marker stays put.
     """
     themes = existing_themes(news)
     fresh: list[str] = []
@@ -116,7 +125,11 @@ def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
     if not fresh:
         return news, []
 
-    lines = news.splitlines(keepends=True)
+    lines = [
+        line
+        for line in news.splitlines(keepends=True)
+        if line.strip() != LATEST_RELEASE_MARKER
+    ]
     insert_at = len(lines)
     for index, line in enumerate(lines):
         if BULLET_PATTERN.match(line.strip()):
@@ -125,9 +138,8 @@ def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
 
     if not news.endswith("\n"):
         lines.append("\n")
-    updated = (
-        lines[:insert_at] + [f"{bullet}\n" for bullet in fresh] + lines[insert_at:]
-    )
+    block = [f"{bullet}\n" for bullet in fresh] + [f"{LATEST_RELEASE_MARKER}\n"]
+    updated = lines[:insert_at] + block + lines[insert_at:]
     return "".join(updated), fresh
 
 


### PR DESCRIPTION
## Summary
- The README's Latest News was hard-capped at the top 3 NEWS.md entries, so two of the five v0.0.720 highlights (Protocol Buffer Indexing, Structural Analysis) never surfaced in the README even after #1391 uncapped NEWS.md itself
- `scripts/update_news.py` now maintains a `<!-- latest-release-end -->` marker directly below the block of entries each release inserts, and `format_latest_news` renders every entry above that marker (falling back to the top 3 when no marker exists)
- Placed the marker in NEWS.md below the five v0.0.720 highlights and regenerated the README, which now shows all five
- Hand edits between releases land above the marker and render too

## Testing
- `pytest codebase_rag/tests/test_update_news.py codebase_rag/tests/test_generate_readme.py codebase_rag/tests/test_release_news_derivation.py` - 36 passed (new tests written red first)
- `ruff check`, `ruff format`, `ty check` clean; README regenerated via `scripts/generate_readme.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Latest News now includes all entries from the current release, rather than being limited to three items.
  * Added announcements for Protocol Buffer indexing and structural analysis capabilities.

* **Documentation**
  * Updated release workflow guidance to use an automatic latest-release marker.
  * Preserved support for manual NEWS.md editing.

* **Bug Fixes**
  * Ensured the latest-release marker moves correctly when new release notes are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->