### PR TITLE
test: assert the suffix-distinct module names, not merely that they differ

### DIFF
--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -275,6 +275,24 @@ class TestQualifiedNames:
         # The display name keeps the dots.
         assert _node_names(mock, SECTION) == {"Release 1.2.3"}
 
+    def test_runs_of_whitespace_collapse_in_the_qualified_name(
+        self, tmp_path: Path
+    ) -> None:
+        # So the same heading reflowed across lines keeps one identity. The
+        # display name keeps the original spacing.
+        mock = _run(tmp_path, {"w.md": "# Alpha   Beta\n"})
+        assert _qns(mock, SECTION) == {f"{_module_qn(tmp_path, 'w.md')}.Alpha Beta"}
+        assert _node_names(mock, SECTION) == {"Alpha   Beta"}
+
+    def test_heading_with_no_text_gets_a_placeholder_name(
+        self, tmp_path: Path
+    ) -> None:
+        # A bare "##" has nothing to name a node after; an empty name would
+        # produce a qualified name ending in a bare separator.
+        mock = _run(tmp_path, {"e.md": "# Top\n\n##\n"})
+        assert "(untitled)" in _node_names(mock, SECTION)
+        assert f"{_module_qn(tmp_path, 'e.md')}.Top.(untitled)" in _qns(mock, SECTION)
+
     def test_heading_literally_containing_the_marker_stays_distinct(
         self, tmp_path: Path
     ) -> None:

--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -47,7 +47,12 @@ def _run(tmp_path: Path, files: dict[str, str]) -> MagicMock:
     for rel, content in files.items():
         path = tmp_path / rel
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content, encoding="utf-8")
+        # newline="" disables the platform newline translation write_text
+        # applies by default: on Windows a "\n" in a fixture would reach disk
+        # as "\r\n", so a heading spanning lines would parse as "Alpha\r\nBeta"
+        # and any assertion naming the literal text would fail there only.
+        # Fixtures are byte-for-byte what the test wrote on every platform.
+        path.write_text(content, encoding="utf-8", newline="")
     mock = MagicMock()
     GraphUpdater(
         ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries

--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -316,6 +316,18 @@ class TestQualifiedNames:
         doc = "# Top\n\n## Notes\n\n## Notes@9\n\nx\n\n## Notes\n"
         mock = _run(tmp_path, {"marker.md": doc})
         qns = _qns(mock, SECTION)
+        # Assert the NAMES, not merely that they are distinct: distinctness is
+        # the property the suffixing establishes, so any scheme that separates
+        # them satisfies it — a counter would pass this test while renaming
+        # the third section "Notes@1", which points at no line in the file.
+        # The suffix has to be the start line for the name to stay meaningful.
+        top = f"{_module_qn(tmp_path, 'marker.md')}.Top"
+        assert qns == {
+            top,
+            f"{top}.Notes",
+            f"{top}.Notes@9",
+            f"{top}.Notes@9@9",
+        }, f"unexpected qualified names: {sorted(qns)}"
         assert len(qns) == len(_nodes(mock, SECTION)), (
             f"qualified names collided, sections merged: {sorted(qns)}"
         )

--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -284,9 +284,7 @@ class TestQualifiedNames:
         assert _qns(mock, SECTION) == {f"{_module_qn(tmp_path, 'w.md')}.Alpha Beta"}
         assert _node_names(mock, SECTION) == {"Alpha   Beta"}
 
-    def test_heading_with_no_text_gets_a_placeholder_name(
-        self, tmp_path: Path
-    ) -> None:
+    def test_heading_with_no_text_gets_a_placeholder_name(self, tmp_path: Path) -> None:
         # A bare "##" has nothing to name a node after; an empty name would
         # produce a qualified name ending in a bare separator.
         mock = _run(tmp_path, {"e.md": "# Top\n\n##\n"})

--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -278,11 +278,21 @@ class TestQualifiedNames:
     def test_runs_of_whitespace_collapse_in_the_qualified_name(
         self, tmp_path: Path
     ) -> None:
-        # So the same heading reflowed across lines keeps one identity. The
-        # display name keeps the original spacing.
+        # Repeated spaces within one heading line. The display name keeps the
+        # original spacing; only the qualified name collapses.
         mock = _run(tmp_path, {"w.md": "# Alpha   Beta\n"})
         assert _qns(mock, SECTION) == {f"{_module_qn(tmp_path, 'w.md')}.Alpha Beta"}
         assert _node_names(mock, SECTION) == {"Alpha   Beta"}
+
+    def test_heading_text_spanning_lines_keeps_one_identity(
+        self, tmp_path: Path
+    ) -> None:
+        # A setext heading's text really can span physical lines, which the
+        # single-line fixture above does not exercise. The newline must not
+        # reach the qualified name, or reflowing a heading would rename it.
+        mock = _run(tmp_path, {"r.md": "Alpha\nBeta\n=====\n"})
+        assert _qns(mock, SECTION) == {f"{_module_qn(tmp_path, 'r.md')}.Alpha Beta"}
+        assert _node_names(mock, SECTION) == {"Alpha\nBeta"}
 
     def test_heading_with_no_text_gets_a_placeholder_name(self, tmp_path: Path) -> None:
         # A bare "##" has nothing to name a node after; an empty name would

--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -321,13 +321,22 @@ class TestFileHandling:
             tmp_path,
             {"docs/guide.md": "# Alpha\n", "docs/guide.markdown": "# Alpha\n"},
         )
-        modules = [
-            p
+        # Asserts the qualified names each file actually gets, not merely
+        # that they differ: a rule that mangled the stem would still produce
+        # two distinct names and satisfy a uniqueness-only check.
+        by_path = {
+            str(p[cs.KEY_PATH]): p[cs.KEY_QUALIFIED_NAME]
             for p in _nodes(mock, MODULE)
             if str(p.get(cs.KEY_PATH, "")).startswith("docs/guide")
-        ]
-        assert len({p[cs.KEY_QUALIFIED_NAME] for p in modules}) == 2
-        assert len(_qns(mock, SECTION)) == 2
+        }
+        assert by_path == {
+            "docs/guide.md": f"{tmp_path.name}.docs.guide_md",
+            "docs/guide.markdown": f"{tmp_path.name}.docs.guide_markdown",
+        }
+        assert _qns(mock, SECTION) == {
+            f"{tmp_path.name}.docs.guide_md.Alpha",
+            f"{tmp_path.name}.docs.guide_markdown.Alpha",
+        }
 
     def test_nested_directory_paths_recorded(self, tmp_path: Path) -> None:
         mock = _run(tmp_path, {"docs/guide/plan.md": "# Deep\n"})

--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -363,15 +363,6 @@ class TestFileHandling:
         mock = _run(tmp_path, {"mod.py": "def f():\n    return 1\n"})
         assert _nodes(mock, SECTION) == []
 
-    def test_other_tiers_keep_suffixless_module_names(self, tmp_path: Path) -> None:
-        # `distinguish_suffix` is opt-in precisely so the ast-grep tier's
-        # qualified names do not change (issue #1429 tracks doing that
-        # deliberately). Without this, flipping the default to True passes
-        # every other test in the suite.
-        mock = _run(tmp_path, {"app.rb": "def hi\n  1\nend\n"})
-        assert f"{tmp_path.name}.app" in _qns(mock, MODULE)
-        assert f"{tmp_path.name}.app_rb" not in _qns(mock, MODULE)
-
 
 def _export_index(tmp_path: Path, document: str = NESTED):
     """Index a document through the protobuf sink and read the artifact back."""

--- a/codebase_rag/tests/test_document_tier.py
+++ b/codebase_rag/tests/test_document_tier.py
@@ -363,6 +363,15 @@ class TestFileHandling:
         mock = _run(tmp_path, {"mod.py": "def f():\n    return 1\n"})
         assert _nodes(mock, SECTION) == []
 
+    def test_other_tiers_keep_suffixless_module_names(self, tmp_path: Path) -> None:
+        # `distinguish_suffix` is opt-in precisely so the ast-grep tier's
+        # qualified names do not change (issue #1429 tracks doing that
+        # deliberately). Without this, flipping the default to True passes
+        # every other test in the suite.
+        mock = _run(tmp_path, {"app.rb": "def hi\n  1\nend\n"})
+        assert f"{tmp_path.name}.app" in _qns(mock, MODULE)
+        assert f"{tmp_path.name}.app_rb" not in _qns(mock, MODULE)
+
 
 def _export_index(tmp_path: Path, document: str = NESTED):
     """Index a document through the protobuf sink and read the artifact back."""


### PR DESCRIPTION
## Summary

`test_same_stem_with_different_suffixes_stays_separate` asserted only that `docs/guide.md` and `docs/guide.markdown` produce **two distinct** qualified names. That is the same predicate the fix under test establishes, so the test could not fail for any reason the fix would cause.

A rule that mangled the stem — prefixing it, truncating it, hashing it — would still produce two different names and pass.

## Verified the test now catches that

Deliberately mangled the stem in `flat_module.py` (`guide_md` → `XXguide_md`) and re-ran:

```
before: passes  (two distinct names, both wrong)
after:  FAILS   (names do not match the expected values)
```

Now asserts the actual qualified names each file receives, and the Section qns rooted under them.

## Why this shape is worth watching for

The property I had in mind when writing the fix was uniqueness, so uniqueness was the property I tested. A test written from the same premise as the fix inherits its blind spots — it can only fail in ways the author already conceived of.

Credit to the `fix-doc-qualified-name` session, which found the identical shape in its own collision tests for #1429 and flagged the pattern.

## Test Plan

- 34 tests pass in `test_document_tier.py`.
- Confirmed the strengthened assertion fails against a deliberately mangled stem, which the uniqueness-only form accepted.

## Type of Change

- [x] Test updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for consistent qualified names when headings contain extra whitespace or multiline setext formatting.
  * Verified that qualified names collapse heading newlines while display names preserve them.
  * Added coverage for untitled headings, ensuring they receive a clear placeholder name.
  * Strengthened validation for files sharing the same name but using different extensions, including their module and section names.
  * Improved cross-platform fixture handling for exact newline preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->