### PR TITLE
fix: warn about public compose ports when the stack is already running (#1380)

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -201,6 +201,9 @@ def _resolve_active_projects(projects: str | None, default_project: str) -> list
 def _maybe_start_stack() -> None:
     mgr = StackManager()
     if mgr.status().state == StackState.RUNNING:
+        # This early return bypasses ensure_running, so it needs its own
+        # public-port check for a stack that is already up (issue #1380).
+        mgr.warn_if_ports_are_public()
         return
     try:
         mgr.ensure_running()

--- a/codebase_rag/stack/cli.py
+++ b/codebase_rag/stack/cli.py
@@ -57,7 +57,11 @@ def down_cmd() -> None:
 
 @cli.command("status", help=ch.CMD_DAEMON_STATUS, short_help=ch.CMD_DAEMON_STATUS)
 def status_cmd() -> None:
-    _print_status(StackManager())
+    mgr = StackManager()
+    # Status is what a user runs against an already-up stack, the one case the
+    # start path's warning never covers (issue #1380).
+    mgr.warn_if_ports_are_public()
+    _print_status(mgr)
 
 
 @cli.command("restart", help=ch.CMD_DAEMON_RESTART, short_help=ch.CMD_DAEMON_RESTART)

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -22,8 +22,12 @@ def _publishes_on_all_interfaces(mapping: object) -> bool:
     even though it names a host.
     """
     if isinstance(mapping, dict):
+        # YAML parses `host_ip: null` (or a bare `host_ip:`) as None, which
+        # Compose treats exactly like an omitted host: publish everywhere.
         declared = [
-            str(value).strip() for key, value in mapping.items() if key == "host_ip"
+            "" if value is None else str(value).strip()
+            for key, value in mapping.items()
+            if key == "host_ip"
         ]
         return not declared or declared[0] in ("", "0.0.0.0", "::")
     if not isinstance(mapping, str):

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -111,7 +111,7 @@ class StackManager:
         """
         try:
             compose = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
-        except (OSError, yaml.YAMLError):
+        except (OSError, UnicodeDecodeError, yaml.YAMLError):
             return []
         if not isinstance(compose, dict):
             return []

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -118,7 +118,14 @@ class StackManager:
         for service, spec in services.items():
             if not isinstance(spec, dict):
                 continue
-            for mapping in spec.get("ports") or []:
+            # The file is user-owned, so `ports` can be any YAML value; a
+            # scalar (`ports: 8080`) is not a mapping list and iterating it
+            # would crash the start and status paths over a file Compose
+            # itself would reject.
+            ports = spec.get("ports")
+            if not isinstance(ports, list):
+                continue
+            for mapping in ports:
                 if _publishes_on_all_interfaces(mapping):
                     public.append(f"{service}: {mapping}")
         return public

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -142,6 +142,16 @@ class StackManager:
             )
         )
 
+    def warn_if_ports_are_public(self) -> None:
+        """Warn about public port bindings independently of the start path.
+
+        `ensure_compose_file` only runs when the stack is being started, so a
+        stack that is already up would keep its pre-#1012 exposure silent
+        (issue #1380). Callers that never render the file go through here.
+        """
+        if self.compose_file.exists():
+            self._warn_if_ports_are_public(self.compose_file)
+
     def check_docker(self) -> None:
         if shutil.which(cs.DOCKER_BIN) is None:
             raise StackError(cs.ERR_DOCKER_NOT_INSTALLED)
@@ -292,6 +302,10 @@ class StackManager:
         current = self.status()
         if current.state == cs.StackState.RUNNING:
             logger.info(cs.MSG_STACK_ALREADY_RUNNING)
+            # The start path warns via ensure_compose_file; a stack that is
+            # already up never reaches it, and its long-lived compose file is
+            # exactly the profile of a pre-#1012 public binding (issue #1380).
+            self.warn_if_ports_are_public()
             return current
         self.up()
         self.wait_healthy()

--- a/codebase_rag/tests/test_stack_loopback_bind.py
+++ b/codebase_rag/tests/test_stack_loopback_bind.py
@@ -170,6 +170,19 @@ class TestPublicPortWarning:
 
         assert self._warnings(manager) == []
 
+    def test_long_form_null_host_ip_warns(self, tmp_path: Path) -> None:
+        # YAML parses `host_ip: null` (or a bare `host_ip:`) as None, which
+        # Compose treats exactly like an omitted host: publish on every
+        # interface. Stringifying it to "None" made it look host-bound.
+        manager = self._manager(
+            tmp_path,
+            "services:\n  qdrant:\n    ports:\n"
+            "      - target: 6333\n        published: 6333\n"
+            "        host_ip: null\n",
+        )
+
+        assert any("ALL interfaces" in message for message in self._warnings(manager))
+
     def test_a_user_edited_file_is_not_clobbered(self, tmp_path: Path) -> None:
         rendered = 'services:\n  memgraph:\n    ports:\n      - "7687:7687"\n'
         manager = self._manager(tmp_path, rendered)

--- a/codebase_rag/tests/test_stack_manager.py
+++ b/codebase_rag/tests/test_stack_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import subprocess
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -357,11 +356,11 @@ class TestMaybeStartStackWarns:
     (#1380)."""
 
     @pytest.fixture
-    def _disable_stack_autostart(self) -> Generator[None, None, None]:
+    def _disable_stack_autostart(self) -> None:
         # Override the conftest autouse mock of `_maybe_start_stack`: this
         # class exercises the real function. Docker stays untouched because
         # the manager and health checks are patched in `_invoke`.
-        yield
+        return
 
     def _invoke(self, stack_home: Path, tmp_path: Path) -> list[str]:
         from codebase_rag.cli import _maybe_start_stack

--- a/codebase_rag/tests/test_stack_manager.py
+++ b/codebase_rag/tests/test_stack_manager.py
@@ -255,6 +255,14 @@ class TestMalformedPortsDeclarations:
     def test_valid_list_still_reports(self, stack_home: Path) -> None:
         assert self._mappings(stack_home, PUBLIC_COMPOSE) == ["memgraph: 7687:7687"]
 
+    def test_invalid_utf8_file_is_ignored(self, stack_home: Path) -> None:
+        # UnicodeDecodeError is a ValueError, not an OSError, so it escaped
+        # the unreadable-file handling and crashed `daemon status` and the
+        # already-running start path with a traceback.
+        target = stack_home / stack_cs.COMPOSE_FILENAME
+        target.write_bytes(b"services:\n  \xff\xfe broken\n")
+        assert StackManager._public_port_mappings(target) == []
+
 
 class TestAlreadyRunningStackWarns:
     """A stack that is already up must still warn about public ports (#1380).

--- a/codebase_rag/tests/test_stack_manager.py
+++ b/codebase_rag/tests/test_stack_manager.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from click.testing import CliRunner
+from loguru import logger
 
+from codebase_rag.stack import cli as stack_cli
 from codebase_rag.stack import constants as stack_cs
 from codebase_rag.stack.manager import StackError, StackManager
 
@@ -207,3 +210,111 @@ def test_up_propagates_failure(stack_home: Path, tmp_path: Path) -> None:
         with pytest.raises(StackError) as exc:
             mgr.up()
     assert "boom" in str(exc.value) or "Failed" in str(exc.value)
+
+
+PUBLIC_COMPOSE = 'services:\n  memgraph:\n    ports:\n      - "7687:7687"\n'
+LOOPBACK_COMPOSE = 'services:\n  memgraph:\n    ports:\n      - "127.0.0.1:7687:7687"\n'
+
+
+def _warnings_from(action: object) -> list[str]:
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="WARNING")
+    try:
+        action()  # type: ignore[operator]
+    finally:
+        logger.remove(sink_id)
+    return messages
+
+
+class TestAlreadyRunningStackWarns:
+    """A stack that is already up must still warn about public ports (#1380).
+
+    `ensure_running` returns before `up()` when the stack is healthy, so the
+    only warning path never ran for exactly the long-lived installs that still
+    carry a pre-#1012 compose file.
+    """
+
+    def _running_manager(self, stack_home: Path, tmp_path: Path) -> StackManager:
+        return StackManager(
+            home=stack_home, package_compose=_make_compose_source(tmp_path)
+        )
+
+    def test_warns_when_already_up_with_public_ports(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        (stack_home / stack_cs.COMPOSE_FILENAME).write_text(
+            PUBLIC_COMPOSE, encoding="utf-8"
+        )
+        mgr = self._running_manager(stack_home, tmp_path)
+        with (
+            patch("codebase_rag.stack.manager.wait_for_memgraph", return_value=True),
+            patch("codebase_rag.stack.manager.wait_for_qdrant", return_value=True),
+            patch.object(mgr, "up") as mock_up,
+        ):
+            messages = _warnings_from(mgr.ensure_running)
+        mock_up.assert_not_called()
+        assert any("ALL interfaces" in message for message in messages), messages
+
+    def test_quiet_when_already_up_with_loopback_ports(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        (stack_home / stack_cs.COMPOSE_FILENAME).write_text(
+            LOOPBACK_COMPOSE, encoding="utf-8"
+        )
+        mgr = self._running_manager(stack_home, tmp_path)
+        with (
+            patch("codebase_rag.stack.manager.wait_for_memgraph", return_value=True),
+            patch("codebase_rag.stack.manager.wait_for_qdrant", return_value=True),
+        ):
+            assert _warnings_from(mgr.ensure_running) == []
+
+    def test_quiet_when_already_up_without_compose_file(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        # A stack can be reachable while the file is absent (deleted by the
+        # user, or containers started by other means); there is nothing to
+        # inspect and nothing to warn about.
+        mgr = self._running_manager(stack_home, tmp_path)
+        with (
+            patch("codebase_rag.stack.manager.wait_for_memgraph", return_value=True),
+            patch("codebase_rag.stack.manager.wait_for_qdrant", return_value=True),
+        ):
+            assert _warnings_from(mgr.ensure_running) == []
+
+
+class TestDaemonStatusWarns:
+    """`cgr daemon status` is what a user runs against an already-up stack, so
+    it must surface the public-port exposure too (#1380)."""
+
+    def _invoke_status(self, stack_home: Path, tmp_path: Path) -> list[str]:
+        mgr = StackManager(
+            home=stack_home, package_compose=_make_compose_source(tmp_path)
+        )
+        with (
+            patch("codebase_rag.stack.cli.StackManager", return_value=mgr),
+            patch("codebase_rag.stack.manager.wait_for_memgraph", return_value=True),
+            patch("codebase_rag.stack.manager.wait_for_qdrant", return_value=True),
+        ):
+            return _warnings_from(lambda: CliRunner().invoke(stack_cli.status_cmd, []))
+
+    def test_status_reports_public_ports(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        (stack_home / stack_cs.COMPOSE_FILENAME).write_text(
+            PUBLIC_COMPOSE, encoding="utf-8"
+        )
+        messages = self._invoke_status(stack_home, tmp_path)
+        assert any("ALL interfaces" in message for message in messages), messages
+
+    def test_status_is_quiet_for_loopback_file(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        (stack_home / stack_cs.COMPOSE_FILENAME).write_text(
+            LOOPBACK_COMPOSE, encoding="utf-8"
+        )
+        assert self._invoke_status(stack_home, tmp_path) == []
+
+    def test_status_is_quiet_without_compose_file(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        assert self._invoke_status(stack_home, tmp_path) == []

--- a/codebase_rag/tests/test_stack_manager.py
+++ b/codebase_rag/tests/test_stack_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -226,6 +227,36 @@ def _warnings_from(action: object) -> list[str]:
     return messages
 
 
+class TestMalformedPortsDeclarations:
+    """A user-owned compose file can hold any YAML; the warning scan must not
+    crash the start or status paths over an invalid `ports` value."""
+
+    def _mappings(self, stack_home: Path, rendered: str) -> list[str]:
+        target = stack_home / stack_cs.COMPOSE_FILENAME
+        target.write_text(rendered, encoding="utf-8")
+        return StackManager._public_port_mappings(target)
+
+    def test_scalar_ports_value_is_ignored(self, stack_home: Path) -> None:
+        # `ports: 8080` parses as an int; iterating it raised TypeError and
+        # aborted `up()` and `daemon status` before any real work.
+        assert (
+            self._mappings(stack_home, "services:\n  memgraph:\n    ports: 8080\n")
+            == []
+        )
+
+    def test_string_ports_value_is_ignored(self, stack_home: Path) -> None:
+        # A bare string iterates per character, which is never a mapping list.
+        assert (
+            self._mappings(
+                stack_home, 'services:\n  memgraph:\n    ports: "8080:8080"\n'
+            )
+            == []
+        )
+
+    def test_valid_list_still_reports(self, stack_home: Path) -> None:
+        assert self._mappings(stack_home, PUBLIC_COMPOSE) == ["memgraph: 7687:7687"]
+
+
 class TestAlreadyRunningStackWarns:
     """A stack that is already up must still warn about public ports (#1380).
 
@@ -318,3 +349,46 @@ class TestDaemonStatusWarns:
         self, stack_home: Path, tmp_path: Path
     ) -> None:
         assert self._invoke_status(stack_home, tmp_path) == []
+
+
+class TestMaybeStartStackWarns:
+    """`_maybe_start_stack` in the main CLI short-circuits on a running stack
+    without going through `ensure_running`, so it needs its own warning call
+    (#1380)."""
+
+    @pytest.fixture
+    def _disable_stack_autostart(self) -> Generator[None, None, None]:
+        # Override the conftest autouse mock of `_maybe_start_stack`: this
+        # class exercises the real function. Docker stays untouched because
+        # the manager and health checks are patched in `_invoke`.
+        yield
+
+    def _invoke(self, stack_home: Path, tmp_path: Path) -> list[str]:
+        from codebase_rag.cli import _maybe_start_stack
+
+        mgr = StackManager(
+            home=stack_home, package_compose=_make_compose_source(tmp_path)
+        )
+        with (
+            patch("codebase_rag.cli.StackManager", return_value=mgr),
+            patch("codebase_rag.stack.manager.wait_for_memgraph", return_value=True),
+            patch("codebase_rag.stack.manager.wait_for_qdrant", return_value=True),
+        ):
+            return _warnings_from(_maybe_start_stack)
+
+    def test_warns_when_stack_already_running(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        (stack_home / stack_cs.COMPOSE_FILENAME).write_text(
+            PUBLIC_COMPOSE, encoding="utf-8"
+        )
+        messages = self._invoke(stack_home, tmp_path)
+        assert any("ALL interfaces" in message for message in messages), messages
+
+    def test_quiet_when_stack_already_running_with_loopback_file(
+        self, stack_home: Path, tmp_path: Path
+    ) -> None:
+        (stack_home / stack_cs.COMPOSE_FILENAME).write_text(
+            LOOPBACK_COMPOSE, encoding="utf-8"
+        )
+        assert self._invoke(stack_home, tmp_path) == []


### PR DESCRIPTION
## Summary

- Warn about a compose file that publishes unauthenticated services on every interface even when the stack is already running: `ensure_running`'s early-return branch, `_maybe_start_stack`'s own early return, and `cgr daemon status` now all check the file, so long-lived pre-#1012 installs finally hear about their exposure.
- Harden the warning scan itself: a non-list `ports` value (e.g. `ports: 8080`) no longer crashes the start and status paths, and a long-form mapping with `host_ip: null` is now correctly classified as an all-interfaces binding.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1380

## Test Plan

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added

All new behavior is covered red-first: warning fires for a public file when the stack is already up (manager, `daemon status`, and `_maybe_start_stack` paths), stays quiet for loopback and missing files, ignores scalar and string `ports` values, and reports a null long-form `host_ip` as public.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of services whose ports are exposed on all network interfaces, including configurations with an explicitly empty host address.
  * Added warnings when a running stack has publicly accessible ports, including during status checks and automatic startup.
  * Improved handling of invalid, unexpected, or unreadable port configuration formats.

* **Tests**
  * Added regression coverage for publicly exposed ports across stack startup and status workflows.
  * Added coverage for malformed and long-form Compose port configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->