### PR TITLE
docs: exclude globs must be quoted and cover the whole path

### DIFF
--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -319,8 +319,8 @@ HELP_DEADCODE_DECORATOR_ROOT = (
 )
 HELP_DEADCODE_EXCLUDE = (
     "Exclude symbols whose file path matches GLOB. The glob must cover the "
-    "whole repo-relative path ('*' spans directories), so quote it -- "
-    "'*tests*', not tests/*. Repeatable."
+    "whole repo-relative path ('*' spans directories) and be quoted "
+    "('tests/*') so the shell cannot expand it first. Repeatable."
 )
 HELP_DEADCODE_INCLUDE_TESTS = (
     "Treat test code as reachable so exercised production code is not reported."
@@ -350,8 +350,8 @@ HELP_DUPLICATES_EXACT_ONLY = (
 )
 HELP_DUPLICATES_EXCLUDE = (
     "Exclude symbols whose file path matches GLOB. The glob must cover the "
-    "whole repo-relative path ('*' spans directories), so quote it -- "
-    "'*tests*', not tests/*. Repeatable."
+    "whole repo-relative path ('*' spans directories) and be quoted "
+    "('tests/*') so the shell cannot expand it first. Repeatable."
 )
 HELP_DUPLICATES_FORMAT = "Report format: table or json."
 HELP_DUPLICATES_OUTPUT = "Write the report to this file instead of stdout."

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -320,7 +320,8 @@ HELP_DEADCODE_DECORATOR_ROOT = (
 HELP_DEADCODE_EXCLUDE = (
     "Exclude symbols whose file path matches GLOB. The glob must cover the "
     "whole repo-relative path ('*' spans directories) and be quoted "
-    "('tests/*') so the shell cannot expand it first. Repeatable."
+    "('tests/*' for a root-level tests directory, '*/tests/*' for nested "
+    "ones) so the shell cannot expand it first. Repeatable."
 )
 HELP_DEADCODE_INCLUDE_TESTS = (
     "Treat test code as reachable so exercised production code is not reported."
@@ -351,7 +352,8 @@ HELP_DUPLICATES_EXACT_ONLY = (
 HELP_DUPLICATES_EXCLUDE = (
     "Exclude symbols whose file path matches GLOB. The glob must cover the "
     "whole repo-relative path ('*' spans directories) and be quoted "
-    "('tests/*') so the shell cannot expand it first. Repeatable."
+    "('tests/*' for a root-level tests directory, '*/tests/*' for nested "
+    "ones) so the shell cannot expand it first. Repeatable."
 )
 HELP_DUPLICATES_FORMAT = "Report format: table or json."
 HELP_DUPLICATES_OUTPUT = "Write the report to this file instead of stdout."

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -318,7 +318,9 @@ HELP_DEADCODE_DECORATOR_ROOT = (
     "Mark symbols with this decorator as entry points. Extends the built-in set."
 )
 HELP_DEADCODE_EXCLUDE = (
-    "Exclude symbols whose file path matches GLOB. '*' spans directories. Repeatable."
+    "Exclude symbols whose file path matches GLOB. The glob must cover the "
+    "whole repo-relative path ('*' spans directories), so quote it -- "
+    "'*tests*', not tests/*. Repeatable."
 )
 HELP_DEADCODE_INCLUDE_TESTS = (
     "Treat test code as reachable so exercised production code is not reported."
@@ -347,7 +349,9 @@ HELP_DUPLICATES_EXACT_ONLY = (
     "Report only identical-fingerprint clone groups; skip similarity scoring."
 )
 HELP_DUPLICATES_EXCLUDE = (
-    "Exclude symbols whose file path matches GLOB. '*' spans directories. Repeatable."
+    "Exclude symbols whose file path matches GLOB. The glob must cover the "
+    "whole repo-relative path ('*' spans directories), so quote it -- "
+    "'*tests*', not tests/*. Repeatable."
 )
 HELP_DUPLICATES_FORMAT = "Report format: table or json."
 HELP_DUPLICATES_OUTPUT = "Write the report to this file instead of stdout."

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -78,7 +78,7 @@ cgr dead-code [OPTIONS]
 | `--project-name`, `-n` | Project to scan. Defaults to the sole indexed project. |
 | `--entry-point`, `-e` | Treat symbols whose qualified name ends with this value as reachable roots. Repeatable. |
 | `--decorator-root` | Treat symbols carrying this decorator as roots. Repeatable. |
-| `--exclude` | Glob matched against a symbol's file path to exclude. Repeatable. |
+| `--exclude` | Glob matched against a symbol's whole repo-relative file path to exclude it; quote it. Repeatable. |
 | `--include-tests` / `--no-include-tests` | Treat test code as reachable roots. On by default. |
 | `--classes` / `--no-classes` | Also report unreachable classes. Off by default. |
 | `--format` | Output format: `table` (default) or `json`. |
@@ -101,7 +101,7 @@ cgr duplicates [OPTIONS]
 | `--threshold` | Minimum similarity for a near-duplicate pair, 0-1. Default `0.8`. |
 | `--min-size` | Minimum skeleton size (tree nodes) for a function to be considered. Default `15`. |
 | `--exact-only` | Report only identical-fingerprint clone groups; skip similarity scoring. |
-| `--exclude` | Glob matched against a symbol's file path to exclude. Repeatable. |
+| `--exclude` | Glob matched against a symbol's whole repo-relative file path to exclude it; quote it. Repeatable. |
 | `--format` | Output format: `table` (default) or `json`. |
 | `--output`, `-o` | Write the report to a file instead of stdout. |
 | `--fail-on-found` | Exit with code 1 when any duplicate is found (useful in CI). |

--- a/docs/guide/dead-code.md
+++ b/docs/guide/dead-code.md
@@ -78,6 +78,20 @@ library invokes and reports noisily. Exclude it by file-path glob:
 cgr dead-code --exclude '*client/core*' --exclude '*.gen.*'
 ```
 
+Two rules keep a pattern from silently excluding nothing:
+
+- **Quote the glob.** Unquoted, the shell expands `--exclude src/gen/*` into
+  a file listing before `cgr` runs — the first file becomes the pattern and
+  the rest are rejected as extra arguments (or, if the glob matches nothing,
+  some shells pass it through and others error out). Quotes make the shell
+  hand the pattern over untouched.
+- **Cover the whole path.** Patterns are matched against the full
+  repo-relative file path (`src/client/core/api.py`), and a glob only counts
+  when it matches that entire string. A bare directory name like `tests`
+  matches nothing; write `'*tests*'`, `'*/tests/*'`, or spell out the path
+  from the repo root (`'src/tests/*'`). `*` spans `/`, so `'*tests*'` also
+  covers nested test directories.
+
 ## Options
 
 | Option | Description |
@@ -85,7 +99,7 @@ cgr dead-code --exclude '*client/core*' --exclude '*.gen.*'
 | `--project-name`, `-n` | Project to scan. Defaults to the sole indexed project. |
 | `--entry-point`, `-e` | Treat symbols whose qualified name ends with this value as reachable roots. Repeatable. |
 | `--decorator-root` | Treat symbols carrying this decorator as roots. Extends the built-in set. Repeatable. |
-| `--exclude` | Glob matched against a symbol's file path to exclude from the report. Repeatable. |
+| `--exclude` | Glob matched against a symbol's whole repo-relative file path to exclude it from the report; quote it. Repeatable. |
 | `--include-tests` / `--no-include-tests` | Treat test code as reachable roots so the production code it exercises is not reported. On by default. |
 | `--classes` / `--no-classes` | Also report unreachable classes. Off by default. |
 | `--format` | Output format: `table` (default) or `json`. |

--- a/docs/guide/dead-code.md
+++ b/docs/guide/dead-code.md
@@ -88,9 +88,10 @@ Two rules keep a pattern from silently excluding nothing:
 - **Cover the whole path.** Patterns are matched against the full
   repo-relative file path (`src/client/core/api.py`), and a glob only counts
   when it matches that entire string. A bare directory name like `tests`
-  matches nothing; write `'*tests*'`, `'*/tests/*'`, or spell out the path
-  from the repo root (`'src/tests/*'`). `*` spans `/`, so `'*tests*'` also
-  covers nested test directories.
+  matches nothing; spell the path out from the repo root (`'tests/*'`,
+  `'src/tests/*'`) and add `'*/tests/*'` when test directories nest deeper.
+  `*` spans `/`, so keep patterns path-scoped: a substring glob like
+  `'*tests*'` also excludes production paths such as `contests/entry.py`.
 
 ## Options
 

--- a/docs/guide/duplicates.md
+++ b/docs/guide/duplicates.md
@@ -449,7 +449,7 @@ test suites repeat scaffolding on purpose. Exclude them by file-path glob
 rather than raising the threshold:
 
 ```bash
-cgr duplicates --exact-only --exclude '*tests*' --exclude '*_generated*'
+cgr duplicates --exact-only --exclude 'tests/*' --exclude '*_generated*'
 ```
 
 Two rules keep a pattern from silently excluding nothing:
@@ -462,9 +462,10 @@ Two rules keep a pattern from silently excluding nothing:
 - **Cover the whole path.** Patterns are matched against the full
   repo-relative file path (`src/billing/cart.py`), and a glob only counts
   when it matches that entire string. A bare directory name like `tests`
-  matches nothing; write `'*tests*'`, `'*/tests/*'`, or spell out the path
-  from the repo root (`'src/tests/*'`). `*` spans `/`, so `'*tests*'` also
-  covers nested test directories.
+  matches nothing; spell the path out from the repo root (`'tests/*'`,
+  `'src/tests/*'`) and add `'*/tests/*'` when test directories nest deeper.
+  `*` spans `/`, so keep patterns path-scoped: a substring glob like
+  `'*tests*'` also excludes production paths such as `contests/entry.py`.
 
 ## Options
 

--- a/docs/guide/duplicates.md
+++ b/docs/guide/duplicates.md
@@ -442,6 +442,30 @@ to focus on substantial duplication:
 cgr duplicates --min-size 25
 ```
 
+## Excluding Paths
+
+Generated code (protobuf stubs, API clients) is duplication by design, and
+test suites repeat scaffolding on purpose. Exclude them by file-path glob
+rather than raising the threshold:
+
+```bash
+cgr duplicates --exact-only --exclude '*tests*' --exclude '*_generated*'
+```
+
+Two rules keep a pattern from silently excluding nothing:
+
+- **Quote the glob.** Unquoted, the shell expands `--exclude src/tests/*`
+  into a file listing before `cgr` runs — the first file becomes the pattern
+  and the rest are rejected as extra arguments (or, if the glob matches
+  nothing, some shells pass it through and others error out). Quotes make
+  the shell hand the pattern over untouched.
+- **Cover the whole path.** Patterns are matched against the full
+  repo-relative file path (`src/billing/cart.py`), and a glob only counts
+  when it matches that entire string. A bare directory name like `tests`
+  matches nothing; write `'*tests*'`, `'*/tests/*'`, or spell out the path
+  from the repo root (`'src/tests/*'`). `*` spans `/`, so `'*tests*'` also
+  covers nested test directories.
+
 ## Options
 
 | Option | Description |
@@ -450,7 +474,7 @@ cgr duplicates --min-size 25
 | `--threshold` | Minimum similarity score for a near-duplicate pair, between 0 and 1. Default `0.8`. |
 | `--exact-only` | Report only identical-fingerprint clone groups; skip similarity scoring. |
 | `--min-size` | Minimum structural size (skeleton nodes) for a function to be considered. Default `15`. |
-| `--exclude` | Glob matched against a symbol's file path to exclude from the report. Repeatable. |
+| `--exclude` | Glob matched against a symbol's whole repo-relative file path to exclude it from the report; quote it. Repeatable. |
 | `--format` | Output format: `table` (default) or `json`. |
 | `--output`, `-o` | Write the report to this file instead of stdout. |
 | `--fail-on-found` | Exit with code 1 when any duplicate is found (useful in CI). |
@@ -500,8 +524,8 @@ cgr duplicates --format json --output duplicates.json --fail-on-found \
   --exclude '*_generated*'
 ```
 
-Generated code (protobuf stubs, API clients) is duplication by design;
-exclude it rather than raising the threshold.
+The exclude globs follow the same rules as everywhere else: quoted, and
+covering the whole repo-relative path.
 
 ## Asking the Agent
 


### PR DESCRIPTION
## Why

`cgr duplicates --exact-only --exclude codebase_rag/tests/*` fails in two silent ways:

1. **Shell expansion**: unquoted, zsh/bash expand the glob into a file listing before `cgr` runs — the first file becomes the pattern and the rest are rejected as unexpected extra arguments (or, when the glob matches nothing, behavior varies by shell).
2. **Whole-path matching**: `--exclude` patterns are `fnmatch`-ed against the entire repo-relative file path, so a pattern that does not span the full path (`tests`, `tests/*` for a non-top-level dir) excludes nothing, with no warning.

## What

Documents both rules everywhere `--exclude` is described:

- `docs/guide/dead-code.md` — expanded the *Excluding Generated Code* section with the two rules
- `docs/guide/duplicates.md` — new *Excluding Paths* section with the same rules and a working example
- `docs/guide/cli-reference.md` — both option-table rows now say whole repo-relative path + quote it
- `codebase_rag/cli_help.py` — `--help` text of both commands carries the constraint (`'*tests*'`, not `tests/*`)

Docs and help text only; no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that dead-code and duplicate-report exclusions match the complete repository-relative file path.
  - Documented that exclusion globs must be quoted and may span directories, including root-level and nested `tests` paths.
  - Added guidance for repository-root paths, scoped patterns, CI usage, and avoiding overly broad matches.
  - Documented opening duplicate members in an editor, navigating to source files, side-by-side comparisons, and configurable diff-tool support.
  - Added the duplicate-report `--open` option to the CLI reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->