### PR TITLE
docs: document macOS pymgclient source-build OpenSSL requirements

### DIFF
--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -4,6 +4,24 @@ description: "Troubleshoot common Code-Graph-RAG issues with Memgraph, Ollama, a
 
 # Troubleshooting
 
+## pymgclient Build Fails on macOS
+
+When pip has no prebuilt `pymgclient` wheel for your platform it builds from
+source, and the build can fail first on a missing CMake and then on OpenSSL
+headers CMake cannot locate (Homebrew does not put OpenSSL on the default
+search paths). Install the build dependencies and point CMake at Homebrew's
+OpenSSL:
+
+```bash
+brew install cmake pkg-config openssl
+export OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
+export PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH"
+```
+
+Then rerun the install in the same shell. Verified recipe: with those
+variables set, `pip install --no-binary pymgclient pymgclient` builds and
+imports cleanly.
+
 ## Check Memgraph Connection
 
 - Ensure Docker containers are running: `docker compose ps`

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -33,9 +33,11 @@ description: "Install Code-Graph-RAG and set up Memgraph for multi-language code
     export PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH"
     ```
 
-    Run the install command again in the same shell so the variables are
-    picked up. See [Troubleshooting](../advanced/troubleshooting.md) for the
-    symptoms this fixes.
+    Then run the `pip install` command from
+    [Install from PyPI](#install-from-pypi) below (or rerun the one that just
+    failed) in the same shell so the variables are picked up. See
+    [Troubleshooting](../advanced/troubleshooting.md) for the symptoms this
+    fixes.
 
 === "Ubuntu/Debian"
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -22,6 +22,21 @@ description: "Install Code-Graph-RAG and set up Memgraph for multi-language code
     brew install cmake ripgrep
     ```
 
+    If `pymgclient` has no prebuilt wheel for your platform (for example older
+    macOS x86_64 setups) and pip falls back to building it from source, the
+    build also needs Homebrew's OpenSSL and, if CMake cannot find it,
+    `pkg-config`:
+
+    ```bash
+    brew install pkg-config openssl
+    export OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
+    export PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig:$PKG_CONFIG_PATH"
+    ```
+
+    Run the install command again in the same shell so the variables are
+    picked up. See [Troubleshooting](../advanced/troubleshooting.md) for the
+    symptoms this fixes.
+
 === "Ubuntu/Debian"
 
     ```bash


### PR DESCRIPTION
## Summary

- Adds the Homebrew OpenSSL and pkg-config guidance to the macOS tab of the installation guide for the case where pip has no prebuilt pymgclient wheel and builds from source
- Adds a "pymgclient Build Fails on macOS" troubleshooting section with the exact exports (`OPENSSL_ROOT_DIR`, `PKG_CONFIG_PATH`)
- Recipe verified on macOS arm64: with those variables set, `pip install --no-binary pymgclient pymgclient` (pymgclient 1.6.0) builds from source and imports cleanly; the variable names match upstream pymgclient's install docs

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Closes #1370

## Test Plan

- [ ] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [ ] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

Ran the documented recipe in a clean Python 3.12 venv on macOS arm64: installed cmake, set `OPENSSL_ROOT_DIR="$(brew --prefix openssl)"` and `PKG_CONFIG_PATH`, then `pip install --no-binary pymgclient pymgclient` compiled successfully and `import mgclient` works.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added macOS installation guidance for environments where `pymgclient` must be built from source.
  * Documented required Homebrew packages, OpenSSL environment configuration, and installation commands.
  * Added troubleshooting steps for common build failures and linked to additional support guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->