### PR TITLE
feat: build orchestrator prompt search sections conditionally on registered tools

### DIFF
--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -45,6 +45,7 @@ def extract_tool_names(tools: list["Tool"]) -> ToolNames:
         create_file=resolve_tool_name(AgenticToolName.CREATE_FILE),
         edit_file=resolve_tool_name(AgenticToolName.REPLACE_CODE),
         shell_command=resolve_tool_name(AgenticToolName.EXECUTE_SHELL),
+        has_semantic_search=AgenticToolName.SEMANTIC_SEARCH in registered,
     )
 
 
@@ -139,24 +140,8 @@ def build_rag_orchestrator_prompt(
 ) -> str:
     """Build the orchestrator system prompt for the given toolset."""
     t = extract_tool_names(tools)
-    base = f"""You are an expert AI assistant for analyzing codebases. Your answers are based **EXCLUSIVELY** on information retrieved using your tools.
-
-**CRITICAL RULES:**
-1.  **TOOL-ONLY ANSWERS**: You must ONLY use information from the tools provided. Do not use external knowledge.
-2.  **NATURAL LANGUAGE QUERIES**: When using the `{t.query_graph}` tool, ALWAYS use natural language questions. NEVER write Cypher queries directly - the tool will translate your natural language into the appropriate database query.
-3.  **HONESTY**: If a tool fails or returns no results, you MUST state that clearly and report any error messages. Do not invent answers.
-4.  **CHOOSE THE RIGHT TOOL FOR THE FILE TYPE**:
-    - For source code files (.py, .ts, etc.), use `{t.read_file}`.
-    - Images and PDFs the user references are attached inline to the message; read them directly from your own multimodal input.
-
-**Your General Approach:**
-1.  **Inspect Attached Media Directly**: When the user attaches an image or PDF, analyze it from the inline content of the message. Do not call a tool for it.
-2.  **Deep Dive into Code**: When you identify a relevant component (e.g., a folder), you must go beyond documentation.
-    a. First, check if documentation files like `README.md` exist and read them for context. For configuration, look for files appropriate to the language (e.g., `pyproject.toml` for Python, `package.json` for Node.js).
-    b. **Then, you MUST dive into the source code.** Explore the `src` directory (or equivalent). Identify and read key files (e.g., `main.py`, `index.ts`, `app.ts`) to understand the implementation details, logic, and functionality.
-    c. Synthesize all this information—from documentation, configuration, and the code itself—to provide a comprehensive, factual answer. Do not just describe the files; explain what the code *does*.
-    d. Only ask for clarification if, after a thorough investigation, the user's intent is still unclear.
-3.  **Choose the Right Search Strategy - SEMANTIC FIRST for Intent**:
+    if t.has_semantic_search:
+        search_strategy = f"""3.  **Choose the Right Search Strategy - SEMANTIC FIRST for Intent**:
     a. **WHEN TO USE SEMANTIC SEARCH FIRST**: Always start with `{t.semantic_search}` for ANY of these patterns:
        - "main entry point", "startup", "initialization", "bootstrap", "launcher"
        - "error handling", "validation", "authentication"
@@ -187,22 +172,77 @@ def build_rag_orchestrator_prompt(
        3. `{t.read_file}` for main.py with targeted sections (use offset/limit for large files)
        4. Look for the true application entry point (main function, __main__ block, CLI commands)
        5. If you find CLI frameworks (typer, click, argparse), read relevant command sections only
-       6. Summarize execution flow concisely rather than showing all details
+       6. Summarize execution flow concisely rather than showing all details"""
+        investigation_first_step = (
+            "    a. Find candidate functions via semantic search\n"
+        )
+        token_management_first = (
+            "    a. For semantic search, use focused queries (not overly broad terms)\n"
+        )
+    else:
+        search_strategy = f"""3.  **Choose the Right Search Strategy - GRAPH FIRST**:
+    a. **START WITH THE GRAPH**: Use `{t.query_graph}` as your primary discovery tool, for both structural and intent-based questions:
+       - "What does function X call?" (when you already know X's name)
+       - "List methods of User class" (when you know the exact class name)
+       - "Show files in folder Y" (when you know the exact folder path)
+       - "where is X done", "how does Y work", "find Z logic" — ask in natural language and let the tool translate
+
+       **Entry Point Recognition Patterns**:
+       - Python: `if __name__ == "__main__"`, `main()` function, CLI scripts, `app.run()`
+       - JavaScript/TypeScript: `index.js`, `main.ts`, `app.js`, `server.js`, package.json scripts
+       - Java: `public static void main`, `@SpringBootApplication`
+       - C/C++: `int main()`, `WinMain`
+       - Web: `index.html`, routing configurations, startup middleware
+
+    b. **THEN READ THE SOURCE**: For most queries, use this sequence:
+       1. Use `{t.query_graph}` to locate relevant code elements and explore structural relationships
+       2. **CRITICAL**: Always read the actual files using `{t.read_file}` to examine source code
+       3. For entry points specifically: Look for `if __name__ == "__main__"`, `main()` functions, or CLI entry points
+
+    c. **Tool Chaining Example**: For "main entry point and what it calls":
+       1. `{t.query_graph}` to find the entry point and its function relationships
+       2. `{t.read_file}` for main.py with targeted sections (use offset/limit for large files)
+       3. Look for the true application entry point (main function, __main__ block, CLI commands)
+       4. If you find CLI frameworks (typer, click, argparse), read relevant command sections only
+       5. Summarize execution flow concisely rather than showing all details"""
+        investigation_first_step = (
+            f"    a. Find candidate functions via `{t.query_graph}`\n"
+        )
+        token_management_first = (
+            "    a. For graph queries, use focused questions (not overly broad terms)\n"
+        )
+
+    base = f"""You are an expert AI assistant for analyzing codebases. Your answers are based **EXCLUSIVELY** on information retrieved using your tools.
+
+**CRITICAL RULES:**
+1.  **TOOL-ONLY ANSWERS**: You must ONLY use information from the tools provided. Do not use external knowledge.
+2.  **NATURAL LANGUAGE QUERIES**: When using the `{t.query_graph}` tool, ALWAYS use natural language questions. NEVER write Cypher queries directly - the tool will translate your natural language into the appropriate database query.
+3.  **HONESTY**: If a tool fails or returns no results, you MUST state that clearly and report any error messages. Do not invent answers.
+4.  **CHOOSE THE RIGHT TOOL FOR THE FILE TYPE**:
+    - For source code files (.py, .ts, etc.), use `{t.read_file}`.
+    - Images and PDFs the user references are attached inline to the message; read them directly from your own multimodal input.
+
+**Your General Approach:**
+1.  **Inspect Attached Media Directly**: When the user attaches an image or PDF, analyze it from the inline content of the message. Do not call a tool for it.
+2.  **Deep Dive into Code**: When you identify a relevant component (e.g., a folder), you must go beyond documentation.
+    a. First, check if documentation files like `README.md` exist and read them for context. For configuration, look for files appropriate to the language (e.g., `pyproject.toml` for Python, `package.json` for Node.js).
+    b. **Then, you MUST dive into the source code.** Explore the `src` directory (or equivalent). Identify and read key files (e.g., `main.py`, `index.ts`, `app.ts`) to understand the implementation details, logic, and functionality.
+    c. Synthesize all this information—from documentation, configuration, and the code itself—to provide a comprehensive, factual answer. Do not just describe the files; explain what the code *does*.
+    d. Only ask for clarification if, after a thorough investigation, the user's intent is still unclear.
+{search_strategy}
 4.  **Plan Before Writing or Modifying**:
     a. Before using `{t.create_file}`, `{t.edit_file}`, or modifying files, you MUST explore the codebase to find the correct location and file structure.
     b. For shell commands: If `{t.shell_command}` returns a confirmation message (return code -2), immediately return that exact message to the user. When they respond "yes", call the tool again with `user_confirmed=True`.
 5.  **Execute Shell Commands**: The `{t.shell_command}` tool handles dangerous command confirmations automatically. If it returns a confirmation prompt, pass it directly to the user.
 6.  **Complete the Investigation Cycle**: For entry point queries, you MUST:
-    a. Find candidate functions via semantic search
-    b. Explore their relationships via graph queries
+{investigation_first_step}    b. Explore their relationships via graph queries
     c. **AUTOMATICALLY read main.py** (or main entry file) - NEVER ask the user for permission
     d. Look for the ACTUAL startup code: `if __name__ == "__main__"`, CLI commands, `main()` functions
     e. If CLI framework detected (typer, click, argparse), examine command functions
     f. Distinguish between helper functions and the real application entry point
     g. Show the complete execution flow from the true entry point through initialization
 7.  **Token Management**: Be efficient with context usage:
-    a. For semantic search, use focused queries (not overly broad terms)
-    b. For file reading, read specific sections when possible using offset/limit
+{token_management_first}    b. For file reading, read specific sections when possible using offset/limit
     c. Summarize large results rather than including full content
     d. Prioritize most relevant findings over comprehensive coverage
 8.  **Synthesize Answer**: Analyze and explain the retrieved content. Cite your sources (file paths or qualified names). Report any errors gracefully.

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -30,8 +30,14 @@ if TYPE_CHECKING:
 def extract_tool_names(tools: list["Tool"]) -> ToolNames:
     registered = {t.name for t in tools}
 
-    def resolve_tool_name(canonical: AgenticToolName) -> str:
-        if canonical not in registered:
+    def resolve_tool_name(
+        canonical: AgenticToolName, *, absence_is_handled: bool = False
+    ) -> str:
+        # `absence_is_handled` marks a tool the prompt can build around. Warning
+        # about one would fire on precisely the configuration that now works,
+        # and a warning that cries wolf gets the other five ignored too
+        # (CodeRabbit, #1446).
+        if canonical not in registered and not absence_is_handled:
             logger.warning(
                 f"Tool '{canonical}' is not registered on the agent; "
                 "the orchestrator prompt references it anyway"
@@ -41,7 +47,9 @@ def extract_tool_names(tools: list["Tool"]) -> ToolNames:
     return ToolNames(
         query_graph=resolve_tool_name(AgenticToolName.QUERY_GRAPH),
         read_file=resolve_tool_name(AgenticToolName.READ_FILE),
-        semantic_search=resolve_tool_name(AgenticToolName.SEMANTIC_SEARCH),
+        semantic_search=resolve_tool_name(
+            AgenticToolName.SEMANTIC_SEARCH, absence_is_handled=True
+        ),
         create_file=resolve_tool_name(AgenticToolName.CREATE_FILE),
         edit_file=resolve_tool_name(AgenticToolName.REPLACE_CODE),
         shell_command=resolve_tool_name(AgenticToolName.EXECUTE_SHELL),

--- a/codebase_rag/tests/test_prompt_tool_names.py
+++ b/codebase_rag/tests/test_prompt_tool_names.py
@@ -1,6 +1,10 @@
 """Regression tests for issue #1199: the orchestrator system prompt must only
 reference tool names that are actually registered on the agent."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from loguru import logger
 from pydantic_ai import Tool
 
 from codebase_rag.prompts import build_rag_orchestrator_prompt, extract_tool_names
@@ -121,3 +125,54 @@ def test_prompt_retains_semantic_section_when_registered() -> None:
     assert "WHEN TO USE SEMANTIC SEARCH FIRST" in prompt
     assert "HYBRID APPROACH" in prompt
     assert f"`{AgenticToolName.SEMANTIC_SEARCH}`" in prompt
+
+
+@contextmanager
+def _captured_warnings() -> Iterator[list[str]]:
+    """Collect loguru WARNING messages; loguru does not feed pytest's caplog."""
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        yield messages
+    finally:
+        logger.remove(sink_id)
+
+
+def test_absent_semantic_search_does_not_warn() -> None:
+    """A supported absence must stay quiet.
+
+    `resolve_tool_name` warns that "the orchestrator prompt references it
+    anyway", which was true when every tool name was interpolated
+    unconditionally. Since #1201 the graph-first branch deliberately omits
+    `semantic_search`, so the warning fires on exactly the configuration the
+    prompt now handles correctly, and it trains operators to ignore a warning
+    that is real for the other five tools (CodeRabbit, #1446).
+    """
+    semantic = str(AgenticToolName.SEMANTIC_SEARCH)
+
+    with _captured_warnings() as messages:
+        extract_tool_names(_tools_without_semantic_search())
+
+    assert not [m for m in messages if semantic in m], (
+        f"warned about a supported semantic-search absence: {messages}"
+    )
+
+
+def test_absent_other_tool_still_warns() -> None:
+    """The warning must survive for absences that are genuinely unhandled.
+
+    Only `semantic_search` has a conditional prompt branch. Suppressing the
+    warning wholesale would silence the five tools whose absence really does
+    leave a dangling reference in the prompt.
+    """
+    read_file = str(AgenticToolName.READ_FILE)
+    tools = [tool for tool in _all_registered_tools() if tool.name != read_file]
+
+    with _captured_warnings() as messages:
+        extract_tool_names(tools)
+
+    assert [m for m in messages if read_file in m], (
+        f"unhandled absence of {read_file} was not reported: {messages}"
+    )

--- a/codebase_rag/tests/test_prompt_tool_names.py
+++ b/codebase_rag/tests/test_prompt_tool_names.py
@@ -5,6 +5,7 @@ from pydantic_ai import Tool
 
 from codebase_rag.prompts import build_rag_orchestrator_prompt, extract_tool_names
 from codebase_rag.tools.tool_descriptions import AgenticToolName
+from codebase_rag.types_defs import ToolNames
 
 STALE_TOOL_NAMES = (
     "query_codebase_knowledge_graph",
@@ -27,6 +28,11 @@ def _all_registered_tools() -> list[Tool]:
     ]
 
 
+def _tool_name_values(names: ToolNames) -> list[str]:
+    """The resolved tool names only, excluding availability flags."""
+    return [value for value in names._asdict().values() if isinstance(value, str)]
+
+
 def test_extract_tool_names_returns_registered_names() -> None:
     tools = _all_registered_tools()
     registered = {tool.name for tool in tools}
@@ -34,6 +40,8 @@ def test_extract_tool_names_returns_registered_names() -> None:
     names = extract_tool_names(tools)
 
     for field, value in names._asdict().items():
+        if not isinstance(value, str):
+            continue
         assert value in registered, f"{field} resolved to unregistered '{value}'"
 
 
@@ -45,7 +53,7 @@ def test_prompt_references_registered_names_not_stale_ones() -> None:
 
     for stale in STALE_TOOL_NAMES:
         assert stale not in prompt
-    for value in extract_tool_names(tools):
+    for value in _tool_name_values(extract_tool_names(tools)):
         assert value in registered
         assert f"`{value}`" in prompt
 
@@ -60,3 +68,56 @@ def test_extract_tool_names_tolerates_missing_tool() -> None:
     names = extract_tool_names(tools)
 
     assert names.semantic_search == str(AgenticToolName.SEMANTIC_SEARCH)
+
+
+def _tools_without_semantic_search() -> list[Tool]:
+    return [
+        tool
+        for tool in _all_registered_tools()
+        if tool.name != str(AgenticToolName.SEMANTIC_SEARCH)
+    ]
+
+
+def test_extract_tool_names_reports_availability() -> None:
+    """Issue #1201: callers need to know which canonical tools are registered,
+    not just what they are named."""
+    full = extract_tool_names(_all_registered_tools())
+    assert full.has_semantic_search is True
+
+    partial = extract_tool_names(_tools_without_semantic_search())
+    assert partial.has_semantic_search is False
+
+
+def test_prompt_omits_semantic_search_when_unregistered() -> None:
+    """Issue #1201: with no semantic_search tool registered, the prompt must not
+    instruct the model to call it -- a call to an unregistered name is dropped
+    silently and burns retries on empty turns."""
+    prompt = build_rag_orchestrator_prompt(_tools_without_semantic_search())
+
+    semantic = str(AgenticToolName.SEMANTIC_SEARCH)
+    assert f"`{semantic}`" not in prompt
+    assert "WHEN TO USE SEMANTIC SEARCH FIRST" not in prompt
+    assert "HYBRID APPROACH" not in prompt
+    assert "semantic search" not in prompt.lower()
+
+
+def test_prompt_keeps_graph_guidance_without_semantic_search() -> None:
+    """The graph-first guidance must survive as the default strategy rather than
+    disappearing along with the semantic-search subsection."""
+    tools = _tools_without_semantic_search()
+    names = extract_tool_names(tools)
+
+    prompt = build_rag_orchestrator_prompt(tools)
+
+    assert f"`{names.query_graph}`" in prompt
+    assert f"`{names.read_file}`" in prompt
+    assert "Search Strategy" in prompt
+
+
+def test_prompt_retains_semantic_section_when_registered() -> None:
+    """Guards against the strategy section silently disappearing for everyone."""
+    prompt = build_rag_orchestrator_prompt(_all_registered_tools())
+
+    assert "WHEN TO USE SEMANTIC SEARCH FIRST" in prompt
+    assert "HYBRID APPROACH" in prompt
+    assert f"`{AgenticToolName.SEMANTIC_SEARCH}`" in prompt

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -361,6 +361,10 @@ class ToolNames(NamedTuple):
     create_file: str
     edit_file: str
     shell_command: str
+    # Whether semantic_search is actually registered. The MCP path omits it when
+    # the vector backend is unavailable, and the prompt must not tell the model
+    # to start with a tool that is absent from its schema (issue #1201).
+    has_semantic_search: bool = True
 
 
 class ConfirmationToolNames(NamedTuple):


### PR DESCRIPTION
Closes #1201.

## The problem

`build_rag_orchestrator_prompt` hardcoded a semantic-search-first strategy. The MCP path omits `semantic_search` when the vector backend is unavailable, so in that configuration the prompt instructed the model to *begin* with a tool absent from its own schema.

That is worse than a cosmetic mismatch: the first instruction under "Choose the Right Search Strategy" said to always start with a tool the model cannot call, so the opening move of every investigation was a guaranteed failed call or an improvised deviation from the prompt.

## What changed

`ToolNames` gains `has_semantic_search`, resolved in `extract_tool_names` from what is actually registered rather than from what the code hopes is registered. `build_rag_orchestrator_prompt` then selects between a semantic-first and a graph-first strategy.

The graph-first variant is not the semantic text with references deleted. `query_graph` accepts natural language, so intent-based questions ("where is X done", "how does Y work") still have a home; they route through the graph instead. Entry-point recognition patterns and the tool-chaining example are rewritten around that sequence rather than left dangling.

## Three leak sites, not one

The issue names the section 3 strategy block. Two further sites leak the same instruction and are fixed here too:

- section 6a, "Find candidate functions via semantic search"
- section 7a, "For semantic search, use focused queries"

Fixing only the site the issue named would have left the prompt still naming an absent tool twice, in a change whose entire purpose is that it never does. Both are now conditional.

## Tests

Red first: the four new tests failed against the old hardcoded prompt, which is what makes them meaningful.

- the semantic-less prompt never mentions the semantic tool name
- the semantic-enabled prompt still does
- both variants keep sections 6 and 7 well-formed
- `extract_tool_names` reports the flag from actual registration

Two pre-existing tests needed adjusting rather than rewriting. Adding a field to a `NamedTuple` is not an additive change: `for value in names` now yields the bool alongside the tool-name strings, so `test_extract_tool_names_returns_registered_names` began asserting `True in {...}`. A `_tool_name_values` helper filters to the string fields. Worth flagging for review, since that iteration pattern breaks silently for any future field.

7 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search guidance based on available search capabilities.
  * Added support for semantic-first investigation when semantic search is available.
  * Added graph-first discovery guidance when semantic search is unavailable.

* **Bug Fixes**
  * Prevented prompts from referencing unavailable semantic-search functionality.
  * Improved reporting of registered search capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->