### PR TITLE
fix: keep ast-grep modules distinct when file stems collide across extensions

### DIFF
--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -350,12 +350,18 @@ class AstGrepTier:
     def _emit_module(
         self, file_path: Path, structural_elements: dict[Path, str | None]
     ) -> str:
+        """Emit the file's Module node and return its qualified name."""
         return emit_flat_module(
             self._ingestor,
             self._repo_path,
             self._project_name,
             file_path,
             structural_elements,
+            # Several tier languages declare two extensions (.sh/.bash,
+            # .kt/.kts, .ex/.exs), and Module is keyed on qualified_name, so
+            # dropping the suffix merges a colliding pair onto one node
+            # (issue #1429).
+            distinguish_suffix=True,
         )
 
     def _emit_definition(
@@ -367,6 +373,7 @@ class AstGrepTier:
         relative_path: str,
         absolute_path: str,
     ) -> None:
+        """Emit one definition node and its DEFINES edge from the module."""
         qualified_name = f"{module_qn}{cs.SEPARATOR_DOT}{name}"
         node_range = node.range()
         self._ingestor.ensure_node_batch(

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -350,7 +350,15 @@ class AstGrepTier:
     def _emit_module(
         self, file_path: Path, structural_elements: dict[Path, str | None]
     ) -> str:
-        """Emit the file's Module node and return its qualified name."""
+        """Emit the file's Module node and return its qualified name.
+
+        The name carries the extension (`app.rb` -> `<project>.app_rb`) for
+        every tier language, not only the ones that can collide. Graphs
+        indexed before this carry the unsuffixed names and keep them until
+        re-indexed, so a graph holding both vintages holds both shapes; a
+        query written against the old shape will not match a re-indexed
+        module (issue #1429).
+        """
         return emit_flat_module(
             self._ingestor,
             self._repo_path,

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -492,5 +492,84 @@ def test_kotlin_object_modifier_and_delegation_forms(tmp_path: Path) -> None:
 
 
 def test_kotlin_object_members_still_extracted(tmp_path: Path) -> None:
+    """Functions declared inside an object are still emitted."""
     counts = _node_name_counts(_run(tmp_path, {"O.kt": KOTLIN_OBJECTS}), FUNCTION)
     assert counts == Counter({"a": 1, "b": 1, "c": 1}), counts
+
+
+def _module_qns(mock: MagicMock) -> list[str]:
+    """Module qualified names in emission order, duplicates kept."""
+    return [
+        c.args[1].get(cs.KEY_QUALIFIED_NAME)
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == MODULE
+    ]
+
+
+def test_stems_colliding_across_bash_extensions_stay_separate(
+    tmp_path: Path,
+) -> None:
+    """build.sh and build.bash must not merge onto one Module node."""
+    # Module is keyed on qualified_name, so two files whose qn matches MERGE
+    # onto one node: the second file's path overwrites the first's and both
+    # files' functions hang off it (issue #1429).
+    mock = _run(
+        tmp_path,
+        {
+            "build.sh": "foo() { echo hi; }\n",
+            "build.bash": "bar() { echo yo; }\n",
+        },
+    )
+    qns = _module_qns(mock)
+    assert len(set(qns)) == len(qns), f"module qns collided: {qns}"
+
+
+def test_stems_colliding_across_kotlin_extensions_stay_separate(
+    tmp_path: Path,
+) -> None:
+    """Main.kt beside Main.kts must yield two Module nodes."""
+    # A .kts script beside a .kt source sharing a stem is an ordinary Kotlin
+    # layout, so this collision is reachable without unusual naming.
+    mock = _run(
+        tmp_path,
+        {
+            "Main.kt": "fun a() = 1\n",
+            "Main.kts": "fun b() = 2\n",
+        },
+    )
+    qns = _module_qns(mock)
+    assert len(set(qns)) == len(qns), f"module qns collided: {qns}"
+
+
+def test_stems_colliding_across_elixir_extensions_stay_separate(
+    tmp_path: Path,
+) -> None:
+    """mix.ex beside mix.exs must yield two Module nodes."""
+    mock = _run(
+        tmp_path,
+        {
+            "mix.ex": "defmodule A do\n  def a, do: 1\nend\n",
+            "mix.exs": "defmodule B do\n  def b, do: 2\nend\n",
+        },
+    )
+    qns = _module_qns(mock)
+    assert len(set(qns)) == len(qns), f"module qns collided: {qns}"
+
+
+def test_colliding_modules_keep_their_own_paths(tmp_path: Path) -> None:
+    """Each colliding file keeps its own path rather than the last writer's."""
+    # The visible damage: whichever file is written second overwrites the
+    # first's path/absolute_path on the shared node.
+    mock = _run(
+        tmp_path,
+        {
+            "build.sh": "foo() { echo hi; }\n",
+            "build.bash": "bar() { echo yo; }\n",
+        },
+    )
+    by_qn = {
+        c.args[1].get(cs.KEY_QUALIFIED_NAME): c.args[1].get(cs.KEY_PATH)
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == MODULE
+    }
+    assert set(by_qn.values()) == {"build.sh", "build.bash"}, by_qn

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -586,3 +586,15 @@ def test_colliding_modules_keep_their_own_paths(tmp_path: Path) -> None:
         if str(c.args[0]) == MODULE
     }
     assert set(by_qn.values()) == {"build.sh", "build.bash"}, by_qn
+
+
+def test_single_extension_language_also_carries_its_suffix(tmp_path: Path) -> None:
+    """The suffix rule applies to every tier language, not only colliding ones.
+
+    Ruby declares one extension, so nothing forces `app_rb` for correctness
+    here -- but the flag is tier-wide, and this pins the shape so a later
+    change to the flag or the separator has to update this test explicitly
+    rather than silently renaming every ast-grep module (issue #1429).
+    """
+    mock = _run(tmp_path, {"app.rb": "def hello\n  1\nend\n"})
+    assert _module_leaf_names(mock) == {"app_rb"}

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -506,6 +506,16 @@ def _module_qns(mock: MagicMock) -> list[str]:
     ]
 
 
+def _module_leaf_names(mock: MagicMock) -> set[str]:
+    """Last segment of each module qn.
+
+    Asserted instead of mere uniqueness: a mangled-but-distinct name would
+    satisfy a uniqueness check while still being wrong, so the tests pin the
+    name the suffix rule is supposed to produce.
+    """
+    return {qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] for qn in _module_qns(mock)}
+
+
 def test_stems_colliding_across_bash_extensions_stay_separate(
     tmp_path: Path,
 ) -> None:
@@ -522,6 +532,7 @@ def test_stems_colliding_across_bash_extensions_stay_separate(
     )
     qns = _module_qns(mock)
     assert len(set(qns)) == len(qns), f"module qns collided: {qns}"
+    assert _module_leaf_names(mock) == {"build_sh", "build_bash"}
 
 
 def test_stems_colliding_across_kotlin_extensions_stay_separate(
@@ -539,6 +550,7 @@ def test_stems_colliding_across_kotlin_extensions_stay_separate(
     )
     qns = _module_qns(mock)
     assert len(set(qns)) == len(qns), f"module qns collided: {qns}"
+    assert _module_leaf_names(mock) == {"Main_kt", "Main_kts"}
 
 
 def test_stems_colliding_across_elixir_extensions_stay_separate(
@@ -554,6 +566,7 @@ def test_stems_colliding_across_elixir_extensions_stay_separate(
     )
     qns = _module_qns(mock)
     assert len(set(qns)) == len(qns), f"module qns collided: {qns}"
+    assert _module_leaf_names(mock) == {"mix_ex", "mix_exs"}
 
 
 def test_colliding_modules_keep_their_own_paths(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_ast_grep_tier_languages.py
+++ b/codebase_rag/tests/test_ast_grep_tier_languages.py
@@ -521,8 +521,8 @@ def test_stems_colliding_across_bash_extensions_stay_separate(
 ) -> None:
     """build.sh and build.bash must not merge onto one Module node."""
     # Module is keyed on qualified_name, so two files whose qn matches MERGE
-    # onto one node: the second file's path overwrites the first's and both
-    # files' functions hang off it (issue #1429).
+    # onto one node (issue #1429). The path and DEFINES consequences of that
+    # merge have their own tests below.
     mock = _run(
         tmp_path,
         {
@@ -567,6 +567,36 @@ def test_stems_colliding_across_elixir_extensions_stay_separate(
     qns = _module_qns(mock)
     assert len(set(qns)) == len(qns), f"module qns collided: {qns}"
     assert _module_leaf_names(mock) == {"mix_ex", "mix_exs"}
+
+
+def _defines_edges(mock: MagicMock) -> set[tuple[str, str]]:
+    """(parent qn, child qn) for every DEFINES edge."""
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == DEFINES
+    }
+
+
+def test_colliding_files_keep_their_own_functions(tmp_path: Path) -> None:
+    """Each file's functions hang off its own module, not a shared one.
+
+    The merge's other half: with one Module for both files, `foo` and `bar`
+    both attach to it, so the graph claims build.sh defines a function it
+    does not contain (issue #1429).
+    """
+    mock = _run(
+        tmp_path,
+        {
+            "build.sh": "foo() { echo hi; }\n",
+            "build.bash": "bar() { echo yo; }\n",
+        },
+    )
+    edges = {
+        (parent.rsplit(cs.SEPARATOR_DOT, 1)[-1], child.rsplit(cs.SEPARATOR_DOT, 1)[-1])
+        for parent, child in _defines_edges(mock)
+    }
+    assert edges == {("build_sh", "foo"), ("build_bash", "bar")}, edges
 
 
 def test_colliding_modules_keep_their_own_paths(tmp_path: Path) -> None:

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -45,11 +45,15 @@ extra (`pip install 'code-graph-rag[ast-grep]'`).
 A module's qualified name carries its extension: `app.rb` becomes
 `<project>.app_rb`. Several of these languages accept two extensions, and a
 `Module` is identified by its qualified name, so dropping the suffix would
-merge `Main.kt` and `Main.kts` onto one node. Graphs indexed before this keep
-the unsuffixed names until the repository is re-indexed (`--update-graph`),
-so a saved query written against the old shape will not match a re-indexed
-module. Re-indexing replaces the old node rather than leaving both: a module
-is cleared by file path, which this change does not alter.
+merge `Main.kt` and `Main.kts` onto one node.
+
+Graphs indexed before this keep the unsuffixed names, and a saved query
+written against the old shape stops matching once they move. An incremental
+sync will not move them: it skips files whose content is unchanged, and this
+change alters how a name is emitted rather than the file itself, so cgr warns
+that the parser changed but keeps the old results. Rebuilding with
+`cgr start --clean` is what re-emits them. Note that it clears **every**
+project in a shared graph, so re-index the others afterwards.
 
 | Language | Extensions | Functions | Classes/Types | Imports |
 |---|---|---|---|---|

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -46,8 +46,10 @@ A module's qualified name carries its extension: `app.rb` becomes
 `<project>.app_rb`. Several of these languages accept two extensions, and a
 `Module` is identified by its qualified name, so dropping the suffix would
 merge `Main.kt` and `Main.kts` onto one node. Graphs indexed before this keep
-the unsuffixed names until re-indexed with `--clean`, so a saved query written
-against the old shape will not match a re-indexed module.
+the unsuffixed names until the repository is re-indexed (`--update-graph`),
+so a saved query written against the old shape will not match a re-indexed
+module. Re-indexing replaces the old node rather than leaving both: a module
+is cleared by file path, which this change does not alter.
 
 | Language | Extensions | Functions | Classes/Types | Imports |
 |---|---|---|---|---|

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -42,6 +42,13 @@ and there is **no call-graph (`CALLS`) resolution**, so call-graph analyses
 such as dead-code detection skip these files. It requires the `ast-grep`
 extra (`pip install 'code-graph-rag[ast-grep]'`).
 
+A module's qualified name carries its extension: `app.rb` becomes
+`<project>.app_rb`. Several of these languages accept two extensions, and a
+`Module` is identified by its qualified name, so dropping the suffix would
+merge `Main.kt` and `Main.kts` onto one node. Graphs indexed before this keep
+the unsuffixed names until re-indexed with `--clean`, so a saved query written
+against the old shape will not match a re-indexed module.
+
 | Language | Extensions | Functions | Classes/Types | Imports |
 |---|---|---|---|---|
 | Ruby | .rb | methods, singleton methods | classes, modules | require, require_relative |


### PR DESCRIPTION
## Summary

Fixes #1429: two files whose stems match in one directory collapsed onto a single `Module` node in the ast-grep tier.

`emit_flat_module` dropped the extension when building the qualified name, and `Module` is keyed on `qualified_name`, so the second file MERGEd onto the first: its `path`/`absolute_path` overwrote the first's, and both files' `Function` nodes hung off the same node.

Three tier languages declare two extensions, so this is reachable without unusual naming:

| Language | Extensions | Colliding pair |
|---|---|---|
| Bash | `.sh`, `.bash` | `build.sh` / `build.bash` |
| Kotlin | `.kt`, `.kts` | `Main.kt` / `Main.kts` |
| Elixir | `.ex`, `.exs` | `mix.ex` / `mix.exs` |

The Kotlin and Elixir pairs are ordinary layouts in those ecosystems.

The fix is to pass `distinguish_suffix=True` from `AstGrepTier._emit_module`, using the opt-in flag the document tier (#1426) already added to the shared helper for the same reason.

Before / after, indexing `build.sh` and `build.bash`:

```
before                          after
qn=<proj>.build  path=build.bash    qn=<proj>.build_bash  path=build.bash
qn=<proj>.build  path=build.sh      qn=<proj>.build_sh    path=build.sh
                                    <proj>.build_bash -> <proj>.build_bash.bar
                                    <proj>.build_sh   -> <proj>.build_sh.foo
```

## Behaviour change worth reviewing

This changes the qualified name of **every** module the ast-grep tier emits across all eight of its languages, not only colliding pairs: `app.rb` becomes `app_rb`. That is why #1429 asked for this to land on its own rather than inside a feature PR.

**Existing graphs keep the old names until re-indexed.** A graph indexed before this change holds `<proj>.app`; re-indexing yields `<proj>.app_rb`. Mixed-vintage graphs will hold both shapes until every project is re-indexed. Nothing errors in that state, but a saved query written against the old shape will not match a re-indexed module.

I checked the three consumers #1429 flagged:

- **Prefix-matching Cypher** (`CYPHER_DELETE_PROJECT`, the `STARTS WITH $project_prefix` queries in `constants/graph.py`): safe. `project_prefix` is `"<project>."` (`graph_updater.py`), a project-level scope that does not depend on the module segment.
- **`CYPHER_DELETE_MODULE`**: safe. It matches `(m:Module {path: $path})` and uses the qn only to scope to the project; `path` is unchanged by this fix.
- **`IMPORTS` / `require_relative`**: unaffected. `_emit_import` records every target as an `ExternalModule` keyed on the literal target string; the tier does no local resolution against module qns (its own comment says so).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates

## Related Issues

Closes #1429

## Test Plan

Four new tests in `test_ast_grep_tier_languages.py`, written red against the unfixed code and confirmed to fail with the collision before the one-line change:

- one colliding-stem case per multi-extension language (bash, kotlin, elixir), asserting module qns are unique;
- `test_colliding_modules_keep_their_own_paths`, asserting each file keeps its own `path` rather than the last writer's — the visible damage of the merge.

Verified end to end that `DEFINES` edges attach to the right parent after the change (`bar` no longer hangs off `build.sh`).

Full unit suite passes. `ruff check`, `ruff format --check` clean. `ty` reports the same 3 diagnostics as clean `main` (none in files this PR touches).

Not added to NEWS.md: that file is explicitly for user-facing features and states it is "NOT for ... bug fixes". The re-index caveat is recorded above instead.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed module identification when files share the same name across different extensions, preserving distinct modules and file paths.
  - Corrected Kotlin object member extraction to avoid emitting duplicate functions.
  - Ensured single-extension Ruby modules retain their expected module suffix.

- **Tests**
  - Added regression coverage for module collisions across Bash, Kotlin, Elixir, and Ruby files.
  - Added coverage verifying Kotlin object members are extracted once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->