### PR TITLE
ci: gate merges on a 5/5 Greptile review of the head commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,9 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 45
     permissions:
+      # contents: read backs the commits API call that resolves an
+      # abbreviated reviewed-commit reference to a full SHA.
+      contents: read
       pull-requests: read
       issues: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,44 +417,48 @@ jobs:
           # comment covers this exact commit.
           deadline=$(( $(date +%s) + 2400 ))
           while :; do
-            # --jq would run per page; slurp the pages so the LATEST scored
-            # comment wins across all of them.
-            body=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            # --jq would run per page; slurp the pages so every scored comment
+            # is considered across all of them. Walk candidates NEWEST FIRST
+            # and act on the first one that reviewed the head commit: picking
+            # the globally latest comment instead would let a late update to
+            # an old-commit review mask a valid 5/5 review of head. Bodies are
+            # multiline, so ship them through base64.
+            candidates=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
               | jq -rs 'add
                         | [.[] | select(.user.login == "greptile-apps[bot]")
                                | select(.body | contains("Confidence Score:"))]
-                        | sort_by(.updated_at) | last | .body // empty')
-            if [ -n "$body" ]; then
+                        | sort_by(.updated_at) | reverse | .[].body | @base64')
+            score=""
+            for encoded in $candidates; do
+              body=$(printf '%s' "$encoded" | base64 -d)
               # Greptile sometimes prints an abbreviated commit instead of a
-              # full-SHA link, so accept 7-40 hex chars and compare as a
-              # prefix of the head SHA.
+              # full-SHA link, so accept 7-40 hex chars.
               reviewed=$(printf '%s' "$body" \
                 | grep -o 'Last reviewed commit.*' \
                 | grep -oE '[0-9a-f]{7,40}' | head -1 || true)
               if [ -n "$reviewed" ] && [ "${#reviewed}" -lt 40 ]; then
                 # Resolve to the full SHA so the comparison below is exact
                 # equality, never a prefix guess; an unresolvable reference
-                # just keeps the poll going.
+                # just skips this candidate.
                 reviewed=$(gh api "repos/$REPO/commits/$reviewed" \
                   --jq .sha 2>/dev/null || true)
               fi
+              [ "$reviewed" = "$HEAD_SHA" ] || continue
               score=$(printf '%s' "$body" \
                 | grep -oE 'Confidence Score: [0-9]+/5' | tail -1 \
                 | grep -oE '[0-9]+' | head -1 || true)
-              if [ -n "$reviewed" ] && [ -n "$score" ] \
-                 && [ "$reviewed" = "$HEAD_SHA" ]; then
-                if [ "$score" = "5" ]; then
-                  echo "✅ Greptile scored $HEAD_SHA at 5/5"
-                  exit 0
-                fi
-                echo "❌ Greptile scored $HEAD_SHA at $score/5 — 5/5 is required to merge."
-                echo "Fix Greptile's findings and push; the next review must reach 5/5."
-                exit 1
+              [ -n "$score" ] && break
+            done
+            if [ -n "$score" ]; then
+              if [ "$score" = "5" ]; then
+                echo "✅ Greptile scored $HEAD_SHA at 5/5"
+                exit 0
               fi
-              echo "Greptile's latest review covers ${reviewed:-<none>}, waiting for $HEAD_SHA ..."
-            else
-              echo "No Greptile review with a confidence score yet, waiting ..."
+              echo "❌ Greptile scored $HEAD_SHA at $score/5 — 5/5 is required to merge."
+              echo "Fix Greptile's findings and push; the next review must reach 5/5."
+              exit 1
             fi
+            echo "No Greptile review of $HEAD_SHA yet, waiting ..."
             if [ "$(date +%s)" -ge "$deadline" ]; then
               echo "❌ No Greptile review of $HEAD_SHA appeared within 40 minutes."
               echo "Re-trigger the Greptile review, then re-run this job."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,66 @@ jobs:
         run: |
           uv run --no-sync pytest codebase_rag/tests/test_go_frontend.py -v --tb=short
 
+  greptile-gate:
+    name: Greptile 5/5 Gate
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 45
+    permissions:
+      pull-requests: read
+      issues: read
+
+    steps:
+      - name: Require a 5/5 Greptile review of the head commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # The merge gate: a pull request is mergeable ONLY when Greptile has
+          # reviewed the CURRENT head commit and scored it 5/5. A stale review,
+          # a missing review, or any lower score fails this job, which fails
+          # "All Checks Pass", which the branch ruleset requires. Greptile
+          # posts its review minutes after a push, so poll until its summary
+          # comment covers this exact commit.
+          deadline=$(( $(date +%s) + 2400 ))
+          while :; do
+            # --jq would run per page; slurp the pages so the LATEST scored
+            # comment wins across all of them.
+            body=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+              | jq -rs 'add
+                        | [.[] | select(.user.login == "greptile-apps[bot]")
+                               | select(.body | contains("Confidence Score:"))]
+                        | sort_by(.updated_at) | last | .body // empty')
+            if [ -n "$body" ]; then
+              reviewed=$(printf '%s' "$body" \
+                | grep -o 'Last reviewed commit.*' \
+                | grep -oE '[0-9a-f]{40}' | head -1 || true)
+              score=$(printf '%s' "$body" \
+                | grep -oE 'Confidence Score: [0-9]+/5' | tail -1 \
+                | grep -oE '[0-9]+' | head -1 || true)
+              if [ "$reviewed" = "$HEAD_SHA" ] && [ -n "$score" ]; then
+                if [ "$score" = "5" ]; then
+                  echo "✅ Greptile scored $HEAD_SHA at 5/5"
+                  exit 0
+                fi
+                echo "❌ Greptile scored $HEAD_SHA at $score/5 — 5/5 is required to merge."
+                echo "Fix Greptile's findings and push; the next review must reach 5/5."
+                exit 1
+              fi
+              echo "Greptile's latest review covers ${reviewed:-<none>}, waiting for $HEAD_SHA ..."
+            else
+              echo "No Greptile review with a confidence score yet, waiting ..."
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "❌ No Greptile review of $HEAD_SHA appeared within 40 minutes."
+              echo "Re-trigger the Greptile review, then re-run this job."
+              exit 1
+            fi
+            sleep 60
+          done
+
   all-checks-pass:
     name: All Checks Pass
     runs-on: ubuntu-latest
@@ -405,6 +465,7 @@ jobs:
         binary-smoke,
         wheel-fresh-resolution,
         go-frontend,
+        greptile-gate,
       ]
     timeout-minutes: 5
 
@@ -445,6 +506,13 @@ jobs:
           fi
           if [[ "${{ needs.go-frontend.result }}" != "success" ]]; then
             echo "❌ Go frontend job failed"
+            exit 1
+          fi
+          # Skipped on push events (Greptile only reviews pull requests); on a
+          # pull request anything but success blocks the merge.
+          if [[ "${{ needs.greptile-gate.result }}" != "success" \
+             && "${{ needs.greptile-gate.result }}" != "skipped" ]]; then
+            echo "❌ Greptile gate failed: a 5/5 review of the head commit is required"
             exit 1
           fi
           echo "✅ All checks passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,13 +425,17 @@ jobs:
                                | select(.body | contains("Confidence Score:"))]
                         | sort_by(.updated_at) | last | .body // empty')
             if [ -n "$body" ]; then
+              # Greptile sometimes prints an abbreviated commit instead of a
+              # full-SHA link, so accept 7-40 hex chars and compare as a
+              # prefix of the head SHA.
               reviewed=$(printf '%s' "$body" \
                 | grep -o 'Last reviewed commit.*' \
-                | grep -oE '[0-9a-f]{40}' | head -1 || true)
+                | grep -oE '[0-9a-f]{7,40}' | head -1 || true)
               score=$(printf '%s' "$body" \
                 | grep -oE 'Confidence Score: [0-9]+/5' | tail -1 \
                 | grep -oE '[0-9]+' | head -1 || true)
-              if [ "$reviewed" = "$HEAD_SHA" ] && [ -n "$score" ]; then
+              if [ -n "$reviewed" ] && [ -n "$score" ] \
+                 && [[ "$HEAD_SHA" == "$reviewed"* ]]; then
                 if [ "$score" = "5" ]; then
                   echo "✅ Greptile scored $HEAD_SHA at 5/5"
                   exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,11 +431,18 @@ jobs:
               reviewed=$(printf '%s' "$body" \
                 | grep -o 'Last reviewed commit.*' \
                 | grep -oE '[0-9a-f]{7,40}' | head -1 || true)
+              if [ -n "$reviewed" ] && [ "${#reviewed}" -lt 40 ]; then
+                # Resolve to the full SHA so the comparison below is exact
+                # equality, never a prefix guess; an unresolvable reference
+                # just keeps the poll going.
+                reviewed=$(gh api "repos/$REPO/commits/$reviewed" \
+                  --jq .sha 2>/dev/null || true)
+              fi
               score=$(printf '%s' "$body" \
                 | grep -oE 'Confidence Score: [0-9]+/5' | tail -1 \
                 | grep -oE '[0-9]+' | head -1 || true)
               if [ -n "$reviewed" ] && [ -n "$score" ] \
-                 && [[ "$HEAD_SHA" == "$reviewed"* ]]; then
+                 && [ "$reviewed" = "$HEAD_SHA" ]; then
                 if [ "$score" = "5" ]; then
                   echo "✅ Greptile scored $HEAD_SHA at 5/5"
                   exit 0


### PR DESCRIPTION
## Why

PR #1394 was merged while Greptile's confidence score stood at 3/5: its check was green, its threads were resolved, and nothing forced the score itself to be checked. The merge gate must not depend on anyone remembering to read it.

## What

A new `greptile-gate` job in CI (pull requests only):

- Polls the PR's Greptile summary comment until **Last reviewed commit** equals the exact head SHA — a stale review of an earlier push never counts.
- Passes only on **Confidence Score: 5/5**.
- Fails immediately on any lower score for the head commit, and fails after 40 minutes if no review of the head commit appears (re-trigger Greptile and re-run the job).

`All Checks Pass` now requires it, and the branch ruleset requires `All Checks Pass`, so a PR below 5/5 is unmergeable by construction. On push events the job is skipped (Greptile only reviews PRs) and the aggregator accepts the skip.

The SHA/score extraction was validated against a real Greptile summary comment (correctly parsed `f4f28d50…` at 2/5, which the gate would reject).

This PR gates itself: it merges only once Greptile scores it 5/5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated pull request review check that waits for a complete, current review with the highest confidence score.
  * Pull requests are blocked when the review is missing, outdated, or below the required score.
  * The check retries while awaiting review completion and reports a clear failure when requirements are not met.
  * Existing push-based checks remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->