### PR TITLE
docs: state what --clean costs when backfilling fingerprints

### DIFF
--- a/docs/guide/duplicates.md
+++ b/docs/guide/duplicates.md
@@ -375,8 +375,13 @@ cgr daemon up
 cgr start --repo-path /path/to/your/repo --update-graph --clean
 ```
 
-Graphs indexed before duplicate detection existed carry no fingerprints;
-re-index once with `--clean` to backfill them.
+Graphs indexed before duplicate detection existed carry no fingerprints.
+Backfilling them needs `--clean`: fingerprints are stamped while a file is
+parsed, and an incremental sync skips files whose content has not changed, so
+`--update-graph` alone re-parses nothing and backfills nothing. Note that
+`--clean` deletes **every** project in the shared graph, not just this one —
+it prompts before destroying others, so confirm only when that graph holds
+this repository alone.
 
 ## Basic Usage
 

--- a/docs/guide/duplicates.md
+++ b/docs/guide/duplicates.md
@@ -375,13 +375,22 @@ cgr daemon up
 cgr start --repo-path /path/to/your/repo --update-graph --clean
 ```
 
-Graphs indexed before duplicate detection existed carry no fingerprints.
-Backfilling them needs `--clean`: fingerprints are stamped while a file is
-parsed, and an incremental sync skips files whose content has not changed, so
-`--update-graph` alone re-parses nothing and backfills nothing. Note that
+Graphs indexed before duplicate detection existed carry no fingerprints, and
+fingerprints are stamped while a file is parsed, so backfilling them means
+re-parsing. Which command does that depends on the hash cache:
+
+- **No hash cache for the repo** (never synced from this machine, or the
+  cache was cleared): `--update-graph` re-parses everything, because a file
+  is skipped only when the cache already holds a matching hash. This
+  backfills fingerprints without touching any other project.
+- **A populated hash cache**: `--update-graph` skips every unchanged file and
+  so backfills nothing. Use `--clean --update-graph` together, which drops
+  the cache and re-indexes in one pass.
+
 `--clean` deletes **every** project in the shared graph, not just this one —
 it prompts before destroying others, so confirm only when that graph holds
-this repository alone.
+this repository alone. `--clean` on its own wipes without re-indexing and
+leaves an empty graph; pair it with `--update-graph`.
 
 ## Basic Usage
 

--- a/docs/guide/duplicates.md
+++ b/docs/guide/duplicates.md
@@ -372,25 +372,35 @@ Index the repository first, so the graph exists in Memgraph:
 
 ```bash
 cgr daemon up
-cgr start --repo-path /path/to/your/repo --update-graph --clean
+cgr start --repo-path /path/to/your/repo --update-graph
 ```
 
 Graphs indexed before duplicate detection existed carry no fingerprints, and
 fingerprints are stamped while a file is parsed, so backfilling them means
-re-parsing. Which command does that depends on the hash cache:
+re-parsing. The command above is enough in most cases; only one situation
+needs `--clean`:
 
 - **No hash cache for the repo** (never synced from this machine, or the
   cache was cleared): `--update-graph` re-parses everything, because a file
-  is skipped only when the cache already holds a matching hash. This
-  backfills fingerprints without touching any other project.
-- **A populated hash cache**: `--update-graph` skips every unchanged file and
-  so backfills nothing. Use `--clean --update-graph` together, which drops
-  the cache and re-indexes in one pass.
+  is skipped only when the cache already holds its key. This backfills
+  fingerprints without touching any other project.
+- **A cache left over from a wiped graph**: `--update-graph` discards it by
+  itself. Before syncing, cgr counts this project's modules in the graph, and
+  finding none it deletes the cache and rebuilds fully — so a database wiped
+  while indexing another repo recovers without `--clean`.
+- **A populated cache matching a graph that still holds this project**: this
+  is the case that needs `--clean --update-graph`. An unchanged file is
+  skipped, so nothing gets re-parsed and no fingerprints are backfilled.
+  Passing both flags drops the cache and re-indexes in one pass.
 
-`--clean` deletes **every** project in the shared graph, not just this one —
-it prompts before destroying others, so confirm only when that graph holds
-this repository alone. `--clean` on its own wipes without re-indexing and
-leaves an empty graph; pair it with `--update-graph`.
+Reach for `--clean` only in that third case. It deletes **every** project in
+the shared graph, not just this one — it prompts before destroying others, so
+confirm only when that graph holds this repository alone, and note that
+`--yes` skips the prompt. If the graph holds other projects you need, index
+this repository into a separate graph instead.
+
+`--clean` on its own wipes without re-indexing and leaves an empty graph;
+always pair it with `--update-graph`.
 
 ## Basic Usage
 


### PR DESCRIPTION
## Summary

`duplicates.md` told users to run `--clean` to backfill fingerprints into an older graph, without mentioning that `--clean` **deletes every project in the shared graph**:

> DESTRUCTIVE: Delete every project from the shared graph and clear the selected repository's sync cache... Asks for confirmation when other projects would be destroyed; use `--yes` to skip the prompt.

A user with several projects indexed, following that instruction to fix a fingerprint problem in **one** repository, loses the others. The confirmation prompt is the only guard, and `--yes` removes it.

## `--clean` stays — it is required

I checked whether the gentler flag would do, and it would not:

- Fingerprints are stamped **at parse time** (`parsers/ast_fingerprint.py` via `function_ingest.py`), so any re-parse backfills them.
- The incremental path **skips files whose content hash is unchanged** (`graph_updater.py:2288-2295` → `skipped_count += 1; continue`). An old graph's files have not changed.
- There is no force-reparse flag.

So `--update-graph` alone re-parses nothing and backfills nothing. Softening the flag would produce an instruction that runs, reports success, and changes nothing — a worse failure than a destructive one, because it is silent. The doc now says this explicitly so a future editor does not fix it that way.

`cgr` takes the same position elsewhere (`logs.py:846`): when parser code changes under an existing graph, it prints *"Incremental sync keeps results from the old parser for unchanged files... Run 'cgr start --clean' to rebuild it from scratch."*

## What I did NOT change, and why

The other "until re-indexed" sentence in this file (line ~506, editor links) is **correct as written** and needs no flag. That feature depends on the Project node's `root_path`, which `run()` writes unconditionally before any file processing (`graph_updater.py:853`), outside the per-file hash skip. A plain `--update-graph` restores it. Verified rather than assumed — the two sentences look alike and only one has the problem.

Confirmed `_confirm_destructive_clean` (`cli.py:272`) exists and is wired into both call sites, so the prompt the doc now mentions is real.

## Test Plan

- `make readme` is a no-op against this prose (it sits outside the marked `<!-- SECTION -->` blocks). Ran it and re-diffed.

## Related

Fixes #1438. Surfaced when the `fix-doc-qualified-name` session cited this line to me as a phrasing precedent while I wrote #1437, then found the precedent was wrong for its own case.

## Type of Change

- [x] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisite instructions to use `--update-graph` by default.
  * Clarified behavior for missing caches, wiped-graph caches, and populated project caches.
  * Explained when re-indexing happens automatically and when `--clean --update-graph` is required.
  * Documented that `--clean` affects all shared-graph projects, `--yes` skips confirmation, and `--clean` alone leaves an empty graph.
  * Clarified that unchanged files are not reparsed during incremental updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->