### PR TITLE
docs: add the claimed label for coordinating concurrent agent sessions

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -89,3 +89,7 @@
 - name: skip-review
   color: ededed
   description: Skip automated code review
+
+- name: claimed
+  color: B60205
+  description: An agent/session is actively working this — check before taking it over


### PR DESCRIPTION
## Why

Several agent sessions work this repo in parallel, in separate clones and worktrees, with no shared view of each other. Ownership is otherwise hard to establish: every session commits under the same user identity, and timestamp correlation actively misleads. In the sibling croft repo this produced duplicated review rounds and a near-miss where two sessions independently prepared to merge the same PR.

## What

Adds a `claimed` label to `.github/labels.yml`:

- **Check for it before starting** on a PR or issue; if present, someone is on it.
- **Add it when you start, remove it when you stop** — including as part of merging, since merging deletes the branch but not the label.
- **Claim the PR once one exists**; claim the issue only for work with no PR yet.

The label already exists on the repo; adding it to the manifest makes it durable and self-documenting. (`label-sync` runs with `prune: false`, so it was never at risk of removal — this is for discoverability.)

## Notes

- **Distinct from `in progress`**, which is a human-facing project-board status. `claimed` is a coordination lock between concurrent sessions, answering a narrower question: may I start touching this right now? `in progress` is currently unused (0 issues, 0 PRs), so there is no established practice to conflict with.
- CONTRIBUTING.md already asks human contributors to comment on an issue before starting, for the same reason; this is the machine-readable version of that courtesy.
- The accompanying agent-facing guidance is **not** in this PR: `CLAUDE.md`, `AGENTS.md`, and `PROJECT.md` are all gitignored in this repo, so that guidance has been installed locally in each clone rather than committed, respecting that decision.
- Manifest validated: parses as YAML, no duplicate label names. All pre-commit hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “claimed” label to indicate when an item is actively being worked on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->