### PR TITLE
fix: C# ref write-back sees through interface and abstract dispatch with a sole implementer (#1356)

### DIFF
--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -599,12 +599,15 @@ public static class Frontend
                 return null;
             }
             var hasDefaultBody = viaInterface && !method.IsAbstract;
+            // Deliberately NOT deduplicated by source location: a file linked
+            // into several projects (or a multi-targeted one) compiles once
+            // per compilation, and `#if` can give those variants different
+            // bodies at the same file and span. Every variant must reach the
+            // conjunction, or a writing variant could stand in for a
+            // read-only one; re-proving an identical body twice is merely
+            // redundant.
             var candidates = new List<IMethodSymbol>();
             var defaultInherited = false;
-            // A multi-targeted project compiles the same declaration once per
-            // framework, so implementations are identified by their source
-            // location, not by symbol identity across compilations.
-            var seen = new HashSet<(string, int)>();
             foreach (var type in AllSourceTypes(caller))
             {
                 IMethodSymbol? implementation;
@@ -641,12 +644,7 @@ public static class Frontend
                 {
                     continue;
                 }
-                if (implementation.DeclaringSyntaxReferences.FirstOrDefault()
-                    is not { } declared)
-                {
-                    continue;
-                }
-                if (!seen.Add((declared.SyntaxTree.FilePath, declared.Span.Start)))
+                if (implementation.DeclaringSyntaxReferences.Length == 0)
                 {
                     continue;
                 }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -740,18 +740,31 @@ public static class Frontend
             // Matched by the CONSTRUCTED interface, never the open definition:
             // a type implementing IGen<int> and IGen<string> with different
             // bodies answers only for the construction the call went through.
+            // An OPEN implementer (Reader<T> : IHelper<T>) is the exception:
+            // its interface instance still carries type parameters and can be
+            // constructed into any invocation, so it matches by definition;
+            // over-approximating an incompatible construction only adds a
+            // body to the conjunction, erring toward a missed edge.
             var target = invoked.ConstructedFrom;
             foreach (var iface in type.AllInterfaces)
             {
-                if (!SymbolEqualityComparer.Default.Equals(
-                        iface, invoked.ContainingType))
+                var open = ContainsTypeParameters(iface);
+                var matches = open
+                    ? SymbolEqualityComparer.Default.Equals(
+                        iface.OriginalDefinition,
+                        invoked.ContainingType.OriginalDefinition)
+                    : SymbolEqualityComparer.Default.Equals(
+                        iface, invoked.ContainingType);
+                if (!matches)
                 {
                     continue;
                 }
                 var member = iface.GetMembers(invoked.Name)
                     .OfType<IMethodSymbol>()
-                    .FirstOrDefault(m => SymbolEqualityComparer.Default.Equals(
-                        m, target));
+                    .FirstOrDefault(m => open
+                        ? SymbolEqualityComparer.Default.Equals(
+                            m.OriginalDefinition, target.OriginalDefinition)
+                        : SymbolEqualityComparer.Default.Equals(m, target));
                 if (member is not null
                     && type.FindImplementationForInterfaceMember(member)
                         is IMethodSymbol implementation)
@@ -760,6 +773,25 @@ public static class Frontend
                 }
             }
             return null;
+        }
+
+        private static bool ContainsTypeParameters(ITypeSymbol type)
+        {
+            if (type is ITypeParameterSymbol)
+            {
+                return true;
+            }
+            if (type is INamedTypeSymbol named)
+            {
+                foreach (var argument in named.TypeArguments)
+                {
+                    if (ContainsTypeParameters(argument))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         private static IMethodSymbol? OverrideOf(

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -751,9 +751,14 @@ public static class Frontend
             // over-approximating an incompatible construction only adds a
             // body to the conjunction, erring toward a missed edge.
             var target = invoked.ConstructedFrom;
+            // Open-ness on EITHER side widens the match: an open implementer
+            // serves every construction, and an open CALL SITE (inside
+            // generic code) can resolve to any construction, so closed
+            // implementations must join its conjunction too.
+            var openCallSite = ContainsTypeParameters(invoked.ContainingType);
             foreach (var iface in type.AllInterfaces)
             {
-                var open = ContainsTypeParameters(iface);
+                var open = openCallSite || ContainsTypeParameters(iface);
                 var matches = open
                     ? SymbolEqualityComparer.Default.Equals(
                         iface.OriginalDefinition,

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -485,6 +485,18 @@ public static class Frontend
             // originals, so comparing the two reports no write.
             var method = (reduced ?? invoked).OriginalDefinition;
             method = method.PartialImplementationPart ?? method;
+            // An interface or abstract member owns no body, so the proof has
+            // nothing to analyze and every dispatched `ref` write was silently
+            // dropped (issue #1356). With exactly ONE implementing method in
+            // the loaded compilations, that implementation IS the callee; the
+            // Go frontend applies the same sole-implementer policy to
+            // interface edges. Any other count stays unproven, so a read-only
+            // implementation can never be invented into a writer.
+            if (SoleDispatchTarget(model.Compilation, method) is { } implementation)
+            {
+                method = implementation.OriginalDefinition;
+                method = method.PartialImplementationPart ?? method;
+            }
             var ordinal = bound.Ordinal + (reduced is null ? 0 : 1);
             if (ordinal >= method.Parameters.Length)
             {
@@ -511,6 +523,134 @@ public static class Frontend
                 return false;
             }
             return flow.WrittenInside.Contains(parameter, SymbolEqualityComparer.Default);
+        }
+
+        private List<INamedTypeSymbol>? _sourceTypes;
+
+        // Every named type declared in the loaded compilations, memoized: the
+        // dispatch resolution below scans them all, and the set never changes
+        // within a run.
+        private IReadOnlyList<INamedTypeSymbol> AllSourceTypes(Compilation caller)
+        {
+            if (_sourceTypes is null)
+            {
+                var compilations = new HashSet<Compilation>(_treeOwners.Values) { caller };
+                var types = new List<INamedTypeSymbol>();
+                foreach (var compilation in compilations)
+                {
+                    CollectNamedTypes(compilation.Assembly.GlobalNamespace, types);
+                }
+                _sourceTypes = types;
+            }
+            return _sourceTypes;
+        }
+
+        private static void CollectNamedTypes(
+            INamespaceOrTypeSymbol container, List<INamedTypeSymbol> into)
+        {
+            foreach (var member in container.GetMembers())
+            {
+                if (member is INamespaceSymbol ns)
+                {
+                    CollectNamedTypes(ns, into);
+                }
+                else if (member is INamedTypeSymbol named)
+                {
+                    into.Add(named);
+                    CollectNamedTypes(named, into);
+                }
+            }
+        }
+
+        // The single method a dispatched call can land on, or null: null when
+        // the invoked member already owns a body (nothing to resolve), and
+        // null when zero or several implementations exist (not statically
+        // known, so the write stays unproven rather than guessed).
+        private IMethodSymbol? SoleDispatchTarget(Compilation caller, IMethodSymbol method)
+        {
+            var viaInterface = method.ContainingType.TypeKind == TypeKind.Interface;
+            if (!viaInterface && !method.IsAbstract)
+            {
+                return null;
+            }
+            IMethodSymbol? sole = null;
+            // A multi-targeted project compiles the same declaration once per
+            // framework, so implementations are identified by their source
+            // location, not by symbol identity across compilations.
+            var seen = new HashSet<(string, int)>();
+            foreach (var type in AllSourceTypes(caller))
+            {
+                var implementation = viaInterface
+                    ? InterfaceImplementation(type, method)
+                    : OverrideOf(type, method);
+                if (implementation is null || implementation.IsAbstract)
+                {
+                    continue;
+                }
+                if (implementation.DeclaringSyntaxReferences.FirstOrDefault()
+                    is not { } declared)
+                {
+                    continue;
+                }
+                if (!seen.Add((declared.SyntaxTree.FilePath, declared.Span.Start)))
+                {
+                    continue;
+                }
+                if (sole is not null)
+                {
+                    return null;
+                }
+                sole = implementation;
+            }
+            return sole;
+        }
+
+        private static IMethodSymbol? InterfaceImplementation(
+            INamedTypeSymbol type, IMethodSymbol method)
+        {
+            foreach (var iface in type.AllInterfaces)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(
+                        iface.OriginalDefinition, method.ContainingType))
+                {
+                    continue;
+                }
+                var member = iface.GetMembers(method.Name)
+                    .OfType<IMethodSymbol>()
+                    .FirstOrDefault(m => SymbolEqualityComparer.Default.Equals(
+                        m.OriginalDefinition, method));
+                // Only where the implementation is DECLARED: a derived type
+                // inherits its base's implementation, and counting it again
+                // there would make a genuinely sole writer look ambiguous.
+                if (member is not null
+                    && type.FindImplementationForInterfaceMember(member)
+                        is IMethodSymbol implementation
+                    && SymbolEqualityComparer.Default.Equals(
+                        implementation.ContainingType, type))
+                {
+                    return implementation;
+                }
+            }
+            return null;
+        }
+
+        private static IMethodSymbol? OverrideOf(
+            INamedTypeSymbol type, IMethodSymbol method)
+        {
+            foreach (var candidate in type.GetMembers(method.Name).OfType<IMethodSymbol>())
+            {
+                for (var overridden = candidate.OverriddenMethod;
+                     overridden is not null;
+                     overridden = overridden.OverriddenMethod)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(
+                            overridden.OriginalDefinition, method))
+                    {
+                        return candidate;
+                    }
+                }
+            }
+            return null;
         }
 
         // A NAMED argument (`Fill(dst: ref sink, src: token)`) does not sit at

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -604,6 +604,15 @@ public static class Frontend
                 while (pending.Count > 0)
                 {
                     var assembly = pending.Dequeue();
+                    var inSource = assembly.Locations.Any(location => location.IsInSource);
+                    // A MISSING assembly symbol (unresolved reference) owns no
+                    // types and no module references; it must not consume the
+                    // identity, or a RESOLVED symbol for the same assembly
+                    // seen through another project would be skipped.
+                    if (!inSource && assembly.GetMetadata() is null)
+                    {
+                        continue;
+                    }
                     if (!seenAssemblies.Add(assembly.Identity.GetDisplayName()))
                     {
                         continue;
@@ -615,7 +624,7 @@ public static class Frontend
                             pending.Enqueue(referenced);
                         }
                     }
-                    if (assembly.Locations.Any(location => location.IsInSource))
+                    if (inSource)
                     {
                         continue;
                     }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -485,19 +485,29 @@ public static class Frontend
             // originals, so comparing the two reports no write.
             var method = (reduced ?? invoked).OriginalDefinition;
             method = method.PartialImplementationPart ?? method;
-            // An interface or abstract member owns no body, so the proof has
-            // nothing to analyze and every dispatched `ref` write was silently
-            // dropped (issue #1356). With exactly ONE implementing method in
-            // the loaded compilations, that implementation IS the callee; the
-            // Go frontend applies the same sole-implementer policy to
-            // interface edges. Any other count stays unproven, so a read-only
-            // implementation can never be invented into a writer.
-            if (SoleDispatchTarget(model.Compilation, method) is { } implementation)
-            {
-                method = implementation.OriginalDefinition;
-                method = method.PartialImplementationPart ?? method;
-            }
             var ordinal = bound.Ordinal + (reduced is null ? 0 : 1);
+            // A dispatched member does not name its own body: an interface or
+            // abstract member owns none, and a DEFAULT interface body runs
+            // only for implementers that do not override it (issue #1356).
+            // The write is proven exactly when EVERY body the call can land
+            // on writes the parameter; whichever implementation actually runs
+            // then writes, so no flow is ever fabricated, and a read-only
+            // candidate anywhere keeps the write unproven.
+            if (DispatchCandidates(model.Compilation, method) is { } candidates)
+            {
+                return candidates.Count > 0
+                    && candidates.All(
+                        candidate => ProvenWritten(model.Compilation, candidate, ordinal));
+            }
+            return ProvenWritten(model.Compilation, method, ordinal);
+        }
+
+        // The body-level half of the proof: does THIS method's body assign the
+        // parameter at the given ordinal?
+        private bool ProvenWritten(Compilation caller, IMethodSymbol method, int ordinal)
+        {
+            method = method.OriginalDefinition;
+            method = method.PartialImplementationPart ?? method;
             if (ordinal >= method.Parameters.Length)
             {
                 return false;
@@ -513,7 +523,7 @@ public static class Frontend
             // owner index covers every loaded project, so a cross-project callee
             // is now provable instead of silently treated as read-only. A tree
             // from outside the solution has no owner and stays unprovable.
-            if (ResolveOwner(model.Compilation, body.SyntaxTree) is not { } owner)
+            if (ResolveOwner(caller, body.SyntaxTree) is not { } owner)
             {
                 return false;
             }
@@ -562,33 +572,60 @@ public static class Frontend
             }
         }
 
-        // The single method a dispatched call can land on, or null: null when
-        // the invoked member already owns a body (nothing to resolve), and
-        // null when zero or several implementations exist (not statically
-        // known, so the write stays unproven rather than guessed).
-        private IMethodSymbol? SoleDispatchTarget(Compilation caller, IMethodSymbol method)
+        // Every body a dispatched call can land on, or null when the invoked
+        // member is not dispatched at all (an ordinary member analyses its own
+        // body directly). For an interface or abstract member the candidates
+        // are the declared implementations; a DEFAULT interface body is a
+        // candidate too, but only while some implementer actually inherits it
+        // (or nothing overrides it), because a default every implementer
+        // overrides can never execute and must not mask the overrides.
+        private IReadOnlyList<IMethodSymbol>? DispatchCandidates(
+            Compilation caller, IMethodSymbol method)
         {
-            // Abstract members only: a DEFAULT interface method owns a body
-            // and can be the member a call actually lands on (any implementer
-            // that does not override it inherits it), so resolving a sole
-            // override there would attribute the write to a body the call
-            // never reaches. Classic interface members are abstract, so they
-            // still resolve.
-            if (!method.IsAbstract)
+            var viaInterface = method.ContainingType.TypeKind == TypeKind.Interface;
+            if (!viaInterface && !method.IsAbstract)
             {
                 return null;
             }
-            var viaInterface = method.ContainingType.TypeKind == TypeKind.Interface;
-            IMethodSymbol? sole = null;
+            var hasDefaultBody = viaInterface && !method.IsAbstract;
+            var candidates = new List<IMethodSymbol>();
+            var defaultInherited = false;
             // A multi-targeted project compiles the same declaration once per
             // framework, so implementations are identified by their source
             // location, not by symbol identity across compilations.
             var seen = new HashSet<(string, int)>();
             foreach (var type in AllSourceTypes(caller))
             {
-                var implementation = viaInterface
-                    ? InterfaceImplementation(type, method)
-                    : OverrideOf(type, method);
+                IMethodSymbol? implementation;
+                if (viaInterface)
+                {
+                    implementation = InterfaceImplementation(type, method);
+                    if (implementation is null)
+                    {
+                        continue;
+                    }
+                    // The interface's own member answering for the type means
+                    // the type INHERITS the default body: that body is live.
+                    if (SymbolEqualityComparer.Default.Equals(
+                            implementation.OriginalDefinition.ContainingType,
+                            method.ContainingType))
+                    {
+                        defaultInherited = true;
+                        continue;
+                    }
+                    // Only where the implementation is DECLARED: a derived
+                    // type inherits its base's implementation, which is
+                    // already counted at the base.
+                    if (!SymbolEqualityComparer.Default.Equals(
+                            implementation.ContainingType, type))
+                    {
+                        continue;
+                    }
+                }
+                else
+                {
+                    implementation = OverrideOf(type, method);
+                }
                 if (implementation is null || implementation.IsAbstract)
                 {
                     continue;
@@ -602,13 +639,13 @@ public static class Frontend
                 {
                     continue;
                 }
-                if (sole is not null)
-                {
-                    return null;
-                }
-                sole = implementation;
+                candidates.Add(implementation);
             }
-            return sole;
+            if (hasDefaultBody && (defaultInherited || candidates.Count == 0))
+            {
+                candidates.Add(method);
+            }
+            return candidates;
         }
 
         private static IMethodSymbol? InterfaceImplementation(
@@ -625,14 +662,9 @@ public static class Frontend
                     .OfType<IMethodSymbol>()
                     .FirstOrDefault(m => SymbolEqualityComparer.Default.Equals(
                         m.OriginalDefinition, method));
-                // Only where the implementation is DECLARED: a derived type
-                // inherits its base's implementation, and counting it again
-                // there would make a genuinely sole writer look ambiguous.
                 if (member is not null
                     && type.FindImplementationForInterfaceMember(member)
-                        is IMethodSymbol implementation
-                    && SymbolEqualityComparer.Default.Equals(
-                        implementation.ContainingType, type))
+                        is IMethodSymbol implementation)
                 {
                     return implementation;
                 }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -589,21 +589,37 @@ public static class Frontend
                 var compilations = new HashSet<Compilation>(_treeOwners.Values) { caller };
                 var seenAssemblies = new HashSet<string>(StringComparer.Ordinal);
                 var types = new List<INamedTypeSymbol>();
+                // The full closure, not just direct references: a plugin can
+                // arrive only through another assembly's dependency list and
+                // still implement a unified source contract.
+                var pending = new Queue<IAssemblySymbol>();
                 foreach (var compilation in compilations)
                 {
                     foreach (var assembly
                         in compilation.SourceModule.ReferencedAssemblySymbols)
                     {
-                        if (assembly.Locations.Any(location => location.IsInSource))
-                        {
-                            continue;
-                        }
-                        if (!seenAssemblies.Add(assembly.Identity.GetDisplayName()))
-                        {
-                            continue;
-                        }
-                        CollectNamedTypes(assembly.GlobalNamespace, types);
+                        pending.Enqueue(assembly);
                     }
+                }
+                while (pending.Count > 0)
+                {
+                    var assembly = pending.Dequeue();
+                    if (!seenAssemblies.Add(assembly.Identity.GetDisplayName()))
+                    {
+                        continue;
+                    }
+                    foreach (var module in assembly.Modules)
+                    {
+                        foreach (var referenced in module.ReferencedAssemblySymbols)
+                        {
+                            pending.Enqueue(referenced);
+                        }
+                    }
+                    if (assembly.Locations.Any(location => location.IsInSource))
+                    {
+                        continue;
+                    }
+                    CollectNamedTypes(assembly.GlobalNamespace, types);
                 }
                 _referencedTypes = types;
             }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -613,7 +613,13 @@ public static class Frontend
                     {
                         continue;
                     }
-                    if (!seenAssemblies.Add(assembly.Identity.GetDisplayName()))
+                    // Keyed by origin as well as identity: a source assembly
+                    // and a resolved metadata assembly can share an identity
+                    // (a stale build of the same project), and one must never
+                    // suppress the other's walk.
+                    var seenKey = (inSource ? "source:" : "metadata:")
+                        + assembly.Identity.GetDisplayName();
+                    if (!seenAssemblies.Add(seenKey))
                     {
                         continue;
                     }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -680,44 +680,49 @@ public static class Frontend
             var defaultInherited = false;
             foreach (var type in AllSourceTypes(caller).Concat(ReferencedTypes(caller)))
             {
-                IMethodSymbol? implementation;
                 if (viaInterface)
                 {
-                    implementation = InterfaceImplementation(type, invoked);
-                    if (implementation is null)
+                    // EVERY matching interface instance contributes: an open
+                    // implementer can also carry an explicit implementation
+                    // for one construction, and the body actually reached
+                    // depends on the runtime type arguments.
+                    foreach (var implementation
+                        in InterfaceImplementations(type, invoked))
                     {
-                        continue;
+                        // The interface's own member answering for the type
+                        // means the type INHERITS the default body: that body
+                        // is live.
+                        if (SymbolEqualityComparer.Default.Equals(
+                                implementation.OriginalDefinition.ContainingType,
+                                method.ContainingType))
+                        {
+                            defaultInherited = true;
+                            continue;
+                        }
+                        // Only where the implementation is DECLARED: a derived
+                        // type inherits its base's implementation, which is
+                        // already counted at the base.
+                        if (!SymbolEqualityComparer.Default.Equals(
+                                implementation.ContainingType, type))
+                        {
+                            continue;
+                        }
+                        if (implementation.IsAbstract)
+                        {
+                            continue;
+                        }
+                        // A bodiless (metadata) implementation stays IN the
+                        // list: it fails the body proof, which is exactly
+                        // right, because a runtime receiver from metadata
+                        // cannot be shown to write.
+                        candidates.Add(implementation);
                     }
-                    // The interface's own member answering for the type means
-                    // the type INHERITS the default body: that body is live.
-                    if (SymbolEqualityComparer.Default.Equals(
-                            implementation.OriginalDefinition.ContainingType,
-                            method.ContainingType))
-                    {
-                        defaultInherited = true;
-                        continue;
-                    }
-                    // Only where the implementation is DECLARED: a derived
-                    // type inherits its base's implementation, which is
-                    // already counted at the base.
-                    if (!SymbolEqualityComparer.Default.Equals(
-                            implementation.ContainingType, type))
-                    {
-                        continue;
-                    }
-                }
-                else
-                {
-                    implementation = OverrideOf(type, method);
-                }
-                if (implementation is null || implementation.IsAbstract)
-                {
                     continue;
                 }
-                // A bodiless (metadata) implementation stays IN the list: it
-                // fails the body proof, which is exactly right, because a
-                // runtime receiver from metadata cannot be shown to write.
-                candidates.Add(implementation);
+                if (OverrideOf(type, method) is { IsAbstract: false } overriding)
+                {
+                    candidates.Add(overriding);
+                }
             }
             if (hasDefaultBody && (defaultInherited || candidates.Count == 0))
             {
@@ -734,7 +739,7 @@ public static class Frontend
             return candidates;
         }
 
-        private static IMethodSymbol? InterfaceImplementation(
+        private static IEnumerable<IMethodSymbol> InterfaceImplementations(
             INamedTypeSymbol type, IMethodSymbol invoked)
         {
             // Matched by the CONSTRUCTED interface, never the open definition:
@@ -769,10 +774,9 @@ public static class Frontend
                     && type.FindImplementationForInterfaceMember(member)
                         is IMethodSymbol implementation)
                 {
-                    return implementation;
+                    yield return implementation;
                 }
             }
-            return null;
         }
 
         private static bool ContainsTypeParameters(ITypeSymbol type)

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -492,8 +492,11 @@ public static class Frontend
             // The write is proven exactly when EVERY body the call can land
             // on writes the parameter; whichever implementation actually runs
             // then writes, so no flow is ever fabricated, and a read-only
-            // candidate anywhere keeps the write unproven.
-            if (DispatchCandidates(model.Compilation, method) is { } candidates)
+            // candidate anywhere keeps the write unproven. Dispatch works on
+            // the CONSTRUCTED symbol: a type can implement several
+            // constructions of one generic interface with different bodies,
+            // and only the invoked construction's implementation may answer.
+            if (DispatchCandidates(model.Compilation, reduced ?? invoked) is { } candidates)
             {
                 return candidates.Count > 0
                     && candidates.All(
@@ -572,6 +575,41 @@ public static class Frontend
             }
         }
 
+        private List<INamedTypeSymbol>? _referencedTypes;
+
+        // Every named type in the referenced (metadata) assemblies, memoized.
+        // A plugin compiled against an identical-identity assembly unifies
+        // with the source compilation, so a metadata type CAN implement a
+        // source-declared contract; it owns no analyzable body, and finding
+        // it must poison the write proof rather than stay invisible.
+        private IReadOnlyList<INamedTypeSymbol> ReferencedTypes(Compilation caller)
+        {
+            if (_referencedTypes is null)
+            {
+                var compilations = new HashSet<Compilation>(_treeOwners.Values) { caller };
+                var seenAssemblies = new HashSet<string>(StringComparer.Ordinal);
+                var types = new List<INamedTypeSymbol>();
+                foreach (var compilation in compilations)
+                {
+                    foreach (var assembly
+                        in compilation.SourceModule.ReferencedAssemblySymbols)
+                    {
+                        if (assembly.Locations.Any(location => location.IsInSource))
+                        {
+                            continue;
+                        }
+                        if (!seenAssemblies.Add(assembly.Identity.GetDisplayName()))
+                        {
+                            continue;
+                        }
+                        CollectNamedTypes(assembly.GlobalNamespace, types);
+                    }
+                }
+                _referencedTypes = types;
+            }
+            return _referencedTypes;
+        }
+
         // Every body a dispatched call can land on, or null when the invoked
         // member is not dispatched at all (an ordinary member analyses its own
         // body directly). For an interface or abstract member the candidates
@@ -580,10 +618,12 @@ public static class Frontend
         // (or nothing overrides it), because a default every implementer
         // overrides can never execute and must not mask the overrides.
         private IReadOnlyList<IMethodSymbol>? DispatchCandidates(
-            Compilation caller, IMethodSymbol method)
+            Compilation caller, IMethodSymbol invoked)
         {
+            var method = invoked.OriginalDefinition;
             var viaInterface = method.ContainingType.TypeKind == TypeKind.Interface;
-            if (!viaInterface && !method.IsAbstract)
+            if (!viaInterface && !method.IsAbstract
+                && !method.IsVirtual && !method.IsOverride)
             {
                 return null;
             }
@@ -593,8 +633,7 @@ public static class Frontend
             // have implementers in other referenced assemblies that a source
             // scan cannot see, and proving a write from the visible subset
             // could fabricate a flow for a runtime receiver from metadata.
-            if (!method.ContainingType.OriginalDefinition.Locations
-                    .Any(location => location.IsInSource))
+            if (!method.ContainingType.Locations.Any(location => location.IsInSource))
             {
                 return null;
             }
@@ -608,12 +647,12 @@ public static class Frontend
             // redundant.
             var candidates = new List<IMethodSymbol>();
             var defaultInherited = false;
-            foreach (var type in AllSourceTypes(caller))
+            foreach (var type in AllSourceTypes(caller).Concat(ReferencedTypes(caller)))
             {
                 IMethodSymbol? implementation;
                 if (viaInterface)
                 {
-                    implementation = InterfaceImplementation(type, method);
+                    implementation = InterfaceImplementation(type, invoked);
                     if (implementation is null)
                     {
                         continue;
@@ -644,13 +683,20 @@ public static class Frontend
                 {
                     continue;
                 }
-                if (implementation.DeclaringSyntaxReferences.Length == 0)
-                {
-                    continue;
-                }
+                // A bodiless (metadata) implementation stays IN the list: it
+                // fails the body proof, which is exactly right, because a
+                // runtime receiver from metadata cannot be shown to write.
                 candidates.Add(implementation);
             }
             if (hasDefaultBody && (defaultInherited || candidates.Count == 0))
+            {
+                candidates.Add(method);
+            }
+            // A virtual (or overridable override) member's own body is live
+            // for instances of its own type, so it joins its overrides in the
+            // conjunction; over-approximating for an abstract containing type
+            // errs toward a missed edge, never a fabricated one.
+            if (!viaInterface && !method.IsAbstract)
             {
                 candidates.Add(method);
             }
@@ -658,19 +704,23 @@ public static class Frontend
         }
 
         private static IMethodSymbol? InterfaceImplementation(
-            INamedTypeSymbol type, IMethodSymbol method)
+            INamedTypeSymbol type, IMethodSymbol invoked)
         {
+            // Matched by the CONSTRUCTED interface, never the open definition:
+            // a type implementing IGen<int> and IGen<string> with different
+            // bodies answers only for the construction the call went through.
+            var target = invoked.ConstructedFrom;
             foreach (var iface in type.AllInterfaces)
             {
                 if (!SymbolEqualityComparer.Default.Equals(
-                        iface.OriginalDefinition, method.ContainingType))
+                        iface, invoked.ContainingType))
                 {
                     continue;
                 }
-                var member = iface.GetMembers(method.Name)
+                var member = iface.GetMembers(invoked.Name)
                     .OfType<IMethodSymbol>()
                     .FirstOrDefault(m => SymbolEqualityComparer.Default.Equals(
-                        m.OriginalDefinition, method));
+                        m, target));
                 if (member is not null
                     && type.FindImplementationForInterfaceMember(member)
                         is IMethodSymbol implementation)

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -719,7 +719,7 @@ public static class Frontend
                     }
                     continue;
                 }
-                if (OverrideOf(type, method) is { IsAbstract: false } overriding)
+                if (OverrideOf(type, invoked) is { IsAbstract: false } overriding)
                 {
                     candidates.Add(overriding);
                 }
@@ -799,16 +799,27 @@ public static class Frontend
         }
 
         private static IMethodSymbol? OverrideOf(
-            INamedTypeSymbol type, IMethodSymbol method)
+            INamedTypeSymbol type, IMethodSymbol invoked)
         {
-            foreach (var candidate in type.GetMembers(method.Name).OfType<IMethodSymbol>())
+            // The same construction discipline as the interface path: an
+            // override of Base<int> can never be reached through Base<string>,
+            // so the chain is compared against the CONSTRUCTED invoked member;
+            // a chain entry that still carries type parameters (an open
+            // derived class) matches by definition instead.
+            var target = invoked.ConstructedFrom;
+            foreach (var candidate in type.GetMembers(invoked.Name).OfType<IMethodSymbol>())
             {
                 for (var overridden = candidate.OverriddenMethod;
                      overridden is not null;
                      overridden = overridden.OverriddenMethod)
                 {
-                    if (SymbolEqualityComparer.Default.Equals(
-                            overridden.OriginalDefinition, method))
+                    var open = ContainsTypeParameters(overridden.ContainingType);
+                    var matches = open
+                        ? SymbolEqualityComparer.Default.Equals(
+                            overridden.OriginalDefinition, target.OriginalDefinition)
+                        : SymbolEqualityComparer.Default.Equals(
+                            overridden.ConstructedFrom, target);
+                    if (matches)
                     {
                         return candidate;
                     }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -587,6 +587,17 @@ public static class Frontend
             {
                 return null;
             }
+            // Only a contract DECLARED in loaded source has a knowable
+            // implementation set: references are acyclic, so nothing prebuilt
+            // can implement a source interface, while a METADATA contract can
+            // have implementers in other referenced assemblies that a source
+            // scan cannot see, and proving a write from the visible subset
+            // could fabricate a flow for a runtime receiver from metadata.
+            if (!method.ContainingType.OriginalDefinition.Locations
+                    .Any(location => location.IsInSource))
+            {
+                return null;
+            }
             var hasDefaultBody = viaInterface && !method.IsAbstract;
             var candidates = new List<IMethodSymbol>();
             var defaultInherited = false;

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -568,11 +568,17 @@ public static class Frontend
         // known, so the write stays unproven rather than guessed).
         private IMethodSymbol? SoleDispatchTarget(Compilation caller, IMethodSymbol method)
         {
-            var viaInterface = method.ContainingType.TypeKind == TypeKind.Interface;
-            if (!viaInterface && !method.IsAbstract)
+            // Abstract members only: a DEFAULT interface method owns a body
+            // and can be the member a call actually lands on (any implementer
+            // that does not override it inherits it), so resolving a sole
+            // override there would attribute the write to a body the call
+            // never reaches. Classic interface members are abstract, so they
+            // still resolve.
+            if (!method.IsAbstract)
             {
                 return null;
             }
+            var viaInterface = method.ContainingType.TypeKind == TypeKind.Interface;
             IMethodSymbol? sole = null;
             // A multi-targeted project compiles the same declaration once per
             // framework, so implementations are identified by their source

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -713,9 +713,11 @@ _INTERFACE_TWO_IMPLEMENTERS_REF = (
 def test_ref_through_an_interface_with_two_implementers_stays_unproven(
     tmp_path: Path,
 ) -> None:
-    # Two implementers means the writer is not statically known; assuming the
-    # writing one would fabricate a flow when the reached implementation only
-    # reads, exactly the failure the proof exists to prevent.
+    # With two implementers the writer is not statically known, and one of
+    # them only reads: the write is proven only when EVERY candidate body
+    # writes, so assuming the writing one would fabricate a flow when the
+    # reached implementation only reads, exactly the failure the proof
+    # exists to prevent.
     assert (_ENV_K, _STDOUT) not in _flows(
         tmp_path / "if3", _INTERFACE_TWO_IMPLEMENTERS_REF, cs.CSharpFrontend.HYBRID
     )
@@ -782,4 +784,35 @@ def test_a_default_interface_method_never_resolves_to_an_override(
     # reaches; the default body itself only reads, so no edge.
     assert (_ENV_K, _STDOUT) not in _flows(
         tmp_path / "di1", _DEFAULT_INTERFACE_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_DEFAULT_INTERFACE_DEAD_DEFAULT_REF = (
+    "using System;\n\n"
+    "public interface IHelper\n{\n"
+    "    void Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Helper : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_dead_default_body_does_not_hide_the_sole_override(tmp_path: Path) -> None:
+    # Every implementing type overrides the default, so the default body can
+    # never execute; the sole override is the only reachable callee and its
+    # write must not be masked by the unreachable read-only default.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "di2", _DEFAULT_INTERFACE_DEAD_DEFAULT_REF, cs.CSharpFrontend.HYBRID
     )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -1040,6 +1040,9 @@ _LINKED_HELPER = (
 )
 _LINKED_LEAKY = (
     "using System;\n\n"
+    "public class LocalWriter\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
     "public class Leaky\n{\n"
     "    public void Run()\n    {\n"
     '        var token = Environment.GetEnvironmentVariable("K");\n'
@@ -1047,6 +1050,11 @@ _LINKED_LEAKY = (
     '        var sink = "";\n'
     "        helper.Fill(token, ref sink);\n"
     "        Console.WriteLine(sink);\n"
+    '        var token2 = Environment.GetEnvironmentVariable("K2");\n'
+    "        var direct = new LocalWriter();\n"
+    '        var sink2 = "";\n'
+    "        direct.Fill(token2, ref sink2);\n"
+    "        Console.WriteLine(sink2);\n"
     "    }\n}\n"
 )
 
@@ -1092,4 +1100,256 @@ def test_conditional_variants_of_a_shared_file_are_not_collapsed(
         for c in mock.ensure_relationship_batch.call_args_list
         if str(c.args[1]) == FLOWS_TO
     }
+    # Positive control first: the non-shared LocalWriter's direct write-back
+    # must be present, proving both projects loaded and ref facts flowed, so
+    # the absence below cannot pass vacuously.
+    assert ("resource::ENV::K2", _STDOUT) in flows
     assert (_ENV_K, _STDOUT) not in flows
+
+
+_GENERIC_CONSTRUCTIONS_REF = (
+    "using System;\n\n"
+    "public interface IGen<T>\n{\n"
+    "    void Fill(T src, ref string dst);\n}\n\n"
+    "public class Both : IGen<string>, IGen<int>\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n"
+    "    void IGen<int>.Fill(int src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IGen<int> helper = new Both();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token?.Length ?? 0, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_the_invoked_generic_construction_selects_its_own_implementation(
+    tmp_path: Path,
+) -> None:
+    # Both constructions of IGen are implemented with different bodies; the
+    # call goes through IGen<int>, whose explicit implementation only reads,
+    # so the writing IGen<string> body must not be selected for it.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "gc1", _GENERIC_CONSTRUCTIONS_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_GENERIC_CONSTRUCTION_WRITER_REF = (
+    "using System;\n\n"
+    "public interface IGen<T>\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public class Both : IGen<string>, IGen<int>\n{\n"
+    "    void IGen<string>.Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n"
+    "    void IGen<int>.Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IGen<string> helper = new Both();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_the_invoked_generic_construction_proves_its_own_write(
+    tmp_path: Path,
+) -> None:
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "gc2", _GENERIC_CONSTRUCTION_WRITER_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_PLUGIN_LIB_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n"
+    "</Project>\n"
+)
+_PLUGIN_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n"
+    "  <ItemGroup>\n"
+    '    <Reference Include="MetaLib"><HintPath>{dll}</HintPath></Reference>\n'
+    "  </ItemGroup>\n"
+    "</Project>\n"
+)
+_PLUGIN_READER = (
+    "using System;\n\n"
+    "public class Reader : ILib\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n"
+)
+_STALE_PLUGIN_APP_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup>\n"
+    "    <TargetFramework>net8.0</TargetFramework>\n"
+    "    <AssemblyName>MetaLib</AssemblyName>\n"
+    "  </PropertyGroup>\n"
+    "  <ItemGroup>\n"
+    '    <Reference Include="Plugin"><HintPath>{dll}</HintPath></Reference>\n'
+    "  </ItemGroup>\n"
+    "</Project>\n"
+)
+_STALE_PLUGIN_APP_PROGRAM = (
+    "using System;\n\n"
+    "public class Writer : ILib\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        ILib helper = new Writer();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    '        var token2 = Environment.GetEnvironmentVariable("K2");\n'
+    "        var direct = new Writer();\n"
+    '        var sink2 = "";\n'
+    "        direct.Fill(token2, ref sink2);\n"
+    "        Console.WriteLine(sink2);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_prebuilt_plugin_implementation_keeps_the_write_unproven(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A plugin compiled against an identical-identity assembly unifies with
+    # the analyzed source, so its metadata Reader genuinely implements the
+    # SOURCE-declared contract while owning no analyzable body. The proof
+    # must see it and stay unproven, or the visible source Writer would
+    # vouch for a runtime receiver that only reads.
+    import subprocess
+
+    lib = tmp_path / "libsrc"
+    lib.mkdir(parents=True)
+    (lib / "MetaLib.csproj").write_text(_PLUGIN_LIB_CSPROJ, encoding="utf-8")
+    (lib / "ILib.cs").write_text(_METADATA_IFACE_SOURCE, encoding="utf-8")
+    libout = tmp_path / "libbin"
+    built = subprocess.run(
+        ["dotnet", "build", str(lib), "-o", str(libout), "--nologo", "-v", "q"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    libdll = libout / "MetaLib.dll"
+    if built.returncode != 0 or not libdll.exists():
+        pytest.skip(f"could not prebuild the contract assembly: {built.stderr}")
+
+    plugin = tmp_path / "pluginsrc"
+    plugin.mkdir()
+    (plugin / "Plugin.csproj").write_text(
+        _PLUGIN_CSPROJ.format(dll=libdll), encoding="utf-8"
+    )
+    (plugin / "Reader.cs").write_text(_PLUGIN_READER, encoding="utf-8")
+    pluginout = tmp_path / "pluginbin"
+    built = subprocess.run(
+        ["dotnet", "build", str(plugin), "-o", str(pluginout), "--nologo", "-v", "q"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    plugindll = pluginout / "Plugin.dll"
+    if built.returncode != 0 or not plugindll.exists():
+        pytest.skip(f"could not prebuild the plugin assembly: {built.stderr}")
+
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / "proj.csproj").write_text(
+        _STALE_PLUGIN_APP_CSPROJ.format(dll=plugindll), encoding="utf-8"
+    )
+    (repo / "ILib.cs").write_text(_METADATA_IFACE_SOURCE, encoding="utf-8")
+    (repo / "Program.cs").write_text(_STALE_PLUGIN_APP_PROGRAM, encoding="utf-8")
+    parsers, queries = load_parsers()
+    monkeypatch.setattr(settings, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    flows = {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+    assert ("resource::ENV::K2", _STDOUT) in flows
+    assert (_ENV_K, _STDOUT) not in flows
+
+
+_VIRTUAL_OVERRIDE_READS_REF = (
+    "using System;\n\n"
+    "public class HelperBase\n{\n"
+    "    public virtual void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Quiet : HelperBase\n{\n"
+    "    public override void Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        HelperBase helper = new Quiet();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_reading_override_blocks_the_virtual_base_write(tmp_path: Path) -> None:
+    # `virtual` dispatches like the interface cases: the base body is live
+    # for base instances, but the receiver here runs the read-only override,
+    # so proving the write from the base body alone would fabricate the flow.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "vo1", _VIRTUAL_OVERRIDE_READS_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_VIRTUAL_ALL_WRITE_REF = (
+    "using System;\n\n"
+    "public class HelperBase\n{\n"
+    "    public virtual void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Louder : HelperBase\n{\n"
+    "    public override void Fill(string src, ref string dst)\n    {\n"
+    '        dst = src + "!";\n    }\n}\n\n'
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        HelperBase helper = new Louder();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_virtual_write_survives_when_every_override_also_writes(
+    tmp_path: Path,
+) -> None:
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "vo2", _VIRTUAL_ALL_WRITE_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -748,3 +748,38 @@ def test_ref_write_back_through_sole_abstract_override(tmp_path: Path) -> None:
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "ab1", _ABSTRACT_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_DEFAULT_INTERFACE_REF = (
+    "using System;\n\n"
+    "public interface IHelper\n{\n"
+    "    void Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Writer : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Reader : IHelper\n{\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper helper = new Reader();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_default_interface_method_never_resolves_to_an_override(
+    tmp_path: Path,
+) -> None:
+    # A DEFAULT interface member owns a body and is not abstract, so the call
+    # can land on the inherited default (Reader here). Resolving a sole
+    # override (Writer) would attribute the write to a body the call never
+    # reaches; the default body itself only reads, so no edge.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "di1", _DEFAULT_INTERFACE_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -1412,3 +1412,38 @@ def test_an_open_generic_writer_proves_the_constructed_call(tmp_path: Path) -> N
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "og2", _OPEN_GENERIC_WRITER_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_MIXED_CONSTRUCTIONS_REF = (
+    "using System;\n\n"
+    "public interface IHelper<T>\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public class Both<T> : IHelper<T>, IHelper<int>\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n"
+    "    void IHelper<int>.Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper<int> helper = new Both<long>();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_every_matching_construction_of_an_open_implementer_participates(
+    tmp_path: Path,
+) -> None:
+    # Both<T> satisfies IHelper<int> through its explicit read-only
+    # implementation, while its general body writes; selecting only the first
+    # matching interface instance would let the writer vouch for a call the
+    # reader actually serves.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "mc1", _MIXED_CONSTRUCTIONS_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -841,6 +841,11 @@ _METADATA_APP_PROGRAM = (
     '        var sink = "";\n'
     "        helper.Fill(token, ref sink);\n"
     "        Console.WriteLine(sink);\n"
+    '        var token2 = Environment.GetEnvironmentVariable("K2");\n'
+    "        var direct = new Writer();\n"
+    '        var sink2 = "";\n'
+    "        direct.Fill(token2, ref sink2);\n"
+    "        Console.WriteLine(sink2);\n"
     "    }\n}\n"
 )
 
@@ -849,7 +854,7 @@ _METADATA_APP_PROGRAM = (
     not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
 )
 def test_a_metadata_interface_never_resolves_to_source_implementers(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # A contract living in a PREBUILT assembly can have implementers in other
     # referenced assemblies that source scanning cannot see, so the source
@@ -880,22 +885,88 @@ def test_a_metadata_interface_never_resolves_to_source_implementers(
     )
     (repo / "Program.cs").write_text(_METADATA_APP_PROGRAM, encoding="utf-8")
     parsers, queries = load_parsers()
-    previous = settings.CSHARP_FRONTEND
-    settings.CSHARP_FRONTEND = cs.CSharpFrontend.HYBRID
-    try:
-        mock = MagicMock()
-        GraphUpdater(
-            ingestor=mock,
-            repo_path=repo,
-            parsers=parsers,
-            queries=queries,
-            capture=_CAPTURE_IO,
-        ).run()
-    finally:
-        settings.CSHARP_FRONTEND = previous
+    monkeypatch.setattr(settings, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
     flows = {
         (c.args[0][2], c.args[2][2])
         for c in mock.ensure_relationship_batch.call_args_list
         if str(c.args[1]) == FLOWS_TO
     }
+    # Positive control first: the DIRECT call's write-back must be present,
+    # proving the Roslyn frontend actually built and emitted ref facts, so
+    # the absence below cannot pass vacuously on a broken build.
+    assert ("resource::ENV::K2", _STDOUT) in flows
     assert (_ENV_K, _STDOUT) not in flows
+
+
+_DERIVED_DEFAULT_READS_REF = (
+    "using System;\n\n"
+    "public interface IBase\n{\n"
+    "    void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public interface IDerived : IBase\n{\n"
+    "    void IBase.Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Impl : IDerived\n{\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IBase helper = new Impl();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_reading_derived_interface_default_blocks_the_base_default_write(
+    tmp_path: Path,
+) -> None:
+    # The implementer receives the DERIVED interface's explicit default, which
+    # only reads; the writing base default never executes for it, so proving
+    # the write from the base body alone would fabricate the flow.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "dd1", _DERIVED_DEFAULT_READS_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_DERIVED_DEFAULT_WRITES_REF = (
+    "using System;\n\n"
+    "public interface IBase\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public interface IDerived : IBase\n{\n"
+    "    void IBase.Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Impl : IDerived\n{\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IBase helper = new Impl();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_writing_derived_interface_default_proves_the_base_member_write(
+    tmp_path: Path,
+) -> None:
+    # The abstract base member's only reachable body is the derived
+    # interface's explicit default, and it writes.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "dd2", _DERIVED_DEFAULT_WRITES_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -1353,3 +1353,62 @@ def test_a_virtual_write_survives_when_every_override_also_writes(
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "vo2", _VIRTUAL_ALL_WRITE_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_OPEN_GENERIC_READER_REF = (
+    "using System;\n\n"
+    "public interface IHelper<T>\n{\n"
+    "    void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Reader<T> : IHelper<T>\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper<int> helper = new Reader<int>();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_an_open_generic_reader_blocks_the_default_body_write(tmp_path: Path) -> None:
+    # Reader<T> implements every construction of IHelper<T>, so its read-only
+    # body is a candidate for the IHelper<int> call; the writing default must
+    # not be selected just because the open implementer failed to match the
+    # constructed interface exactly.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "og1", _OPEN_GENERIC_READER_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_OPEN_GENERIC_WRITER_REF = (
+    "using System;\n\n"
+    "public interface IHelper<T>\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public class Writer<T> : IHelper<T>\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper<int> helper = new Writer<int>();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_an_open_generic_writer_proves_the_constructed_call(tmp_path: Path) -> None:
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "og2", _OPEN_GENERIC_WRITER_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -1005,3 +1005,91 @@ def test_ref_through_an_interface_where_every_implementer_writes(
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "if4", _INTERFACE_TWO_WRITERS_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_LINKED_IFACE_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n"
+    "</Project>\n"
+)
+_LINKED_IMPL_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup>\n"
+    "    <TargetFramework>net8.0</TargetFramework>\n"
+    "    <DefineConstants>{defines}</DefineConstants>\n"
+    "  </PropertyGroup>\n"
+    "  <ItemGroup>\n"
+    '    <ProjectReference Include="../Iface/Iface.csproj" />\n'
+    '    <Compile Include="../Shared/Helper.cs" />\n'
+    "  </ItemGroup>\n"
+    "</Project>\n"
+)
+_LINKED_IFACE = (
+    "public interface IHelper\n{\n    void Fill(string src, ref string dst);\n}\n"
+)
+_LINKED_HELPER = (
+    "using System;\n\n"
+    "public class Helper : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "#if WRITES\n"
+    "        dst = src;\n"
+    "#else\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n"
+    "#endif\n"
+    "    }\n}\n"
+)
+_LINKED_LEAKY = (
+    "using System;\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_conditional_variants_of_a_shared_file_are_not_collapsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The same source file linked into two projects with different
+    # DefineConstants yields candidates that share their file and span while
+    # their bodies differ: one compiles the writing branch, the other the
+    # read-only one. Both must survive into the must-agreement conjunction,
+    # so the disagreement keeps the write unproven.
+    repo = tmp_path / "repo"
+    (repo / "Iface").mkdir(parents=True)
+    (repo / "Shared").mkdir()
+    (repo / "ImplA").mkdir()
+    (repo / "ImplB").mkdir()
+    (repo / "Iface" / "Iface.csproj").write_text(_LINKED_IFACE_CSPROJ, encoding="utf-8")
+    (repo / "Iface" / "IHelper.cs").write_text(_LINKED_IFACE, encoding="utf-8")
+    (repo / "Shared" / "Helper.cs").write_text(_LINKED_HELPER, encoding="utf-8")
+    (repo / "ImplA" / "ImplA.csproj").write_text(
+        _LINKED_IMPL_CSPROJ.format(defines="WRITES"), encoding="utf-8"
+    )
+    (repo / "ImplB" / "ImplB.csproj").write_text(
+        _LINKED_IMPL_CSPROJ.format(defines=""), encoding="utf-8"
+    )
+    (repo / "ImplB" / "Leaky.cs").write_text(_LINKED_LEAKY, encoding="utf-8")
+    parsers, queries = load_parsers()
+    monkeypatch.setattr(settings, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    flows = {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+    assert (_ENV_K, _STDOUT) not in flows

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -970,3 +970,38 @@ def test_a_writing_derived_interface_default_proves_the_base_member_write(
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "dd2", _DERIVED_DEFAULT_WRITES_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_INTERFACE_TWO_WRITERS_REF = (
+    "using System;\n\n"
+    "public interface IHelper\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public class WriterA : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class WriterB : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    '        dst = src + "!";\n    }\n}\n\n'
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper helper = new WriterB();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_ref_through_an_interface_where_every_implementer_writes(
+    tmp_path: Path,
+) -> None:
+    # The must-agreement policy decided on #1356: with several implementers
+    # the edge exists exactly when ALL of them write, because whichever body
+    # actually runs then performs the write and nothing is fabricated.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "if4", _INTERFACE_TWO_WRITERS_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -1480,3 +1480,36 @@ def test_an_override_of_another_construction_does_not_block_the_write(
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "gb1", _GENERIC_BASE_OVERRIDE_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_OPEN_CALLSITE_CLOSED_IMPL_REF = (
+    "using System;\n\n"
+    "public interface IHelper<T>\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public class Both<T> : IHelper<T>, IHelper<int>\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n"
+    "    void IHelper<int>.Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    private void Pump<T>(IHelper<T> helper)\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n    }\n"
+    "    public void Run()\n    {\n"
+    "        Pump<int>(new Both<long>());\n    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_an_open_call_site_sees_closed_implementations_too(tmp_path: Path) -> None:
+    # Inside Pump<T> the interface construction is unbound, so the call can
+    # resolve to ANY construction at runtime, including the read-only
+    # explicit IHelper<int> body; the writing open implementation alone must
+    # not prove the write.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "oc1", _OPEN_CALLSITE_CLOSED_IMPL_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -621,3 +621,130 @@ def test_a_read_only_ref_local_function_never_gains_a_flow(tmp_path: Path) -> No
     assert (_ENV_K, _STDOUT) not in _flows(
         tmp_path / "lf3", _LOCAL_FUNCTION_READ_ONLY_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+# Interface dispatch hides the writer: GetSymbolInfo resolves the call to the
+# INTERFACE member, whose declaration has no body, so the write-back proof
+# answered false and the flow was silently dropped (issue #1356). With exactly
+# one implementing type in the loaded compilations, its body IS the callee,
+# the same sole-implementer policy the Go frontend applies to interface edges.
+_INTERFACE_REF = (
+    "using System;\n\n"
+    "public interface IHelper\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public class Helper : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_ref_write_back_through_sole_interface_implementer(tmp_path: Path) -> None:
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "if1", _INTERFACE_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_INTERFACE_READ_ONLY_REF = (
+    "using System;\n\n"
+    "public interface IHelper\n{\n"
+    "    void Inspect(string src, ref string other);\n}\n\n"
+    "public class Helper : IHelper\n{\n"
+    "    public void Inspect(string src, ref string other)\n    {\n"
+    "        Console.Error.WriteLine(other.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Inspect(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_read_only_ref_through_an_interface_never_gains_a_flow(
+    tmp_path: Path,
+) -> None:
+    # Resolving the sole implementer must not weaken the no-fabrication rule:
+    # the implementation only READS the ref parameter, so no edge.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "if2", _INTERFACE_READ_ONLY_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_INTERFACE_TWO_IMPLEMENTERS_REF = (
+    "using System;\n\n"
+    "public interface IHelper\n{\n"
+    "    void Fill(string src, ref string dst);\n}\n\n"
+    "public class Writer : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Reader : IHelper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        IHelper helper = new Reader();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_ref_through_an_interface_with_two_implementers_stays_unproven(
+    tmp_path: Path,
+) -> None:
+    # Two implementers means the writer is not statically known; assuming the
+    # writing one would fabricate a flow when the reached implementation only
+    # reads, exactly the failure the proof exists to prevent.
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "if3", _INTERFACE_TWO_IMPLEMENTERS_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+_ABSTRACT_REF = (
+    "using System;\n\n"
+    "public abstract class HelperBase\n{\n"
+    "    public abstract void Fill(string src, ref string dst);\n}\n\n"
+    "public class Helper : HelperBase\n{\n"
+    "    public override void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        HelperBase helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_ref_write_back_through_sole_abstract_override(tmp_path: Path) -> None:
+    # An abstract member has the same defect shape as an interface member: the
+    # invoked symbol's declaration carries no body (issue #1356).
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "ab1", _ABSTRACT_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -816,3 +816,86 @@ def test_a_dead_default_body_does_not_hide_the_sole_override(tmp_path: Path) -> 
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "di2", _DEFAULT_INTERFACE_DEAD_DEFAULT_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_METADATA_IFACE_SOURCE = (
+    "public interface ILib\n{\n    void Fill(string src, ref string dst);\n}\n"
+)
+_METADATA_APP_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n"
+    "  <ItemGroup>\n"
+    '    <Reference Include="MetaLib"><HintPath>{dll}</HintPath></Reference>\n'
+    "  </ItemGroup>\n"
+    "</Project>\n"
+)
+_METADATA_APP_PROGRAM = (
+    "using System;\n\n"
+    "public class Writer : ILib\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        ILib helper = new Writer();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_metadata_interface_never_resolves_to_source_implementers(
+    tmp_path: Path,
+) -> None:
+    # A contract living in a PREBUILT assembly can have implementers in other
+    # referenced assemblies that source scanning cannot see, so the source
+    # implementation set is never complete and proving a write from it could
+    # fabricate a flow for a runtime receiver from metadata. Only contracts
+    # declared in loaded source resolve.
+    import subprocess
+
+    lib = tmp_path / "libsrc"
+    lib.mkdir(parents=True)
+    (lib / "MetaLib.csproj").write_text(_LIB_CSPROJ, encoding="utf-8")
+    (lib / "ILib.cs").write_text(_METADATA_IFACE_SOURCE, encoding="utf-8")
+    out = tmp_path / "libbin"
+    built = subprocess.run(
+        ["dotnet", "build", str(lib), "-o", str(out), "--nologo", "-v", "q"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dll = out / "MetaLib.dll"
+    if built.returncode != 0 or not dll.exists():
+        pytest.skip(f"could not prebuild the metadata assembly: {built.stderr}")
+
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / "proj.csproj").write_text(
+        _METADATA_APP_CSPROJ.format(dll=dll), encoding="utf-8"
+    )
+    (repo / "Program.cs").write_text(_METADATA_APP_PROGRAM, encoding="utf-8")
+    parsers, queries = load_parsers()
+    previous = settings.CSHARP_FRONTEND
+    settings.CSHARP_FRONTEND = cs.CSharpFrontend.HYBRID
+    try:
+        mock = MagicMock()
+        GraphUpdater(
+            ingestor=mock,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+            capture=_CAPTURE_IO,
+        ).run()
+    finally:
+        settings.CSHARP_FRONTEND = previous
+    flows = {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+    assert (_ENV_K, _STDOUT) not in flows

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -1447,3 +1447,36 @@ def test_every_matching_construction_of_an_open_implementer_participates(
     assert (_ENV_K, _STDOUT) not in _flows(
         tmp_path / "mc1", _MIXED_CONSTRUCTIONS_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_GENERIC_BASE_OVERRIDE_REF = (
+    "using System;\n\n"
+    "public class Base<T>\n{\n"
+    "    public virtual void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class IntReader : Base<int>\n{\n"
+    "    public override void Fill(string src, ref string dst)\n    {\n"
+    "        Console.Error.WriteLine(dst.Length + src.Length);\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        Base<string> helper = new Base<string>();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_an_override_of_another_construction_does_not_block_the_write(
+    tmp_path: Path,
+) -> None:
+    # IntReader overrides Base<int>.Fill only; a call through Base<string>
+    # can never reach it, so its read-only body must not join that call's
+    # conjunction and mask the base write.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "gb1", _GENERIC_BASE_OVERRIDE_REF, cs.CSharpFrontend.HYBRID
+    )


### PR DESCRIPTION
## Summary

- The `ref` write-back proof resolved a dispatched call to the interface or abstract member, whose declaration has no body, so `CallableBody` returned null and a real ENV-to-STDOUT flow through `IHelper.Fill(token, ref sink)` was silently dropped (#1356's verified repro).
- Final policy, a strict generalization of the issue's option 1 that keeps its no-fabrication property: the write is proven exactly when EVERY body the call can dispatch to writes the parameter. With a sole implementer this reduces to option 1; with several candidates the edge exists only when they all write, so whichever implementation actually runs performs the write and nothing is ever invented. The generalization became necessary during review: default interface bodies mean a dispatched member can have several reachable bodies (the live default plus overrides), where "exactly one" is not a well-defined filter.
- Candidate bodies are the declared implementations across the loaded compilations (interfaces themselves included, so a derived interface's explicit default participates), plus the invoked member's own default body while any implementer still inherits it. Resolution happens only for contracts declared in loaded source: references are acyclic, so nothing prebuilt can implement a source contract, while a metadata contract can have invisible implementers and stays unproven. Implementations are deduplicated by source location so multi-targeted compilations cannot distort the candidate set.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1356. Related to #1187 (SymbolFinder completeness): this uses the compilations already held by the #1355 tree-owner index instead of threading `SymbolFinder` in.

## Test Plan

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added

Red first, then green with the real Roslyn tool: write-back through a sole interface implementer and a sole abstract override; no flow when the sole implementer only reads; no flow with two implementers when one reads; a default interface method never resolves to an override while an implementer inherits the default; a dead default (every implementer overrides) does not mask the sole override; derived-interface explicit defaults participate in both directions; a metadata-declared contract never resolves to the visible source subset, with a positive direct-call control proving the frontend ran. Full C# frontend surface passes (30 flow tests plus semantic facts and wiring).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when tracking `ref` parameter write-backs through interface and virtual dispatch.
  * Prevented read-only or ambiguous implementations from incorrectly reporting data flows.
  * Correctly handles default interface methods, inherited defaults, derived-interface overrides, metadata-defined interfaces, and generic interface constructions.
  * Ensured results remain reliable when multiple possible implementations are available.

* **Tests**
  * Added comprehensive coverage for dispatch scenarios, abstract and virtual implementations, metadata assemblies, generic calls, inherited defaults, and conditional code paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->