### PR TITLE
docs: explain the piwheels Bookworm failure and document the Python 3.12 floor

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -70,8 +70,9 @@ pip install "code-graph-rag[treesitter-full] @ git+https://github.com/vitali87/c
 - `cmake` (for building pymgclient)
 - `ripgrep` (`rg`) (for shell command text searching)
 
-The wheel is pure Python (`py3-none-any`), so it installs on any platform with
-Python 3.12 or newer. The piwheels build for Debian Bookworm shows as failed
+The wheel is pure Python (`py3-none-any`), so the package itself installs on
+any platform with Python 3.12 or newer (dependencies may still need platform
+wheels or build tools, such as `cmake` for `pymgclient`). The piwheels build for Debian Bookworm shows as failed
 because Bookworm's system Python is 3.11, which is below our floor. On
 Raspberry Pi OS Bookworm, install into a Python 3.12 environment so the pip
 commands above actually run under 3.12: with [uv](https://docs.astral.sh/uv/)

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -75,8 +75,8 @@ Python 3.12 or newer. The piwheels build for Debian Bookworm shows as failed
 because Bookworm's system Python is 3.11, which is below our floor. On
 Raspberry Pi OS Bookworm, install into a Python 3.12 environment so the pip
 commands above actually run under 3.12: with [uv](https://docs.astral.sh/uv/)
-run `uv venv --python 3.12 && source .venv/bin/activate` (uv downloads 3.12
-automatically), or install CPython 3.12 yourself and use
+run `uv venv --python 3.12 --seed && source .venv/bin/activate` (uv downloads
+3.12 automatically; `--seed` puts pip in the environment), or install CPython 3.12 yourself and use
 `python3.12 -m pip install ...`.
 
 ## CLI Quick Start

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -73,8 +73,11 @@ pip install "code-graph-rag[treesitter-full] @ git+https://github.com/vitali87/c
 The wheel is pure Python (`py3-none-any`), so it installs on any platform with
 Python 3.12 or newer. The piwheels build for Debian Bookworm shows as failed
 because Bookworm's system Python is 3.11, which is below our floor. On
-Raspberry Pi OS Bookworm, install a newer interpreter first (for example
-`uv python install 3.12`) and the PyPI wheel installs normally.
+Raspberry Pi OS Bookworm, install into a Python 3.12 environment so the pip
+commands above actually run under 3.12: with [uv](https://docs.astral.sh/uv/)
+run `uv venv --python 3.12 && source .venv/bin/activate` (uv downloads 3.12
+automatically), or install CPython 3.12 yourself and use
+`python3.12 -m pip install ...`.
 
 ## CLI Quick Start
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -70,6 +70,12 @@ pip install "code-graph-rag[treesitter-full] @ git+https://github.com/vitali87/c
 - `cmake` (for building pymgclient)
 - `ripgrep` (`rg`) (for shell command text searching)
 
+The wheel is pure Python (`py3-none-any`), so it installs on any platform with
+Python 3.12 or newer. The piwheels build for Debian Bookworm shows as failed
+because Bookworm's system Python is 3.11, which is below our floor. On
+Raspberry Pi OS Bookworm, install a newer interpreter first (for example
+`uv python install 3.12`) and the PyPI wheel installs normally.
+
 ## CLI Quick Start
 
 The package installs a `cgr` command.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ To run code newer than the latest release, install from git:
 uv tool install "code-graph-rag[treesitter-full,semantic] @ git+https://github.com/vitali87/code-graph-rag@main"
 ```
 
-You also need Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites, source installs, and environment setup are in the [Installation](docs/getting-started/installation.md) guide.
+You also need Python 3.12+, Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites, source installs, and environment setup are in the [Installation](docs/getting-started/installation.md) guide.
+
+> [!NOTE]
+> The wheel is pure Python (`py3-none-any`), so it installs on any platform with Python 3.12 or newer. The [piwheels](https://www.piwheels.org/project/code-graph-rag/) build for Debian Bookworm shows as failed because Bookworm's system Python is 3.11, which is below our floor. On Raspberry Pi OS Bookworm, install a newer interpreter first (for example `uv python install 3.12`) and the PyPI wheel installs normally.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ uv tool install "code-graph-rag[treesitter-full,semantic] @ git+https://github.c
 You also need Python 3.12+, Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites, source installs, and environment setup are in the [Installation](docs/getting-started/installation.md) guide.
 
 > [!NOTE]
-> The wheel is pure Python (`py3-none-any`), so it installs on any platform with Python 3.12 or newer. The [piwheels](https://www.piwheels.org/project/code-graph-rag/) build for Debian Bookworm shows as failed because Bookworm's system Python is 3.11, which is below our floor. On Raspberry Pi OS Bookworm, install a newer interpreter first (for example `uv python install 3.12`) and the PyPI wheel installs normally.
+> The wheel is pure Python (`py3-none-any`), so it installs on any platform with Python 3.12 or newer. The [piwheels](https://www.piwheels.org/project/code-graph-rag/) build for Debian Bookworm shows as failed because Bookworm's system Python is 3.11, which is below our floor. On Raspberry Pi OS Bookworm, pin the interpreter explicitly, for example `uv tool install --python 3.12 "code-graph-rag[treesitter-full,semantic]"`; uv downloads Python 3.12 automatically and the PyPI wheel installs normally.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ uv tool install "code-graph-rag[treesitter-full,semantic] @ git+https://github.c
 You also need Python 3.12+, Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites, source installs, and environment setup are in the [Installation](docs/getting-started/installation.md) guide.
 
 > [!NOTE]
-> The wheel is pure Python (`py3-none-any`), so it installs on any platform with Python 3.12 or newer. The [piwheels](https://www.piwheels.org/project/code-graph-rag/) build for Debian Bookworm shows as failed because Bookworm's system Python is 3.11, which is below our floor. On Raspberry Pi OS Bookworm, pin the interpreter explicitly, for example `uv tool install --python 3.12 "code-graph-rag[treesitter-full,semantic]"`; uv downloads Python 3.12 automatically and the PyPI wheel installs normally.
+> The wheel is pure Python (`py3-none-any`), so the package itself installs on any platform with Python 3.12 or newer (dependencies may still need platform wheels or build tools, such as `cmake` for `pymgclient`). The [piwheels](https://www.piwheels.org/project/code-graph-rag/) build for Debian Bookworm shows as failed because Bookworm's system Python is 3.11, which is below our floor. On Raspberry Pi OS Bookworm, pin the interpreter explicitly, for example `uv tool install --python 3.12 "code-graph-rag[treesitter-full,semantic]"`; uv downloads Python 3.12 automatically and the PyPI wheel installs normally.
 
 ## Quick Start
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ description: "Install Code-Graph-RAG and set up Memgraph for multi-language code
 
 ## Prerequisites
 
-- Python 3.12+ (the wheel is pure Python, but the interpreter floor is strict; Debian Bookworm ships Python 3.11, which is why the [piwheels](https://www.piwheels.org/project/code-graph-rag/) Bookworm build shows as failed. On Raspberry Pi OS Bookworm, install a newer interpreter first, for example `uv python install 3.12`.)
+- Python 3.12+ (the wheel is pure Python, but the interpreter floor is strict; Debian Bookworm ships Python 3.11, which is why the [piwheels](https://www.piwheels.org/project/code-graph-rag/) Bookworm build shows as failed. On Raspberry Pi OS Bookworm, run the install commands below inside a Python 3.12 environment, for example `uv venv --python 3.12 && source .venv/bin/activate`, so pip actually uses 3.12.)
 - Docker & Docker Compose (for Memgraph)
 - **cmake** (required for building pymgclient dependency)
 - **ripgrep** (`rg`) (required for shell command text searching)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ description: "Install Code-Graph-RAG and set up Memgraph for multi-language code
 
 ## Prerequisites
 
-- Python 3.12+ (the wheel is pure Python, but the interpreter floor is strict; Debian Bookworm ships Python 3.11, which is why the [piwheels](https://www.piwheels.org/project/code-graph-rag/) Bookworm build shows as failed. On Raspberry Pi OS Bookworm, run the install commands below inside a Python 3.12 environment, for example `uv venv --python 3.12 && source .venv/bin/activate`, so pip actually uses 3.12.)
+- Python 3.12+ (the wheel is pure Python, but the interpreter floor is strict; Debian Bookworm ships Python 3.11, which is why the [piwheels](https://www.piwheels.org/project/code-graph-rag/) Bookworm build shows as failed. On Raspberry Pi OS Bookworm, run the install commands below inside a Python 3.12 environment, for example `uv venv --python 3.12 --seed && source .venv/bin/activate`, so pip exists in the environment and actually uses 3.12.)
 - Docker & Docker Compose (for Memgraph)
 - **cmake** (required for building pymgclient dependency)
 - **ripgrep** (`rg`) (required for shell command text searching)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,7 @@ description: "Install Code-Graph-RAG and set up Memgraph for multi-language code
 
 ## Prerequisites
 
-- Python 3.12+
+- Python 3.12+ (the wheel is pure Python, but the interpreter floor is strict; Debian Bookworm ships Python 3.11, which is why the [piwheels](https://www.piwheels.org/project/code-graph-rag/) Bookworm build shows as failed. On Raspberry Pi OS Bookworm, install a newer interpreter first, for example `uv python install 3.12`.)
 - Docker & Docker Compose (for Memgraph)
 - **cmake** (required for building pymgclient dependency)
 - **ripgrep** (`rg`) (required for shell command text searching)


### PR DESCRIPTION
## Summary

- Documents why the piwheels Bookworm build fails: Bookworm's system Python is 3.11 while this project pins `requires-python = ">=3.12"`; the wheel itself is pure Python (`py3-none-any`) and installs fine under any Python 3.12+
- Adds the Python 3.12+ floor and a Raspberry Pi OS Bookworm workaround to README.md, PYPI_README.md, and docs/getting-started/installation.md, using commands that actually bind the interpreter (`uv tool install --python 3.12 ...`, `uv venv --python 3.12 --seed && source .venv/bin/activate`, or `python3.12 -m pip install ...`)
- Lowering the floor to 3.11 was ruled out: the codebase now uses PEP 695 syntax (3.12+) extensively, including `type` aliases throughout `codebase_rag/types_defs.py` and generic function/class syntax in `codebase_rag/decorators.py`, `codebase_rag/parser_loader.py`, and `codebase_rag/main.py`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Closes #1243

## Test Plan

- [ ] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [ ] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

Docs-only change; verified the rendered Markdown and confirmed the documented commands bind pip to Python 3.12 (`uv venv --python 3.12 --seed` seeds pip into the environment; `uv tool install --python 3.12` pins the interpreter). Reviewer bots (Greptile T-Rex) reproduced the failure of the old unqualified `pip install` on system 3.11 and the success under an explicit 3.12 environment.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation requirements to Python 3.12 or newer.
  * Clarified that dependencies may require platform wheels or build tools such as `cmake`.
  * Expanded Raspberry Pi OS Bookworm guidance, including the Python 3.11 piwheels limitation.
  * Updated virtual environment instructions to use Python 3.12 and ensure pip is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->