### PR TITLE
docs: accept and pin the shadow-unaware nested factory identity resolution as a documented limitation

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1826,7 +1826,9 @@ class FlowProcessor:
             # same-class/inherited `of(..)` or a local nested `Path` class still
             # matches, mis-attributing a literal identity where `<dynamic>` would
             # be correct. Fixing it needs the full call resolver in this
-            # deliberately lightweight path, for a contradictory-Java trigger.
+            # deliberately lightweight path, for triggers that are valid but
+            # uncommon Java (a shadowed static import, or a local nested class
+            # reusing a well-known name).
             if raw is not None and (
                 raw in jc.identity_calls
                 or jc.flow.import_map.get(raw) in jc.identity_calls

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1795,10 +1795,10 @@ class FlowProcessor:
     def _lean_ctor_identity(
         self, node: Node, ctor: HandleConstructor, jc: _JsCtx
     ) -> str:
-        # The handle's resource identity: the constructor's literal target, or -- when
-        # that is a factory call / `new` identity-carrier one level down
-        # (`Files.newBufferedWriter(Path.of("cfg"))`, `new PrintWriter(new File("x"))`)
-        # -- the literal it carries.
+        """Resolve the handle's resource identity: the constructor's literal
+        target, or -- when that is a factory call / `new` identity-carrier one
+        level down (`Files.newBufferedWriter(Path.of("cfg"))`,
+        `new PrintWriter(new File("x"))`) -- the literal it carries."""
         d = jc.descriptor
         identity = literal_target(
             node,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1822,6 +1822,11 @@ class FlowProcessor:
             # factory bare (`of("cfg")`); resolve it through the import map to its
             # qualified form before the identity-call check, so the literal is still
             # recovered (Greptile review, #1204).
+            # Membership is NOT shadow-aware (#1216, accepted limitation): a
+            # same-class/inherited `of(..)` or a local nested `Path` class still
+            # matches, mis-attributing a literal identity where `<dynamic>` would
+            # be correct. Fixing it needs the full call resolver in this
+            # deliberately lightweight path, for a contradictory-Java trigger.
             if raw is not None and (
                 raw in jc.identity_calls
                 or jc.flow.import_map.get(raw) in jc.identity_calls

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1952,7 +1952,9 @@ class IOAccessProcessor:
             # same-class/inherited `of(..)` or a local nested `Path` class still
             # matches, mis-attributing a literal identity where `<dynamic>` would
             # be correct. Fixing it needs the full call resolver in this
-            # deliberately lightweight path, for a contradictory-Java trigger.
+            # deliberately lightweight path, for triggers that are valid but
+            # uncommon Java (a shadowed static import, or a local nested class
+            # reusing a well-known name).
             if raw is not None and (
                 raw in lean_handles.identity_calls
                 or import_map.get(raw) in lean_handles.identity_calls

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1924,6 +1924,10 @@ class IOAccessProcessor:
         lean_handles: _LeanHandles,
         import_map: dict[str, str],
     ) -> str:
+        """Resolve the handle's resource identity: the constructor's literal
+        target, or -- when that is a factory call / `new` identity-carrier one
+        level down (`Files.newBufferedWriter(Path.of("cfg"))`) -- the literal
+        it carries."""
         identity = literal_target(
             call_node,
             ctor.target_arg,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1948,6 +1948,11 @@ class IOAccessProcessor:
             # A static import (`import static java.nio.file.Path.of`) spells the
             # factory bare (`of("cfg")`); resolve it through the import map to its
             # qualified form so the literal is still recovered (Greptile review, #1204).
+            # Membership is NOT shadow-aware (#1216, accepted limitation): a
+            # same-class/inherited `of(..)` or a local nested `Path` class still
+            # matches, mis-attributing a literal identity where `<dynamic>` would
+            # be correct. Fixing it needs the full call resolver in this
+            # deliberately lightweight path, for a contradictory-Java trigger.
             if raw is not None and (
                 raw in lean_handles.identity_calls
                 or import_map.get(raw) in lean_handles.identity_calls

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -491,13 +491,15 @@ def test_java_files_factory_static_import_identity(tmp_path: Path) -> None:
 def test_java_static_import_shadowed_by_method_pins_literal_identity(
     tmp_path: Path,
 ) -> None:
-    # Pins the accepted limitation (#1216): the same-class `of(..)` method
-    # shadows the static import in real Java, so the correct identity would be
-    # FILE::<dynamic>, but the membership check still maps the bare `of`
-    # through the import map to `java.nio.file.Path.of` and recovers the
-    # literal. Shadow-awareness would need the full call resolver in a
-    # deliberately lightweight path; the shadowing is valid but uncommon Java
-    # (the static import is unusable at this call site).
+    """Pin the accepted limitation (#1216), static-import spelling.
+
+    The same-class `of(..)` method shadows the static import in real Java, so
+    the correct identity would be FILE::<dynamic>, but the membership check
+    still maps the bare `of` through the import map to `java.nio.file.Path.of`
+    and recovers the literal. Shadow-awareness would need the full call
+    resolver in a deliberately lightweight path; the shadowing is valid but
+    uncommon Java (the static import is unusable at this call site).
+    """
     files = {
         "A.java": (
             "import static java.nio.file.Path.of;\n"
@@ -520,10 +522,12 @@ def test_java_static_import_shadowed_by_method_pins_literal_identity(
 def test_java_nested_class_shadowing_pathof_pins_literal_identity(
     tmp_path: Path,
 ) -> None:
-    # Pins the accepted limitation (#1216), qualified spelling: `Path.of` here
-    # is a local nested class, not `java.nio.file.Path`, yet the textual
-    # `Path.of` matches the registry entry and yields a literal identity where
-    # FILE::<dynamic> would be correct.
+    """Pin the accepted limitation (#1216), qualified spelling.
+
+    `Path.of` here is a local nested class, not `java.nio.file.Path`, yet the
+    textual `Path.of` matches the registry entry and yields a literal identity
+    where FILE::<dynamic> would be correct.
+    """
     files = {
         "A.java": (
             "import java.nio.file.Files;\n"

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -496,7 +496,8 @@ def test_java_static_import_shadowed_by_method_pins_literal_identity(
     # FILE::<dynamic>, but the membership check still maps the bare `of`
     # through the import map to `java.nio.file.Path.of` and recovers the
     # literal. Shadow-awareness would need the full call resolver in a
-    # deliberately lightweight path; the trigger is contradictory Java.
+    # deliberately lightweight path; the shadowing is valid but uncommon Java
+    # (the static import is unusable at this call site).
     files = {
         "A.java": (
             "import static java.nio.file.Path.of;\n"

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -488,6 +488,60 @@ def test_java_files_factory_static_import_identity(tmp_path: Path) -> None:
     assert _ENV_FILE in _run_flow(tmp_path, files)
 
 
+def test_java_static_import_shadowed_by_method_pins_literal_identity(
+    tmp_path: Path,
+) -> None:
+    # Pins the accepted limitation (#1216): the same-class `of(..)` method
+    # shadows the static import in real Java, so the correct identity would be
+    # FILE::<dynamic>, but the membership check still maps the bare `of`
+    # through the import map to `java.nio.file.Path.of` and recovers the
+    # literal. Shadow-awareness would need the full call resolver in a
+    # deliberately lightweight path; the trigger is contradictory Java.
+    files = {
+        "A.java": (
+            "import static java.nio.file.Path.of;\n"
+            "import java.nio.file.Files;\n"
+            "import java.nio.file.Path;\n"
+            "import java.io.BufferedWriter;\n"
+            "class A {\n"
+            "  static Path of(String p) { return null; }\n"
+            "  void leak() throws Exception {\n"
+            '    String s = System.getenv("K");\n'
+            '    BufferedWriter w = Files.newBufferedWriter(of("out.txt"));\n'
+            "    w.write(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_java_nested_class_shadowing_pathof_pins_literal_identity(
+    tmp_path: Path,
+) -> None:
+    # Pins the accepted limitation (#1216), qualified spelling: `Path.of` here
+    # is a local nested class, not `java.nio.file.Path`, yet the textual
+    # `Path.of` matches the registry entry and yields a literal identity where
+    # FILE::<dynamic> would be correct.
+    files = {
+        "A.java": (
+            "import java.nio.file.Files;\n"
+            "import java.io.BufferedWriter;\n"
+            "class A {\n"
+            "  static class Path {\n"
+            "    static java.nio.file.Path of(String p) { return null; }\n"
+            "  }\n"
+            "  void leak() throws Exception {\n"
+            '    String s = System.getenv("K");\n'
+            '    BufferedWriter w = Files.newBufferedWriter(Path.of("out.txt"));\n'
+            "    w.write(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
 def test_java_read_only_filereader_emits_no_flow(tmp_path: Path) -> None:
     # `new FileReader` is a READ-only handle, so it never binds as a write sink.
     # The write-named `.write(s)` carries genuine taint, so this fails if the

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -311,10 +311,12 @@ def test_java_files_new_buffered_reader_path_of(tmp_path: Path) -> None:
 def test_java_nested_class_shadowing_pathof_pins_literal_identity(
     tmp_path: Path,
 ) -> None:
-    # Pins the accepted limitation (#1216) in the READS_FROM/WRITES_TO walk:
-    # `Path.of` here is a local nested class, not `java.nio.file.Path`, yet
-    # the textual `Path.of` matches the identity registry and the handle gets
-    # the concrete literal where FILE::<dynamic> would be correct.
+    """Pin the accepted limitation (#1216) in the READS_FROM/WRITES_TO walk.
+
+    `Path.of` here is a local nested class, not `java.nio.file.Path`, yet the
+    textual `Path.of` matches the identity registry and the handle gets the
+    concrete literal where FILE::<dynamic> would be correct.
+    """
     files = {
         "A.java": (
             "import java.nio.file.Files;\n"

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -308,6 +308,31 @@ def test_java_files_new_buffered_reader_path_of(tmp_path: Path) -> None:
     assert _has(rels, "A.load", READS_FROM, "resource::FILE::cfg.txt")
 
 
+def test_java_nested_class_shadowing_pathof_pins_literal_identity(
+    tmp_path: Path,
+) -> None:
+    # Pins the accepted limitation (#1216) in the READS_FROM/WRITES_TO walk:
+    # `Path.of` here is a local nested class, not `java.nio.file.Path`, yet
+    # the textual `Path.of` matches the identity registry and the handle gets
+    # the concrete literal where FILE::<dynamic> would be correct.
+    files = {
+        "A.java": (
+            "import java.nio.file.Files;\n"
+            "class A {\n"
+            "  static class Path {\n"
+            "    static java.nio.file.Path of(String p) { return null; }\n"
+            "  }\n"
+            "  void load() throws Exception {\n"
+            '    var r = Files.newBufferedReader(Path.of("cfg.txt"));\n'
+            "    r.readLine();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run_io(tmp_path, files)
+    assert _has(rels, "A.load", READS_FROM, "resource::FILE::cfg.txt")
+
+
 def test_java_connection_statement_query(tmp_path: Path) -> None:
     # DriverManager.getConnection binds a DATABASE handle; createStatement
     # DERIVES a same-resource handle; executeQuery reads through it.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -442,10 +442,12 @@ module is re-exported under its own name. A project that does
   check, not shadow-aware (issue #1216): a same-class or inherited method named
   `of`, or a local nested class named `Path`, still matches the
   `java.nio.file.Path.of` registry entry, so the handle gets a concrete literal
-  identity where `<dynamic>` would be correct. The trigger is contradictory Java
-  (shadowing a symbol you static-import leaves the import dead and linted), and
-  closing it would mean threading the full call resolver into an intentionally
-  cheap path shared by every language, so this stays an accepted limitation.
+  identity where `<dynamic>` would be correct. Both triggers are valid but
+  uncommon Java: for the static-import spelling, a same-class member shadows the
+  import (leaving it unusable at that call site); for the qualified spelling, a
+  local nested class reuses a well-known name like `Path`. Closing either would
+  mean threading the full call resolver into an intentionally cheap path shared
+  by every language, so this stays an accepted limitation.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -437,6 +437,15 @@ module is re-exported under its own name. A project that does
   registry tables the `READS_FROM`/`WRITES_TO` walk uses. Every catalogued
   handle-write shape across the lean languages now emits a flow edge rather than a
   false `NO_FLOW`.
+- Nested factory **identity resolution** (`Files.newBufferedWriter(Path.of("cfg"))`
+  and the static-imported `of("cfg")` spelling) is a lightweight registry-membership
+  check, not shadow-aware (issue #1216): a same-class or inherited method named
+  `of`, or a local nested class named `Path`, still matches the
+  `java.nio.file.Path.of` registry entry, so the handle gets a concrete literal
+  identity where `<dynamic>` would be correct. The trigger is contradictory Java
+  (shadowing a symbol you static-import leaves the import dead and linted), and
+  closing it would mean threading the full call resolver into an intentionally
+  cheap path shared by every language, so this stays an accepted limitation.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.


### PR DESCRIPTION
## Summary

Resolves #1216 the way its triage comment recommends: the shadow-unaware membership check in nested factory identity resolution is accepted as a documented, pinned limitation rather than fixed with a heavyweight resolver integration.

The gap: `_ctor_identity` (READS_FROM/WRITES_TO walk) and `_lean_ctor_identity` (FLOWS_TO lean walk) resolve `Files.newBufferedWriter(Path.of("cfg"))` and the static-imported `of("cfg")` spelling by lightweight membership against `IO_IDENTITY_UNWRAP_CALLS`. A same-class or inherited `of(..)` method, or a local nested class named `Path`, still matches the `java.nio.file.Path.of` registry entry, so the handle gets a concrete literal identity where `<dynamic>` would be correct.

Why accept it: both triggers are valid but uncommon Java (for the static-import spelling, a same-class member shadows the import, leaving it unusable at that call site; for the qualified spelling, a local nested class reuses a well-known name like `Path`), the impact is a coarser identity rather than a spurious or missing flow, and closing it would mean threading the full Java call resolver into an identity path that is intentionally cheap membership shared by every language. Closure as a documented limitation is explicitly approved on the issue (see the 2026-08-25 comment on #1216).

What this PR adds:
- A known-limitation bullet in the deliberate-ceilings list of `docs/architecture/data-flow-edges.md`.
- Code comments at both membership checks pointing at #1216 so the next reader does not rediscover the gap.
- Three pin tests capturing the current behavior: the static-import spelling shadowed by a same-class `of(..)` method (flow walk), and the qualified `Path.of` spelling shadowed by a local nested `Path` class (both walks).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates

## Related Issues

Closes #1216

## Test Plan

- `pytest codebase_rag/tests/test_flow_handle_writes.py codebase_rag/tests/test_io_handle_edges.py` (132 passed), including the three new pin tests proving the literal is still recovered under both shadowing spellings.
- `ruff check` and `ruff format --check` clean on all touched files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented a known limitation where shadowed Java file-path factory calls may be attributed to the wrong literal resource identity.
  * Clarified that same-class, inherited, or nested shadowing can affect identity resolution.
  * Noted that affected cases may produce a concrete file identity instead of a dynamic identity.

* **Tests**
  * Added regression coverage for static-import and nested `Path` shadowing.
  * Confirmed the current literal-identity behavior for affected file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->