### PR TITLE
docs: note that document module names carry their extension

### DIFF
--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -95,9 +95,14 @@ so a saved query written against the old names stops matching once the graph
 is rebuilt. An incremental sync will not move it: `.md` files were already
 hashed before this tier existed, so `--update-graph` sees them unchanged and
 skips them, leaving the graph exactly as it was. Rebuilding needs
-`cgr start --clean`, which is the remedy `cgr` itself recommends when parser
-code has changed — note that it clears **every** project in the shared graph,
-so run it only when that graph holds just this repository.
+`cgr start --clean --update-graph`: `--clean` on its own wipes the database,
+clears the embeddings, drops the hash cache and returns without indexing
+anything, so it would leave you with an empty graph rather than renamed
+document modules. Both flags together wipe and then re-index in one pass —
+and because the wipe drops the hash cache, the re-index treats every file as
+new, which is what re-emits the documents under their suffixed names. Note
+that the wipe clears **every** project in the shared graph, so run it only
+when that graph holds just this repository.
 Requires the `treesitter-full` extra.
 
 ## Language-Agnostic Design

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -89,9 +89,15 @@ A document's qualified name keeps its extension, so `docs/guide.md` becomes
 `<project>.docs.guide_md`. The suffix is part of the name because both `.md`
 and `.markdown` are handled here, and dropping it would merge `guide.md` and
 `guide.markdown` onto one `Module` node along with any identically-named
-sections. Graphs indexed before document support existed hold unsuffixed
-document module names; re-index to move them to the current shape, and note
-that a saved query written against the old names will stop matching.
+sections. A graph indexed before document support existed holds no `Section`
+nodes at all, and any document `Module` it holds carries an unsuffixed name,
+so a saved query written against the old names stops matching once the graph
+is rebuilt. An incremental sync will not move it: `.md` files were already
+hashed before this tier existed, so `--update-graph` sees them unchanged and
+skips them, leaving the graph exactly as it was. Rebuilding needs
+`cgr start --clean`, which is the remedy `cgr` itself recommends when parser
+code has changed — note that it clears **every** project in the shared graph,
+so run it only when that graph holds just this repository.
 Requires the `treesitter-full` extra.
 
 ## Language-Agnostic Design

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -84,6 +84,14 @@ Documents have no functions, classes, or calls, so they get neither of the
 code tiers above and are absent from call-graph analyses such as dead-code
 detection. Markdown files still receive the `File` node every indexed file
 gets, so a base install without the grammar simply indexes them as files.
+
+A document's qualified name keeps its extension, so `docs/guide.md` becomes
+`<project>.docs.guide_md`. The suffix is part of the name because both `.md`
+and `.markdown` are handled here, and dropping it would merge `guide.md` and
+`guide.markdown` onto one `Module` node along with any identically-named
+sections. Graphs indexed before document support existed hold unsuffixed
+document module names; re-index to move them to the current shape, and note
+that a saved query written against the old names will stop matching.
 Requires the `treesitter-full` extra.
 
 ## Language-Agnostic Design


### PR DESCRIPTION
## Summary

#1426 made a document's qualified name keep its suffix — `docs/guide.md` becomes `<project>.docs.guide_md` — so that `.md` and `.markdown` files sharing a stem cannot merge onto one `Module` node along with their identically-named sections.

That was recorded in the #1426 PR body, which is invisible after merge, and nowhere a user would look. This adds it to the "Document Support (document tier)" section of `docs/architecture/language-support.md`.

## Why it matters to users

A graph indexed before document support existed holds **unsuffixed** document module names and keeps them until re-indexed. A saved query written against the old shape silently stops matching a re-indexed module, with nothing explaining why.

## Consistency

Matches the phrasing `duplicates.md` already uses for the same class of change ("Graphs indexed before duplicate detection existed carry no fingerprints; re-index once with `--clean` to backfill them"), so the tiers read alike.

Verified `make readme` leaves it alone: `language-support.md` is a generator target, but the generator only replaces marked `<!-- SECTION -->` blocks and this prose sits outside them. Ran it and re-diffed — no change.

## Related

Retrospective documentation for #1426. Raised by the `fix-doc-qualified-name` session, which hit the identical gap for the ast-grep tier in #1435 and flagged that the document tier had it too.

## Type of Change

- [x] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented updated qualified-name handling for Markdown modules, including extension preservation and collision avoidance.
  * Clarified compatibility considerations for existing graphs and incremental synchronization.
  * Added guidance for rebuilding graphs and explained the effects of clean rebuild options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->