### PR TITLE
refactor: reduce cognitive complexity of _similar_groups and _emit_duplicates below Sonar threshold

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -1528,6 +1528,68 @@ def _build_duplicates_table(groups: list[DuplicateGroup], project_name: str) -> 
     return table
 
 
+def _emit_duplicates_json(
+    groups: list[DuplicateGroup],
+    output: Path | None,
+    skipped_symbols: int,
+    truncated: bool,
+) -> None:
+    # Envelope, not a bare list: scan-completeness metadata must reach
+    # JSON consumers too, or a CI artifact reads as a complete scan when
+    # symbols went unanalyzed or group enumeration hit its cap.
+    payload = json.dumps(
+        {
+            cs.KEY_DUPLICATE_GROUPS: groups,
+            cs.KEY_SKIPPED_SYMBOLS: skipped_symbols,
+            cs.KEY_TRUNCATED: truncated,
+        },
+        indent=2,
+    )
+    if output is None:
+        typer.echo(payload)
+        return
+    output.write_text(payload, encoding=cs.ENCODING_UTF8)
+    _print_duplicates_written(len(groups), output)
+
+
+def _duplicates_notices(
+    skipped_symbols: int, truncated: bool, all_skipped: bool
+) -> list[str]:
+    # As with dead-code, the completeness notices follow the report into its
+    # sink so a saved artifact never reads as "all clean" when symbols went
+    # unanalyzed or group enumeration hit its cap.
+    notices = []
+    if all_skipped:
+        notices.append(cs.CLI_DUPLICATES_STALE_GRAPH.format(count=skipped_symbols))
+    elif skipped_symbols:
+        notices.append(
+            cs.CLI_DUPLICATES_STRUCTURAL_TIER_SKIPPED.format(count=skipped_symbols)
+        )
+    if truncated:
+        notices.append(cs.CLI_DUPLICATES_TRUNCATED_NOTICE)
+    return notices
+
+
+def _print_duplicates_written(count: int, output: Path) -> None:
+    app_context.console.print(
+        style(
+            cs.CLI_DUPLICATES_WRITTEN.format(count=count, path=output),
+            cs.Color.GREEN,
+        )
+    )
+
+
+def _write_duplicates_file(
+    table: Table, notices: list[str], group_count: int, output: Path
+) -> None:
+    with output.open("w", encoding=cs.ENCODING_UTF8) as fh:
+        file_console = Console(file=fh)
+        file_console.print(table)
+        for notice in notices:
+            file_console.print(notice)
+    _print_duplicates_written(group_count, output)
+
+
 def _emit_duplicates(
     groups: list[DuplicateGroup],
     output_format: cs.DuplicatesFormat,
@@ -1538,58 +1600,17 @@ def _emit_duplicates(
     analyzed_symbols: int = 0,
 ) -> None:
     if output_format == cs.DuplicatesFormat.JSON:
-        # Envelope, not a bare list: scan-completeness metadata must reach
-        # JSON consumers too, or a CI artifact reads as a complete scan when
-        # symbols went unanalyzed or group enumeration hit its cap.
-        payload = json.dumps(
-            {
-                cs.KEY_DUPLICATE_GROUPS: groups,
-                cs.KEY_SKIPPED_SYMBOLS: skipped_symbols,
-                cs.KEY_TRUNCATED: truncated,
-            },
-            indent=2,
-        )
-        if output is not None:
-            output.write_text(payload, encoding=cs.ENCODING_UTF8)
-            app_context.console.print(
-                style(
-                    cs.CLI_DUPLICATES_WRITTEN.format(count=len(groups), path=output),
-                    cs.Color.GREEN,
-                )
-            )
-            return
-        typer.echo(payload)
+        _emit_duplicates_json(groups, output, skipped_symbols, truncated)
         return
 
-    # As with dead-code, the completeness notices follow the report into its
-    # sink so a saved artifact never reads as "all clean" when symbols went
-    # unanalyzed or group enumeration hit its cap.
-    notices = []
     # Every symbol skipped and none analyzed: the graph was indexed before
     # fingerprint stamping, so "no duplicates" would be vacuous and the
     # pattern-tier wording a misdiagnosis - recommend a re-index instead.
     all_skipped = skipped_symbols > 0 and analyzed_symbols == 0
-    if all_skipped:
-        notices.append(cs.CLI_DUPLICATES_STALE_GRAPH.format(count=skipped_symbols))
-    elif skipped_symbols:
-        notices.append(
-            cs.CLI_DUPLICATES_STRUCTURAL_TIER_SKIPPED.format(count=skipped_symbols)
-        )
-    if truncated:
-        notices.append(cs.CLI_DUPLICATES_TRUNCATED_NOTICE)
+    notices = _duplicates_notices(skipped_symbols, truncated, all_skipped)
     table = _build_duplicates_table(groups, project_name)
     if output is not None:
-        with output.open("w", encoding=cs.ENCODING_UTF8) as fh:
-            file_console = Console(file=fh)
-            file_console.print(table)
-            for notice in notices:
-                file_console.print(notice)
-        app_context.console.print(
-            style(
-                cs.CLI_DUPLICATES_WRITTEN.format(count=len(groups), path=output),
-                cs.Color.GREEN,
-            )
-        )
+        _write_duplicates_file(table, notices, len(groups), output)
         for notice in notices:
             app_context.console.print(style(notice, cs.Color.YELLOW))
         return

--- a/codebase_rag/duplicates.py
+++ b/codebase_rag/duplicates.py
@@ -380,6 +380,64 @@ def _supplemental_cliques(
     return subcliques
 
 
+def _edge_qualifies(left: _Entry, right: _Entry, threshold: float) -> bool:
+    first, second = left.branches, right.branches
+    smaller, larger = min(len(first), len(second)), max(len(first), len(second))
+    # Necessary condition for Jaccard >= threshold: even a full subset
+    # overlap cannot exceed smaller/larger.
+    if larger == 0 or smaller / larger < threshold:
+        return False
+    if _jaccard(first, second) < threshold:
+        return False
+    return not _only_nested_members(left.members, right.members)
+
+
+def _threshold_adjacency(
+    order: list[_Entry], pairs: set[tuple[int, int]], threshold: float
+) -> dict[int, set[int]]:
+    adjacency: dict[int, set[int]] = {}
+    for left, right in pairs:
+        if not _edge_qualifies(order[left], order[right], threshold):
+            continue
+        adjacency.setdefault(left, set()).add(right)
+        adjacency.setdefault(right, set()).add(left)
+    return adjacency
+
+
+def _pruned_members(positions: list[int], order: list[_Entry]) -> list[DuplicateMember]:
+    return _drop_contained_members(
+        [member for position in positions for member in order[position].members]
+    )
+
+
+def _clique_emissions(
+    clique: list[int], order: list[_Entry]
+) -> list[tuple[list[int], list[DuplicateMember]]]:
+    members = _pruned_members(clique, order)
+    emissions = [(clique, members)]
+    emissions.extend(
+        (subclique, _pruned_members(subclique, order))
+        for subclique in _supplemental_cliques(clique, order, members)
+    )
+    return emissions
+
+
+def _similar_group(
+    positions: list[int], members: list[DuplicateMember], order: list[_Entry]
+) -> DuplicateGroup:
+    similarity = min(
+        _jaccard(order[left].branches, order[right].branches)
+        for at, left in enumerate(positions)
+        for right in positions[at + 1 :]
+    )
+    return DuplicateGroup(
+        kind=cs.KIND_SIMILAR,
+        similarity=round(similarity, 3),
+        node_count=max(order[position].node_count for position in positions),
+        members=_sorted_members(members),
+    )
+
+
 def _similar_groups(
     entries: dict[str, _Entry], config: DuplicatesConfig
 ) -> tuple[list[DuplicateGroup], bool]:
@@ -393,24 +451,10 @@ def _similar_groups(
     # A legitimately appears in {A, B} and in {A, C}.
     threshold, max_groups = config.threshold, config.max_similar_groups
     order = list(entries.values())
-    adjacency: dict[int, set[int]] = {}
     pairs, pairs_truncated = _candidate_pairs(
         order, threshold, config.max_candidate_pairs
     )
-    for left, right in pairs:
-        first, second = order[left].branches, order[right].branches
-        smaller, larger = min(len(first), len(second)), max(len(first), len(second))
-        # Necessary condition for Jaccard >= threshold: even a full subset
-        # overlap cannot exceed smaller/larger.
-        if larger == 0 or smaller / larger < threshold:
-            continue
-        if _jaccard(first, second) < threshold:
-            continue
-        if _only_nested_members(order[left].members, order[right].members):
-            continue
-        adjacency.setdefault(left, set()).add(right)
-        adjacency.setdefault(right, set()).add(left)
-
+    adjacency = _threshold_adjacency(order, pairs, threshold)
     cliques, cliques_truncated = _maximal_cliques(adjacency, max_groups)
     if cliques_truncated:
         logger.warning(ls.DUPLICATES_GROUPS_TRUNCATED.format(cap=max_groups))
@@ -418,45 +462,14 @@ def _similar_groups(
     groups: list[DuplicateGroup] = []
     seen_member_sets: set[frozenset[str]] = set()
     for clique in cliques:
-        members = _drop_contained_members(
-            [member for position in clique for member in order[position].members]
-        )
-        emit = [(clique, members)]
-        emit.extend(
-            (
-                subclique,
-                _drop_contained_members(
-                    [
-                        member
-                        for position in subclique
-                        for member in order[position].members
-                    ]
-                ),
-            )
-            for subclique in _supplemental_cliques(clique, order, members)
-        )
-        for group_positions, group_members in emit:
+        for group_positions, group_members in _clique_emissions(clique, order):
             if len(group_members) < 2:
                 continue
             key = frozenset(m[cs.KEY_QUALIFIED_NAME] for m in group_members)
             if key in seen_member_sets:
                 continue
             seen_member_sets.add(key)
-            similarity = min(
-                _jaccard(order[left].branches, order[right].branches)
-                for at, left in enumerate(group_positions)
-                for right in group_positions[at + 1 :]
-            )
-            groups.append(
-                DuplicateGroup(
-                    kind=cs.KIND_SIMILAR,
-                    similarity=round(similarity, 3),
-                    node_count=max(
-                        order[position].node_count for position in group_positions
-                    ),
-                    members=_sorted_members(group_members),
-                )
-            )
+            groups.append(_similar_group(group_positions, group_members, order))
     return groups, truncated
 
 


### PR DESCRIPTION
Fixes the two SonarCloud new issues (python:S3776) that PR #1404 introduced: _similar_groups in codebase_rag/duplicates.py (complexity 19) and _emit_duplicates in codebase_rag/cli.py (complexity 17). Pure refactor, no behavior change: edge qualification, threshold adjacency, clique emission construction, JSON emission, notice assembly, and file writing are extracted into focused helpers. All duplicates test suites pass unchanged; lint, format, and ty are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal organization of duplicate detection and duplicate report generation.
  * Preserved existing duplicate grouping, filtering, truncation, and completeness-notice behavior.
  * JSON and table reports continue to include the same information and output notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->