### PR TITLE
fix: C# internal namespace imports target the referenced Module nodes (#1347)

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -217,6 +217,7 @@ TS_CSHARP_EQUALS_VALUE_CLAUSE = "equals_value_clause"
 TS_CSHARP_FIELD_NAME = "name"
 TS_CSHARP_FIELD_OPERATOR = "operator"
 TS_CSHARP_FIELD_TYPE = "type"
+TS_CSHARP_TYPE_ARGUMENT_LIST = "type_argument_list"
 # method_declaration/local_function_statement expose the return type via
 # `returns` (there is no `type` field on them).
 TS_CSHARP_FIELD_RETURNS = "returns"

--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -25,6 +25,7 @@ TS_CSHARP_STRUCT_DECLARATION = "struct_declaration"
 TS_CSHARP_RECORD_DECLARATION = "record_declaration"
 TS_CSHARP_INTERFACE_DECLARATION = "interface_declaration"
 TS_CSHARP_ENUM_DECLARATION = "enum_declaration"
+TS_CSHARP_DELEGATE_DECLARATION = "delegate_declaration"
 
 # A conditional-compilation block wrapping a declaration's attributes
 # (`#if SYMBOL [Attr] #endif`) parses as this node, which sits as the leading

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1804,6 +1804,15 @@ class GraphUpdater:
                 if path == file_path:
                     self.factory.import_processor.drop_rust_module_import_state(qn)
 
+        # Same discipline for C#: a deleted file's namespaces, identifier
+        # evidence, and using entries must not survive into the next flush
+        # (issue #1347).
+        if file_path.suffix == cs.EXT_CS:
+            qn_to_path = self.factory.definition_processor.module_qn_to_file_path
+            for qn, path in qn_to_path.items():
+                if path == file_path:
+                    self.factory.import_processor.drop_csharp_module_import_state(qn)
+
         # Ownership guard for the prefix sweep: another file's inline-mod
         # chain can share this file's qn prefix (the #1017 shape), and a
         # sweep by prefix alone deregisters functions that file still owns —

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1017,12 +1017,6 @@ class GraphUpdater:
         if module_impls:
             logger.info("Resolved {} C++20 module implementation links", module_impls)
 
-        imports_emitted = self.factory.import_processor.flush_deferred_import_edges(
-            known_module_paths
-        )
-        if imports_emitted:
-            logger.info("Emitted {} verified IMPORTS edges", imports_emitted)
-
         # Last containment step: every node-registering pass above (deferred
         # C++ methods, Go receivers, kept forward declarations) must finish
         # before parent qns are verified against the registry.
@@ -1033,6 +1027,15 @@ class GraphUpdater:
         logger.info(ls.FOUND_FUNCTIONS, count=len(self.function_registry))
         logger.info(ls.PASS_3_CALLS)
         self._process_function_calls()
+
+        # IMPORTS flush AFTER Pass 3: a C# namespace import lands on the
+        # modules the file actually resolved entities from, and those
+        # resolutions are recorded during call processing (issue #1347).
+        imports_emitted = self.factory.import_processor.flush_deferred_import_edges(
+            known_module_paths
+        )
+        if imports_emitted:
+            logger.info("Emitted {} verified IMPORTS edges", imports_emitted)
 
         # LINQ query-operator edges join AFTER Pass 3 with the complete
         # function-location registry (both ends must be registered nodes).

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -3635,20 +3635,8 @@ class CallProcessor:
 
             callee_type, callee_qn = callee_info
 
-            if language == cs.SupportedLanguage.CSHARP and callee_qn.startswith(
-                f"{self.project_name}{cs.SEPARATOR_DOT}"
-            ):
-                # A resolved first-party callee pins the C# namespace import
-                # to the module that defines it (issue #1347); external
-                # resolutions (stdlib, builtins) never carry the project
-                # prefix and are skipped.
-                target_module = module_qn_for_entity(
-                    callee_qn, self.module_qn_to_file_path
-                )
-                if target_module is not None and target_module != module_qn:
-                    resolver.import_processor.record_resolved_cross_module_use(
-                        module_qn, target_module
-                    )
+            if language == cs.SupportedLanguage.CSHARP:
+                self._record_csharp_cross_module_use(module_qn, callee_qn)
 
             if (
                 language == cs.SupportedLanguage.CPP
@@ -5706,6 +5694,7 @@ class CallProcessor:
                             rel_type,
                             (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, target_qn),
                         )
+                        self._record_csharp_cross_module_use(module_qn, target_qn)
                     return
         if not (
             resolved := resolve_func(
@@ -5738,6 +5727,20 @@ class CallProcessor:
                 source_spec,
                 rel_type,
                 (res_type, cs.KEY_QUALIFIED_NAME, target_qn),
+            )
+            if language == cs.SupportedLanguage.CSHARP:
+                self._record_csharp_cross_module_use(module_qn, target_qn)
+
+    def _record_csharp_cross_module_use(self, module_qn: str, entity_qn: str) -> None:
+        # A resolved first-party entity pins the C# namespace import to the
+        # module that defines it (issue #1347); external resolutions (stdlib,
+        # builtins) never carry the project prefix and are skipped.
+        if not entity_qn.startswith(f"{self.project_name}{cs.SEPARATOR_DOT}"):
+            return
+        target_module = module_qn_for_entity(entity_qn, self.module_qn_to_file_path)
+        if target_module is not None and target_module != module_qn:
+            self._resolver.import_processor.record_resolved_cross_module_use(
+                module_qn, target_module
             )
 
     def _ingest_callable_param_calls(
@@ -6572,6 +6575,7 @@ class CallProcessor:
                 seen.add(name)
                 if prop_qn != caller_qn:
                     ensure_rel(caller_spec, refs_rel, (method_label, qn_key, prop_qn))
+                    self._record_csharp_cross_module_use(module_qn, prop_qn)
 
         stack = list(caller_node.children)
         while stack:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -51,6 +51,7 @@ from .utils import (
     go_parameter_names,
     is_method_node,
     js_ts_parameter_names,
+    module_qn_for_entity,
     python_parameter_names,
     safe_decode_text,
     sorted_captures,
@@ -3633,6 +3634,21 @@ class CallProcessor:
                 continue
 
             callee_type, callee_qn = callee_info
+
+            if language == cs.SupportedLanguage.CSHARP and callee_qn.startswith(
+                f"{self.project_name}{cs.SEPARATOR_DOT}"
+            ):
+                # A resolved first-party callee pins the C# namespace import
+                # to the module that defines it (issue #1347); external
+                # resolutions (stdlib, builtins) never carry the project
+                # prefix and are skipped.
+                target_module = module_qn_for_entity(
+                    callee_qn, self.module_qn_to_file_path
+                )
+                if target_module is not None and target_module != module_qn:
+                    resolver.import_processor.record_resolved_cross_module_use(
+                        module_qn, target_module
+                    )
 
             if (
                 language == cs.SupportedLanguage.CPP

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -39,6 +39,7 @@ from ..utils import (
     extract_modifiers_and_decorators,
     function_span_key,
     ingest_method,
+    module_qn_for_entity,
     record_cpp_definition_span,
     safe_decode_text,
     sorted_captures,
@@ -513,6 +514,16 @@ class ClassIngestMixin:
             if resolved is None:
                 continue
             parent_qn, is_external = resolved
+            if not is_external and entry.language == cs.SupportedLanguage.CSHARP:
+                # A resolved first-party base pins the C# namespace import to
+                # the module defining it (issue #1347).
+                target_module = module_qn_for_entity(
+                    parent_qn, self.module_qn_to_file_path
+                )
+                if target_module is not None and target_module != entry.module_qn:
+                    self.import_processor.record_resolved_cross_module_use(
+                        entry.module_qn, target_module
+                    )
             external_label: str | None = None
             if is_external:
                 # The import pass mints the same node for IMPORTS edges, so

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -490,6 +490,8 @@ class ImportProcessor:
         "_cpp_module_qn_map",
         "_cpp_qn_to_rel",
         "_deferred_import_edges",
+        "_inferred_module_imports",
+        "_csharp_module_namespaces",
         "_cpp_declaration_mappings",
         "_rust_dir_listing",
         "_rust_entry_mod_decls",
@@ -549,6 +551,8 @@ class ImportProcessor:
         # IMPORTS edges held back until every file is parsed, so internal
         # targets verify against the full module registry (issue #652).
         self._deferred_import_edges: list[DeferredImportEdge] = []
+        self._inferred_module_imports: dict[str, set[str]] = {}
+        self._csharp_module_namespaces: dict[str, set[str]] = {}
         # Exact-case directory listings and entry-file `mod` declarations for
         # Rust path rewriting (issue #1007); cleared per run by
         # reset_rust_path_caches so watch re-runs re-observe the filesystem.
@@ -848,6 +852,13 @@ class ImportProcessor:
         lang_config = queries[language]["config"]
 
         self.import_mapping[module_qn] = {}
+        # A watch-mode re-parse must not carry references the edited file no
+        # longer makes (issue #1347).
+        self._inferred_module_imports.pop(module_qn, None)
+        if language == cs.SupportedLanguage.CSHARP:
+            self._csharp_module_namespaces[module_qn] = self._collect_csharp_namespaces(
+                root_node
+            )
         # A re-parsed module that no longer directly exports one function
         # must not leave the stale whole-module alias mapping behind.
         self.commonjs_direct_exports.pop(module_qn, None)
@@ -937,6 +948,49 @@ class ImportProcessor:
             )
         )
 
+    def _collect_csharp_namespaces(self, root_node: Node) -> set[str]:
+        # Namespaces appear only at the top level and inside namespace bodies,
+        # so the walk prunes into nothing else; nesting composes dotted names.
+        found: set[str] = set()
+
+        def walk(container: Node, prefix: str) -> None:
+            for child in container.named_children:
+                if child.type not in (
+                    cs.TS_CSHARP_NAMESPACE_DECLARATION,
+                    cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION,
+                ):
+                    continue
+                name_node = child.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
+                if name_node is None:
+                    continue
+                name = safe_decode_with_fallback(name_node)
+                if not name:
+                    continue
+                full = f"{prefix}{cs.SEPARATOR_DOT}{name}" if prefix else name
+                found.add(full)
+                if child.type == cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION:
+                    continue
+                if (body := child.child_by_field_name(cs.FIELD_BODY)) is not None:
+                    walk(body, full)
+
+        walk(root_node, "")
+        return found
+
+    def record_resolved_cross_module_use(
+        self, importing_module_qn: str, target_module_qn: str
+    ) -> None:
+        """Remember that a resolved call/reference/inherit crossed modules.
+
+        A C# `using` names a NAMESPACE, not a file, so the import edge can
+        only be pinned to real Module nodes by observing which modules the
+        importing file actually resolved entities from (issue #1347).
+        """
+        if importing_module_qn == target_module_qn:
+            return
+        self._inferred_module_imports.setdefault(importing_module_qn, set()).add(
+            target_module_qn
+        )
+
     def set_java_generated_roots(self, roots: list[tuple[str, ...]]) -> None:
         # The probe closure reads the attribute late-bound, but its lru cache
         # may hold pre-discovery misses; clear so generated imports resolve.
@@ -963,6 +1017,17 @@ class ImportProcessor:
         self._deferred_import_edges = []
         known_module_qns = set(known_module_paths)
         module_aliases = self._module_alias_map(known_module_qns)
+        # namespace -> the indexed modules DECLARING it, from the per-file
+        # scan done at parse time: C# namespaces need not mirror directory
+        # names, so path-based guessing cannot answer "is this internal".
+        csharp_namespace_modules: dict[str, set[str]] = {}
+        for csharp_module_qn, namespaces in self._csharp_module_namespaces.items():
+            if csharp_module_qn not in known_module_qns:
+                continue
+            for namespace in namespaces:
+                csharp_namespace_modules.setdefault(namespace, set()).add(
+                    csharp_module_qn
+                )
         emitted = 0
         for entry in deferred:
             # `from pkg.transport import TTransport` is ambiguous in
@@ -1022,6 +1087,33 @@ class ImportProcessor:
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, target),
                 )
                 emitted += 1
+                continue
+            if entry.language == cs.SupportedLanguage.CSHARP and (
+                declaring := csharp_namespace_modules.get(entry.full_name)
+            ):
+                # A `using` names a NAMESPACE. When indexed modules declare
+                # that namespace, the edge lands on the specific modules this
+                # file actually resolved entities from; a namespace-keyed
+                # ExternalModule would be a dead end no edge ever connects to
+                # the defining files (issue #1347). A namespace nothing
+                # declares falls through to the external handling below.
+                inferred = self._inferred_module_imports.get(entry.module_qn, set())
+                for target_module_qn in sorted(inferred & declaring):
+                    if target_module_qn in known_module_qns:
+                        self.ingestor.ensure_relationship_batch(
+                            (
+                                cs.NodeLabel.MODULE,
+                                cs.KEY_QUALIFIED_NAME,
+                                entry.module_qn,
+                            ),
+                            cs.RelationshipType.IMPORTS,
+                            (
+                                cs.NodeLabel.MODULE,
+                                cs.KEY_QUALIFIED_NAME,
+                                target_module_qn,
+                            ),
+                        )
+                        emitted += 1
                 continue
             module_path = self._resolve_module_path(entry.full_name, entry.language)
             target_label = self._module_label(module_path)

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -959,6 +959,7 @@ class ImportProcessor:
         cs.TS_CSHARP_RECORD_DECLARATION,
         cs.TS_CSHARP_INTERFACE_DECLARATION,
         cs.TS_CSHARP_ENUM_DECLARATION,
+        cs.TS_CSHARP_DELEGATE_DECLARATION,
     )
 
     def _collect_csharp_namespaces(self, root_node: Node) -> dict[str, set[str]]:
@@ -1028,6 +1029,21 @@ class ImportProcessor:
                     break
         return frozenset(found)
 
+    def requeue_csharp_import_edges(self) -> None:
+        """Re-queue every parsed C# module's using entries for a fresh flush.
+
+        A watched edit to a PROVIDER file deletes and recreates its Module
+        node, severing edges from unchanged importers, whose deferred entries
+        were consumed by an earlier flush. The persistent import mapping still
+        holds their using directives, and re-emission is idempotent MERGEs
+        (issue #1347).
+        """
+        for module_qn in self._csharp_module_namespaces:
+            for imported_path in self.import_mapping.get(module_qn, {}).values():
+                self.defer_import_edge(
+                    module_qn, imported_path, cs.SupportedLanguage.CSHARP
+                )
+
     def _csharp_namespace_modules(
         self, known_module_qns: set[str]
     ) -> dict[str, dict[str, set[str]]]:
@@ -1092,7 +1108,17 @@ class ImportProcessor:
         if self.ingestor is None:
             return 0
         inferred = self._inferred_module_imports.get(entry.module_qn, set())
-        used = self._csharp_module_identifiers.get(entry.module_qn, frozenset())
+        # Names the importer DECLARES itself are not evidence: an unqualified
+        # mention binds to the local type, not the imported namespace's.
+        own_types: set[str] = set()
+        for own_declared in self._csharp_module_namespaces.get(
+            entry.module_qn, {}
+        ).values():
+            own_types.update(own_declared)
+        used = (
+            self._csharp_module_identifiers.get(entry.module_qn, frozenset())
+            - own_types
+        )
         targets = {
             target
             for target, declared_types in declaring.items()

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -492,6 +492,7 @@ class ImportProcessor:
         "_deferred_import_edges",
         "_inferred_module_imports",
         "_csharp_module_namespaces",
+        "_csharp_module_identifiers",
         "_cpp_declaration_mappings",
         "_rust_dir_listing",
         "_rust_entry_mod_decls",
@@ -552,7 +553,8 @@ class ImportProcessor:
         # targets verify against the full module registry (issue #652).
         self._deferred_import_edges: list[DeferredImportEdge] = []
         self._inferred_module_imports: dict[str, set[str]] = {}
-        self._csharp_module_namespaces: dict[str, set[str]] = {}
+        self._csharp_module_namespaces: dict[str, dict[str, set[str]]] = {}
+        self._csharp_module_identifiers: dict[str, frozenset[str]] = {}
         # Exact-case directory listings and entry-file `mod` declarations for
         # Rust path rewriting (issue #1007); cleared per run by
         # reset_rust_path_caches so watch re-runs re-observe the filesystem.
@@ -859,6 +861,9 @@ class ImportProcessor:
             self._csharp_module_namespaces[module_qn] = self._collect_csharp_namespaces(
                 root_node
             )
+            self._csharp_module_identifiers[module_qn] = (
+                self._collect_csharp_identifiers(root_node)
+            )
         # A re-parsed module that no longer directly exports one function
         # must not leave the stale whole-module alias mapping behind.
         self.commonjs_direct_exports.pop(module_qn, None)
@@ -948,10 +953,32 @@ class ImportProcessor:
             )
         )
 
-    def _collect_csharp_namespaces(self, root_node: Node) -> set[str]:
+    _CSHARP_TYPE_DECLARATIONS = (
+        cs.TS_CSHARP_CLASS_DECLARATION,
+        cs.TS_CSHARP_STRUCT_DECLARATION,
+        cs.TS_CSHARP_RECORD_DECLARATION,
+        cs.TS_CSHARP_INTERFACE_DECLARATION,
+        cs.TS_CSHARP_ENUM_DECLARATION,
+    )
+
+    def _collect_csharp_namespaces(self, root_node: Node) -> dict[str, set[str]]:
         # Namespaces appear only at the top level and inside namespace bodies,
         # so the walk prunes into nothing else; nesting composes dotted names.
-        found: set[str] = set()
+        # Each namespace carries the TYPE NAMES it declares in this file: the
+        # name-level evidence that pins a type-only `using` to the module.
+        found: dict[str, set[str]] = {}
+
+        def type_names(container: Node) -> set[str]:
+            names: set[str] = set()
+            for child in container.named_children:
+                if child.type not in self._CSHARP_TYPE_DECLARATIONS:
+                    continue
+                name_node = child.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
+                if name_node is not None and (
+                    name := safe_decode_with_fallback(name_node)
+                ):
+                    names.add(name)
+            return names
 
         def walk(container: Node, prefix: str) -> None:
             for child in container.named_children:
@@ -967,14 +994,39 @@ class ImportProcessor:
                 if not name:
                     continue
                 full = f"{prefix}{cs.SEPARATOR_DOT}{name}" if prefix else name
-                found.add(full)
                 if child.type == cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION:
+                    found.setdefault(full, set()).update(type_names(container))
                     continue
-                if (body := child.child_by_field_name(cs.FIELD_BODY)) is not None:
+                body = child.child_by_field_name(cs.FIELD_BODY)
+                if body is not None:
+                    found.setdefault(full, set()).update(type_names(body))
                     walk(body, full)
+                else:
+                    found.setdefault(full, set())
 
         walk(root_node, "")
         return found
+
+    def _collect_csharp_identifiers(self, root_node: Node) -> frozenset[str]:
+        # Every identifier the file mentions, as coarse evidence for pinning
+        # type-only namespace uses; a linear cursor walk keeps it cheap.
+        found: set[str] = set()
+        cursor = root_node.walk()
+        reached_root = False
+        while not reached_root:
+            node = cursor.node
+            if node is not None and node.type == cs.TS_CSHARP_IDENTIFIER:
+                if text := safe_decode_text(node):
+                    found.add(text)
+            if cursor.goto_first_child():
+                continue
+            while True:
+                if cursor.goto_next_sibling():
+                    break
+                if not cursor.goto_parent():
+                    reached_root = True
+                    break
+        return frozenset(found)
 
     def _recover_unparsed_csharp_namespaces(
         self, known_module_paths: dict[str, str]
@@ -997,31 +1049,44 @@ class ImportProcessor:
             try:
                 source = Path(path).read_bytes()
             except OSError:
-                self._csharp_module_namespaces[module_qn] = set()
+                self._csharp_module_namespaces[module_qn] = {}
+                self._csharp_module_identifiers[module_qn] = frozenset()
                 continue
             tree = parser.parse(source)
             self._csharp_module_namespaces[module_qn] = self._collect_csharp_namespaces(
                 tree.root_node
             )
+            self._csharp_module_identifiers[module_qn] = (
+                self._collect_csharp_identifiers(tree.root_node)
+            )
 
     def _emit_csharp_internal_imports(
         self,
         entry: DeferredImportEdge,
-        declaring: set[str],
+        declaring: dict[str, set[str]],
         known_module_qns: set[str],
     ) -> int:
         """IMPORTS edges for a `using` of a namespace declared in the repo.
 
         A `using` names a NAMESPACE. When indexed modules declare it, the edge
-        lands on the specific modules this file actually resolved entities
-        from; a namespace-keyed ExternalModule would be a dead end no edge
-        ever connects to the defining files (issue #1347).
+        lands on the specific modules this file actually uses: either a
+        resolved call/reference/inherit crossed into the module, or the file
+        mentions a type name the module declares under that namespace. A
+        namespace-keyed ExternalModule would be a dead end no edge ever
+        connects to the defining files (issue #1347).
         """
         if self.ingestor is None:
             return 0
         inferred = self._inferred_module_imports.get(entry.module_qn, set())
+        used = self._csharp_module_identifiers.get(entry.module_qn, frozenset())
+        targets = {
+            target
+            for target, declared_types in declaring.items()
+            if target != entry.module_qn
+            and (target in inferred or not used.isdisjoint(declared_types))
+        }
         emitted = 0
-        for target_module_qn in sorted(inferred & declaring):
+        for target_module_qn in sorted(targets):
             if target_module_qn not in known_module_qns:
                 continue
             self.ingestor.ensure_relationship_batch(
@@ -1081,13 +1146,13 @@ class ImportProcessor:
         # their source, or the internal detection would silently fail in
         # watch mode and resurrect the dead-end ExternalModule.
         self._recover_unparsed_csharp_namespaces(known_module_paths)
-        csharp_namespace_modules: dict[str, set[str]] = {}
+        csharp_namespace_modules: dict[str, dict[str, set[str]]] = {}
         for csharp_module_qn, namespaces in self._csharp_module_namespaces.items():
             if csharp_module_qn not in known_module_qns:
                 continue
-            for namespace in namespaces:
-                csharp_namespace_modules.setdefault(namespace, set()).add(
-                    csharp_module_qn
+            for namespace, declared_types in namespaces.items():
+                csharp_namespace_modules.setdefault(namespace, {})[csharp_module_qn] = (
+                    declared_types
                 )
         emitted = 0
         for entry in deferred:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1006,32 +1006,47 @@ class ImportProcessor:
         self._walk_csharp_namespaces(root_node, "", found)
         return found
 
+    @staticmethod
+    def _csharp_field_of(node: Node) -> str | None:
+        parent = node.parent
+        if parent is None:
+            return None
+        for index, child in enumerate(parent.children):
+            if child.id == node.id:
+                return parent.field_name_for_child(index)
+        return None
+
     def _collect_csharp_identifiers(self, root_node: Node) -> frozenset[str]:
-        # Identifier MENTIONS minus every NAME-POSITION identifier: a name
-        # position (parameter, variable, member, type name) declares rather
-        # than references, and any same-named mention in the file most
-        # plausibly binds to that local declaration, so the whole name is
-        # withdrawn as evidence rather than risking a false import edge.
+        # Three tiers of identifier occurrences: TYPE-POSITION mentions are
+        # definitive references (a namesake property, `Widget Widget`, is
+        # idiomatic C# and must keep its evidence); NAME-POSITION identifiers
+        # declare rather than reference; everything else is a plain mention
+        # whose spelling is withdrawn when the file also declares it, because
+        # such a mention binds to the local declaration.
+        type_positions: set[str] = set()
         mentions: set[str] = set()
         declared: set[str] = set()
         stack = [root_node]
         while stack:
             node = stack.pop()
-            if node.type == cs.TS_CSHARP_IDENTIFIER and (
-                text := safe_decode_text(node)
-            ):
-                parent = node.parent
-                named_child = (
-                    parent.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
-                    if parent is not None
-                    else None
-                )
-                if named_child is not None and named_child.id == node.id:
-                    declared.add(text)
-                else:
-                    mentions.add(text)
             stack.extend(node.children)
-        return frozenset(mentions - declared)
+            if node.type != cs.TS_CSHARP_IDENTIFIER:
+                continue
+            text = safe_decode_text(node)
+            if not text:
+                continue
+            field = self._csharp_field_of(node)
+            parent_type = node.parent.type if node.parent is not None else None
+            if field == cs.TS_CSHARP_FIELD_TYPE or parent_type in (
+                cs.TS_CSHARP_BASE_LIST,
+                cs.TS_CSHARP_TYPE_ARGUMENT_LIST,
+            ):
+                type_positions.add(text)
+            elif field == cs.TS_CSHARP_FIELD_NAME:
+                declared.add(text)
+            else:
+                mentions.add(text)
+        return frozenset(type_positions | (mentions - declared))
 
     def drop_csharp_module_import_state(self, module_qn: str) -> None:
         # A deleted C# file must stop declaring its namespaces, contributing

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -976,6 +976,34 @@ class ImportProcessor:
         walk(root_node, "")
         return found
 
+    def _recover_unparsed_csharp_namespaces(
+        self, known_module_paths: dict[str, str]
+    ) -> None:
+        pending = [
+            (module_qn, path)
+            for module_qn, path in known_module_paths.items()
+            if module_qn not in self._csharp_module_namespaces
+            and str(path).endswith(cs.EXT_CS)
+        ]
+        if not pending:
+            return
+        from ..parser_loader import load_parsers
+
+        parsers, _queries = load_parsers()
+        if cs.SupportedLanguage.CSHARP not in parsers:
+            return
+        parser = parsers[cs.SupportedLanguage.CSHARP]
+        for module_qn, path in pending:
+            try:
+                source = Path(path).read_bytes()
+            except OSError:
+                self._csharp_module_namespaces[module_qn] = set()
+                continue
+            tree = parser.parse(source)
+            self._csharp_module_namespaces[module_qn] = self._collect_csharp_namespaces(
+                tree.root_node
+            )
+
     def _emit_csharp_internal_imports(
         self,
         entry: DeferredImportEdge,
@@ -1047,7 +1075,12 @@ class ImportProcessor:
         module_aliases = self._module_alias_map(known_module_qns)
         # namespace -> the indexed modules DECLARING it, from the per-file
         # scan done at parse time: C# namespaces need not mirror directory
-        # names, so path-based guessing cannot answer "is this internal".
+        # names, so path-based guessing cannot answer "is this internal". An
+        # incremental run only re-parses CHANGED files, so unchanged C#
+        # modules recover their namespaces here from a targeted parse of
+        # their source, or the internal detection would silently fail in
+        # watch mode and resurrect the dead-end ExternalModule.
+        self._recover_unparsed_csharp_namespaces(known_module_paths)
         csharp_namespace_modules: dict[str, set[str]] = {}
         for csharp_module_qn, namespaces in self._csharp_module_namespaces.items():
             if csharp_module_qn not in known_module_qns:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1028,6 +1028,20 @@ class ImportProcessor:
                     break
         return frozenset(found)
 
+    def _csharp_namespace_modules(
+        self, known_module_qns: set[str]
+    ) -> dict[str, dict[str, set[str]]]:
+        # namespace -> {declaring module qn -> type names it declares there}.
+        # C# namespaces need not mirror directory names, so path-based
+        # guessing cannot answer "is this internal"; the per-file scans can.
+        namespace_modules: dict[str, dict[str, set[str]]] = {}
+        for module_qn, namespaces in self._csharp_module_namespaces.items():
+            if module_qn not in known_module_qns:
+                continue
+            for namespace, declared_types in namespaces.items():
+                namespace_modules.setdefault(namespace, {})[module_qn] = declared_types
+        return namespace_modules
+
     def _recover_unparsed_csharp_namespaces(
         self, known_module_paths: dict[str, str]
     ) -> None:
@@ -1146,14 +1160,7 @@ class ImportProcessor:
         # their source, or the internal detection would silently fail in
         # watch mode and resurrect the dead-end ExternalModule.
         self._recover_unparsed_csharp_namespaces(known_module_paths)
-        csharp_namespace_modules: dict[str, dict[str, set[str]]] = {}
-        for csharp_module_qn, namespaces in self._csharp_module_namespaces.items():
-            if csharp_module_qn not in known_module_qns:
-                continue
-            for namespace, declared_types in namespaces.items():
-                csharp_namespace_modules.setdefault(namespace, {})[csharp_module_qn] = (
-                    declared_types
-                )
+        csharp_namespace_modules = self._csharp_namespace_modules(known_module_qns)
         emitted = 0
         for entry in deferred:
             # `from pkg.transport import TTransport` is ambiguous in

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -976,6 +976,34 @@ class ImportProcessor:
         walk(root_node, "")
         return found
 
+    def _emit_csharp_internal_imports(
+        self,
+        entry: DeferredImportEdge,
+        declaring: set[str],
+        known_module_qns: set[str],
+    ) -> int:
+        """IMPORTS edges for a `using` of a namespace declared in the repo.
+
+        A `using` names a NAMESPACE. When indexed modules declare it, the edge
+        lands on the specific modules this file actually resolved entities
+        from; a namespace-keyed ExternalModule would be a dead end no edge
+        ever connects to the defining files (issue #1347).
+        """
+        if self.ingestor is None:
+            return 0
+        inferred = self._inferred_module_imports.get(entry.module_qn, set())
+        emitted = 0
+        for target_module_qn in sorted(inferred & declaring):
+            if target_module_qn not in known_module_qns:
+                continue
+            self.ingestor.ensure_relationship_batch(
+                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
+                cs.RelationshipType.IMPORTS,
+                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, target_module_qn),
+            )
+            emitted += 1
+        return emitted
+
     def record_resolved_cross_module_use(
         self, importing_module_qn: str, target_module_qn: str
     ) -> None:
@@ -1091,29 +1119,9 @@ class ImportProcessor:
             if entry.language == cs.SupportedLanguage.CSHARP and (
                 declaring := csharp_namespace_modules.get(entry.full_name)
             ):
-                # A `using` names a NAMESPACE. When indexed modules declare
-                # that namespace, the edge lands on the specific modules this
-                # file actually resolved entities from; a namespace-keyed
-                # ExternalModule would be a dead end no edge ever connects to
-                # the defining files (issue #1347). A namespace nothing
-                # declares falls through to the external handling below.
-                inferred = self._inferred_module_imports.get(entry.module_qn, set())
-                for target_module_qn in sorted(inferred & declaring):
-                    if target_module_qn in known_module_qns:
-                        self.ingestor.ensure_relationship_batch(
-                            (
-                                cs.NodeLabel.MODULE,
-                                cs.KEY_QUALIFIED_NAME,
-                                entry.module_qn,
-                            ),
-                            cs.RelationshipType.IMPORTS,
-                            (
-                                cs.NodeLabel.MODULE,
-                                cs.KEY_QUALIFIED_NAME,
-                                target_module_qn,
-                            ),
-                        )
-                        emitted += 1
+                emitted += self._emit_csharp_internal_imports(
+                    entry, declaring, known_module_qns
+                )
                 continue
             module_path = self._resolve_module_path(entry.full_name, entry.language)
             target_label = self._module_label(module_path)

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1007,18 +1007,40 @@ class ImportProcessor:
         return found
 
     def _collect_csharp_identifiers(self, root_node: Node) -> frozenset[str]:
-        # Every identifier the file mentions, as coarse evidence for pinning
-        # type-only namespace uses; an explicit stack keeps it linear.
-        found: set[str] = set()
+        # Identifier MENTIONS minus every NAME-POSITION identifier: a name
+        # position (parameter, variable, member, type name) declares rather
+        # than references, and any same-named mention in the file most
+        # plausibly binds to that local declaration, so the whole name is
+        # withdrawn as evidence rather than risking a false import edge.
+        mentions: set[str] = set()
+        declared: set[str] = set()
         stack = [root_node]
         while stack:
             node = stack.pop()
             if node.type == cs.TS_CSHARP_IDENTIFIER and (
                 text := safe_decode_text(node)
             ):
-                found.add(text)
+                parent = node.parent
+                named_child = (
+                    parent.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
+                    if parent is not None
+                    else None
+                )
+                if named_child is not None and named_child.id == node.id:
+                    declared.add(text)
+                else:
+                    mentions.add(text)
             stack.extend(node.children)
-        return frozenset(found)
+        return frozenset(mentions - declared)
+
+    def drop_csharp_module_import_state(self, module_qn: str) -> None:
+        # A deleted C# file must stop declaring its namespaces, contributing
+        # identifier evidence, and queueing its using entries, or the requeue
+        # would rebuild edges a clean rebuild of the same tree never emits.
+        self._csharp_module_namespaces.pop(module_qn, None)
+        self._csharp_module_identifiers.pop(module_qn, None)
+        self._inferred_module_imports.pop(module_qn, None)
+        self.import_mapping.pop(module_qn, None)
 
     def requeue_csharp_import_edges(self) -> None:
         """Re-queue every parsed C# module's using entries for a fresh flush.

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -962,71 +962,62 @@ class ImportProcessor:
         cs.TS_CSHARP_DELEGATE_DECLARATION,
     )
 
+    def _csharp_declared_type_names(self, container: Node) -> set[str]:
+        names: set[str] = set()
+        for child in container.named_children:
+            if child.type not in self._CSHARP_TYPE_DECLARATIONS:
+                continue
+            name_node = child.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
+            if name_node is not None and (name := safe_decode_with_fallback(name_node)):
+                names.add(name)
+        return names
+
+    def _walk_csharp_namespaces(
+        self, container: Node, prefix: str, found: dict[str, set[str]]
+    ) -> None:
+        for child in container.named_children:
+            if child.type not in (
+                cs.TS_CSHARP_NAMESPACE_DECLARATION,
+                cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION,
+            ):
+                continue
+            name_node = child.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
+            if name_node is None or not (name := safe_decode_with_fallback(name_node)):
+                continue
+            full = f"{prefix}{cs.SEPARATOR_DOT}{name}" if prefix else name
+            if child.type == cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION:
+                found.setdefault(full, set()).update(
+                    self._csharp_declared_type_names(container)
+                )
+                continue
+            body = child.child_by_field_name(cs.FIELD_BODY)
+            if body is None:
+                found.setdefault(full, set())
+                continue
+            found.setdefault(full, set()).update(self._csharp_declared_type_names(body))
+            self._walk_csharp_namespaces(body, full, found)
+
     def _collect_csharp_namespaces(self, root_node: Node) -> dict[str, set[str]]:
         # Namespaces appear only at the top level and inside namespace bodies,
         # so the walk prunes into nothing else; nesting composes dotted names.
         # Each namespace carries the TYPE NAMES it declares in this file: the
         # name-level evidence that pins a type-only `using` to the module.
         found: dict[str, set[str]] = {}
-
-        def type_names(container: Node) -> set[str]:
-            names: set[str] = set()
-            for child in container.named_children:
-                if child.type not in self._CSHARP_TYPE_DECLARATIONS:
-                    continue
-                name_node = child.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
-                if name_node is not None and (
-                    name := safe_decode_with_fallback(name_node)
-                ):
-                    names.add(name)
-            return names
-
-        def walk(container: Node, prefix: str) -> None:
-            for child in container.named_children:
-                if child.type not in (
-                    cs.TS_CSHARP_NAMESPACE_DECLARATION,
-                    cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION,
-                ):
-                    continue
-                name_node = child.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
-                if name_node is None:
-                    continue
-                name = safe_decode_with_fallback(name_node)
-                if not name:
-                    continue
-                full = f"{prefix}{cs.SEPARATOR_DOT}{name}" if prefix else name
-                if child.type == cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION:
-                    found.setdefault(full, set()).update(type_names(container))
-                    continue
-                body = child.child_by_field_name(cs.FIELD_BODY)
-                if body is not None:
-                    found.setdefault(full, set()).update(type_names(body))
-                    walk(body, full)
-                else:
-                    found.setdefault(full, set())
-
-        walk(root_node, "")
+        self._walk_csharp_namespaces(root_node, "", found)
         return found
 
     def _collect_csharp_identifiers(self, root_node: Node) -> frozenset[str]:
         # Every identifier the file mentions, as coarse evidence for pinning
-        # type-only namespace uses; a linear cursor walk keeps it cheap.
+        # type-only namespace uses; an explicit stack keeps it linear.
         found: set[str] = set()
-        cursor = root_node.walk()
-        reached_root = False
-        while not reached_root:
-            node = cursor.node
-            if node is not None and node.type == cs.TS_CSHARP_IDENTIFIER:
-                if text := safe_decode_text(node):
-                    found.add(text)
-            if cursor.goto_first_child():
-                continue
-            while True:
-                if cursor.goto_next_sibling():
-                    break
-                if not cursor.goto_parent():
-                    reached_root = True
-                    break
+        stack = [root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_CSHARP_IDENTIFIER and (
+                text := safe_decode_text(node)
+            ):
+                found.add(text)
+            stack.extend(node.children)
         return frozenset(found)
 
     def requeue_csharp_import_edges(self) -> None:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1541,3 +1541,21 @@ def is_method_node(func_node: ASTNode, lang_config: LanguageSpec) -> bool:
             return False
         current = current.parent
     return False
+
+
+def module_qn_for_entity(
+    entity_qn: str, module_paths: Mapping[str, object]
+) -> str | None:
+    """The indexed module a fully-qualified entity belongs to, or None.
+
+    Entity qns extend their module's qn with class and member segments, so
+    the module is the longest strict prefix that names an indexed module
+    (issue #1347). Only key membership is read, so the mapping's value type
+    does not matter.
+    """
+    candidate = entity_qn
+    while cs.SEPARATOR_DOT in candidate:
+        candidate = candidate.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        if candidate in module_paths:
+            return candidate
+    return None

--- a/codebase_rag/tests/test_csharp_imports.py
+++ b/codebase_rag/tests/test_csharp_imports.py
@@ -222,3 +222,153 @@ public class RemoteStorageProvider
         for c in get_relationships(mock_ingestor, "IMPORTS")
     }
     assert (installer_qn, "Module", provider_qn) in edges, edges
+
+
+def test_type_only_namespace_use_still_pins_the_import(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # The importing file uses the namespace ONLY in type positions (a field
+    # declaration); no call, inherit, or delegate resolution ever fires, so
+    # the declared-type-name evidence must carry the edge (issue #1347).
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Holder.cs").write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Holder
+{
+    private RemoteStorageProvider _provider;
+
+    public Holder(RemoteStorageProvider provider)
+    {
+        _provider = provider;
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "RemoteStorageProvider.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "Unused.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class UnusedThing
+{
+    public static void Noop() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][0]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    holder = next((f for f, _tl, _t in imports if f.endswith(".HostApp.Holder")), None)
+    assert holder is not None, imports
+    assert any(
+        f == holder
+        and tl == "Module"
+        and t.endswith(".PlatformLib.RemoteStorageProvider")
+        for f, tl, t in imports
+    ), imports
+    assert not any(
+        f == holder and t.endswith(".PlatformLib.Unused") for f, _tl, t in imports
+    ), imports
+
+
+def test_watched_modification_reemits_internal_import_edges(
+    csharp_project: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A watched edit runs the realtime path, not run(): the deferred import
+    # flush must happen there too, or the live graph loses the module-level
+    # import edges until the next full index (issue #1347).
+    import sys
+    from typing import Protocol, runtime_checkable
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from watchdog.events import FileModifiedEvent
+
+    import realtime_updater
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, queries = load_parsers()
+    if "c_sharp" not in parsers:
+        pytest.skip("c_sharp parser not available")
+
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    installer = host / "Installer.cs"
+    installer.write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Installer
+{
+    public void Wire()
+    {
+        RemoteStorageProvider.Ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "RemoteStorageProvider.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=csharp_project,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    class _AnyProtocol(Protocol):
+        pass
+
+    monkeypatch.setattr(
+        realtime_updater, "QueryProtocol", runtime_checkable(_AnyProtocol)
+    )
+    handler = realtime_updater.CodeChangeEventHandler(updater, debounce_seconds=0)
+    handler.ignore_patterns = handler.ignore_patterns - {"tmp", "temp"}
+
+    installer.write_text(
+        installer.read_text(encoding="utf-8") + "\n// touched\n", encoding="utf-8"
+    )
+    mock_ingestor.reset_mock()
+    handler.dispatch(FileModifiedEvent(str(installer)))
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert any(
+        f.endswith(".HostApp.Installer")
+        and t.endswith(".PlatformLib.RemoteStorageProvider")
+        for f, t in imports
+    ), imports

--- a/codebase_rag/tests/test_csharp_imports.py
+++ b/codebase_rag/tests/test_csharp_imports.py
@@ -548,3 +548,131 @@ public class RemoteStorageProvider
         and t.endswith(".PlatformLib.RemoteStorageProvider")
         for f, t in imports
     ), imports
+
+
+def test_a_name_position_identifier_is_not_import_evidence(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # The file's only textual match with the namespace's declared types is a
+    # PARAMETER NAME; a name position declares, it does not reference, so it
+    # must not pin the import.
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Naming.cs").write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Naming
+{
+    public void Configure(string RemoteStorageProvider)
+    {
+        System.Console.WriteLine(RemoteStorageProvider);
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "RemoteStorageProvider.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert not any(
+        f.endswith(".HostApp.Naming")
+        and t.endswith(".PlatformLib.RemoteStorageProvider")
+        for f, t in imports
+    ), imports
+
+
+def test_watched_provider_deletion_stops_targeting_its_module(
+    csharp_project: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Deleting the provider must also drop its in-memory C# import state, or
+    # the requeue rebuilds an IMPORTS edge to a Module that no longer exists,
+    # diverging from what a clean rebuild of the same tree would produce.
+    from typing import Protocol, runtime_checkable
+
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[2]))
+    from watchdog.events import FileDeletedEvent
+
+    import realtime_updater
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, queries = load_parsers()
+    if "c_sharp" not in parsers:
+        pytest.skip("c_sharp parser not available")
+
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Installer.cs").write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Installer
+{
+    public void Wire()
+    {
+        RemoteStorageProvider.Ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    provider = lib / "RemoteStorageProvider.cs"
+    provider.write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=csharp_project,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    class _AnyProtocol(Protocol):
+        pass
+
+    monkeypatch.setattr(
+        realtime_updater, "QueryProtocol", runtime_checkable(_AnyProtocol)
+    )
+    handler = realtime_updater.CodeChangeEventHandler(updater, debounce_seconds=0)
+    handler.ignore_patterns = handler.ignore_patterns - {"tmp", "temp"}
+
+    provider.unlink()
+    mock_ingestor.reset_mock()
+    handler.dispatch(FileDeletedEvent(str(provider)))
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][0]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert not any(
+        tl == "Module" and t.endswith(".PlatformLib.RemoteStorageProvider")
+        for _f, tl, t in imports
+    ), imports

--- a/codebase_rag/tests/test_csharp_imports.py
+++ b/codebase_rag/tests/test_csharp_imports.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from codebase_rag.constants import SupportedLanguage
 from codebase_rag.tests.conftest import get_relationships, run_updater
 
 SKIP = "c_sharp"
@@ -117,3 +118,107 @@ public class UnusedThing
         edge[1] == installer and edge[2] == "ExternalModule" and edge[3] == "System"
         for edge in imports
     ), imports
+
+
+def test_method_group_only_usage_still_pins_the_import(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # The importing file never INVOKES anything from the namespace; it only
+    # passes a method group as a delegate. The reference resolution is the
+    # sole evidence, and it must still pin the IMPORTS edge (issue #1347).
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Wiring.cs").write_text(
+        """
+using System;
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Wiring
+{
+    public void Hook()
+    {
+        Register(Provider.Handle);
+    }
+
+    private void Register(Action target)
+    {
+        target();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "Provider.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class Provider
+{
+    public static void Handle() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][0]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    wiring = next((f for f, _tl, _t in imports if f.endswith(".HostApp.Wiring")), None)
+    assert wiring is not None, imports
+    assert any(
+        f == wiring and t.endswith(".PlatformLib.Provider") and tl == "Module"
+        for f, tl, t in imports
+    ), imports
+    assert not any(
+        f == wiring and t == "Acme.Core.PlatformLib" for f, _tl, t in imports
+    ), imports
+
+
+def test_unparsed_module_namespaces_recover_at_flush(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # An incremental run re-parses only CHANGED files: the provider module is
+    # known (rehydrated) but its parse_imports never ran this run, so its
+    # declared namespace must be recovered from source at flush time or the
+    # internal detection silently fails (issue #1347).
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    lib = csharp_project / "PlatformLib"
+    lib.mkdir()
+    provider_path = lib / "RemoteStorageProvider.cs"
+    provider_path.write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    processor = ImportProcessor(
+        repo_path=csharp_project, project_name="proj", ingestor=mock_ingestor
+    )
+    installer_qn = "proj.HostApp.Installer"
+    provider_qn = "proj.PlatformLib.RemoteStorageProvider"
+    processor.import_mapping[installer_qn] = {"PlatformLib": "Acme.Core.PlatformLib"}
+    processor.defer_import_edge(
+        installer_qn, "Acme.Core.PlatformLib", SupportedLanguage.CSHARP
+    )
+    processor.record_resolved_cross_module_use(installer_qn, provider_qn)
+    emitted = processor.flush_deferred_import_edges(
+        {
+            installer_qn: str(csharp_project / "HostApp" / "Installer.cs"),
+            provider_qn: str(provider_path),
+        }
+    )
+    assert emitted == 1
+    edges = {
+        (str(c.args[0][2]), str(c.args[2][0]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert (installer_qn, "Module", provider_qn) in edges, edges

--- a/codebase_rag/tests/test_csharp_imports.py
+++ b/codebase_rag/tests/test_csharp_imports.py
@@ -676,3 +676,49 @@ public class RemoteStorageProvider
         tl == "Module" and t.endswith(".PlatformLib.RemoteStorageProvider")
         for _f, tl, t in imports
     ), imports
+
+
+def test_a_namesake_property_keeps_the_type_evidence(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # `RemoteStorageProvider RemoteStorageProvider { get; set; }` is idiomatic
+    # C#: the property NAME matches the TYPE. The type-position use is real
+    # evidence and must survive the name-position subtraction.
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Options.cs").write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Options
+{
+    public RemoteStorageProvider RemoteStorageProvider { get; set; }
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "RemoteStorageProvider.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][0]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert any(
+        f.endswith(".HostApp.Options")
+        and tl == "Module"
+        and t.endswith(".PlatformLib.RemoteStorageProvider")
+        for f, tl, t in imports
+    ), imports

--- a/codebase_rag/tests/test_csharp_imports.py
+++ b/codebase_rag/tests/test_csharp_imports.py
@@ -372,3 +372,181 @@ public class RemoteStorageProvider
         and t.endswith(".PlatformLib.RemoteStorageProvider")
         for f, t in imports
     ), imports
+
+
+def test_a_locally_declared_name_is_not_evidence_for_an_import(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # The file declares its OWN RemoteStorageProvider and never uses the
+    # imported namespace: an unqualified mention binds to the local type, so
+    # the name must not count as evidence for the namespace's module.
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Shadow.cs").write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+
+public class Shadow
+{
+    public void Wire()
+    {
+        RemoteStorageProvider.Ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "RemoteStorageProvider.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert not any(
+        f.endswith(".HostApp.Shadow")
+        and t.endswith(".PlatformLib.RemoteStorageProvider")
+        for f, t in imports
+    ), imports
+
+
+def test_delegate_only_namespace_use_still_pins_the_import(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Consumer.cs").write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Consumer
+{
+    private StorageChanged _handler;
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "Events.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public delegate void StorageChanged(string path);
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][0]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert any(
+        f.endswith(".HostApp.Consumer")
+        and tl == "Module"
+        and t.endswith(".PlatformLib.Events")
+        for f, tl, t in imports
+    ), imports
+
+
+def test_watched_provider_edit_keeps_the_importers_edge(
+    csharp_project: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Editing the PROVIDER deletes and recreates its Module node, severing the
+    # unchanged importer's edge; the importer never re-parses, so its using
+    # entries must be requeued from the persistent import mapping or the edge
+    # stays lost until a full re-index (issue #1347).
+    import sys
+    from typing import Protocol, runtime_checkable
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from watchdog.events import FileModifiedEvent
+
+    import realtime_updater
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, queries = load_parsers()
+    if "c_sharp" not in parsers:
+        pytest.skip("c_sharp parser not available")
+
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Installer.cs").write_text(
+        """
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Installer
+{
+    public void Wire()
+    {
+        RemoteStorageProvider.Ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    provider = lib / "RemoteStorageProvider.cs"
+    provider.write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=csharp_project,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    class _AnyProtocol(Protocol):
+        pass
+
+    monkeypatch.setattr(
+        realtime_updater, "QueryProtocol", runtime_checkable(_AnyProtocol)
+    )
+    handler = realtime_updater.CodeChangeEventHandler(updater, debounce_seconds=0)
+    handler.ignore_patterns = handler.ignore_patterns - {"tmp", "temp"}
+
+    provider.write_text(
+        provider.read_text(encoding="utf-8") + "\n// touched\n", encoding="utf-8"
+    )
+    mock_ingestor.reset_mock()
+    handler.dispatch(FileModifiedEvent(str(provider)))
+
+    imports = {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    assert any(
+        f.endswith(".HostApp.Installer")
+        and t.endswith(".PlatformLib.RemoteStorageProvider")
+        for f, t in imports
+    ), imports

--- a/codebase_rag/tests/test_csharp_imports.py
+++ b/codebase_rag/tests/test_csharp_imports.py
@@ -36,3 +36,84 @@ public class Program { public void Main() {} }
     imports = get_relationships(mock_ingestor, "IMPORTS")
     # Every using directive above should produce an IMPORTS edge.
     assert len(imports) >= 4, f"expected >=4 IMPORTS, got {len(imports)}"
+
+
+def test_internal_namespace_import_targets_referenced_modules(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # A `using` of a namespace defined INSIDE the repo must land on the
+    # specific Module nodes whose types the file actually references, not on
+    # a dead-end ExternalModule keyed by the namespace string (issue #1347).
+    host = csharp_project / "HostApp"
+    lib = csharp_project / "PlatformLib"
+    host.mkdir()
+    lib.mkdir()
+    (host / "Installer.cs").write_text(
+        """
+using System;
+using Acme.Core.PlatformLib;
+
+namespace Acme.Core.HostApp;
+public class Installer
+{
+    public void Wire()
+    {
+        RemoteStorageProvider.Ping();
+        Console.WriteLine("wired");
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "RemoteStorageProvider.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class RemoteStorageProvider
+{
+    public static void Ping() {}
+}
+""",
+        encoding="utf-8",
+    )
+    (lib / "Unused.cs").write_text(
+        """
+namespace Acme.Core.PlatformLib;
+public class UnusedThing
+{
+    public static void Noop() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    imports = {
+        (str(c.args[0][0]), str(c.args[0][2]), str(c.args[2][0]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "IMPORTS")
+    }
+    installer = next(
+        (f for _fl, f, _tl, _t in imports if f.endswith(".HostApp.Installer")), None
+    )
+    assert installer is not None, imports
+
+    provider_edges = [
+        edge
+        for edge in imports
+        if edge[1] == installer
+        and edge[3].endswith(".PlatformLib.RemoteStorageProvider")
+    ]
+    assert provider_edges, imports
+    assert all(edge[2] == "Module" for edge in provider_edges), provider_edges
+
+    assert not any(
+        edge[1] == installer and edge[3] == "Acme.Core.PlatformLib" for edge in imports
+    ), imports
+    assert not any(
+        edge[1] == installer and edge[3].endswith(".PlatformLib.Unused")
+        for edge in imports
+    ), imports
+    # A genuinely external namespace keeps its ExternalModule edge.
+    assert any(
+        edge[1] == installer and edge[2] == "ExternalModule" and edge[3] == "System"
+        for edge in imports
+    ), imports

--- a/codebase_rag/tests/test_csharp_imports.py
+++ b/codebase_rag/tests/test_csharp_imports.py
@@ -296,10 +296,9 @@ def test_watched_modification_reemits_internal_import_edges(
     # A watched edit runs the realtime path, not run(): the deferred import
     # flush must happen there too, or the live graph loses the module-level
     # import edges until the next full index (issue #1347).
-    import sys
     from typing import Protocol, runtime_checkable
 
-    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[2]))
     from watchdog.events import FileModifiedEvent
 
     import realtime_updater
@@ -474,10 +473,9 @@ def test_watched_provider_edit_keeps_the_importers_edge(
     # unchanged importer's edge; the importer never re-parses, so its using
     # entries must be requeued from the persistent import mapping or the edge
     # stays lost until a full re-index (issue #1347).
-    import sys
     from typing import Protocol, runtime_checkable
 
-    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[2]))
     from watchdog.events import FileModifiedEvent
 
     import realtime_updater

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -363,7 +363,10 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         # The re-parsed file queued deferred IMPORTS edges, and C# namespace
         # imports additionally pin to the cross-module uses the call pass
         # just recorded, so the flush must run on this path too or a watched
-        # edit leaves the live graph without its import edges (issue #1347).
+        # edit leaves the live graph without its import edges. Unchanged C#
+        # importers are requeued as well: editing a PROVIDER recreated its
+        # Module node and severed their edges (issue #1347).
+        self.updater.factory.import_processor.requeue_csharp_import_edges()
         self.updater.factory.import_processor.flush_deferred_import_edges(
             self.updater.known_module_paths()
         )

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -360,6 +360,14 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         ingestor.execute_write(CYPHER_DELETE_CALLS)
         self.updater._process_function_calls()
 
+        # The re-parsed file queued deferred IMPORTS edges, and C# namespace
+        # imports additionally pin to the cross-module uses the call pass
+        # just recorded, so the flush must run on this path too or a watched
+        # edit leaves the live graph without its import edges (issue #1347).
+        self.updater.factory.import_processor.flush_deferred_import_edges(
+            self.updater.known_module_paths()
+        )
+
         # Step 5: Flush changes to database
         self.updater.ingestor.flush_all()
         logger.success(logs.GRAPH_UPDATED.format(name=path.name))


### PR DESCRIPTION
## Summary

- A C# `using` of a namespace defined inside the repo produced an `IMPORTS` edge to a dead-end `ExternalModule` keyed by the namespace string, with nothing connecting it to the files that define the referenced types (#1347's example graph). The edge now lands on the specific `Module` nodes whose entities the importing file actually resolved, and only on those; unreferenced files in the namespace get no edge, and genuinely external namespaces keep their `ExternalModule` edge.
- Implementation follows the issue's design with one deviation: internal-ness is decided from namespaces DECLARED by indexed modules, collected per file at parse time from `namespace`/file-scoped declarations, instead of the suggested dot-bounded path matching, because C# namespaces need not mirror directory names and module qns are path-based. Cross-module resolutions are recorded from the two hook sites the issue names (call/reference resolution in the call processor, deferred inherits/implements resolution), guarded to first-party targets by the project-qn prefix, and reset per module for watch-mode re-parses.
- One ordering change was required that the issue's plan presupposed: `flush_deferred_import_edges` ran before Pass 3, when no call resolutions existed yet, so the flush now runs right after `_process_function_calls()`. The full unit suite passes with the move.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1347

## Test Plan

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added

Red first: a HostApp file `using Acme.Core.PlatformLib` referencing one of two files in that namespace must import that file's Module node (Module-to-Module), must not import the namespace ExternalModule, must not import the unreferenced file, and `using System` must stay an ExternalModule edge. All 454 import-related tests and the full unit suite (7900 passed) are green; the single local failure is the live dotnet trace test, which fails identically on clean main with this machine's dotnet 10 and is unrelated.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved C# namespace import resolution and links to the correct internal modules.
  - Improved cross-module dependency detection for calls, method references, property reads, delegates, and inheritance.
  - Prevented locally defined or unused types from appearing as imports.
  - Preserved external namespace handling when no internal module matches.
  - Improved import updates during incremental and watched-file processing.

- **Tests**
  - Added coverage for internal, external, deferred, type-only, delegate-only, shadowed, and real-time C# namespace imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->