### PR TITLE
docs: accept and document the same-qn bodied module node merge with a pin test

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1782,6 +1782,12 @@ class ClassIngestMixin:
                     name=module_name, qn=inline_module_qn
                 )
             )
+            # Same-qn bodied twins (mutually-exclusive cfg mods, or two impls
+            # each declaring a method-local mod) upsert this ONE node: Module
+            # identity is the global qualified_name, so the last twin's
+            # properties win. Accepted representational merge (#1164); call
+            # resolution stays per-twin through each mod body's own uses
+            # (#1163), so only the node's location properties are lossy.
             self.ingestor.ensure_node_batch(cs.NodeLabel.MODULE, module_props)
             # Record the inline module qn so deferred import verification
             # counts it as a real internal target.

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -6290,10 +6290,16 @@ def test_two_bodied_cfg_twin_mods_merge_into_one_module_node(
     )
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
     base = "rs_cfg_twin_merged_node.src"
-    modules = _module_qns(mock_ingestor)
-    assert f"{base}.foo.run" in modules, modules
-    twin_variants = {qn for qn in modules if qn.startswith(f"{base}.foo.run@")}
-    assert not twin_variants, twin_variants
+    module_qn_writes = [
+        props["qualified_name"]
+        for label, props in (
+            c[0] for c in mock_ingestor.ensure_node_batch.call_args_list
+        )
+        if label == "Module" and props["qualified_name"].startswith(f"{base}.foo.run")
+    ]
+    # Both twins must have been ingested, and both must have written the
+    # bare qn: one node identity, no @<start_line> variants.
+    assert module_qn_writes == [f"{base}.foo.run"] * 2, module_qn_writes
 
 
 def _module_qns(mock_ingestor: MagicMock) -> set[str]:

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -6257,6 +6257,45 @@ def test_two_bodied_cfg_twin_mods_keep_separate_uses(
     assert (f"{base}.foo.run.gb", f"{base}.alpha.helper") not in calls, calls
 
 
+def test_two_bodied_cfg_twin_mods_merge_into_one_module_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Pins the accepted representational merge (#1164): Module identity is
+    # the global qualified_name, so same-qn bodied cfg twins upsert ONE
+    # Module node (no @<start_line> variant, unlike Function/Method/Class
+    # twins). Resolution stays per-twin regardless, per the test above.
+    project = temp_repo / "rs_cfg_twin_merged_node"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_cfg_twin_merged_node"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": (
+                '#[cfg(feature = "ext")]\n'
+                "pub mod run {\n"
+                "    pub fn ga() -> u32 {\n"
+                "        2\n"
+                "    }\n"
+                "}\n\n"
+                '#[cfg(not(feature = "ext"))]\n'
+                "pub mod run {\n"
+                "    pub fn gb() -> u32 {\n"
+                "        3\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_cfg_twin_merged_node.src"
+    modules = _module_qns(mock_ingestor)
+    assert f"{base}.foo.run" in modules, modules
+    twin_variants = {qn for qn in modules if qn.startswith(f"{base}.foo.run@")}
+    assert not twin_variants, twin_variants
+
+
 def _module_qns(mock_ingestor: MagicMock) -> set[str]:
     return {
         props["qualified_name"]

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -100,6 +100,8 @@ The first definition keeps the plain dotted qualified name; each later definitio
 
 A `CALLS` edge to a name that has more than one definition links to every variant, since each is a runtime-possible target.
 
+`Module`, `File`, and `Folder` nodes are also identified by `qualified_name`, but without the `@<start_line>` suffix mechanism: two bodied modules that share one qualified name (for example mutually-exclusive `#[cfg]` twin `mod` blocks in one Rust file) merge into a single `Module` node whose location properties come from the last definition ingested. This is an accepted representational merge: call resolution is unaffected, because each twin's functions bind through their own module body's imports rather than a merged import map.
+
 ## Macros
 
 Macro definitions map onto the existing `Function` label rather than a dedicated node type, since macros are a cross-language concept (C and C++ `#define`, Rust `macro_rules!`). Macro Function nodes carry `is_macro: true`, macro invocations resolve to their definitions and emit `CALLS` edges, and dead-code analysis treats macros like any function.

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -100,7 +100,7 @@ The first definition keeps the plain dotted qualified name; each later definitio
 
 A `CALLS` edge to a name that has more than one definition links to every variant, since each is a runtime-possible target.
 
-`Module`, `File`, and `Folder` nodes are also identified by `qualified_name`, but without the `@<start_line>` suffix mechanism: two bodied modules that share one qualified name (for example mutually-exclusive `#[cfg]` twin `mod` blocks in one Rust file) merge into a single `Module` node whose location properties come from the last definition ingested. This is an accepted representational merge: call resolution is unaffected, because each twin's functions bind through their own module body's imports rather than a merged import map.
+`Module` nodes are also identified by `qualified_name` (`File` and `Folder` nodes are keyed by `absolute_path` instead, so they stay per-checkout), but without the `@<start_line>` suffix mechanism: two bodied modules that share one qualified name (for example mutually-exclusive `#[cfg]` twin `mod` blocks in one Rust file) merge into a single `Module` node whose location properties come from the last definition ingested. This is an accepted representational merge: call resolution is unaffected, because each twin's functions bind through their own module body's imports rather than a merged import map.
 
 ## Macros
 

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -100,7 +100,7 @@ The first definition keeps the plain dotted qualified name; each later definitio
 
 A `CALLS` edge to a name that has more than one definition links to every variant, since each is a runtime-possible target.
 
-`Module` nodes are also identified by `qualified_name` (`File` and `Folder` nodes are keyed by `absolute_path` instead, so they stay per-checkout), but without the `@<start_line>` suffix mechanism: two bodied modules that share one qualified name (for example mutually-exclusive `#[cfg]` twin `mod` blocks in one Rust file) merge into a single `Module` node whose location properties come from the last definition ingested. This is an accepted representational merge: call resolution is unaffected, because each twin's functions bind through their own module body's imports rather than a merged import map.
+`Module` nodes are also identified by `qualified_name` (`File` and `Folder` nodes are keyed by `absolute_path` instead, so they stay per-checkout), but without the `@<start_line>` suffix mechanism: bodied modules that share one qualified name (for example mutually-exclusive `#[cfg]` twin `mod` blocks in one Rust file) merge into a single `Module` node whose location properties come from the last definition ingested. This is an accepted representational merge: call resolution is unaffected, because each twin's functions bind through their own module body's imports rather than a merged import map.
 
 ## Macros
 


### PR DESCRIPTION
## Summary

Issue #1164 flagged a decision: two bodied modules sharing one qualified name (mutually-exclusive `#[cfg]` twin `mod` blocks, or two impls each with a method-local `mod`) merge into a single `MODULE` graph node, because `Module` identity is the global `qualified_name`. This PR takes the option the issue itself recommends as cheapest-correct: accept the representational merge and document it, rather than adding a discriminator to `Module` identity plus a schema migration for a rare edge case. Call resolution is unaffected either way, since #1163 already binds each twin's functions through their own mod-body uses.

- `docs/architecture/graph-schema.md`: new paragraph in "Qualified Name Uniqueness" documenting that `Module`/`File`/`Folder` identity has no `@<start_line>` suffix mechanism, so same-qn bodied twins merge with last-writer-wins location properties, and why resolution is unaffected.
- `codebase_rag/parsers/class_ingest/mixin.py`: comment at the `ensure_node_batch(MODULE, ...)` site recording the accepted merge (#1164) and the resolution guarantee (#1163).
- `codebase_rag/tests/test_rust_crate_path_trait_linking.py`: pin test asserting the twins upsert one `Module` node and no `@<start_line>` variant appears, guarding the documented behavior against silent drift.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test updates

## Related Issues

Closes #1164

## Test Plan

- [x] `uv run pytest codebase_rag/tests/test_rust_crate_path_trait_linking.py` (145 passed, including the new pin test)
- [x] `ruff check` and `ruff format --check` clean on touched files

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified how same-qualified-name Rust modules, including mutually exclusive configuration variants, are represented in the code graph, including merged identity and call-resolution behavior.

- **Tests**
  - Added coverage confirming that mutually exclusive, same-qualified-name module declarations are ingested consistently, share one module identity, and preserve call resolution for each module definition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->