### PR TITLE
fix: re-parse ast-grep and document files on watched edits

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2470,6 +2470,12 @@ class GraphUpdater:
         file_bytes: bytes | None = None,
         pre_parsed: tuple[Node, dict[str, list] | None] | None = None,
     ) -> None:
+        """Ingest one file through the first tier that claims it.
+
+        Tries tree-sitter, then dependency manifests, then the secondary
+        tiers; every file gets a File node regardless, so an unclaimed
+        extension is still represented in the graph.
+        """
         if self._cpp_frontend_covered:
             rel = cached_relative_path(filepath, self.repo_path).as_posix()
             if rel in self._cpp_frontend_covered:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2533,6 +2533,7 @@ class GraphUpdater:
         return False
 
     def _ast_for(self, file_path: Path) -> Node | None:
+        """The cached AST root for a file, or None when it is not cached."""
         entry = self.ast_cache.load(file_path)
         return entry[0] if entry else None
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2500,16 +2500,31 @@ class GraphUpdater:
                 self._parsed_files.append((filepath, language))
         elif self._is_dependency_file(filepath.name, filepath):
             self.factory.definition_processor.process_dependencies(filepath)
-        elif self.ast_grep_tier.handles(filepath.suffix):
-            self.ast_grep_tier.process_file(
-                filepath, self.factory.structure_processor.structural_elements
-            )
-        elif self.document_tier.handles(filepath.suffix):
-            self.document_tier.process_file(
-                filepath, self.factory.structure_processor.structural_elements
-            )
+        else:
+            self.process_with_secondary_tier(filepath)
 
         self.factory.structure_processor.process_generic_file(filepath, filepath.name)
+
+    def process_with_secondary_tier(self, filepath: Path) -> bool:
+        """Parse a file with whichever non-tree-sitter tier claims it.
+
+        Shared with the file watcher, which re-parses one changed file and
+        would otherwise handle only tree-sitter languages: it deletes a
+        file's Module (and everything hanging off it) before re-parsing, so
+        a tier it does not know about loses its symbols entirely rather than
+        merely going stale (issue #1427).
+
+        Returns True when a tier took the file, so the batch path can keep
+        its if/elif chain.
+        """
+        structural_elements = self.factory.structure_processor.structural_elements
+        if self.ast_grep_tier.handles(filepath.suffix):
+            self.ast_grep_tier.process_file(filepath, structural_elements)
+            return True
+        if self.document_tier.handles(filepath.suffix):
+            self.document_tier.process_file(filepath, structural_elements)
+            return True
+        return False
 
     def _ast_for(self, file_path: Path) -> Node | None:
         entry = self.ast_cache.load(file_path)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2540,9 +2540,11 @@ class GraphUpdater:
     def _load_ast_from_disk(
         self, file_path: Path
     ) -> tuple[Node, cs.SupportedLanguage] | None:
-        # BoundedASTCache loader: re-parse an evicted file. Evicted files carry
-        # stale captures (nodes from the discarded tree), so drop them:
-        # downstream recomputes captures from the fresh tree.
+        """Re-parse a file the AST cache evicted, for BoundedASTCache.
+
+        Evicted files carry stale captures (nodes from the discarded tree),
+        so those are dropped: downstream recomputes them from the fresh tree.
+        """
         language = get_language_for_extension(file_path.suffix)
         if language is None or language not in self.parsers:
             return None

--- a/codebase_rag/tests/test_realtime_event_filtering.py
+++ b/codebase_rag/tests/test_realtime_event_filtering.py
@@ -145,6 +145,56 @@ class TestNonCodeFileHandling:
         mock_updater.factory.definition_processor.process_file.assert_not_called()
 
 
+class TestSecondaryTierReparse:
+    # Step 1 of a change always deletes the file's Module and everything
+    # hanging off it (DEFINES for the ast-grep tier, CONTAINS_SECTION for the
+    # document tier). If Step 3 does not re-parse, the edit EMPTIES the file
+    # in the graph rather than refreshing it, while still logging success
+    # (issue #1427). Tree-sitter languages have always re-parsed; these tiers
+    # did not.
+    def test_markdown_edit_reparses_through_the_document_tier(
+        self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
+    ) -> None:
+        f = temp_repo / "plan.md"
+        f.write_text("# Heading\n", encoding="utf-8")
+        handler.dispatch(FileModifiedEvent(str(f)))
+        mock_updater.process_with_secondary_tier.assert_called_once_with(f)
+
+    def test_ruby_edit_reparses_through_the_secondary_tier(
+        self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
+    ) -> None:
+        f = temp_repo / "app.rb"
+        f.write_text("def hi\n  1\nend\n", encoding="utf-8")
+        handler.dispatch(FileModifiedEvent(str(f)))
+        mock_updater.process_with_secondary_tier.assert_called_once_with(f)
+
+    def test_created_file_also_reparses(
+        self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
+    ) -> None:
+        f = temp_repo / "new.md"
+        f.write_text("# New\n", encoding="utf-8")
+        handler.dispatch(FileCreatedEvent(str(f)))
+        mock_updater.process_with_secondary_tier.assert_called_once_with(f)
+
+    def test_tree_sitter_file_does_not_take_the_secondary_path(
+        self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
+    ) -> None:
+        # Python is handled by definition_processor; routing it through the
+        # secondary tiers too would parse it twice.
+        f = temp_repo / "mod.py"
+        f.write_text("def f():\n    return 1\n", encoding="utf-8")
+        handler.dispatch(FileModifiedEvent(str(f)))
+        mock_updater.factory.definition_processor.process_file.assert_called_once()
+        mock_updater.process_with_secondary_tier.assert_not_called()
+
+    def test_deletion_does_not_reparse(
+        self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
+    ) -> None:
+        f = temp_repo / "gone.md"
+        handler.dispatch(FileDeletedEvent(str(f)))
+        mock_updater.process_with_secondary_tier.assert_not_called()
+
+
 class TestMixedEventSequences:
     def test_rapid_create_modify_delete(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path

--- a/codebase_rag/tests/test_realtime_event_filtering.py
+++ b/codebase_rag/tests/test_realtime_event_filtering.py
@@ -123,6 +123,7 @@ class TestNonCodeFileHandling:
     def test_non_code_file_deletion_removes_file_node(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
+        """Deleting a non-code file removes its File node and nothing else."""
         f = temp_repo / "notes.md"
         handler.dispatch(FileDeletedEvent(str(f)))
         delete_file_calls = [

--- a/codebase_rag/tests/test_realtime_event_filtering.py
+++ b/codebase_rag/tests/test_realtime_event_filtering.py
@@ -139,6 +139,7 @@ class TestNonCodeFileHandling:
     def test_non_code_file_has_no_module_node(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
+        """A non-code file gets no Module node, only its File node."""
         f = temp_repo / "data.md"
         f.write_text("text", encoding="utf-8")
         handler.dispatch(FileCreatedEvent(str(f)))
@@ -206,6 +207,7 @@ class TestMixedEventSequences:
     def test_rapid_create_modify_delete(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
+        """A create/modify/delete burst ends with the file fully removed."""
         f = temp_repo / "ephemeral.py"
         f.write_text("a = 1", encoding="utf-8")
         handler.dispatch(FileCreatedEvent(str(f)))

--- a/codebase_rag/tests/test_realtime_event_filtering.py
+++ b/codebase_rag/tests/test_realtime_event_filtering.py
@@ -155,6 +155,7 @@ class TestSecondaryTierReparse:
     def test_markdown_edit_reparses_through_the_document_tier(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
+        """A watched Markdown edit re-parses instead of losing its Sections."""
         f = temp_repo / "plan.md"
         f.write_text("# Heading\n", encoding="utf-8")
         handler.dispatch(FileModifiedEvent(str(f)))
@@ -163,6 +164,7 @@ class TestSecondaryTierReparse:
     def test_ruby_edit_reparses_through_the_secondary_tier(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
+        """A watched Ruby edit re-parses instead of losing its definitions."""
         f = temp_repo / "app.rb"
         f.write_text("def hi\n  1\nend\n", encoding="utf-8")
         handler.dispatch(FileModifiedEvent(str(f)))
@@ -171,6 +173,7 @@ class TestSecondaryTierReparse:
     def test_created_file_also_reparses(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
+        """A newly created file is parsed by its tier, not only deleted-and-skipped."""
         f = temp_repo / "new.md"
         f.write_text("# New\n", encoding="utf-8")
         handler.dispatch(FileCreatedEvent(str(f)))
@@ -179,8 +182,11 @@ class TestSecondaryTierReparse:
     def test_tree_sitter_file_does_not_take_the_secondary_path(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
-        # Python is handled by definition_processor; routing it through the
-        # secondary tiers too would parse it twice.
+        """A tree-sitter file takes only its own branch, so it is parsed once.
+
+        Python is handled by definition_processor; routing it through the
+        secondary tiers as well would parse it twice.
+        """
         f = temp_repo / "mod.py"
         f.write_text("def f():\n    return 1\n", encoding="utf-8")
         handler.dispatch(FileModifiedEvent(str(f)))
@@ -190,6 +196,7 @@ class TestSecondaryTierReparse:
     def test_deletion_does_not_reparse(
         self, handler: CodeChangeEventHandler, mock_updater: MagicMock, temp_repo: Path
     ) -> None:
+        """A delete has nothing to re-parse, so no tier runs for it."""
         f = temp_repo / "gone.md"
         handler.dispatch(FileDeletedEvent(str(f)))
         mock_updater.process_with_secondary_tier.assert_not_called()

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -303,6 +303,13 @@ class CodeChangeEventHandler(FileSystemEventHandler):
                     root_node, language = result
                     self.updater.ast_cache[path] = (root_node, language)
                     self.updater.register_parsed_file(path, language)
+            else:
+                # Step 1 deleted this file's Module and everything hanging
+                # off it. Without this the ast-grep and document tiers never
+                # re-parse, so an edit EMPTIES a Ruby file's definitions or a
+                # Markdown file's sections from the graph instead of
+                # refreshing them (issue #1427).
+                self.updater.process_with_secondary_tier(path)
 
             # Create File node for ALL files (code and non-code like .md, .json, etc.)
             self.updater.factory.structure_processor.process_generic_file(

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -227,6 +227,12 @@ class CodeChangeEventHandler(FileSystemEventHandler):
             self._process_change_locked(event)
 
     def _process_change_locked(self, event: FileSystemEvent) -> None:
+        """Re-ingest one changed file, holding the updater lock.
+
+        Deletes what the file previously contributed to the graph, then
+        re-parses it. The delete comes first, so every path that can reach
+        this must re-parse through some tier or the file is left empty.
+        """
         src_path = event.src_path
         if isinstance(src_path, bytes):
             src_path = src_path.decode()


### PR DESCRIPTION
## Summary

Under `cgr start --watch`, editing a Ruby or Markdown file **emptied it in the graph** instead of refreshing it — and the handler logged `Graph updated successfully` while doing so.

The watcher's Step 1 always deletes the file's `Module` and everything hanging off it (`DEFINES` for the ast-grep tier, `CONTAINS_SECTION` for the document tier). Step 3 then re-parses **only** tree-sitter languages, so a file belonging to either other tier lost its definitions with nothing to re-create them. A full re-index restored everything, which is probably why this went unnoticed.

## Verified, not assumed

Dispatch comparison using the real registries — the exact condition from `realtime_updater.py` Step 3 against what `_process_single_file` would do:

```
file           realtime re-parses?    batch would use
m.py           True                   tree-sitter
app.rb         False                  ast-grep tier
d.md           False                  document tier
Main.kt        False                  ast-grep tier
doc.markdown   False                  document tier
```

End to end against a **real** `GraphUpdater` with a recording ingestor, indexing a file and then dispatching one `FileModifiedEvent` that adds a symbol:

```
                          before fix          after fix
markdown  Section    1 -> 0   [LOST]      1 -> 2   [OK]
ruby      Function   1 -> 0   [LOST]      1 -> 2   [OK]
```

Reverting the fix also fails 3 of the 5 new tests, so they are real regression coverage rather than tests that pass either way.

## The fix

The tier dispatch moves out of `GraphUpdater._process_single_file` into `GraphUpdater.process_with_secondary_tier`, which the batch path and the watcher now share. That is the point: a tier added later gets wired into **both** callers at once, instead of only into batch indexing — which is exactly how this bug arose when the ast-grep tier landed, and how the document tier inherited it in #1428.

The watcher calls it on the `else` branch of the existing tree-sitter check, so a Python file is not parsed twice (covered by a test).

## Scope

Affects every ast-grep tier language — Ruby, Kotlin, Swift, Elixir, Haskell, Solidity, Bash, Nix — plus Markdown via the document tier. Tree-sitter languages were always fine.

## Test Plan

- New `TestSecondaryTierReparse` in `codebase_rag/tests/test_realtime_event_filtering.py` (5 tests): Markdown edit, Ruby edit, created file, tree-sitter file taking the other branch, and deletion not re-parsing.
- 303 passed across every suite touching realtime updating, graph updating, the tiers, incremental indexing, and the document tier.
- Full suite reached 70% with zero failures before a local interruption; CI runs the complete matrix.
- `ruff check`, `ruff format --check` clean. `ty check` shows one pre-existing warning at `graph_updater.py:2750` (`fetch_all` on `Unknown | IngestorProtocol`), unrelated to this change and present on a clean tree.

## Related Issues

Fixes #1427.

Found while building #1428 and filed rather than folded in, which is why it lands separately.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file-change handling so edits and newly created files in supported secondary formats are properly reprocessed.
  * Prevented Ruby definitions and Markdown sections from disappearing from search results after edits.
  * Ensured unsupported or unrecognized file types remain represented in the project index.
  * Preserved existing behavior for primary parsed languages and file deletions.
  * Improved refresh reliability for files handled by secondary language and document processing.
  * Improved handling of cached syntax information during file refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->