### PR TITLE
fix: validate labels.yml on the PR that changes it rather than after merge

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -91,5 +91,5 @@
   description: Skip automated code review
 
 - name: claimed
-  color: B60205
+  color: b60205
   description: An agent/session is actively working this — check before taking it over

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,13 @@ jobs:
         run: |
           uv run ruff format --check .
 
+      # label-sync.yml runs only on push to main, so a malformed manifest
+      # would fail after merge rather than on the PR that broke it. Checking
+      # it here puts the failure on the change that causes it (issue #1434).
+      - name: Validate labels.yml
+        run: |
+          uv run python scripts/validate_labels.py
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,14 @@ repos:
         pass_filenames: false
   - repo: local
     hooks:
+      - id: validate-labels
+        name: validate labels.yml
+        entry: uv run --frozen --no-sync python scripts/validate_labels.py
+        language: system
+        files: ^\.github/labels\.yml$
+        pass_filenames: false
+  - repo: local
+    hooks:
       - id: generate-readme
         name: generate README sections
         entry: uv run --frozen --no-sync python scripts/hooks/generate_readme.py

--- a/codebase_rag/tests/test_validate_labels.py
+++ b/codebase_rag/tests/test_validate_labels.py
@@ -78,6 +78,12 @@ class TestRejectsMalformed:
         with pytest.raises(LabelError, match="parse"):
             validate_labels("- name: [unclosed\n")
 
+    def test_padded_name_is_rejected(self) -> None:
+        """Surrounding whitespace survives into the label name and is
+        invisible in review, so `--add-label` would then miss it."""
+        with pytest.raises(LabelError, match="whitespace"):
+            validate_labels("- name: '  a  '\n  color: b60205\n  description: d\n")
+
     def test_empty_list_is_rejected(self) -> None:
         """`[]` parses fine but would leave the sync managing no labels, so a
         PR could silently empty the configuration."""

--- a/codebase_rag/tests/test_validate_labels.py
+++ b/codebase_rag/tests/test_validate_labels.py
@@ -106,6 +106,12 @@ class TestRejectsMalformed:
         with pytest.raises(LabelError, match="differing only in case"):
             validate_labels(text)
 
+    def test_control_character_in_name_is_rejected(self) -> None:
+        """A newline inside a name is invisible in review and makes the label
+        ambiguous with a two-label list wherever names are passed as text."""
+        with pytest.raises(LabelError, match="control character"):
+            validate_labels('- name: "a\\nb"\n  color: b60205\n  description: d\n')
+
     def test_padded_name_is_rejected(self) -> None:
         """Surrounding whitespace survives into the label name and is
         invisible in review, so `--add-label` would then miss it."""

--- a/codebase_rag/tests/test_validate_labels.py
+++ b/codebase_rag/tests/test_validate_labels.py
@@ -78,6 +78,18 @@ class TestRejectsMalformed:
         with pytest.raises(LabelError, match="parse"):
             validate_labels("- name: [unclosed\n")
 
+    def test_case_differing_duplicate_is_rejected(self) -> None:
+        """GitHub matches label names case-insensitively (GET /labels/BUG
+        returns `bug`), but the syncer keys a case-sensitive map on the exact
+        name. Two such entries become two sync operations racing over one
+        real label, so the outcome depends on goroutine ordering."""
+        text = (
+            "- name: Bug\n  color: b60205\n  description: d\n"
+            "- name: bug\n  color: c60205\n  description: e\n"
+        )
+        with pytest.raises(LabelError, match="differing only in case"):
+            validate_labels(text)
+
     def test_padded_name_is_rejected(self) -> None:
         """Surrounding whitespace survives into the label name and is
         invisible in review, so `--add-label` would then miss it."""

--- a/codebase_rag/tests/test_validate_labels.py
+++ b/codebase_rag/tests/test_validate_labels.py
@@ -90,6 +90,22 @@ class TestRejectsMalformed:
         with pytest.raises(LabelError, match="differing only in case"):
             validate_labels(text)
 
+    def test_trailing_newline_colour_is_rejected(self) -> None:
+        """`re.match` stops at `$`, which sits before a final newline, so a
+        quoted "b60205\\n" would pass an anchored-looking pattern."""
+        with pytest.raises(LabelError, match="color"):
+            validate_labels('- name: a\n  color: "b60205\\n"\n  description: d\n')
+
+    def test_non_ascii_case_collision_is_rejected(self) -> None:
+        """`str.lower()` leaves 'Straße' and 'STRASSE' distinct; casefold is
+        the comparison built for caseless matching."""
+        text = (
+            "- name: Straße\n  color: b60205\n  description: d\n"
+            "- name: STRASSE\n  color: c60205\n  description: e\n"
+        )
+        with pytest.raises(LabelError, match="differing only in case"):
+            validate_labels(text)
+
     def test_padded_name_is_rejected(self) -> None:
         """Surrounding whitespace survives into the label name and is
         invisible in review, so `--add-label` would then miss it."""

--- a/codebase_rag/tests/test_validate_labels.py
+++ b/codebase_rag/tests/test_validate_labels.py
@@ -1,0 +1,78 @@
+"""Validation for `.github/labels.yml` (issue #1434).
+
+The sync workflow only runs on push to main, so a malformed manifest fails
+after merge rather than on the PR that broke it. These pin the checks that
+move that failure onto the PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_labels import LabelError, validate_labels
+
+VALID = """
+- name: bug
+  color: d73a4a
+  description: Something isn't working correctly
+
+- name: claimed
+  color: b60205
+  description: An agent session is working this
+"""
+
+
+class TestAcceptsValid:
+    def test_well_formed_manifest_passes(self) -> None:
+        """A manifest meeting every rule raises nothing."""
+        assert validate_labels(VALID) == 2
+
+    def test_the_shipped_manifest_is_valid(self) -> None:
+        """The real file must satisfy its own validator."""
+        manifest = Path(__file__).parent.parent.parent / ".github" / "labels.yml"
+        assert validate_labels(manifest.read_text(encoding="utf-8")) >= 1
+
+
+class TestRejectsMalformed:
+    def test_duplicate_name_is_rejected(self) -> None:
+        """Two entries sharing a name make the sync order-dependent."""
+        text = VALID + "\n- name: bug\n  color: 111111\n  description: dupe\n"
+        with pytest.raises(LabelError, match="duplicate"):
+            validate_labels(text)
+
+    def test_uppercase_colour_is_rejected(self) -> None:
+        """GitHub preserves case, but relying on that is undocumented."""
+        with pytest.raises(LabelError, match="color"):
+            validate_labels("- name: a\n  color: B60205\n  description: d\n")
+
+    def test_hash_prefixed_colour_is_rejected(self) -> None:
+        """The syncer wants six bare hex digits, not CSS notation."""
+        with pytest.raises(LabelError, match="color"):
+            validate_labels("- name: a\n  color: '#b60205'\n  description: d\n")
+
+    def test_short_colour_is_rejected(self) -> None:
+        """Three-digit shorthand is not accepted by the API."""
+        with pytest.raises(LabelError, match="color"):
+            validate_labels("- name: a\n  color: fff\n  description: d\n")
+
+    def test_missing_key_is_rejected(self) -> None:
+        """Every entry needs name, color and description."""
+        with pytest.raises(LabelError, match="description"):
+            validate_labels("- name: a\n  color: b60205\n")
+
+    def test_non_list_is_rejected(self) -> None:
+        """The syncer iterates the document as a list of mappings."""
+        with pytest.raises(LabelError, match="list"):
+            validate_labels("name: a\ncolor: b60205\n")
+
+    def test_invalid_yaml_is_rejected(self) -> None:
+        """A parse failure must report as a label error, not a traceback."""
+        with pytest.raises(LabelError, match="parse"):
+            validate_labels("- name: [unclosed\n")
+
+    def test_empty_manifest_is_rejected(self) -> None:
+        """An empty file would silently sync nothing."""
+        with pytest.raises(LabelError, match="empty"):
+            validate_labels("\n")

--- a/codebase_rag/tests/test_validate_labels.py
+++ b/codebase_rag/tests/test_validate_labels.py
@@ -78,6 +78,38 @@ class TestRejectsMalformed:
         with pytest.raises(LabelError, match="parse"):
             validate_labels("- name: [unclosed\n")
 
+    def test_empty_list_is_rejected(self) -> None:
+        """`[]` parses fine but would leave the sync managing no labels, so a
+        PR could silently empty the configuration."""
+        with pytest.raises(LabelError, match="no labels"):
+            validate_labels("[]\n")
+
+    def test_null_name_is_rejected(self) -> None:
+        """The syncer consumes name as a string; null would become 'None'."""
+        with pytest.raises(LabelError, match="name"):
+            validate_labels("- name: null\n  color: b60205\n  description: d\n")
+
+    def test_numeric_name_is_rejected(self) -> None:
+        """An unquoted numeric name must not be coerced into a string."""
+        with pytest.raises(LabelError, match="name"):
+            validate_labels("- name: 123\n  color: b60205\n  description: d\n")
+
+    def test_null_description_is_rejected(self) -> None:
+        """Present-but-null is not a usable description."""
+        with pytest.raises(LabelError, match="description"):
+            validate_labels("- name: a\n  color: b60205\n  description: null\n")
+
+    def test_collection_description_is_rejected(self) -> None:
+        """A list where a string belongs would reach the API malformed."""
+        with pytest.raises(LabelError, match="description"):
+            validate_labels("- name: a\n  color: b60205\n  description: [a, b]\n")
+
+    def test_unquoted_numeric_colour_explains_the_quoting(self) -> None:
+        """`color: 000000` parses as the integer 0, so say why rather than
+        reporting a value the file does not visibly contain."""
+        with pytest.raises(LabelError, match="quote"):
+            validate_labels("- name: a\n  color: 000000\n  description: d\n")
+
     def test_empty_manifest_is_rejected(self) -> None:
         """An empty file would silently sync nothing."""
         with pytest.raises(LabelError, match="empty"):

--- a/codebase_rag/tests/test_validate_labels.py
+++ b/codebase_rag/tests/test_validate_labels.py
@@ -52,6 +52,12 @@ class TestRejectsMalformed:
         with pytest.raises(LabelError, match="color"):
             validate_labels("- name: a\n  color: '#b60205'\n  description: d\n")
 
+    def test_unquoted_hash_colour_explains_the_yaml_comment(self) -> None:
+        """An unquoted '#rrggbb' parses as null, so say why rather than
+        reporting the value as 'None'."""
+        with pytest.raises(LabelError, match="YAML comment"):
+            validate_labels("- name: a\n  color: #b60205\n  description: d\n")
+
     def test_short_colour_is_rejected(self) -> None:
         """Three-digit shorthand is not accepted by the API."""
         with pytest.raises(LabelError, match="color"):

--- a/scripts/validate_labels.py
+++ b/scripts/validate_labels.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate `.github/labels.yml` before it can reach main (issue #1434).
+
+`label-sync.yml` triggers on push to main with a paths filter, so it never
+runs on a pull request: a malformed manifest fails after merge, on main,
+invisibly to the PR that broke it. This is the same shape as a check that
+cannot fail the thing it guards, so the validation runs as a pre-commit hook
+and in CI instead.
+
+The rules mirror what the sync action actually consumes: a list of mappings,
+each with a unique `name`, a bare six-digit lowercase hex `color`, and a
+`description`.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+COLOR_RE = re.compile(r"^[0-9a-f]{6}$")
+REQUIRED_KEYS = ("name", "color", "description")
+
+
+class LabelError(ValueError):
+    """A manifest that the label syncer would reject or misread."""
+
+
+def validate_labels(text: str) -> int:
+    """Check a labels manifest, returning how many entries it defines.
+
+    Raises `LabelError` with a message naming the offending entry. Colour
+    casing is enforced because GitHub happens to preserve it, which makes
+    an uppercase value work by undocumented behaviour rather than by
+    contract.
+    """
+    import yaml
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise LabelError(f"could not parse labels.yml: {exc}") from exc
+
+    if data is None:
+        raise LabelError("labels.yml is empty")
+    if not isinstance(data, list):
+        raise LabelError(
+            f"labels.yml must be a list of labels, got {type(data).__name__}"
+        )
+
+    seen: set[str] = set()
+    for index, entry in enumerate(data):
+        where = f"entry {index}"
+        if not isinstance(entry, dict):
+            raise LabelError(f"{where}: must be a mapping, got {type(entry).__name__}")
+        for key in REQUIRED_KEYS:
+            if key not in entry:
+                raise LabelError(f"{where}: missing '{key}'")
+        name = str(entry["name"])
+        if name in seen:
+            raise LabelError(f"{where}: duplicate label name {name!r}")
+        seen.add(name)
+        color = str(entry["color"])
+        if not COLOR_RE.match(color):
+            raise LabelError(
+                f"{where} ({name}): color must be six lowercase hex digits "
+                f"with no '#', got {color!r}"
+            )
+    return len(data)
+
+
+def main() -> int:
+    """Validate the manifest, printing the failure and returning non-zero."""
+    manifest = Path(__file__).parent.parent / ".github" / "labels.yml"
+    try:
+        count = validate_labels(manifest.read_text(encoding="utf-8"))
+    except LabelError as exc:
+        sys.stderr.write(f"{manifest.name}: {exc}\n")
+        return 1
+    sys.stdout.write(f"{manifest.name}: {count} labels OK\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_labels.py
+++ b/scripts/validate_labels.py
@@ -75,6 +75,15 @@ def validate_labels(text: str) -> int:
             )
         if name in seen:
             raise LabelError(f"{where}: duplicate label name {name!r}")
+        # GitHub matches label names case-insensitively (GET /labels/BUG
+        # returns `bug`), but the syncer keys a case-SENSITIVE map on the
+        # exact name, so two entries differing only in case become two
+        # concurrent operations against one real label.
+        if name.lower() in {other.lower() for other in seen}:
+            raise LabelError(
+                f"{where}: label name {name!r} duplicates an earlier entry "
+                f"differing only in case; GitHub treats them as one label"
+            )
         seen.add(name)
 
         description = entry["description"]

--- a/scripts/validate_labels.py
+++ b/scripts/validate_labels.py
@@ -47,6 +47,10 @@ def validate_labels(text: str) -> int:
         raise LabelError(
             f"labels.yml must be a list of labels, got {type(data).__name__}"
         )
+    if not data:
+        # An empty list parses cleanly and would leave the syncer managing
+        # nothing, so a change that empties the file must not read as valid.
+        raise LabelError("labels.yml defines no labels")
 
     seen: set[str] = set()
     for index, entry in enumerate(data):
@@ -56,10 +60,24 @@ def validate_labels(text: str) -> int:
         for key in REQUIRED_KEYS:
             if key not in entry:
                 raise LabelError(f"{where}: missing '{key}'")
-        name = str(entry["name"])
+
+        # The syncer consumes name and description as strings. Coercing a
+        # null, number or list here would push a malformed value through to
+        # the API instead of reporting it against the line that wrote it.
+        name = entry["name"]
+        if not isinstance(name, str) or not name.strip():
+            raise LabelError(f"{where}: name must be a non-empty string, got {name!r}")
         if name in seen:
             raise LabelError(f"{where}: duplicate label name {name!r}")
         seen.add(name)
+
+        description = entry["description"]
+        if not isinstance(description, str) or not description.strip():
+            raise LabelError(
+                f"{where} ({name}): description must be a non-empty string, "
+                f"got {description!r}"
+            )
+
         raw_color = entry["color"]
         if raw_color is None:
             # An unquoted '#rrggbb' is a YAML comment, so the value parses as
@@ -68,11 +86,18 @@ def validate_labels(text: str) -> int:
                 f"{where} ({name}): color is empty. An unquoted '#' starts a "
                 f"YAML comment, so write six bare hex digits (b60205)."
             )
-        color = str(raw_color)
-        if not COLOR_RE.match(color):
+        if not isinstance(raw_color, str):
+            # `color: 000000` is the integer 0, and `color: 123456` is an int
+            # too: both need quoting to survive as six digits.
+            raise LabelError(
+                f"{where} ({name}): color parsed as {type(raw_color).__name__} "
+                f"{raw_color!r}; quote it so leading zeros and digit-only "
+                f"values stay text (color: '000000')."
+            )
+        if not COLOR_RE.match(raw_color):
             raise LabelError(
                 f"{where} ({name}): color must be six lowercase hex digits "
-                f"with no '#', got {color!r}"
+                f"with no '#', got {raw_color!r}"
             )
     return len(data)
 

--- a/scripts/validate_labels.py
+++ b/scripts/validate_labels.py
@@ -67,6 +67,12 @@ def validate_labels(text: str) -> int:
         name = entry["name"]
         if not isinstance(name, str) or not name.strip():
             raise LabelError(f"{where}: name must be a non-empty string, got {name!r}")
+        if name != name.strip():
+            # Surrounding whitespace survives into the label and is invisible
+            # in review, so `gh pr edit --add-label` then misses it.
+            raise LabelError(
+                f"{where}: name has leading or trailing whitespace: {name!r}"
+            )
         if name in seen:
             raise LabelError(f"{where}: duplicate label name {name!r}")
         seen.add(name)

--- a/scripts/validate_labels.py
+++ b/scripts/validate_labels.py
@@ -67,6 +67,11 @@ def validate_labels(text: str) -> int:
         name = entry["name"]
         if not isinstance(name, str) or not name.strip():
             raise LabelError(f"{where}: name must be a non-empty string, got {name!r}")
+        if any(ord(char) < 32 for char in name):
+            # Invisible in review, and a name holding a newline is
+            # indistinguishable from a two-label list wherever names are
+            # passed as text.
+            raise LabelError(f"{where}: name contains a control character: {name!r}")
         if name != name.strip():
             # Surrounding whitespace survives into the label and is invisible
             # in review, so `gh pr edit --add-label` then misses it.

--- a/scripts/validate_labels.py
+++ b/scripts/validate_labels.py
@@ -60,7 +60,15 @@ def validate_labels(text: str) -> int:
         if name in seen:
             raise LabelError(f"{where}: duplicate label name {name!r}")
         seen.add(name)
-        color = str(entry["color"])
+        raw_color = entry["color"]
+        if raw_color is None:
+            # An unquoted '#rrggbb' is a YAML comment, so the value parses as
+            # null: report the cause rather than the confusing 'None'.
+            raise LabelError(
+                f"{where} ({name}): color is empty. An unquoted '#' starts a "
+                f"YAML comment, so write six bare hex digits (b60205)."
+            )
+        color = str(raw_color)
         if not COLOR_RE.match(color):
             raise LabelError(
                 f"{where} ({name}): color must be six lowercase hex digits "

--- a/scripts/validate_labels.py
+++ b/scripts/validate_labels.py
@@ -78,8 +78,9 @@ def validate_labels(text: str) -> int:
         # GitHub matches label names case-insensitively (GET /labels/BUG
         # returns `bug`), but the syncer keys a case-SENSITIVE map on the
         # exact name, so two entries differing only in case become two
-        # concurrent operations against one real label.
-        if name.lower() in {other.lower() for other in seen}:
+        # concurrent operations against one real label. casefold, not lower:
+        # lower() leaves 'Straße' and 'STRASSE' distinct.
+        if name.casefold() in {other.casefold() for other in seen}:
             raise LabelError(
                 f"{where}: label name {name!r} duplicates an earlier entry "
                 f"differing only in case; GitHub treats them as one label"
@@ -109,7 +110,7 @@ def validate_labels(text: str) -> int:
                 f"{raw_color!r}; quote it so leading zeros and digit-only "
                 f"values stay text (color: '000000')."
             )
-        if not COLOR_RE.match(raw_color):
+        if not COLOR_RE.fullmatch(raw_color):
             raise LabelError(
                 f"{where} ({name}): color must be six lowercase hex digits "
                 f"with no '#', got {raw_color!r}"


### PR DESCRIPTION
## Summary

Fixes #1434: `.github/labels.yml` was never validated before reaching `main`.

`label-sync.yml` triggers on `push` to `main` with a paths filter, plus `workflow_dispatch` and a weekly cron. There is no `pull_request` trigger, so a malformed manifest fails **after** merge, on main, invisibly to the PR that broke it. The validation existed but ran where it could not block the thing it validates.

This adds `scripts/validate_labels.py` and runs it in two places:

- a **pre-commit hook** scoped to `files: ^\.github/labels\.yml$`
- a **CI step** in Lint & Format, which is the part that actually closes the gap, since a hook only protects contributors who installed it

The rules mirror what the sync action consumes: a list of mappings, each with a unique `name`, a bare six-digit lowercase `color`, and a `description`.

## It caught a live defect

Running it against `main` failed immediately:

```
labels.yml: entry 22 (claimed): color must be six lowercase hex digits with no '#', got 'B60205'
```

`claimed` was the only uppercase entry among the 23. GitHub happens to preserve casing, so nothing was broken, but that is undocumented behaviour rather than a contract. Lowercased in this PR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates

## Related Issues

Closes #1434

## Test Plan

19 tests in `codebase_rag/tests/test_validate_labels.py`, written red before the validator existed (`ModuleNotFoundError`, then each rule in turn).

Every rule was mutation-tested — the rule disabled and the suite re-run — to confirm the assertion constrains the behaviour rather than describing it:

| Mutant | Killed by |
|---|---|
| colour regex accepts uppercase | `test_uppercase_colour_is_rejected` |
| duplicate-name check disabled | `test_duplicate_name_is_rejected` |
| missing-key check disabled | `test_missing_key_is_rejected` |
| non-list check disabled | `test_non_list_is_rejected` |
| null-colour branch disabled | `test_unquoted_hash_colour_explains_the_yaml_comment` |
| empty-list check disabled | `test_empty_list_is_rejected` |
| name type check disabled | `test_null_name_is_rejected`, `test_numeric_name_is_rejected` |
| description type check disabled | `test_null_description_is_rejected`, `test_collection_description_is_rejected` |
| colour type check disabled | `test_unquoted_numeric_colour_explains_the_quoting` |
| whitespace guard disabled | `test_padded_name_is_rejected` |
| case-collision check disabled | `test_case_differing_duplicate_is_rejected` |

### Rules added during review

Greptile and CodeRabbit found four gaps in the first version, each reproduced before fixing: an empty list (`[]`) passed and would have left the syncer managing nothing; `name` and `description` were coerced with `str(...)` or checked only for presence, so null/numeric/collection values passed through.

Probing beyond what was reported found two more:

- **Names padded with whitespace** (`'  a  '`) created a label with literal spaces, invisible in review, which `gh pr edit --add-label` would then fail to match.
- **Names differing only in case** are a genuine race. The pinned syncer (`micnncim/action-label-syncer@3abd5ab`) keys a **case-sensitive** `map[string]Label` on the exact name, while the GitHub API matches **case-insensitively** — verified directly, `GET /labels/BUG` returns the label named `bug`. So `Bug` and `bug` become two concurrent goroutines operating on one real label, and the outcome depends on scheduling.

An extra unknown key is deliberately still accepted: the syncer ignores unrecognised fields, and rejecting them would break forward compatibility if GitHub adds one.

Verified the **exit code**, not only the printed message, since a validator that reports a problem and exits 0 is inert:

```
malformed manifest -> exit=1, names the offending entry
valid manifest     -> exit=0, "labels.yml: 23 labels OK"
```

Also confirmed the hook blocks through `pre-commit` itself rather than only when the script is run directly.

One error-message refinement came out of that testing: an unquoted `#b60205` is a YAML comment, so the value parses as null and the first version reported `got 'None'`. The rejection was right and the message was misleading; it now explains the cause.

Full unit suite passes (8038). `ruff check`, `ruff format --check` clean. `ty` reports the same 2 diagnostics as clean `main`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized label color formatting for consistent display.
  * Prevented invalid label configurations from being accepted.

* **Chores**
  * Added automated validation for label configuration during project checks and local commits.
  * Validation detects malformed files, duplicate labels, invalid names or descriptions, missing fields, and incorrectly formatted colors.

* **Tests**
  * Added comprehensive coverage for valid and invalid label configurations, including the published label set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->