### PR TITLE
fix: recommend 'cgr start --clean --update-graph' instead of bare --clean

### DIFF
--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -845,8 +845,10 @@ HASH_CACHE_ORPHANED = (
 PARSER_FINGERPRINT_SAVE_FAILED = "Failed to save parser fingerprint to {path}: {error}"
 PARSER_FINGERPRINT_MISMATCH = (
     "Parser code changed since this graph was built. Incremental sync keeps "
-    "results from the old parser for unchanged files, so the graph may be "
-    "stale. Run 'cgr start --clean' to rebuild it from scratch."
+    "results from the old parser for files not touched since the last sync, so "
+    "the graph may be stale. Run 'cgr start --clean --update-graph' to rebuild "
+    "it from scratch. '--clean' on its own deletes the graph without rebuilding "
+    "it, and deletes every project in a shared database, not just this one."
 )
 
 REHYDRATE_QUERY_FAILED = (

--- a/codebase_rag/tests/test_clean_remedy_strings.py
+++ b/codebase_rag/tests/test_clean_remedy_strings.py
@@ -29,13 +29,23 @@ _LANGUAGE_SUPPORT_DOC = (
 #
 # Three delimiter forms are recognised, because a remedy is equally dangerous
 # however it happens to be punctuated: single-quoted, backticked, and bare
-# (running to sentence punctuation or end of line). The `run` imperative stays
-# mandatory -- it is what separates advice from prose that merely discusses the
-# flag, which `test_prose_about_clean_is_not_flagged` pins.
+# (running to sentence punctuation, a command connector, or end of line). The
+# `run` imperative stays mandatory -- it is what separates advice from prose
+# that merely discusses the flag, which `test_prose_about_clean_is_not_flagged`
+# pins.
+#
+# The bare form must also stop at a connector such as "then" or "followed by".
+# Without that it swallows the *next* invocation too, and a trailing safe
+# command launders a destructive leading one: "Run cgr start --clean then run
+# cgr start --update-graph" captured as a single string, whose
+# `--update-graph` satisfied the check for a command that does not have it.
+_CONNECTOR = r"(?:\s+(?:and\s+)?then\b|\s+followed\s+by\b|\s+before\b|\s+&&)"
+
 _REMEDY = re.compile(
     r"run\s+(?:'([^'\n]*--clean[^'\n]*)'"
     r"|`([^`\n]*--clean[^`\n]*)`"
-    r"|([^'\"`\n]*?--clean[^'\"`\n,.;:!?]*))",
+    r"|((?:(?!" + _CONNECTOR + r")[^'\"`\n])*?--clean"
+    r"(?:(?!" + _CONNECTOR + r")[^'\"`\n,.;:!?])*))",
     re.IGNORECASE,
 )
 
@@ -121,6 +131,33 @@ class TestCleanRemedyStrings:
         commands = _commands(text)
         assert commands
         assert all("--update-graph" not in c for c in commands)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Run cgr start --clean then run cgr start --update-graph",
+            "Run cgr start --clean and then run cgr start --update-graph",
+            "Run cgr start --clean followed by cgr start --update-graph",
+            "Run cgr start --clean && cgr start --update-graph",
+            "Run cgr start --clean before cgr start --update-graph",
+        ],
+    )
+    def test_bare_match_stops_at_a_command_connector(self, text: str) -> None:
+        """A later safe command must not launder an earlier destructive one.
+
+        The bare alternative ran to sentence punctuation, so two commands joined
+        by "then" captured as a single string. `--update-graph` from the *second*
+        command then satisfied the acceptance check for the *first*, and a string
+        opening with a destructive bare `--clean` passed (CodeRabbit, #1444).
+
+        Each invocation must be judged on its own, so the destructive one is
+        still reported however safe its successor is.
+        """
+        commands = _commands(text)
+        assert commands
+        assert any("--update-graph" not in c for c in commands), (
+            f"the destructive first command was laundered by a later one: {commands}"
+        )
 
     @pytest.mark.parametrize(
         "text",

--- a/codebase_rag/tests/test_clean_remedy_strings.py
+++ b/codebase_rag/tests/test_clean_remedy_strings.py
@@ -39,7 +39,15 @@ _LANGUAGE_SUPPORT_DOC = (
 # command launders a destructive leading one: "Run cgr start --clean then run
 # cgr start --update-graph" captured as a single string, whose
 # `--update-graph` satisfied the check for a command that does not have it.
-_CONNECTOR = r"(?:\s+(?:and\s+)?then\b|\s+followed\s+by\b|\s+before\b|\s+&&)"
+#
+# `and` is a connector on its own, not merely an optional prefix to `then`. The
+# first version of this fix only ever matched `and` as part of `and then`, so
+# "Run cgr start --clean and run cgr start --update-graph" still captured as one
+# string and laundered exactly as before -- the bug the connector list exists to
+# prevent, surviving in the conjunction nobody enumerated (Greptile P1, #1444).
+_CONNECTOR = (
+    r"(?:\s+and\s+then\b|\s+and\b|\s+then\b|\s+followed\s+by\b|\s+before\b|\s+&&)"
+)
 
 _REMEDY = re.compile(
     r"run\s+(?:'([^'\n]*--clean[^'\n]*)'"
@@ -140,6 +148,12 @@ class TestCleanRemedyStrings:
             "Run cgr start --clean followed by cgr start --update-graph",
             "Run cgr start --clean && cgr start --update-graph",
             "Run cgr start --clean before cgr start --update-graph",
+            # Standalone "and", with no "then" after it, was the hole the first
+            # connector fix left: `and` was only ever optional *before* `then`,
+            # never a boundary on its own (Greptile P1, #1444).
+            "Run cgr start --clean and run cgr start --update-graph",
+            "Run cgr start --clean, and run cgr start --update-graph",
+            "Run cgr start --clean and cgr start --update-graph",
         ],
     )
     def test_bare_match_stops_at_a_command_connector(self, text: str) -> None:

--- a/codebase_rag/tests/test_clean_remedy_strings.py
+++ b/codebase_rag/tests/test_clean_remedy_strings.py
@@ -13,15 +13,42 @@ flag rather than for the flag alone.
 """
 
 import re
+from pathlib import Path
 
 import pytest
 
 from codebase_rag import logs
 
+_LANGUAGE_SUPPORT_DOC = (
+    Path(__file__).resolve().parents[2] / "docs/architecture/language-support.md"
+)
+
 # "Run 'cgr start --clean'" and friends: an imperative followed by a command
-# containing --clean, up to the closing quote. `--update-graph` appearing
-# anywhere inside that command is what makes the advice correct.
-_REMEDY = re.compile(r"run\s+'([^']*--clean[^']*)'", re.IGNORECASE)
+# containing --clean. `--update-graph` appearing anywhere inside that command is
+# what makes the advice correct.
+#
+# Three delimiter forms are recognised, because a remedy is equally dangerous
+# however it happens to be punctuated: single-quoted, backticked, and bare
+# (running to sentence punctuation or end of line). The `run` imperative stays
+# mandatory -- it is what separates advice from prose that merely discusses the
+# flag, which `test_prose_about_clean_is_not_flagged` pins.
+_REMEDY = re.compile(
+    r"run\s+(?:'([^'\n]*--clean[^'\n]*)'"
+    r"|`([^`\n]*--clean[^`\n]*)`"
+    r"|([^'\"`\n]*?--clean[^'\"`\n,.;:!?]*))",
+    re.IGNORECASE,
+)
+
+
+def _commands(text: str) -> list[str]:
+    """Every remedy command in `text`, whichever delimiter form it used.
+
+    `_REMEDY` has one capture group per delimiter form, so each match yields a
+    tuple with exactly one non-empty element.
+    """
+    return [
+        group.strip() for match in _REMEDY.findall(text) for group in match if group
+    ]
 
 
 def _string_constants() -> dict[str, str]:
@@ -35,7 +62,7 @@ def _string_constants() -> dict[str, str]:
 def _remedies() -> list[tuple[str, str]]:
     found = []
     for name, value in _string_constants().items():
-        for command in _REMEDY.findall(value):
+        for command in _commands(value):
             found.append((name, command))
     return found
 
@@ -77,6 +104,40 @@ class TestCleanRemedyStrings:
     @pytest.mark.parametrize(
         "text",
         [
+            "Run `cgr start --clean` to rebuild it from scratch.",
+            "run `cgr start --clean --yes` to fix this",
+            "Run cgr start --clean to rebuild it from scratch.",
+            "run cgr start --clean --yes, then re-index",
+        ],
+    )
+    def test_detector_catches_unquoted_and_backticked_remedies(self, text: str) -> None:
+        """A remedy is dangerous however it is punctuated (CodeRabbit, #1444).
+
+        The original matcher only inspected single-quoted commands, so a string
+        saying "Run `cgr start --clean`" recommended destructive cleanup while
+        `test_no_remedy_recommends_bare_clean` stayed green -- a hole in the very
+        guard that exists to have none.
+        """
+        commands = _commands(text)
+        assert commands
+        assert all("--update-graph" not in c for c in commands)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Run `cgr start --clean --update-graph` to rebuild it.",
+            "Run cgr start --clean --update-graph to rebuild it.",
+        ],
+    )
+    def test_detector_accepts_corrected_unquoted_forms(self, text: str) -> None:
+        """The corrected wording must pass in every delimiter form too."""
+        commands = _commands(text)
+        assert commands
+        assert all("--update-graph" in c for c in commands)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
             "Run 'cgr start --clean' to rebuild it from scratch.",
             "run 'cgr start --clean --yes' to fix this",
         ],
@@ -88,14 +149,14 @@ class TestCleanRemedyStrings:
         matching is broken. Planting the exact phrasing the rule exists to
         forbid proves it is the former.
         """
-        commands = _REMEDY.findall(text)
+        commands = _commands(text)
         assert commands
         assert all("--update-graph" not in c for c in commands)
 
     def test_detector_accepts_the_corrected_form(self) -> None:
         """The fixed wording must pass, or the rule would forbid the remedy too."""
         text = "Run 'cgr start --clean --update-graph' to rebuild it."
-        commands = _REMEDY.findall(text)
+        commands = _commands(text)
         assert commands
         assert all("--update-graph" in c for c in commands)
 
@@ -106,7 +167,23 @@ class TestCleanRemedyStrings:
         this keeps a future tightening of the rule from flagging it.
         """
         assert "--clean" in logs.MG_LIST_PROJECTS_FAILED
-        assert not _REMEDY.findall(logs.MG_LIST_PROJECTS_FAILED)
+        assert not _commands(logs.MG_LIST_PROJECTS_FAILED)
+
+    def test_docs_name_the_mtime_mechanism(self) -> None:
+        """The skip rule is an mtime comparison, not content hashing (#1444).
+
+        `graph_updater.py` skips a file when `filepath.stat().st_mtime <=
+        cache_mtime`. Saying only "files not modified since the last sync"
+        reads as content-based detection, which would make the parser-migration
+        warning sound avoidable: touching a file forces a re-parse even when its
+        content is identical, and that is precisely the distinction a user
+        forcing a migration needs.
+        """
+        doc = _LANGUAGE_SUPPORT_DOC.read_text(encoding="utf-8")
+        assert "mtime" in doc, (
+            "language-support.md must name the mtime comparison explicitly "
+            "rather than implying content-based change detection"
+        )
 
     @pytest.mark.parametrize(
         "text",
@@ -127,4 +204,4 @@ class TestCleanRemedyStrings:
         bare form. These phrasings recur whenever someone documents the flag
         properly, so they are pinned rather than left to chance.
         """
-        assert not _REMEDY.findall(text)
+        assert not _commands(text)

--- a/codebase_rag/tests/test_clean_remedy_strings.py
+++ b/codebase_rag/tests/test_clean_remedy_strings.py
@@ -1,0 +1,130 @@
+"""No user-facing remedy string tells the user to run a bare `cgr start --clean`.
+
+`--clean` without `--update-graph` is destructive-only: `cli.py` deletes the
+graph, clears the embeddings and the hash cache, then returns before indexing
+anything (issues #1441, #1442). Advising it as a *fix* therefore hands the user
+an empty graph, and in a shared database destroys every other project too.
+
+The rule is narrower than "never mention --clean": a string may name the flag
+while describing which operation is running, which is what
+`MG_LIST_PROJECTS_FAILED` does. Only strings that *recommend running* it are
+constrained, so the check looks for an imperative ("run '...'") wrapping the
+flag rather than for the flag alone.
+"""
+
+import re
+
+import pytest
+
+from codebase_rag import logs
+
+# "Run 'cgr start --clean'" and friends: an imperative followed by a command
+# containing --clean, up to the closing quote. `--update-graph` appearing
+# anywhere inside that command is what makes the advice correct.
+_REMEDY = re.compile(r"run\s+'([^']*--clean[^']*)'", re.IGNORECASE)
+
+
+def _string_constants() -> dict[str, str]:
+    return {
+        name: value
+        for name, value in vars(logs).items()
+        if not name.startswith("_") and isinstance(value, str)
+    }
+
+
+def _remedies() -> list[tuple[str, str]]:
+    found = []
+    for name, value in _string_constants().items():
+        for command in _REMEDY.findall(value):
+            found.append((name, command))
+    return found
+
+
+class TestCleanRemedyStrings:
+    def test_corpus_is_non_empty(self) -> None:
+        """Guard the guard: an empty corpus would make every check below vacuous.
+
+        This is the failure the rest of the class cannot detect on its own. If
+        `vars(logs)` stopped yielding strings, `_remedies()` would return an
+        empty list and the assertions would pass while inspecting nothing.
+        """
+        assert len(_string_constants()) > 100
+
+    def test_clean_is_mentioned_somewhere(self) -> None:
+        """The traversal reaches the strings this module is about."""
+        mentioning = [n for n, v in _string_constants().items() if "--clean" in v]
+        assert "PARSER_FINGERPRINT_MISMATCH" in mentioning
+
+    def test_at_least_one_remedy_is_matched(self) -> None:
+        """The regex matches real content, not just the empty set.
+
+        Without this, weakening `_REMEDY` to something that never matches would
+        leave `test_no_remedy_recommends_bare_clean` green.
+        """
+        assert _remedies()
+
+    def test_no_remedy_recommends_bare_clean(self) -> None:
+        bare = [
+            (name, command)
+            for name, command in _remedies()
+            if "--update-graph" not in command
+        ]
+        assert not bare, (
+            "These strings advise a bare --clean, which deletes the graph "
+            f"without rebuilding it: {bare}"
+        )
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Run 'cgr start --clean' to rebuild it from scratch.",
+            "run 'cgr start --clean --yes' to fix this",
+        ],
+    )
+    def test_detector_catches_a_planted_bare_remedy(self, text: str) -> None:
+        """Mutation check, inlined so it runs on every CI pass.
+
+        A grep-style rule reports green both when nothing is wrong and when the
+        matching is broken. Planting the exact phrasing the rule exists to
+        forbid proves it is the former.
+        """
+        commands = _REMEDY.findall(text)
+        assert commands
+        assert all("--update-graph" not in c for c in commands)
+
+    def test_detector_accepts_the_corrected_form(self) -> None:
+        """The fixed wording must pass, or the rule would forbid the remedy too."""
+        text = "Run 'cgr start --clean --update-graph' to rebuild it."
+        commands = _REMEDY.findall(text)
+        assert commands
+        assert all("--update-graph" in c for c in commands)
+
+    def test_operational_mentions_are_not_treated_as_remedies(self) -> None:
+        """Naming the flag while describing an operation is not advice.
+
+        `MG_LIST_PROJECTS_FAILED` says what failed *before* --clean ran. Pinning
+        this keeps a future tightening of the rule from flagging it.
+        """
+        assert "--clean" in logs.MG_LIST_PROJECTS_FAILED
+        assert not _REMEDY.findall(logs.MG_LIST_PROJECTS_FAILED)
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "needs `--clean`:",
+            "recovers without `--clean`.",
+            "Reach for `--clean` only in that third case. It deletes every project.",
+            "`--clean` on its own wipes without re-indexing the repository.",
+        ],
+    )
+    def test_prose_about_clean_is_not_flagged(self, text: str) -> None:
+        """Sentences that discuss the flag without recommending it must not match.
+
+        A line-scoped "mentions --clean but not --update-graph" rule scores 100%
+        false positives on correct documentation: measured against a known-good
+        write-up of this flag, all four hits were noise. The last two are the
+        sharpest, since a naive rule flags the very sentences warning against the
+        bare form. These phrasings recur whenever someone documents the flag
+        properly, so they are pinned rather than left to chance.
+        """
+        assert not _REMEDY.findall(text)

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -49,9 +49,11 @@ merge `Main.kt` and `Main.kts` onto one node.
 
 Graphs indexed before this keep the unsuffixed names, and a saved query
 written against the old shape stops matching once they move. An incremental
-sync will not move them: it skips files not modified since the last sync, and
-this change alters how a name is emitted rather than the file itself, so cgr
-warns that the parser changed but keeps the old results. Rebuilding with
+sync will not move them: it compares each file's mtime against the hash cache
+rather than hashing its content, so it skips every file whose mtime has not
+advanced since the last sync. This change alters how a name is emitted rather
+than the file itself, so cgr warns that the parser changed but keeps the old
+results. Rebuilding with
 `cgr start --clean --update-graph` is what re-emits them. Both flags are
 required: `--clean` on its own deletes the graph and returns without
 rebuilding. Note that it clears **every** project in a shared graph, so

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -49,11 +49,13 @@ merge `Main.kt` and `Main.kts` onto one node.
 
 Graphs indexed before this keep the unsuffixed names, and a saved query
 written against the old shape stops matching once they move. An incremental
-sync will not move them: it skips files whose content is unchanged, and this
-change alters how a name is emitted rather than the file itself, so cgr warns
-that the parser changed but keeps the old results. Rebuilding with
-`cgr start --clean` is what re-emits them. Note that it clears **every**
-project in a shared graph, so re-index the others afterwards.
+sync will not move them: it skips files not modified since the last sync, and
+this change alters how a name is emitted rather than the file itself, so cgr
+warns that the parser changed but keeps the old results. Rebuilding with
+`cgr start --clean --update-graph` is what re-emits them. Both flags are
+required: `--clean` on its own deletes the graph and returns without
+rebuilding. Note that it clears **every** project in a shared graph, so
+re-index the others afterwards.
 
 | Language | Extensions | Functions | Classes/Types | Imports |
 |---|---|---|---|---|


### PR DESCRIPTION
Closes #1441
Closes #1442

## The bug

`cgr start --clean` without `--update-graph` is destructive-only. In `cli.py`:

```python
if clean and not update_graph:
    repo_to_clean = Path(target_repo_path)
    with connect_memgraph(effective_batch_size) as ingestor:
        _confirm_destructive_clean(ingestor, resolved_project_name, yes)
        ingestor.clean_database()
    clear_all_embeddings()
    _delete_hash_cache(repo_to_clean)
    return   # <-- indexes nothing
```

It deletes the graph, clears the embeddings and the hash cache, then returns
before indexing. In a shared database it deletes *every* project, not just the
one named.

Two user-facing places recommended exactly that as the fix for a stale graph.
The runtime one is the more serious: `PARSER_FINGERPRINT_MISMATCH` fires
precisely when the user has a genuine staleness problem and is therefore most
likely to copy-paste the advice, so following it left them with an empty graph
plus collateral destruction of unrelated projects.

## Why one PR

Shipping the doc fix and the string fix separately guarantees a window where one
contradicts the other, and that window is exactly when someone hits this case
and goes looking for a second opinion.

## Changes

**`codebase_rag/logs.py`** — `PARSER_FINGERPRINT_MISMATCH` now says
`cgr start --clean --update-graph`, and states what the bare form does so the
warning is not merely correct but hard to misread.

**`docs/architecture/language-support.md`** — same remedy correction, plus a
second fix in the sentence above it. That line claimed the sync "skips files
whose content is unchanged". The skip is an **mtime** comparison
(`graph_updater.py:2258-2273`), not a content hash. This mattered more than the
phrasing: the reason this case is a bug at all is that content *is* unchanged
while the correct output changed, so the old premise contradicted the
paragraph's own conclusion. A reader who noticed the tension would resolve it by
disbelieving the remedy.

**`codebase_rag/tests/test_clean_remedy_strings.py`** (new) — pins that no
user-facing remedy string recommends a bare `--clean`.

## Scope of the sweep

Narrower than it first looked. Across all Python source there are 10 `--clean`
occurrences and only **one** was a wrong remedy. The rest are the flag
definition, the confirmation prompt, blast-radius warnings, and a PyInstaller
constant. In docs, every instructional site already writes
`--update-graph --clean` together (`quickstart.md:29`, `dead-code.md:41`,
`graph-export.md:14`, `graph-loader.md:20`). `cli-reference.md:35` was correct
all along and is effectively the spec.

The bare-as-remedy phrasing existed in three prose lines total: the two fixed
here, and `docs/guide/duplicates.md:379`. That third one is **already fixed** on
the head of in-flight PR #1439 and is deliberately untouched here to avoid a
conflicting edit to a file owned by another open PR.

The pin added here is deliberately scoped to Python string constants
(`vars(logs)`), which is what #1442 is about. Extending it to Markdown would
make this branch red for a reason unrelated to this bug until #1439 merges, and
a test that fails for the wrong reason is the one most likely to get loosened by
whoever sees the unexplained failure.

## When `--clean` is actually needed

Verified against `graph_updater.py`, not inferred:

| Situation | Correct remedy |
|---|---|
| No hash cache | `--update-graph` alone backfills it |
| Cache orphaned (wiped db, fresh Memgraph) | `--update-graph` alone; `_drop_cache_if_graph_lost` clears it automatically |
| Cache valid, graph intact, **parser changed** | `--clean --update-graph`, the only destructive case |

## On the test

A grep-style rule over a constants module is exactly the shape that reports green
both when everything is clean and when the traversal is broken, so it carries
four anti-vacuity guards: corpus size, reachability of the specific constant,
non-empty match set, and a parametrized planted-string check that runs on every
CI pass rather than as a one-off manual mutation.

The rule matches an imperative wrapping the command (`run '...--clean...'`) and
requires `--update-graph` inside it, rather than flagging the flag alone.
Naming the flag and recommending it are different speech acts:
`MG_LIST_PROJECTS_FAILED` mentions `--clean` while describing which operation
failed, and a flat rule would flag it falsely. Measured against a known-good
write-up of this flag, a naive line-scoped rule scored four false positives and
zero true ones; two of those were sentences *warning against* the bare form.
Those phrasings are pinned as must-not-match, since they recur whenever someone
documents the flag properly.

## Verification

Mutation-tested: reverting the `logs.py` fix turns the suite red with
`1 failed, 7 passed`, and the failure names the offending constant directly:

```
AssertionError: These strings advise a bare --clean, which deletes the graph
without rebuilding it: [('PARSER_FINGERPRINT_MISMATCH', 'cgr start --clean')]
```

Restoring the fix returns it to green. The scaffolding tests stay green in both
directions, which is what distinguishes a pin that constrains behaviour from one
that merely describes it.

Integration tests were **not** run locally (the local Docker daemon is down, so
every `testcontainers` fixture fails at setup on this machine regardless of the
change); that coverage comes from CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parser mismatch guidance during incremental synchronization.
  * Clarified that unchanged files retain results from the previous parser.
  * Updated remediation instructions to use `cgr start --clean --update-graph`.

* **Documentation**
  * Clarified that `--clean` alone only deletes the graph.
  * Documented that cleaning a shared graph removes all projects, which must then be re-indexed.
  * Explained that synchronization uses file modification times to detect changes and skips files whose timestamps have not advanced.
  * Clarified that parser changes require a full graph rebuild.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->