### PR TITLE
feat: duplicates eval plus fixes for five bugs found dogfooding clone detection across 14 repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ cgr-trace.jsonl
 evals/results/corpora/
 evals/results/**/agentic_qa*records*.jsonl
 evals/results/logs/
+.cgr-parser-fingerprint

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -1438,7 +1438,7 @@ def dead_code(
         with connect_memgraph(batch_size=1) as ingestor:
             projects = ingestor.list_projects()
             resolved = _resolve_dead_code_project(project_name, projects)
-            if resolved is not None:
+            if resolved is not None and resolved in projects:
                 logger.info(ls.DEADCODE_SCANNING.format(project_name=resolved))
                 rows, structural_tier_symbols = collect_dead_code_with_coverage(
                     ingestor,
@@ -1453,6 +1453,21 @@ def dead_code(
         )
         logger.exception(ls.DEADCODE_ERROR.format(error=e))
         raise typer.Exit(1) from e
+
+    # An explicit name absent from the graph must error, not scan a
+    # nonexistent prefix and report a clean project (the duplicates command
+    # gained this guard first). Raised OUTSIDE the connection context so a
+    # user typo never trips the service layer's error logging on exit.
+    if resolved is not None and resolved not in projects:
+        app_context.console.print(
+            style(
+                cs.CLI_ERR_DEADCODE_UNKNOWN_PROJECT.format(
+                    project=resolved, projects=projects
+                ),
+                cs.Color.RED,
+            )
+        )
+        raise typer.Exit(1)
 
     if resolved is None:
         message = (
@@ -1520,6 +1535,7 @@ def _emit_duplicates(
     project_name: str,
     skipped_symbols: int = 0,
     truncated: bool = False,
+    analyzed_symbols: int = 0,
 ) -> None:
     if output_format == cs.DuplicatesFormat.JSON:
         # Envelope, not a bare list: scan-completeness metadata must reach
@@ -1549,7 +1565,13 @@ def _emit_duplicates(
     # sink so a saved artifact never reads as "all clean" when symbols went
     # unanalyzed or group enumeration hit its cap.
     notices = []
-    if skipped_symbols:
+    # Every symbol skipped and none analyzed: the graph was indexed before
+    # fingerprint stamping, so "no duplicates" would be vacuous and the
+    # pattern-tier wording a misdiagnosis - recommend a re-index instead.
+    all_skipped = skipped_symbols > 0 and analyzed_symbols == 0
+    if all_skipped:
+        notices.append(cs.CLI_DUPLICATES_STALE_GRAPH.format(count=skipped_symbols))
+    elif skipped_symbols:
         notices.append(
             cs.CLI_DUPLICATES_STRUCTURAL_TIER_SKIPPED.format(count=skipped_symbols)
         )
@@ -1573,7 +1595,8 @@ def _emit_duplicates(
         return
 
     if not groups:
-        app_context.console.print(style(cs.CLI_DUPLICATES_NONE, cs.Color.GREEN))
+        if not all_skipped:
+            app_context.console.print(style(cs.CLI_DUPLICATES_NONE, cs.Color.GREEN))
     else:
         app_context.console.print(table)
         members = sum(len(group["members"]) for group in groups)
@@ -1638,19 +1661,7 @@ def duplicates(
         with connect_memgraph(batch_size=1) as ingestor:
             projects = ingestor.list_projects()
             resolved = _resolve_dead_code_project(project_name, projects)
-            # An explicit name absent from the graph must error, not scan a
-            # nonexistent prefix and report a clean project.
-            if resolved is not None and resolved not in projects:
-                app_context.console.print(
-                    style(
-                        cs.CLI_ERR_DUPLICATES_UNKNOWN_PROJECT.format(
-                            project=resolved, projects=projects
-                        ),
-                        cs.Color.RED,
-                    )
-                )
-                raise typer.Exit(1)
-            if resolved is not None:
+            if resolved is not None and resolved in projects:
                 logger.info(ls.DUPLICATES_SCANNING.format(project_name=resolved))
                 report = collect_duplicates_with_coverage(
                     ingestor,
@@ -1662,14 +1673,27 @@ def duplicates(
                         exclude_patterns=tuple(exclude),
                     ),
                 )
-    except typer.Exit:
-        raise
     except Exception as e:
         app_context.console.print(
             style(cs.CLI_ERR_DUPLICATES_FAILED.format(error=e), cs.Color.RED)
         )
         logger.exception(ls.DUPLICATES_ERROR.format(error=e))
         raise typer.Exit(1) from e
+
+    # An explicit name absent from the graph must error, not scan a
+    # nonexistent prefix and report a clean project. Raised OUTSIDE the
+    # connection context: a user typo is not a connection failure and must
+    # not trip the service layer's error logging on exit.
+    if resolved is not None and resolved not in projects:
+        app_context.console.print(
+            style(
+                cs.CLI_ERR_DUPLICATES_UNKNOWN_PROJECT.format(
+                    project=resolved, projects=projects
+                ),
+                cs.Color.RED,
+            )
+        )
+        raise typer.Exit(1)
 
     if resolved is None:
         message = (
@@ -1687,6 +1711,7 @@ def duplicates(
         resolved,
         report.skipped_symbols,
         report.truncated,
+        report.analyzed_symbols,
     )
 
     if fail_on_found and report.groups:

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -153,6 +153,9 @@ CLI_ERR_DEADCODE_NO_PROJECTS = (
 CLI_ERR_DEADCODE_AMBIGUOUS_PROJECT = (
     "Multiple projects found: {projects}. Specify which one with --project-name/-n."
 )
+CLI_ERR_DEADCODE_UNKNOWN_PROJECT = (
+    "Project '{project}' is not indexed. Indexed projects: {projects}."
+)
 
 CLI_DUPLICATES_CONNECTING = "Scanning for structurally duplicated functions..."
 CLI_DUPLICATES_TABLE_TITLE = "Duplicate Code Groups ({project_name})"
@@ -170,6 +173,11 @@ CLI_DUPLICATES_WRITTEN = "Wrote {count} group(s) to {path}"
 CLI_DUPLICATES_STRUCTURAL_TIER_SKIPPED = (
     "{count} symbol(s) were not analyzed (no structural fingerprint: "
     "pattern-tier language or bodiless declaration)."
+)
+CLI_DUPLICATES_STALE_GRAPH = (
+    "None of the {count} function(s)/method(s) in this project carry a "
+    "structural fingerprint; the graph predates fingerprint stamping. "
+    "Re-index the repository (cgr start --update-graph) and rerun."
 )
 CLI_DUPLICATES_TRUNCATED_NOTICE = (
     "Similar-group enumeration reached its cap; some qualifying groups may "

--- a/codebase_rag/constants/duplicates.py
+++ b/codebase_rag/constants/duplicates.py
@@ -62,6 +62,11 @@ AST_FP_MIN_BRANCH_NODES = 5
 # this marker (function_definition) to find the real body.
 AST_FP_WRAPPED_DEF_SUBSTRING = "function"
 
+# Expression-bodied definitions whose logic is a plain named child instead of
+# a body field: a C# property_declaration never has a body field, and its
+# `=> expr` form keeps the expression in an arrow_expression_clause.
+AST_FP_EXPRESSION_BODY_TYPES = frozenset({"arrow_expression_clause"})
+
 # Byte separators framing a node's token and child digests in the Merkle hash.
 AST_FP_HASH_OPEN = b"("
 AST_FP_HASH_CLOSE = b")"

--- a/codebase_rag/constants/duplicates.py
+++ b/codebase_rag/constants/duplicates.py
@@ -57,6 +57,11 @@ AST_FP_BLOCK_PARENT_EXTRAS = frozenset({"statement_list", "compound_statement"})
 # nearly every function and would dominate the candidate index.
 AST_FP_MIN_BRANCH_NODES = 5
 
+# Wrapper definitions (C++ template_declaration) carry no body field of
+# their own; the fingerprint walk descends into the child whose type carries
+# this marker (function_definition) to find the real body.
+AST_FP_WRAPPED_DEF_SUBSTRING = "function"
+
 # Byte separators framing a node's token and child digests in the Merkle hash.
 AST_FP_HASH_OPEN = b"("
 AST_FP_HASH_CLOSE = b")"

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -265,17 +265,18 @@ def _qn_within(outer_qn: str, inner_qn: str) -> bool:
 def _member_nested_in(outer: DuplicateMember, inner: DuplicateMember) -> bool:
     """True when inner's definition sits textually inside outer's.
 
-    Proper line containment proves it outright. An IDENTICAL line span
-    (minified one-liners) cannot: lines alone do not separate a one-line
-    factory's closure from an adjacent one-line definition, so the
-    qualified-name hierarchy decides - a nested definition's qn extends its
-    container's, an adjacent one's never does.
+    Only STRICT containment on both boundaries proves nesting by lines
+    alone. Any shared boundary is ambiguous - a one-liner at 5-5 beside a
+    sibling spanning 5-9 shares a start line without nesting, and minified
+    one-liners share both - so there the qualified-name hierarchy decides:
+    a nested definition's qn extends its container's, a sibling's never
+    does.
     """
     if not _span_contains(outer, inner):
         return False
     if (
         outer["start_line"] < inner["start_line"]
-        or inner["end_line"] < outer["end_line"]
+        and inner["end_line"] < outer["end_line"]
     ):
         return True
     return _qn_within(outer["qualified_name"], inner["qualified_name"])

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -10,6 +10,7 @@
 # project.
 from __future__ import annotations
 
+import re
 from fnmatch import fnmatch
 from math import ceil
 
@@ -244,6 +245,42 @@ def _span_contains(outer: DuplicateMember, inner: DuplicateMember) -> bool:
     )
 
 
+# Registration artifacts on a qualified name ("@<line>", optionally
+# "_<col>"), never part of the written name; stripped before any
+# hierarchy comparison.
+_DUP_QN_MARKER_RE = re.compile(
+    re.escape(cs.DUP_QN_MARKER)
+    + r"\d+(?:"
+    + re.escape(cs.DUP_QN_COLUMN_MARKER)
+    + r"\d+)?"
+)
+
+
+def _qn_within(outer_qn: str, inner_qn: str) -> bool:
+    outer = _DUP_QN_MARKER_RE.sub("", outer_qn)
+    inner = _DUP_QN_MARKER_RE.sub("", inner_qn)
+    return inner.startswith(outer + cs.SEPARATOR_DOT)
+
+
+def _member_nested_in(outer: DuplicateMember, inner: DuplicateMember) -> bool:
+    """True when inner's definition sits textually inside outer's.
+
+    Proper line containment proves it outright. An IDENTICAL line span
+    (minified one-liners) cannot: lines alone do not separate a one-line
+    factory's closure from an adjacent one-line definition, so the
+    qualified-name hierarchy decides - a nested definition's qn extends its
+    container's, an adjacent one's never does.
+    """
+    if not _span_contains(outer, inner):
+        return False
+    if (
+        outer["start_line"] < inner["start_line"]
+        or inner["end_line"] < outer["end_line"]
+    ):
+        return True
+    return _qn_within(outer["qualified_name"], inner["qualified_name"])
+
+
 def _only_nested_members(
     first: list[DuplicateMember], second: list[DuplicateMember]
 ) -> bool:
@@ -257,7 +294,9 @@ def _only_nested_members(
     entries a real clone pair.
     """
     return all(
-        _span_contains(a, b) or _span_contains(b, a) for a in first for b in second
+        _member_nested_in(a, b) or _member_nested_in(b, a)
+        for a in first
+        for b in second
     )
 
 
@@ -271,19 +310,15 @@ def _drop_contained_members(
     would seat the enclosing function next to its own nested closure. The
     nested member is the redundant one: its exact-twin relationship is
     already a Stage-1 group, while the container's only real partner is the
-    external copy. Proper containment only, so two distinct definitions
-    sharing a span (minified one-liners) both survive.
+    external copy. Nesting requires proper containment or a qualified-name
+    hierarchy on an identical span, so two distinct definitions sharing a
+    span (adjacent minified one-liners) both survive.
     """
     return [
         member
         for member in members
         if not any(
-            other is not member
-            and _span_contains(other, member)
-            and (
-                other["start_line"] < member["start_line"]
-                or member["end_line"] < other["end_line"]
-            )
+            other is not member and _member_nested_in(other, member)
             for other in members
         )
     ]

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -342,6 +342,44 @@ def _jaccard(first: frozenset[str], second: frozenset[str]) -> float:
     return len(first & second) / union if union else 0.0
 
 
+def _entry_contains_any(container: _Entry, contained: _Entry) -> bool:
+    return any(
+        _member_nested_in(outer, inner)
+        for outer in container.members
+        for inner in contained.members
+    )
+
+
+def _supplemental_cliques(
+    clique: list[int], order: list[_Entry], kept: list[DuplicateMember]
+) -> list[list[int]]:
+    """Sub-cliques preserving a fully-pruned entry's non-container partners.
+
+    Dropping nested members can erase an ENTIRE entry from a clique (two
+    factories carrying their identical closures). Its relationship to a
+    partner that contains none of its members (a standalone function similar
+    to the closures) is covered by no other group, so each such entry is
+    re-emitted with exactly those partners.
+    """
+    kept_ids = {id(member) for member in kept}
+    pruned = [
+        position
+        for position in clique
+        if not any(id(member) in kept_ids for member in order[position].members)
+    ]
+    subcliques: list[list[int]] = []
+    for position in pruned:
+        partners = [
+            other
+            for other in clique
+            if other != position
+            and not _entry_contains_any(order[other], order[position])
+        ]
+        if partners:
+            subcliques.append(sorted([position, *partners]))
+    return subcliques
+
+
 def _similar_groups(
     entries: dict[str, _Entry], config: DuplicatesConfig
 ) -> tuple[list[DuplicateGroup], bool]:
@@ -378,25 +416,47 @@ def _similar_groups(
         logger.warning(ls.DUPLICATES_GROUPS_TRUNCATED.format(cap=max_groups))
     truncated = pairs_truncated or cliques_truncated
     groups: list[DuplicateGroup] = []
+    seen_member_sets: set[frozenset[str]] = set()
     for clique in cliques:
-        similarity = min(
-            _jaccard(order[left].branches, order[right].branches)
-            for at, left in enumerate(clique)
-            for right in clique[at + 1 :]
-        )
         members = _drop_contained_members(
             [member for position in clique for member in order[position].members]
         )
-        if len(members) < 2:
-            continue
-        groups.append(
-            DuplicateGroup(
-                kind=cs.KIND_SIMILAR,
-                similarity=round(similarity, 3),
-                node_count=max(order[position].node_count for position in clique),
-                members=_sorted_members(members),
+        emit = [(clique, members)]
+        emit.extend(
+            (
+                subclique,
+                _drop_contained_members(
+                    [
+                        member
+                        for position in subclique
+                        for member in order[position].members
+                    ]
+                ),
             )
+            for subclique in _supplemental_cliques(clique, order, members)
         )
+        for group_positions, group_members in emit:
+            if len(group_members) < 2:
+                continue
+            key = frozenset(m[cs.KEY_QUALIFIED_NAME] for m in group_members)
+            if key in seen_member_sets:
+                continue
+            seen_member_sets.add(key)
+            similarity = min(
+                _jaccard(order[left].branches, order[right].branches)
+                for at, left in enumerate(group_positions)
+                for right in group_positions[at + 1 :]
+            )
+            groups.append(
+                DuplicateGroup(
+                    kind=cs.KIND_SIMILAR,
+                    similarity=round(similarity, 3),
+                    node_count=max(
+                        order[position].node_count for position in group_positions
+                    ),
+                    members=_sorted_members(group_members),
+                )
+            )
     return groups, truncated
 
 

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -256,10 +256,20 @@ _DUP_QN_MARKER_RE = re.compile(
 )
 
 
+# C#/Java qualified names carry a parameter signature ("Run(int)") that a
+# nested definition's qn does not repeat ("Run.Local"); stripped before the
+# hierarchy comparison, alongside the registration markers.
+_QN_SIGNATURE_RE = re.compile(r"\([^()]*\)")
+
+
+def _qn_normalized(qn: str) -> str:
+    return _QN_SIGNATURE_RE.sub("", _DUP_QN_MARKER_RE.sub("", qn))
+
+
 def _qn_within(outer_qn: str, inner_qn: str) -> bool:
-    outer = _DUP_QN_MARKER_RE.sub("", outer_qn)
-    inner = _DUP_QN_MARKER_RE.sub("", inner_qn)
-    return inner.startswith(outer + cs.SEPARATOR_DOT)
+    return _qn_normalized(inner_qn).startswith(
+        _qn_normalized(outer_qn) + cs.SEPARATOR_DOT
+    )
 
 
 def _member_nested_in(outer: DuplicateMember, inner: DuplicateMember) -> bool:
@@ -302,38 +312,28 @@ def _only_nested_members(
 
 
 def _drop_contained_members(
-    expanded: list[tuple[int, DuplicateMember]],
+    members: list[DuplicateMember],
 ) -> list[DuplicateMember]:
     """Drop members nested inside another member of the same group.
 
-    When a closure's fingerprint also matches a copy elsewhere, the entry
-    edge legitimately survives, but expanding the entry's full member list
-    would seat the enclosing function next to its own nested closure. The
-    nested member is the redundant one: its exact-twin relationship is
-    already a Stage-1 group, while the container's only real partner is the
-    external copy. Nesting requires proper containment or a qualified-name
-    hierarchy on an identical span, so two distinct definitions sharing a
-    span (adjacent minified one-liners) both survive. A nested member is
-    only dropped while a same-entry sibling (its exact twin) survives to
-    represent the clone class, so no entry's relationship ever leaves the
-    report.
+    Expanding an entry's full member list can seat an enclosing function
+    next to its own nested closure (the closure's fingerprint matching a
+    copy elsewhere keeps the entry edge legitimately alive, and two similar
+    factories can carry their identical closures as one all-nested entry).
+    The nested member is always the redundant one: whenever its entry has
+    more than one member, the Stage-1 exact group already reports the
+    closure clone class, and its container's real partners stay in this
+    group. Nesting requires proper containment or a qualified-name
+    hierarchy on a shared boundary, so two distinct definitions sharing a
+    span (adjacent minified one-liners) both survive.
     """
-    nested = [
-        any(
-            other is not member and _member_nested_in(other, member)
-            for _pos, other in expanded
-        )
-        for _pos, member in expanded
-    ]
-    entries_with_free_member = {
-        position
-        for (position, _member), is_nested in zip(expanded, nested, strict=True)
-        if not is_nested
-    }
     return [
         member
-        for (position, member), is_nested in zip(expanded, nested, strict=True)
-        if not (is_nested and position in entries_with_free_member)
+        for member in members
+        if not any(
+            other is not member and _member_nested_in(other, member)
+            for other in members
+        )
     ]
 
 
@@ -385,11 +385,7 @@ def _similar_groups(
             for right in clique[at + 1 :]
         )
         members = _drop_contained_members(
-            [
-                (position, member)
-                for position in clique
-                for member in order[position].members
-            ]
+            [member for position in clique for member in order[position].members]
         )
         if len(members) < 2:
             continue

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -302,7 +302,7 @@ def _only_nested_members(
 
 
 def _drop_contained_members(
-    members: list[DuplicateMember],
+    expanded: list[tuple[int, DuplicateMember]],
 ) -> list[DuplicateMember]:
     """Drop members nested inside another member of the same group.
 
@@ -313,15 +313,27 @@ def _drop_contained_members(
     already a Stage-1 group, while the container's only real partner is the
     external copy. Nesting requires proper containment or a qualified-name
     hierarchy on an identical span, so two distinct definitions sharing a
-    span (adjacent minified one-liners) both survive.
+    span (adjacent minified one-liners) both survive. A nested member is
+    only dropped while a same-entry sibling (its exact twin) survives to
+    represent the clone class, so no entry's relationship ever leaves the
+    report.
     """
+    nested = [
+        any(
+            other is not member and _member_nested_in(other, member)
+            for _pos, other in expanded
+        )
+        for _pos, member in expanded
+    ]
+    entries_with_free_member = {
+        position
+        for (position, _member), is_nested in zip(expanded, nested, strict=True)
+        if not is_nested
+    }
     return [
         member
-        for member in members
-        if not any(
-            other is not member and _member_nested_in(other, member)
-            for other in members
-        )
+        for (position, member), is_nested in zip(expanded, nested, strict=True)
+        if not (is_nested and position in entries_with_free_member)
     ]
 
 
@@ -373,7 +385,11 @@ def _similar_groups(
             for right in clique[at + 1 :]
         )
         members = _drop_contained_members(
-            [member for position in clique for member in order[position].members]
+            [
+                (position, member)
+                for position in clique
+                for member in order[position].members
+            ]
         )
         if len(members) < 2:
             continue

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -231,6 +231,31 @@ def _pairs_from_index(
     return pairs, False
 
 
+def _span_contains(outer: DuplicateMember, inner: DuplicateMember) -> bool:
+    return (
+        outer["path"] == inner["path"]
+        and outer["start_line"] <= inner["start_line"]
+        and inner["end_line"] <= outer["end_line"]
+    )
+
+
+def _only_nested_members(
+    first: list[DuplicateMember], second: list[DuplicateMember]
+) -> bool:
+    """True when every cross pair is one definition inside the other.
+
+    A factory's body contains its nested function, so the outer branch set is
+    a superset of the inner's and Jaccard clears any threshold - yet "this
+    function duplicates its own body" is a false positive by construction.
+    The exemption is scoped to pure containment: one non-nested cross pair
+    (the closure's fingerprint also matching a copy elsewhere) keeps the
+    entries a real clone pair.
+    """
+    return all(
+        _span_contains(a, b) or _span_contains(b, a) for a in first for b in second
+    )
+
+
 def _jaccard(first: frozenset[str], second: frozenset[str]) -> float:
     union = len(first | second)
     return len(first & second) / union if union else 0.0
@@ -261,6 +286,8 @@ def _similar_groups(
         if larger == 0 or smaller / larger < threshold:
             continue
         if _jaccard(first, second) < threshold:
+            continue
+        if _only_nested_members(order[left].members, order[right].members):
             continue
         adjacency.setdefault(left, set()).add(right)
         adjacency.setdefault(right, set()).add(left)

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -94,7 +94,12 @@ def collect_duplicates_with_coverage(
             -group["node_count"],
         )
     )
-    return DuplicatesReport(groups=groups, skipped_symbols=skipped, truncated=truncated)
+    return DuplicatesReport(
+        groups=groups,
+        skipped_symbols=skipped,
+        truncated=truncated,
+        analyzed_symbols=len(rows),
+    )
 
 
 def _entries_from_rows(

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -261,6 +261,34 @@ def _only_nested_members(
     )
 
 
+def _drop_contained_members(
+    members: list[DuplicateMember],
+) -> list[DuplicateMember]:
+    """Drop members nested inside another member of the same group.
+
+    When a closure's fingerprint also matches a copy elsewhere, the entry
+    edge legitimately survives, but expanding the entry's full member list
+    would seat the enclosing function next to its own nested closure. The
+    nested member is the redundant one: its exact-twin relationship is
+    already a Stage-1 group, while the container's only real partner is the
+    external copy. Proper containment only, so two distinct definitions
+    sharing a span (minified one-liners) both survive.
+    """
+    return [
+        member
+        for member in members
+        if not any(
+            other is not member
+            and _span_contains(other, member)
+            and (
+                other["start_line"] < member["start_line"]
+                or member["end_line"] < other["end_line"]
+            )
+            for other in members
+        )
+    ]
+
+
 def _jaccard(first: frozenset[str], second: frozenset[str]) -> float:
     union = len(first | second)
     return len(first & second) / union if union else 0.0
@@ -308,7 +336,11 @@ def _similar_groups(
             for at, left in enumerate(clique)
             for right in clique[at + 1 :]
         )
-        members = [member for position in clique for member in order[position].members]
+        members = _drop_contained_members(
+            [member for position in clique for member in order[position].members]
+        )
+        if len(members) < 2:
+            continue
         groups.append(
             DuplicateGroup(
                 kind=cs.KIND_SIMILAR,

--- a/codebase_rag/parsers/ast_fingerprint.py
+++ b/codebase_rag/parsers/ast_fingerprint.py
@@ -51,7 +51,18 @@ def _resolve_body(func_node: Node) -> Node | None:
     body = func_node.child_by_field_name(cs.FIELD_BODY)
     if body is not None:
         return body
-    return dart_body_node(func_node)
+    dart_body = dart_body_node(func_node)
+    if dart_body is not None:
+        return dart_body
+    # A wrapper definition (C++ template_declaration) has no body field of
+    # its own: the body lives on the inner function_definition. Recursing
+    # also covers nested wrappers (member templates of class templates).
+    for child in func_node.named_children:
+        if cs.AST_FP_WRAPPED_DEF_SUBSTRING in child.type:
+            inner = _resolve_body(child)
+            if inner is not None:
+                return inner
+    return None
 
 
 def _token_for(node: Node) -> str | None:

--- a/codebase_rag/parsers/ast_fingerprint.py
+++ b/codebase_rag/parsers/ast_fingerprint.py
@@ -62,6 +62,11 @@ def _resolve_body(func_node: Node) -> Node | None:
             inner = _resolve_body(child)
             if inner is not None:
                 return inner
+    # An expression-bodied definition (C# `=> expr` property/member) keeps
+    # its logic in a plain named child rather than a body field.
+    for child in func_node.named_children:
+        if child.type in cs.AST_FP_EXPRESSION_BODY_TYPES:
+            return child
     return None
 
 

--- a/codebase_rag/tests/test_dead_code_command.py
+++ b/codebase_rag/tests/test_dead_code_command.py
@@ -179,6 +179,19 @@ class TestDeadCodeCommand:
         assert result.exit_code == 1
         mock_ingestor.fetch_all.assert_not_called()
 
+    def test_unknown_project_errors(self, runner: CliRunner) -> None:
+        # `-n typo` must error, not scan a nonexistent prefix and report a
+        # clean project (the duplicates command already guards this).
+        mock_ingestor = _make_mock_ingestor(projects=["myproj"], fetch_result=[])
+        with patch("codebase_rag.cli.connect_memgraph", return_value=mock_ingestor):
+            result = runner.invoke(app, ["dead-code", "-n", "typo"])
+
+        assert result.exit_code == 1
+        assert "is not indexed" in result.output
+        # The user error must be raised AFTER the connection closes cleanly,
+        # or the service layer logs a spurious ERROR + traceback on exit.
+        assert mock_ingestor.__exit__.call_args[0][0] is None
+
     def test_errors_when_no_projects(self, runner: CliRunner) -> None:
         mock_ingestor = _make_mock_ingestor(projects=[], fetch_result=[])
         with patch("codebase_rag.cli.connect_memgraph", return_value=mock_ingestor):

--- a/codebase_rag/tests/test_duplicates_collect.py
+++ b/codebase_rag/tests/test_duplicates_collect.py
@@ -396,8 +396,11 @@ class TestSimilarGroups:
         # inner and its external copy share a fingerprint: one exact group.
         assert {"proj.m.factory.inner", "proj.other.copy"} in member_sets
         # factory vs the inner-fingerprint entry is a real cross-file clone
-        # relationship (factory vs proj.other.copy), so the edge survives.
-        assert any("proj.m.factory" in members for members in member_sets)
+        # relationship, but only via the EXTERNAL copy: the similar group
+        # must seat factory with proj.other.copy alone, never with its own
+        # nested closure (whose exact twin is already reported above).
+        assert {"proj.m.factory", "proj.other.copy"} in member_sets
+        assert len(groups) == 2
 
     def test_exact_copies_are_not_rereported_as_similar(self) -> None:
         ingestor = FakeIngestor(

--- a/codebase_rag/tests/test_duplicates_collect.py
+++ b/codebase_rag/tests/test_duplicates_collect.py
@@ -635,6 +635,89 @@ class TestSimilarGroups:
                 and "proj.b.factory_two.helper" in members
             )
 
+    def test_dropped_closure_entry_keeps_standalone_partner_pair(self) -> None:
+        # Two similar factories, their identical closures (one exact entry),
+        # and a standalone function similar to everything: one 4-entry
+        # clique. Dropping the nested closures from the main group must not
+        # erase the closure-to-standalone relationship - it is not covered
+        # by any exact group, so a supplemental group carries it.
+        closure_branches = [f"b{i}" for i in range(5)]
+        factory_a = [f"b{i}" for i in range(9)] + ["x1"]
+        factory_b = [f"b{i}" for i in range(9)] + ["x2"]
+        standalone = [f"b{i}" for i in range(6)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.a.factory_one",
+                    "aaaa",
+                    factory_a,
+                    path="proj/a.py",
+                    start_line=10,
+                    end_line=40,
+                ),
+                _row(
+                    "proj.b.factory_two",
+                    "eeee",
+                    factory_b,
+                    path="proj/b.py",
+                    start_line=10,
+                    end_line=40,
+                ),
+                _row(
+                    "proj.a.factory_one.helper",
+                    "cccc",
+                    closure_branches,
+                    path="proj/a.py",
+                    start_line=15,
+                    end_line=30,
+                ),
+                _row(
+                    "proj.b.factory_two.helper",
+                    "cccc",
+                    closure_branches,
+                    path="proj/b.py",
+                    start_line=15,
+                    end_line=30,
+                ),
+                _row(
+                    "proj.s.standalone",
+                    "dddd",
+                    standalone,
+                    path="proj/s.py",
+                    start_line=3,
+                    end_line=20,
+                ),
+            ]
+        )
+        config = default_duplicates_config(threshold=0.5)
+        groups = collect_duplicates(ingestor, "proj", config)
+        member_sets = [
+            {m["qualified_name"] for m in group["members"]} for group in groups
+        ]
+        # Main clique group: factories with the standalone, closures pruned.
+        assert {
+            "proj.a.factory_one",
+            "proj.b.factory_two",
+            "proj.s.standalone",
+        } in member_sets
+        # Supplemental group: the pruned closure entry with its non-container
+        # partner, so the closure-standalone relationship survives.
+        assert {
+            "proj.a.factory_one.helper",
+            "proj.b.factory_two.helper",
+            "proj.s.standalone",
+        } in member_sets
+        # And never a factory beside its own closure.
+        for members in member_sets:
+            assert not (
+                "proj.a.factory_one" in members
+                and "proj.a.factory_one.helper" in members
+            )
+            assert not (
+                "proj.b.factory_two" in members
+                and "proj.b.factory_two.helper" in members
+            )
+
     def test_parameterized_qn_still_proves_same_line_nesting(self) -> None:
         # C#/Java qualified names carry a signature (`Run(int)`) that a
         # nested local function's qn does not repeat (`Run.Local`): the

--- a/codebase_rag/tests/test_duplicates_collect.py
+++ b/codebase_rag/tests/test_duplicates_collect.py
@@ -576,6 +576,108 @@ class TestSimilarGroups:
         assert {"proj.m.factory.inner", "proj.other.cousin"} in member_sets
         assert len(groups) == 2
 
+    def test_all_nested_closure_entry_is_dropped_from_similar_group(self) -> None:
+        # Two similar factories each contain an identical closure (one exact
+        # entry, every member nested in a group co-member). The closure clone
+        # class is the Stage-1 exact group; the similar group must pair the
+        # factories alone, never a factory beside its own closure.
+        shared = [f"b{i}" for i in range(9)]
+        closure_branches = shared[:5]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.a.factory_one",
+                    "aaaa",
+                    [*shared, "x1"],
+                    path="proj/a.py",
+                    start_line=10,
+                    end_line=40,
+                ),
+                _row(
+                    "proj.b.factory_two",
+                    "eeee",
+                    [*shared, "x2"],
+                    path="proj/b.py",
+                    start_line=10,
+                    end_line=40,
+                ),
+                _row(
+                    "proj.a.factory_one.helper",
+                    "cccc",
+                    closure_branches,
+                    path="proj/a.py",
+                    start_line=15,
+                    end_line=30,
+                ),
+                _row(
+                    "proj.b.factory_two.helper",
+                    "cccc",
+                    closure_branches,
+                    path="proj/b.py",
+                    start_line=15,
+                    end_line=30,
+                ),
+            ]
+        )
+        config = default_duplicates_config(threshold=0.5)
+        groups = collect_duplicates(ingestor, "proj", config)
+        member_sets = [
+            {m["qualified_name"] for m in group["members"]} for group in groups
+        ]
+        assert {"proj.a.factory_one.helper", "proj.b.factory_two.helper"} in member_sets
+        for members in member_sets:
+            assert not (
+                "proj.a.factory_one" in members
+                and "proj.a.factory_one.helper" in members
+            )
+            assert not (
+                "proj.b.factory_two" in members
+                and "proj.b.factory_two.helper" in members
+            )
+
+    def test_parameterized_qn_still_proves_same_line_nesting(self) -> None:
+        # C#/Java qualified names carry a signature (`Run(int)`) that a
+        # nested local function's qn does not repeat (`Run.Local`): the
+        # hierarchy check must strip signatures or same-line nesting is
+        # never recognized and the method pairs with its own local function.
+        shared = [f"b{i}" for i in range(9)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.N.Sample.Run(int)",
+                    "aaaa",
+                    [*shared, "outer_extra"],
+                    path="proj/Sample.cs",
+                    start_line=5,
+                    end_line=5,
+                ),
+                _row(
+                    "proj.N.Sample.Run.Local",
+                    "bbbb",
+                    shared,
+                    path="proj/Sample.cs",
+                    start_line=5,
+                    start_col=30,
+                    end_line=5,
+                ),
+                _row(
+                    "proj.Other.LocalCopy",
+                    "bbbb",
+                    shared,
+                    path="proj/Other.cs",
+                    start_line=3,
+                    end_line=3,
+                ),
+            ]
+        )
+        groups = collect_duplicates(ingestor, "proj", _CONFIG)
+        member_sets = [
+            {m["qualified_name"] for m in group["members"]} for group in groups
+        ]
+        assert {"proj.N.Sample.Run.Local", "proj.Other.LocalCopy"} in member_sets
+        assert {"proj.N.Sample.Run(int)", "proj.Other.LocalCopy"} in member_sets
+        assert len(groups) == 2
+
     def test_exact_copies_are_not_rereported_as_similar(self) -> None:
         ingestor = FakeIngestor(
             [

--- a/codebase_rag/tests/test_duplicates_collect.py
+++ b/codebase_rag/tests/test_duplicates_collect.py
@@ -534,6 +534,48 @@ class TestSimilarGroups:
             "proj.min.fourth",
         }
 
+    def test_closure_pair_with_distinct_external_function_is_kept(self) -> None:
+        # An external function with a DIFFERENT fingerprint that is similar
+        # to both a factory and its closure: the factory-closure edge is
+        # filtered, so two overlapping cliques emerge, and the closure's own
+        # relationship with the external function must be reported.
+        shared = [f"b{i}" for i in range(9)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.m.factory",
+                    "aaaa",
+                    [*shared, "outer_extra"],
+                    path="proj/m.py",
+                    start_line=30,
+                    end_line=60,
+                ),
+                _row(
+                    "proj.m.factory.inner",
+                    "bbbb",
+                    [*shared, "inner_extra"],
+                    path="proj/m.py",
+                    start_line=38,
+                    end_line=58,
+                ),
+                _row(
+                    "proj.other.cousin",
+                    "cccc",
+                    [*shared, "cousin_extra"],
+                    path="proj/other.py",
+                    start_line=5,
+                    end_line=25,
+                ),
+            ]
+        )
+        groups = collect_duplicates(ingestor, "proj", _CONFIG)
+        member_sets = [
+            {m["qualified_name"] for m in group["members"]} for group in groups
+        ]
+        assert {"proj.m.factory", "proj.other.cousin"} in member_sets
+        assert {"proj.m.factory.inner", "proj.other.cousin"} in member_sets
+        assert len(groups) == 2
+
     def test_exact_copies_are_not_rereported_as_similar(self) -> None:
         ingestor = FakeIngestor(
             [

--- a/codebase_rag/tests/test_duplicates_collect.py
+++ b/codebase_rag/tests/test_duplicates_collect.py
@@ -402,6 +402,83 @@ class TestSimilarGroups:
         assert {"proj.m.factory", "proj.other.copy"} in member_sets
         assert len(groups) == 2
 
+    def test_same_line_nested_closure_with_external_copy_is_dropped(self) -> None:
+        # Minified one-liners: the factory and its closure share the SAME
+        # start and end line, so line spans cannot prove nesting - but the
+        # qualified-name hierarchy can (factory.closure sits under factory).
+        # The similar group must still seat the factory with the external
+        # copy only, never with its own closure.
+        shared = [f"b{i}" for i in range(9)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.min.factory",
+                    "aaaa",
+                    [*shared, "outer_extra"],
+                    path="proj/min.py",
+                    start_line=5,
+                    end_line=5,
+                ),
+                _row(
+                    "proj.min.factory.closure",
+                    "bbbb",
+                    shared,
+                    path="proj/min.py",
+                    start_line=5,
+                    start_col=24,
+                    end_line=5,
+                ),
+                _row(
+                    "proj.other.closure_copy",
+                    "bbbb",
+                    shared,
+                    path="proj/other.py",
+                    start_line=3,
+                    end_line=3,
+                ),
+            ]
+        )
+        groups = collect_duplicates(ingestor, "proj", _CONFIG)
+        member_sets = [
+            {m["qualified_name"] for m in group["members"]} for group in groups
+        ]
+        assert {"proj.min.factory.closure", "proj.other.closure_copy"} in member_sets
+        assert {"proj.min.factory", "proj.other.closure_copy"} in member_sets
+        assert len(groups) == 2
+
+    def test_same_line_adjacent_definitions_still_pair(self) -> None:
+        # Two DISTINCT minified definitions can share one line span without
+        # any nesting (side-by-side one-liners). Their qualified names are
+        # unrelated, so the nested-member rules must not eat the pair.
+        shared = [f"b{i}" for i in range(9)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.min.first",
+                    "aaaa",
+                    [*shared, "x1"],
+                    path="proj/min.py",
+                    start_line=5,
+                    end_line=5,
+                ),
+                _row(
+                    "proj.min.second",
+                    "bbbb",
+                    [*shared, "x2"],
+                    path="proj/min.py",
+                    start_line=5,
+                    start_col=60,
+                    end_line=5,
+                ),
+            ]
+        )
+        groups = collect_duplicates(ingestor, "proj", _CONFIG)
+        assert len(groups) == 1
+        assert {m["qualified_name"] for m in groups[0]["members"]} == {
+            "proj.min.first",
+            "proj.min.second",
+        }
+
     def test_exact_copies_are_not_rereported_as_similar(self) -> None:
         ingestor = FakeIngestor(
             [

--- a/codebase_rag/tests/test_duplicates_collect.py
+++ b/codebase_rag/tests/test_duplicates_collect.py
@@ -479,6 +479,61 @@ class TestSimilarGroups:
             "proj.min.second",
         }
 
+    def test_shared_boundary_siblings_still_pair(self) -> None:
+        # Sibling definitions can share ONE line boundary without nesting: a
+        # one-liner at 5-5 beside a definition spanning 5-9 (or 9-9 closing a
+        # 5-9 span). Containment is only proven by STRICT bounds on both
+        # sides; a shared boundary defers to the qualified-name hierarchy.
+        shared = [f"b{i}" for i in range(9)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.min.first",
+                    "aaaa",
+                    [*shared, "x1"],
+                    path="proj/min.py",
+                    start_line=5,
+                    end_line=5,
+                ),
+                _row(
+                    "proj.min.second",
+                    "bbbb",
+                    [*shared, "x2"],
+                    path="proj/min.py",
+                    start_line=5,
+                    start_col=40,
+                    end_line=9,
+                ),
+                _row(
+                    "proj.min.third",
+                    "cccc",
+                    [*shared, "x3"],
+                    path="proj/tail.py",
+                    start_line=9,
+                    end_line=9,
+                ),
+                _row(
+                    "proj.min.fourth",
+                    "dddd",
+                    [*shared, "x4"],
+                    path="proj/tail.py",
+                    start_line=5,
+                    end_line=9,
+                ),
+            ]
+        )
+        groups = collect_duplicates(ingestor, "proj", _CONFIG)
+        # All four are mutually similar: ONE 4-clique. A wrongly dropped
+        # first-second (or third-fourth) edge would split it into two
+        # overlapping 3-cliques instead.
+        assert len(groups) == 1
+        assert {m["qualified_name"] for m in groups[0]["members"]} == {
+            "proj.min.first",
+            "proj.min.second",
+            "proj.min.third",
+            "proj.min.fourth",
+        }
+
     def test_exact_copies_are_not_rereported_as_similar(self) -> None:
         ingestor = FakeIngestor(
             [

--- a/codebase_rag/tests/test_duplicates_collect.py
+++ b/codebase_rag/tests/test_duplicates_collect.py
@@ -41,6 +41,7 @@ def _row(
     start_line: int = 1,
     start_col: int = 0,
     label: str = _FUNCTION,
+    end_line: int | None = None,
 ) -> ResultRow:
     return {
         "label": label,
@@ -49,7 +50,7 @@ def _row(
         "path": path if path is not None else f"proj/{qn.replace('.', '_')}.py",
         "start_line": start_line,
         "start_col": start_col,
-        "end_line": start_line + 9,
+        "end_line": end_line if end_line is not None else start_line + 9,
         "ast_fingerprint": fingerprint,
         "ast_fingerprint_nodes": nodes,
         "ast_branch_fingerprints": branches,
@@ -326,6 +327,77 @@ class TestSimilarGroups:
         exact, truncated = _maximal_cliques(adjacency, cap=8)
         assert len(exact) == 8
         assert truncated is False
+
+    def test_enclosing_function_is_not_similar_to_its_own_closure(self) -> None:
+        # A factory's body contains its nested function, so the outer branch
+        # set is a superset of the inner's and Jaccard clears any threshold.
+        # "This function duplicates its own body" is a false positive by
+        # construction: a nested pair must never form a similar group
+        # (create_query_tool vs its query_codebase_knowledge_graph closure).
+        shared = [f"b{i}" for i in range(9)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.m.factory",
+                    "aaaa",
+                    [*shared, "outer_extra"],
+                    path="proj/m.py",
+                    start_line=30,
+                    end_line=60,
+                ),
+                _row(
+                    "proj.m.factory.inner",
+                    "bbbb",
+                    shared,
+                    path="proj/m.py",
+                    start_line=38,
+                    end_line=58,
+                ),
+            ]
+        )
+        assert collect_duplicates(ingestor, "proj", _CONFIG) == []
+
+    def test_nested_pair_with_external_copy_still_groups(self) -> None:
+        # The nested-pair exemption is scoped to containment: when the
+        # closure's fingerprint ALSO matches a copy elsewhere, the entries
+        # are a real clone pair and the group must survive.
+        shared = [f"b{i}" for i in range(9)]
+        ingestor = FakeIngestor(
+            [
+                _row(
+                    "proj.m.factory",
+                    "aaaa",
+                    [*shared, "outer_extra"],
+                    path="proj/m.py",
+                    start_line=30,
+                    end_line=60,
+                ),
+                _row(
+                    "proj.m.factory.inner",
+                    "bbbb",
+                    shared,
+                    path="proj/m.py",
+                    start_line=38,
+                    end_line=58,
+                ),
+                _row(
+                    "proj.other.copy",
+                    "bbbb",
+                    shared,
+                    path="proj/other.py",
+                    start_line=5,
+                ),
+            ]
+        )
+        groups = collect_duplicates(ingestor, "proj", _CONFIG)
+        member_sets = [
+            {m["qualified_name"] for m in group["members"]} for group in groups
+        ]
+        # inner and its external copy share a fingerprint: one exact group.
+        assert {"proj.m.factory.inner", "proj.other.copy"} in member_sets
+        # factory vs the inner-fingerprint entry is a real cross-file clone
+        # relationship (factory vs proj.other.copy), so the edge survives.
+        assert any("proj.m.factory" in members for members in member_sets)
 
     def test_exact_copies_are_not_rereported_as_similar(self) -> None:
         ingestor = FakeIngestor(

--- a/codebase_rag/tests/test_duplicates_command.py
+++ b/codebase_rag/tests/test_duplicates_command.py
@@ -120,6 +120,35 @@ class TestDuplicatesCommand:
         assert result.exit_code == 0
         assert cs.CLI_DUPLICATES_NONE in result.output
 
+    def test_stale_graph_with_zero_fingerprints_recommends_reindex(
+        self, runner: CliRunner
+    ) -> None:
+        # A graph indexed before fingerprint stamping has symbols but zero
+        # fingerprints: "No duplicated functions found" plus the pattern-tier
+        # notice misdiagnoses it. The command must say the graph predates
+        # structural fingerprints and recommend a re-index.
+        mock_ingestor = _make_mock_ingestor(projects=["myproj"], rows=[], skipped=30190)
+        with patch("codebase_rag.cli.connect_memgraph", return_value=mock_ingestor):
+            result = runner.invoke(app, ["duplicates"])
+
+        assert result.exit_code == 0
+        assert "re-index" in result.output.lower()
+        assert cs.CLI_DUPLICATES_NONE not in result.output
+
+    def test_some_fingerprints_and_no_groups_still_reports_clean(
+        self, runner: CliRunner, clone_rows: list[ResultRow]
+    ) -> None:
+        # Symbols WERE analyzed and none duplicated: the clean message stays,
+        # with the ordinary skipped notice for the bodiless remainder.
+        lone = [dict(clone_rows[0], ast_fingerprint="one-of-a-kind")]
+        mock_ingestor = _make_mock_ingestor(projects=["myproj"], rows=lone, skipped=3)
+        with patch("codebase_rag.cli.connect_memgraph", return_value=mock_ingestor):
+            result = runner.invoke(app, ["duplicates"])
+
+        assert result.exit_code == 0
+        assert cs.CLI_DUPLICATES_NONE in result.output
+        assert "re-index" not in result.output.lower()
+
     def test_unknown_project_errors(self, runner: CliRunner) -> None:
         # `-n typo` must error, not scan a nonexistent prefix and report a
         # clean project.
@@ -129,6 +158,9 @@ class TestDuplicatesCommand:
 
         assert result.exit_code == 1
         assert "is not indexed" in result.output
+        # The user error must be raised AFTER the connection closes cleanly,
+        # or the service layer logs a spurious ERROR + traceback on exit.
+        assert mock_ingestor.__exit__.call_args[0][0] is None
 
     def test_no_projects_errors(self, runner: CliRunner) -> None:
         mock_ingestor = _make_mock_ingestor(projects=[], rows=[])

--- a/codebase_rag/tests/test_duplicates_eval.py
+++ b/codebase_rag/tests/test_duplicates_eval.py
@@ -1,0 +1,211 @@
+# Duplicates eval: the full parse -> graph -> duplicates pipeline runs over
+# controlled fixture repos whose clone pairs are known by construction. The
+# engine itself is unit-tested in test_duplicates_collect.py, so a fixture
+# mismatch here indicts fingerprint ingest or the eval's graph-to-rows
+# replay, not the grouping logic.
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.duplicates import default_duplicates_config
+from evals.duplicates import (
+    cgr_duplicates,
+    duplicate_pairs,
+    score_duplicates,
+)
+
+_CONFIG = default_duplicates_config()
+
+_LOOP_BODY_A = (
+    "def total_price(items, tax, floor):\n"
+    "    result = 0\n"
+    "    for item in items:\n"
+    "        if item.price > floor:\n"
+    "            result += item.price * tax\n"
+    "        else:\n"
+    "            result -= item.rebate\n"
+    "    return result\n"
+)
+
+# Same skeleton as _LOOP_BODY_A with every identifier renamed: a Type-2 clone.
+_LOOP_BODY_B = (
+    "def sum_weights(boxes, scale, cutoff):\n"
+    "    acc = 0\n"
+    "    for box in boxes:\n"
+    "        if box.weight > cutoff:\n"
+    "            acc += box.weight * scale\n"
+    "        else:\n"
+    "            acc -= box.slack\n"
+    "    return acc\n"
+)
+
+_UNRELATED = (
+    "def greet(name, punct):\n    upper = name.upper()\n    return upper + punct\n"
+)
+
+
+def _write_repo(root: Path, files: dict[str, str]) -> None:
+    root.mkdir(parents=True)
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    for filename, source in files.items():
+        (root / filename).write_text(source, encoding="utf-8")
+
+
+def test_cgr_duplicates_finds_renamed_copy(tmp_path: Path) -> None:
+    # A renamed copy across files is a Type-2 clone: one exact group holding
+    # both definitions, the structurally different function left out.
+    src = tmp_path / "proj"
+    _write_repo(
+        src,
+        {
+            "billing.py": _LOOP_BODY_A,
+            "shipping.py": _LOOP_BODY_B,
+            "other.py": _UNRELATED,
+        },
+    )
+    report = cgr_duplicates(src, "proj", _CONFIG)
+    assert len(report.groups) == 1
+    group = report.groups[0]
+    assert group["kind"] == cs.KIND_EXACT
+    assert {m["qualified_name"] for m in group["members"]} == {
+        "proj.billing.total_price",
+        "proj.shipping.sum_weights",
+    }
+
+
+def test_cgr_duplicates_groups_method_with_function_twin(tmp_path: Path) -> None:
+    # Only the body is fingerprinted, so a method copying a module function
+    # is the same clone (label-agnostic grouping).
+    src = tmp_path / "proj"
+    counter = (
+        "class Counter:\n"
+        + "\n".join("    " + line for line in _LOOP_BODY_A.splitlines())
+        + "\n"
+    )
+    _write_repo(src, {"billing.py": _LOOP_BODY_A, "counter.py": counter})
+    report = cgr_duplicates(src, "proj", _CONFIG)
+    assert len(report.groups) == 1
+    assert {m["label"] for m in report.groups[0]["members"]} == {
+        cs.NodeLabel.FUNCTION.value,
+        cs.NodeLabel.METHOD.value,
+    }
+
+
+def test_cgr_duplicates_ignores_small_functions(tmp_path: Path) -> None:
+    # Identical one-liners are below the default min-nodes floor: reporting
+    # every trivial getter pair is pure noise.
+    src = tmp_path / "proj"
+    _write_repo(
+        src,
+        {
+            "a.py": "def get_x(o):\n    return o.x\n",
+            "b.py": "def get_y(o):\n    return o.x\n",
+        },
+    )
+    report = cgr_duplicates(src, "proj", _CONFIG)
+    assert report.groups == []
+
+
+def test_cgr_duplicates_finds_edited_copy(tmp_path: Path) -> None:
+    # A copy with one statement swapped keeps >= 80% of its statement-level
+    # branches: a Type-3 clone reported as a similar group below 1.0. The
+    # shared statements must be structurally distinct (identifiers and
+    # literals normalize away), or they dedupe into one branch digest.
+    shared = [
+        "    a = compute(data.f, w[0]) + bias.get(0)",
+        "    b = compute(data.f) * w[1] - bias.get(1)",
+        "    c = [transform(x) for x in data.rows]",
+        "    d = {k: v for k, v in data.items()}",
+        "    e = helper(a, b, c) if a else other(d)",
+        "    f = data.name.strip().lower().split(',')",
+        "    g = (a, b, [c, d], {'k': e})",
+        "    h = sum(x * 2 for x in c) + len(d)",
+        "    log.info('m', extra={'a': a})",
+    ]
+    original = "def transform_rows(data, w, bias, log):\n"
+    original += "\n".join(shared) + "\n"
+    original += "    total = merge_all(a, b, c, d)\n"
+    original += "    return total\n"
+    edited = "def transform_cols(data, w, bias, log):\n"
+    edited += "\n".join(shared) + "\n"
+    edited += "    total = [combine(x) for x in c]\n"
+    edited += "    return total\n"
+    src = tmp_path / "proj"
+    _write_repo(src, {"orig.py": original, "edit.py": edited})
+    report = cgr_duplicates(src, "proj", _CONFIG)
+    similar = [g for g in report.groups if g["kind"] == cs.KIND_SIMILAR]
+    assert len(similar) == 1
+    assert {m["qualified_name"] for m in similar[0]["members"]} == {
+        "proj.orig.transform_rows",
+        "proj.edit.transform_cols",
+    }
+    assert 0.8 <= similar[0]["similarity"] < 1.0
+
+
+def test_cgr_duplicates_honours_exclude_patterns(tmp_path: Path) -> None:
+    # A generated twin excluded by glob may not leave a one-member "group".
+    src = tmp_path / "proj"
+    _write_repo(
+        src,
+        {"real.py": _LOOP_BODY_A, "gen_client.py": _LOOP_BODY_B},
+    )
+    config = default_duplicates_config(exclude_patterns=("*gen_*",))
+    report = cgr_duplicates(src, "proj", config)
+    assert report.groups == []
+
+
+def test_duplicate_pairs_expands_groups_to_member_pairs() -> None:
+    # Pair-level grading is the clone-detection standard: a trio group is
+    # three pairs, and pairs are order-normalized.
+    groups = [
+        {
+            "kind": cs.KIND_EXACT,
+            "similarity": 1.0,
+            "node_count": 20,
+            "members": [
+                {
+                    "label": "Function",
+                    "qualified_name": qn,
+                    "name": qn.rsplit(".", 1)[-1],
+                    "path": "p.py",
+                    "start_line": 1,
+                    "end_line": 9,
+                }
+                for qn in ("proj.c.three", "proj.a.one", "proj.b.two")
+            ],
+        }
+    ]
+    assert duplicate_pairs(groups) == {
+        ("proj.a.one", "proj.b.two"),
+        ("proj.a.one", "proj.c.three"),
+        ("proj.b.two", "proj.c.three"),
+    }
+
+
+def test_score_duplicates_prf() -> None:
+    cgr = {("a", "b"), ("a", "c")}
+    oracle = {("a", "b"), ("b", "d")}
+    result = score_duplicates(cgr, oracle)
+    row = result.rows[0]
+    assert (row["tp"], row["fp"], row["fn"]) == (1, 1, 1)
+    bucket = next(iter(result.diff.values()))
+    assert bucket["missing"] == ["b<->d"]
+    assert bucket["extra"] == ["a<->c"]
+
+
+def test_cgr_duplicates_end_to_end_scores_perfectly(tmp_path: Path) -> None:
+    # The graded loop: fixture oracle pairs vs the pipeline's reported pairs
+    # must agree exactly (precision = recall = 1.0).
+    src = tmp_path / "proj"
+    _write_repo(
+        src,
+        {
+            "billing.py": _LOOP_BODY_A,
+            "shipping.py": _LOOP_BODY_B,
+            "other.py": _UNRELATED,
+        },
+    )
+    report = cgr_duplicates(src, "proj", _CONFIG)
+    oracle = {("proj.billing.total_price", "proj.shipping.sum_weights")}
+    result = score_duplicates(duplicate_pairs(report.groups), oracle)
+    assert result.rows[0]["precision"] == 1.0
+    assert result.rows[0]["recall"] == 1.0

--- a/codebase_rag/tests/test_duplicates_eval.py
+++ b/codebase_rag/tests/test_duplicates_eval.py
@@ -141,6 +141,30 @@ def test_cgr_duplicates_finds_edited_copy(tmp_path: Path) -> None:
     assert 0.8 <= similar[0]["similarity"] < 1.0
 
 
+def test_cgr_duplicates_does_not_pair_factory_with_its_closure(tmp_path: Path) -> None:
+    # A factory function's body IS its nested closure plus a return: the
+    # outer branch set contains the inner's, so overlap scoring sees a
+    # near-perfect match. Reporting a function as a duplicate of its own
+    # closure is unactionable noise (the create_query_tool shape).
+    factory = (
+        "def create_tool(db, log):\n"
+        "    def run_query(query, limit):\n"
+        "        cleaned = query.strip().lower()\n"
+        "        rows = db.execute(cleaned, limit=limit)\n"
+        "        counted = [decorate(row) for row in rows]\n"
+        "        mapping = {row.key: row for row in counted}\n"
+        "        picked = mapping.get(cleaned) if mapping else None\n"
+        "        log.info('ran', extra={'q': cleaned})\n"
+        "        total = sum(row.cost * 2 for row in counted)\n"
+        "        return (picked, total, [rows, counted])\n"
+        "    return run_query\n"
+    )
+    src = tmp_path / "proj"
+    _write_repo(src, {"factory.py": factory})
+    report = cgr_duplicates(src, "proj", _CONFIG)
+    assert report.groups == []
+
+
 def test_cgr_duplicates_honours_exclude_patterns(tmp_path: Path) -> None:
     # A generated twin excluded by glob may not leave a one-member "group".
     src = tmp_path / "proj"

--- a/codebase_rag/tests/test_duplicates_ingest.py
+++ b/codebase_rag/tests/test_duplicates_ingest.py
@@ -145,3 +145,34 @@ def test_cpp_template_function_gets_a_fingerprint(
     assert original.get(cs.KEY_AST_FINGERPRINT) is not None
     assert original[cs.KEY_AST_FINGERPRINT] == renamed[cs.KEY_AST_FINGERPRINT]
     assert original[cs.KEY_AST_BRANCH_FINGERPRINTS]
+
+
+CSHARP_ARROW_A = """
+class PriceSheet {
+    decimal Total => items.Sum(i => i.Price * factor) + shipping.Base + Fees(items);
+}
+"""
+
+CSHARP_ARROW_B = """
+class WeightSheet {
+    decimal Load => boxes.Sum(b => b.Mass * scale) + pallet.Tare + Slack(boxes);
+}
+"""
+
+
+def test_csharp_expression_bodied_property_gets_a_fingerprint(
+    temp_repo: Path, mock_ingestor: _MockIngestor
+) -> None:
+    # A C# property_declaration NEVER has a `body` field: an expression-bodied
+    # property carries its logic in a plain arrow_expression_clause child, so
+    # every such property silently skipped clone detection (Humanizer: 2311
+    # skipped symbols, largely properties).
+    (temp_repo / "First.cs").write_text(CSHARP_ARROW_A)
+    (temp_repo / "Second.cs").write_text(CSHARP_ARROW_B)
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="c_sharp")
+
+    methods = _props_by_name(mock_ingestor, cs.NodeLabel.METHOD.value)
+    original = methods["Total"]
+    renamed = methods["Load"]
+    assert original.get(cs.KEY_AST_FINGERPRINT) is not None
+    assert original[cs.KEY_AST_FINGERPRINT] == renamed[cs.KEY_AST_FINGERPRINT]

--- a/codebase_rag/tests/test_duplicates_ingest.py
+++ b/codebase_rag/tests/test_duplicates_ingest.py
@@ -42,6 +42,31 @@ class Counter:
 """
 
 
+CPP_TEMPLATE_A = """
+template <typename T>
+const T& pick_first(const std::vector<T>& items, int fallback) {
+    for (const auto& item : items) {
+        if (item.weight > fallback) {
+            return item;
+        }
+    }
+    return items.front();
+}
+"""
+
+CPP_TEMPLATE_B = """
+template <typename V>
+const V& choose_lead(const std::vector<V>& boxes, int floor) {
+    for (const auto& box : boxes) {
+        if (box.weight > floor) {
+            return box;
+        }
+    }
+    return boxes.front();
+}
+"""
+
+
 def _props_by_name(
     mock_ingestor: _MockIngestor, label: str
 ) -> dict[str, dict[str, object]]:
@@ -101,3 +126,22 @@ def test_method_fingerprint_matches_the_module_function_twin(
         method_props[cs.KEY_AST_FINGERPRINT]
         == functions["total_price"][cs.KEY_AST_FINGERPRINT]
     )
+
+
+def test_cpp_template_function_gets_a_fingerprint(
+    temp_repo: Path, mock_ingestor: _MockIngestor
+) -> None:
+    # A C++ template function is registered on its template_declaration
+    # wrapper, which has no `body` field of its own - the body lives on the
+    # inner function_definition. Skipping it silently exempts every template
+    # function from clone detection (fmt: 1012 of its symbols).
+    (temp_repo / "first.cpp").write_text(CPP_TEMPLATE_A)
+    (temp_repo / "second.cpp").write_text(CPP_TEMPLATE_B)
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
+
+    functions = _props_by_name(mock_ingestor, cs.NodeLabel.FUNCTION.value)
+    original = functions["pick_first"]
+    renamed = functions["choose_lead"]
+    assert original.get(cs.KEY_AST_FINGERPRINT) is not None
+    assert original[cs.KEY_AST_FINGERPRINT] == renamed[cs.KEY_AST_FINGERPRINT]
+    assert original[cs.KEY_AST_BRANCH_FINGERPRINTS]

--- a/codebase_rag/tests/test_eval_capture_merge.py
+++ b/codebase_rag/tests/test_eval_capture_merge.py
@@ -1,0 +1,52 @@
+# The eval harness's in-memory ingestors stand in for the production graph
+# service, whose node writes are MERGE (n {qn}) SET n += props - additive.
+# Several passes deliberately emit PARTIAL rows for existing nodes (the Rust
+# external-trait-override flag is {qualified_name, overrides_external} only),
+# so a capture that replaces the whole property dict wipes path/span/
+# fingerprint off real definitions and corrupts every eval built on it
+# (dead-code loses path rules, duplicates counts the node as skipped).
+from codebase_rag import constants as cs
+from evals.cgr_graph import _CapturingIngestor, _StatefulIngestor
+
+_METHOD = cs.NodeLabel.METHOD.value
+_FULL = {
+    cs.KEY_QUALIFIED_NAME: "proj.error.Error.fmt",
+    cs.KEY_NAME: "fmt",
+    cs.KEY_PATH: "src/error.rs",
+    cs.KEY_START_LINE: 700,
+    cs.KEY_END_LINE: 710,
+    cs.KEY_AST_FINGERPRINT: "ffff",
+}
+_PARTIAL = {
+    cs.KEY_QUALIFIED_NAME: "proj.error.Error.fmt",
+    cs.KEY_OVERRIDES_EXTERNAL: True,
+}
+
+
+def test_capturing_ingestor_merges_partial_node_rows() -> None:
+    ingestor = _CapturingIngestor()
+    ingestor.ensure_node_batch(_METHOD, dict(_FULL))
+    ingestor.ensure_node_batch(_METHOD, dict(_PARTIAL))
+    props = ingestor.nodes[(_METHOD, "proj.error.Error.fmt")]
+    assert props[cs.KEY_PATH] == "src/error.rs"
+    assert props[cs.KEY_AST_FINGERPRINT] == "ffff"
+    assert props[cs.KEY_OVERRIDES_EXTERNAL] is True
+
+
+def test_capturing_ingestor_later_full_row_still_updates() -> None:
+    # += semantics overwrite keys present in the new row; only absent keys
+    # survive from the old one.
+    ingestor = _CapturingIngestor()
+    ingestor.ensure_node_batch(_METHOD, dict(_FULL))
+    updated = dict(_FULL, **{cs.KEY_END_LINE: 720})
+    ingestor.ensure_node_batch(_METHOD, updated)
+    assert ingestor.nodes[(_METHOD, "proj.error.Error.fmt")][cs.KEY_END_LINE] == 720
+
+
+def test_stateful_ingestor_merges_partial_node_rows() -> None:
+    ingestor = _StatefulIngestor()
+    ingestor.ensure_node_batch(_METHOD, dict(_FULL))
+    ingestor.ensure_node_batch(_METHOD, dict(_PARTIAL))
+    props = ingestor.nodes[(_METHOD, "proj.error.Error.fmt")]
+    assert props[cs.KEY_PATH] == "src/error.rs"
+    assert props[cs.KEY_OVERRIDES_EXTERNAL] is True

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -527,6 +527,11 @@ class DuplicatesReport(NamedTuple):
     # True when similar-group enumeration stopped at the configured cap:
     # qualifying groups may be missing and every consumer must say so.
     truncated: bool
+    # Fingerprint-bearing symbols the scan actually examined. Zero with a
+    # positive skipped count means the graph predates fingerprint stamping
+    # (indexed before the feature): "no duplicates" would be vacuous and the
+    # CLI recommends a re-index instead.
+    analyzed_symbols: int = 0
 
 
 class GraphQueryClient(Protocol):

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -130,4 +130,5 @@ The function- and class-defining AST node types captured per language (auto-gene
 - **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **Scala**: `class_definition`, `function_declaration`, `function_definition`, `object_definition`, `trait_definition`
+- **SQL (PostgreSQL)**: `create_function`
 <!-- /SECTION:language_mappings -->

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -25,6 +25,7 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 | TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
 | TypeScript | Fully Supported | .ts, .mts, .cts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
 | Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
+| SQL (PostgreSQL) | In Development | .sql | ✓ | - | ✓ | - | Stored functions (CREATE FUNCTION), schema-qualified names, invocations between routines. CREATE PROCEDURE and in-depth PL/pgSQL bodies await upstream grammar support: the published grammar parses plain SQL statements only |
 <!-- /SECTION:supported_languages -->
 
 ## Structural Support (ast-grep tier)

--- a/evals/README.md
+++ b/evals/README.md
@@ -352,6 +352,32 @@ corpus mode is informational only, because a real repo has no independent dead-c
 oracle (true reachability needs the very call graph under test). On `codebase_rag`
 it currently reports 4450 unreachable functions/methods (tests excluded).
 
+## Duplicates — structural clone detection over the captured graph
+
+cgr's `duplicates` command groups structural clones (exact/renamed copies by
+whole-skeleton fingerprint, edited copies by branch-overlap similarity). The
+engine reads fingerprint rows from the database, which the deterministic
+in-memory harness cannot query, so this eval replays the two duplicate Cypher
+fetches over the captured graph and runs the same engine on top.
+
+```bash
+uv run python -m evals.duplicates --target codebase_rag  # informational report
+uv run python -m evals.duplicates --target ../some-repo --threshold 0.7
+```
+
+Grading is pair-level (the clone-detection standard): every unordered member
+pair of every reported group, scored precision/recall against fixture repos
+whose clone pairs are known by construction. The engine is unit-tested on
+hand-built rows (`test_duplicates_collect.py`), so a fixture mismatch indicts
+fingerprint ingest or the graph capture, not the grouping. The graded eval is
+the fixture suite `codebase_rag/tests/test_duplicates_eval.py`; the CLI's
+corpus mode is informational only, because a real repo has no independent
+clone oracle. The corpus mode was dogfooded across ten repos in nine languages
+(flask, requests, express, zod, gin, anyhow, gson, fmt, monolog,
+plenary.nvim): every sampled exact group reproduces from raw source, reports
+are deterministic, pair sets shrink monotonically as the threshold rises, and
+the in-memory harness matches the live `cgr duplicates` CLI pair-for-pair.
+
 ## Cross-project — resolution across top-level packages (monorepo)
 
 Every other eval runs on a single top-level package (`codebase_rag`), so none

--- a/evals/README.md
+++ b/evals/README.md
@@ -372,9 +372,10 @@ hand-built rows (`test_duplicates_collect.py`), so a fixture mismatch indicts
 fingerprint ingest or the graph capture, not the grouping. The graded eval is
 the fixture suite `codebase_rag/tests/test_duplicates_eval.py`; the CLI's
 corpus mode is informational only, because a real repo has no independent
-clone oracle. The corpus mode was dogfooded across ten repos in nine languages
-(flask, requests, express, zod, gin, anyhow, gson, fmt, monolog,
-plenary.nvim): every sampled exact group reproduces from raw source, reports
+clone oracle. The corpus mode was dogfooded across fourteen repos in eleven
+languages (flask, requests, django, express, zod, gin, anyhow, gson, fmt,
+libuv, Humanizer, scopt, monolog, plenary.nvim): every sampled exact group
+reproduces from raw source, reports
 are deterministic, pair sets shrink monotonically as the threshold rises, and
 the in-memory harness matches the live `cgr duplicates` CLI pair-for-pair.
 

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -18,8 +18,13 @@ class _CapturingIngestor:
         self.rels: list[_RelTuple] = []
 
     def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        # Production writes are MERGE (n {qn}) SET n += props: additive. Some
+        # passes deliberately re-emit a node with a PARTIAL row (the Rust
+        # external-trait-override flag carries only qualified_name +
+        # overrides_external), so replacing the dict would wipe path/span/
+        # fingerprint off the already-captured definition.
         uid = properties[cs.NODE_UNIQUE_CONSTRAINTS[label]]
-        self.nodes[(str(label), uid)] = dict(properties)
+        self.nodes.setdefault((str(label), uid), {}).update(properties)
 
     def ensure_relationship_batch(
         self,
@@ -112,8 +117,10 @@ class _StatefulIngestor:
         self.edge_props: dict[_RelTuple, PropertyDict] = {}
 
     def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        # Same += merge semantics as _CapturingIngestor: partial re-emissions
+        # must never wipe the properties of an already-ingested node.
         uid = properties[cs.NODE_UNIQUE_CONSTRAINTS[label]]
-        self.nodes[(str(label), uid)] = dict(properties)
+        self.nodes.setdefault((str(label), uid), {}).update(properties)
 
     def ensure_relationship_batch(
         self,

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -632,6 +632,17 @@ DEAD_CODE_DIFF_PREFIX = "dead-code:"
 DEAD_CODE_LABEL = "dead-code"
 DEAD_CODE_TITLE = "cgr dead-code eval: reachability over the captured graph"
 
+# Duplicates eval: replay the duplicate-fingerprint Cypher fetches over the
+# captured graph and run codebase_rag.duplicates on top, grading reported
+# clone PAIRS against fixtures whose duplicates are known by construction.
+# The engine is unit-tested on hand-built rows, so a fixture mismatch points
+# at fingerprint ingest or the graph capture, not the grouping.
+DUPLICATES_DEFAULT_TARGET = "codebase_rag"
+DUPLICATES_REPORT_FILENAME = "duplicates_report.json"
+DUPLICATES_DIFF_PREFIX = "duplicates:"
+DUPLICATES_LABEL = "duplicate-pairs"
+DUPLICATES_PAIR_SEP = "<->"
+
 # Cross-project (monorepo) eval: does cgr resolve CALLS and IMPORTS across
 # top-level package boundaries? The single-package corpora the other evals use
 # never exercise this, yet monorepo RAG is cgr's headline. Graded on synthetic

--- a/evals/duplicates.py
+++ b/evals/duplicates.py
@@ -1,0 +1,195 @@
+# Duplicates eval. cgr's `duplicates` command groups structural clones via
+# the engine in codebase_rag.duplicates, which reads fingerprint rows from
+# the database. The in-memory harness cannot query a database, so a small
+# adapter replays the two duplicate Cypher fetches over the captured graph
+# and the same engine runs on top; graded fixtures know their clone pairs by
+# construction (codebase_rag/tests/test_duplicates_eval.py). The engine is
+# unit-tested, so a fixture mismatch indicts fingerprint ingest or the
+# capture, not the grouping.
+import json
+from itertools import combinations
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from loguru import logger
+
+from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
+from codebase_rag.duplicates import (
+    collect_duplicates_with_coverage,
+    default_duplicates_config,
+)
+from codebase_rag.types_defs import (
+    DuplicateGroup,
+    DuplicatesConfig,
+    DuplicatesReport,
+    PropertyDict,
+    PropertyValue,
+    ResultRow,
+)
+
+from . import constants as ec
+from . import logs as ls
+from .cgr_graph import _capture
+from .score import _prf
+from .types_defs import DiffBucket, LocationStats, ScoreResult, ScoreRow
+
+console_target = Path(ec.DUPLICATES_DEFAULT_TARGET)
+_EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
+_DUPLICATE_LABELS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value})
+_ROW_KEYS = (
+    cs.KEY_QUALIFIED_NAME,
+    cs.KEY_NAME,
+    cs.KEY_PATH,
+    cs.KEY_START_LINE,
+    cs.KEY_START_COL,
+    cs.KEY_END_LINE,
+    cs.KEY_AST_FINGERPRINT,
+    cs.KEY_AST_FINGERPRINT_NODES,
+    cs.KEY_AST_BRANCH_FINGERPRINTS,
+)
+
+
+class _GraphRows:
+    """Replays the duplicate Cypher fetches over a captured node map.
+
+    Mirrors CYPHER_DUPLICATE_FINGERPRINTS / CYPHER_DUPLICATE_SKIPPED_COUNT
+    exactly: Function|Method labels, qualified_name prefix match, split on
+    ast_fingerprint presence. Any other query is out of contract and returns
+    nothing, like the base capture ingestor.
+    """
+
+    def __init__(self, nodes: dict[tuple[str, PropertyValue], PropertyDict]) -> None:
+        self._nodes = nodes
+
+    def fetch_all(
+        self, query: str, params: dict[str, PropertyValue] | None = None
+    ) -> list[ResultRow]:
+        prefix = str((params or {}).get(cs.KEY_PROJECT_PREFIX) or "")
+        if query == cq.CYPHER_DUPLICATE_FINGERPRINTS:
+            return [
+                _row(label, props)
+                for (label, _uid), props in self._nodes.items()
+                if _in_scope(label, props, prefix)
+                and props.get(cs.KEY_AST_FINGERPRINT) is not None
+            ]
+        if query == cq.CYPHER_DUPLICATE_SKIPPED_COUNT:
+            skipped = sum(
+                1
+                for (label, _uid), props in self._nodes.items()
+                if _in_scope(label, props, prefix)
+                and props.get(cs.KEY_AST_FINGERPRINT) is None
+            )
+            return [{cs.KEY_SKIPPED: skipped}]
+        return []
+
+
+def _in_scope(label: str, props: PropertyDict, prefix: str) -> bool:
+    qualified_name = props.get(cs.KEY_QUALIFIED_NAME)
+    return label in _DUPLICATE_LABELS and str(qualified_name or "").startswith(prefix)
+
+
+def _row(label: str, props: PropertyDict) -> ResultRow:
+    row: ResultRow = {cs.KEY_LABEL: label}
+    for key in _ROW_KEYS:
+        row[key] = props.get(key)  # type: ignore[assignment]
+    return row
+
+
+def cgr_duplicates(
+    target: Path, project: str, config: DuplicatesConfig
+) -> DuplicatesReport:
+    ingestor = _capture(target, project)
+    return collect_duplicates_with_coverage(_GraphRows(ingestor.nodes), project, config)
+
+
+def duplicate_pairs(groups: list[DuplicateGroup]) -> set[tuple[str, str]]:
+    # Pair-level grading (the clone-detection standard): every unordered
+    # member pair of every group, order-normalized so set algebra works.
+    pairs: set[tuple[str, str]] = set()
+    for group in groups:
+        names = sorted({member[cs.KEY_QUALIFIED_NAME] for member in group["members"]})
+        pairs.update(combinations(names, 2))
+    return pairs
+
+
+def _pair_repr(pair: tuple[str, str]) -> str:
+    return ec.DUPLICATES_PAIR_SEP.join(pair)
+
+
+def score_duplicates(
+    cgr: set[tuple[str, str]], oracle: set[tuple[str, str]]
+) -> ScoreResult:
+    rows: list[ScoreRow] = []
+    diff: dict[str, DiffBucket] = {}
+    row = _prf(ec.Category.NODE.value, ec.DUPLICATES_LABEL, cgr, oracle)
+    if row is not None:
+        rows.append(row)
+        diff[ec.DUPLICATES_DIFF_PREFIX + ec.DUPLICATES_LABEL] = DiffBucket(
+            missing=sorted(_pair_repr(pair) for pair in oracle - cgr),
+            extra=sorted(_pair_repr(pair) for pair in cgr - oracle),
+        )
+    return ScoreResult(rows=rows, location=_EMPTY_LOCATION, diff=diff)
+
+
+def main(
+    target: Annotated[
+        Path, typer.Option(help="cgr source to report duplicates for.")
+    ] = console_target,
+    project_name: Annotated[
+        str, typer.Option(help="cgr project name; defaults to target dir name.")
+    ] = "",
+    threshold: Annotated[
+        float, typer.Option(help="Jaccard similarity threshold for edited copies.")
+    ] = cs.DUPLICATES_DEFAULT_THRESHOLD,
+    min_size: Annotated[
+        int, typer.Option(help="Minimum skeleton node count for a candidate.")
+    ] = cs.DUPLICATES_DEFAULT_MIN_NODES,
+    exact_only: Annotated[
+        bool, typer.Option(help="Skip similarity analysis; exact groups only.")
+    ] = False,
+    exclude: Annotated[
+        list[str] | None,
+        typer.Option(help="Glob(s) matched against a member's file path to exclude."),
+    ] = None,
+    out_dir: Annotated[
+        Path, typer.Option(help="Directory for the duplicates report json.")
+    ] = Path(ec.DEFAULT_OUT_DIR),
+) -> None:
+    # Corpus mode is informational: a real repo has no independent clone
+    # oracle, so it reports cgr's duplicate groups for inspection. The graded
+    # eval lives in the tests.
+    target = target.resolve()
+    project = project_name or target.name
+    logger.info(ls.DUPLICATES_TARGET.format(target=target, project=project))
+
+    config = default_duplicates_config(
+        threshold=threshold,
+        min_nodes=min_size,
+        exact_only=exact_only,
+        exclude_patterns=tuple(exclude or ()),
+    )
+    report = cgr_duplicates(target, project, config)
+    members = sum(len(group["members"]) for group in report.groups)
+    logger.success(
+        ls.DUPLICATES_DONE.format(
+            groups=len(report.groups),
+            members=members,
+            skipped=report.skipped_symbols,
+            truncated=report.truncated,
+        )
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        cs.KEY_DUPLICATE_GROUPS: report.groups,
+        cs.KEY_SKIPPED_SYMBOLS: report.skipped_symbols,
+        cs.KEY_TRUNCATED: report.truncated,
+    }
+    report_path = out_dir / ec.DUPLICATES_REPORT_FILENAME
+    report_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/evals/logs.py
+++ b/evals/logs.py
@@ -82,6 +82,11 @@ INSTANTIATION_ORACLE_DONE = "oracle constructor calls: {count}"
 INSTANTIATION_CGR_DONE = "cgr INSTANTIATES edges: {count}"
 DEAD_CODE_TARGET = "Dead-code eval over {target} (project={project})"
 DEAD_CODE_DONE = "cgr reports {count} unreachable functions/methods"
+DUPLICATES_TARGET = "Duplicates eval over {target} (project={project})"
+DUPLICATES_DONE = (
+    "cgr reports {groups} duplicate group(s) covering {members} definition(s)"
+    " ({skipped} skipped, truncated={truncated})"
+)
 GO_RETRIEVAL_ORACLE = "Running go/ast call oracle ({binary}) over {target}"
 GO_RETRIEVAL_ORACLE_DONE = "go/ast first-party call edges: {count}"
 GO_RETRIEVAL_CGR = "Building cgr Go CALLS edges for {target} (project={project})"


### PR DESCRIPTION
## What

Adds a graded eval for `cgr duplicates`, then dogfoods the engine extensively across 14 real repositories in 11 languages plus the live memgraph CLI, fixing every bug found. Closes #1398, closes #1399, closes #1400, closes #1401, closes #1402, closes #1405 (#1403 stays open as an enhancement).

### The eval (`evals/duplicates.py` + `codebase_rag/tests/test_duplicates_eval.py`)

Mirrors the dead-code eval design: an adapter replays the two duplicate Cypher fetches over the in-memory captured graph and runs the production engine on top. Grading is pair-level (the clone-detection standard) with precision/recall via the shared `_prf` scorer, on fixture repos whose clone pairs are known by construction: renamed copies (Type-2), method/function twins, edited copies above threshold (Type-3), min-size and exclude-glob filtering, and a factory-vs-closure fixture. Corpus mode (`python -m evals.duplicates --target <repo>`) writes the JSON report for dogfooding, with threshold/min-size/exact-only/exclude knobs.

### Bugs found by dogfooding, each fixed with a red/green test

1. **A function reported as a similar duplicate of its own nested closure** (#1398). The outer branch set is a superset of the inner's, so Jaccard clears any threshold; 16 pure false-positive groups on this repo, far more on callback-heavy JS/TS (express dropped 513 to 392 groups). Stage 2 now drops candidate edges whose every cross-member pair is span-nested, keeping the edge when the closure's fingerprint also matches a copy elsewhere.
2. **Eval capture ingestors wiped node properties on partial re-emission** (#1399). Production writes are `MERGE ... SET n += props`; the Rust external-trait-override pass re-emits `{qualified_name, overrides_external}` only, which the capture's dict replacement turned into a two-property stub (no path/span/fingerprint). Both in-memory ingestors now merge. On anyhow this restored 44 trait-impl methods (64 skipped down to 20) and surfaced two real clone groups.
3. **C++ template functions never fingerprinted** (#1400). `template_declaration` has no `body` field, so every template function silently skipped clone detection - 1012 symbols on fmt. `_resolve_body` now descends through wrapper definitions recursively; fmt goes to 379 skipped / 130 groups, all newly found groups verified against raw source.
4. **`cgr dead-code -n typo` reported a clean project; `cgr duplicates -n typo` logged an ERROR + traceback** (#1401). Dead-code gains the unknown-project guard duplicates already had, and both commands now raise user errors after the connection closes cleanly, so a typo no longer trips the service layer's exception logging.
5. **Stale pre-fingerprint graph reported "No duplicated functions found"** (#1402). `DuplicatesReport` now carries `analyzed_symbols`; when zero symbols were analyzed but some skipped, the CLI suppresses the vacuous clean message and tells the user to re-index.

6. **C# expression-bodied members never fingerprinted** (#1405). `property_declaration` has no `body` field; the `=> expr` logic lives in a plain `arrow_expression_clause` child. `_resolve_body` now falls back to expression-body children; Humanizer drops from 2311 to 1268 skipped symbols and gains 7 verified groups.

Also gitignores `.cgr-parser-fingerprint`, which scans drop into the repo root.

## Dogfood evidence

- Corpus scans over flask, requests, express, zod, gin, anyhow, gson, fmt, monolog, plenary.nvim, libuv, Humanizer, scopt, and django: zero crashes, zero structural issues (span sanity, no intra-group duplicate members, no group dupes, no nested-pair groups).
- 100+ sampled exact groups re-verified by re-parsing both spans from disk and comparing skeleton fingerprints: zero mismatches.
- Live-CLI parity: `cgr duplicates` against memgraph on requests produces the identical 57 clone pairs as the in-memory harness.
- Invariants: byte-identical reports across reruns; pair sets strictly monotone across thresholds 0.7/0.8/0.9; `--exact-only` output equals the full run's exact subset.
- Similar groups spot-checked in source across languages (flask blueprint-vs-app test twins, gin binding-test family, monolog handler constructors): genuine near-clones.

## Tests

Red/green TDD throughout; full suite green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added duplicate-code evaluation with configurable thresholds, exclusions, scoring, and JSON reports.
  - Added PostgreSQL stored-function coverage to the language support documentation.
  - Added fingerprint support for expression-bodied definitions and C++ templates.

- **Bug Fixes**
  - Improved duplicate detection by excluding nested self-pairs while retaining valid external matches.
  - Unknown or unindexed projects now produce clear errors.
  - Stale graphs now request re-indexing instead of reporting no duplicates.
  - Partial scan results now accurately reflect analysis status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->