### PR TITLE
feat: Ruby structure oracle graded against Prism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ evals/oracles/java_oracle/.build-lock
 evals/oracles/lua_oracle/node_modules/
 # PHP oracle deps (the source + package-lock.json are committed)
 evals/oracles/php_oracle/node_modules/
+# Ruby oracle deps (the source + package-lock.json are committed)
+evals/oracles/ruby_oracle/node_modules/
 # Node oracle install bookkeeping (completion marker + concurrent-install lock)
 evals/oracles/*/.node-deps-installed
 evals/oracles/*/.node-deps-lock/

--- a/codebase_rag/tests/test_node_oracle_deps.py
+++ b/codebase_rag/tests/test_node_oracle_deps.py
@@ -96,3 +96,29 @@ def test_failed_oracle_surfaces_stderr(tmp_path: Path) -> None:
         pytest.raises(RuntimeError, match="Cannot find module"),
     ):
         run_node_oracle_payload(tmp_path, script, ())
+
+
+def test_oracle_output_is_decoded_as_utf8_not_the_locale(tmp_path: Path) -> None:
+    """Node writes UTF-8; the locale decides nothing about how it is read.
+
+    `text=True` alone decodes with the locale encoding, which is cp1252 on a
+    Windows runner. A Ruby class named `Café` then came back mangled and the
+    failure surfaced far from here as a lookup miss rather than a decode
+    error, so the encoding is pinned explicitly.
+
+    Asserting on the kwarg rather than on round-tripped text keeps this
+    meaningful on a UTF-8 machine, where the bug is invisible by definition.
+    """
+    (tmp_path / ec.NODE_DEPS_MARKER).touch()
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = '{"nodes": [], "edges": [], "calls": []}'
+    proc.stderr = ""
+    script = tmp_path / "ruby_ast.js"
+    with (
+        patch("evals.oracles._common.shutil.which", return_value="node"),
+        patch("evals.oracles._common.subprocess.run", return_value=proc) as run_mock,
+    ):
+        run_node_oracle_payload(tmp_path, script, ())
+
+    assert run_mock.call_args.kwargs["encoding"] == "utf-8"

--- a/codebase_rag/tests/test_ruby_structure_oracle.py
+++ b/codebase_rag/tests/test_ruby_structure_oracle.py
@@ -1,0 +1,170 @@
+# Covers the Ruby structure oracle harness (evals/oracles/ruby_oracle):
+# Prism, Ruby's official parser, is authoritative ground truth, and cgr's Ruby
+# nodes are graded against it on (kind, file, start_line).
+#
+# Ruby reaches the graph through the ast-grep structural tier (".rb" maps to
+# ast_grep_id "ruby"), which is a weaker tier than the tree-sitter one; grading
+# it against a real parser is the point of issue #1190's Ruby gap.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evals.oracles import ruby_oracle_available, run_ruby_oracle
+
+# Every construct here is one the oracle must find. Kept small so the labels
+# stay reviewable, and deliberately mixed so a parser that only handles the
+# common form is visibly wrong:
+#   - a bare top-level method
+#   - a class with an instance method and a `self.` class method
+#   - a module with a nested class, so qualification has to nest
+#   - a singleton method defined on an object
+RUBY_SRC = """\
+def free_fn(a)
+  a + 1
+end
+
+class Greeter
+  def hello(name)
+    "hi #{name}"
+  end
+
+  def self.build
+    new
+  end
+end
+
+module Outer
+  class Inner
+    def deep
+      42
+    end
+  end
+end
+"""
+
+
+def _require_ruby() -> None:
+    if not ruby_oracle_available():
+        pytest.skip("node/npm toolchain not available")
+
+
+def test_oracle_finds_every_ruby_definition(tmp_path: Path) -> None:
+    """The oracle must see all five definitions, not just the easy ones.
+
+    A parser that handled only `def` at top level would find two of these and
+    still return a non-empty payload, so asserting "some nodes came back" would
+    pass against a substantially broken oracle.
+    """
+    _require_ruby()
+    project = tmp_path / "ruby_oracle_test"
+    project.mkdir()
+    (project / "m.rb").write_text(RUBY_SRC, encoding="utf-8")
+
+    oracle = run_ruby_oracle(project)
+    names = {node.name for node in oracle.nodes.values()}
+
+    assert {"free_fn", "hello", "build", "deep"} <= names, names
+
+
+def test_oracle_reports_classes(tmp_path: Path) -> None:
+    _require_ruby()
+    project = tmp_path / "ruby_oracle_test"
+    project.mkdir()
+    (project / "m.rb").write_text(RUBY_SRC, encoding="utf-8")
+
+    oracle = run_ruby_oracle(project)
+    names = {node.name for node in oracle.nodes.values()}
+
+    assert {"Greeter", "Inner"} <= names, names
+
+
+def test_modules_are_excluded_but_their_contents_are_not(tmp_path: Path) -> None:
+    """A Ruby module emits no node, yet what it contains still does.
+
+    cgr has no Module label, so grading modules against one would report a
+    recall miss no implementation could fix; calling a module a Class instead
+    would put a falsehood in ground truth and would score a future Module label
+    as a regression. Excluding it keeps the gap visible and honest.
+
+    The paired positive assertion is what makes this meaningful: asserting only
+    that "Outer" is absent would pass just as well if the module body never
+    parsed at all.
+    """
+    _require_ruby()
+    project = tmp_path / "ruby_oracle_test"
+    project.mkdir()
+    (project / "m.rb").write_text(RUBY_SRC, encoding="utf-8")
+
+    oracle = run_ruby_oracle(project)
+    names = {node.name for node in oracle.nodes.values()}
+
+    assert "Outer" not in names, names
+    # The class and method nested inside that module are real definitions cgr
+    # does emit, so they must survive the module's exclusion.
+    assert "Inner" in names, names
+    assert "deep" in names, names
+
+
+def test_def_directly_inside_a_module_is_a_method(tmp_path: Path) -> None:
+    """Excluding the module must not demote its methods to top-level Functions."""
+    _require_ruby()
+    project = tmp_path / "ruby_module_method"
+    project.mkdir()
+    (project / "helpers.rb").write_text(
+        "module Helpers\n  def helper\n    1\n  end\nend\n", encoding="utf-8"
+    )
+
+    oracle = run_ruby_oracle(project)
+    kinds = {node.name: key.kind for key, node in oracle.nodes.items()}
+
+    assert kinds.get("helper") == "Method", kinds
+
+
+def test_oracle_line_numbers_are_one_based(tmp_path: Path) -> None:
+    """Off-by-one here would misalign every node against cgr's spans."""
+    _require_ruby()
+    project = tmp_path / "ruby_oracle_test"
+    project.mkdir()
+    (project / "m.rb").write_text(RUBY_SRC, encoding="utf-8")
+
+    oracle = run_ruby_oracle(project)
+    # nodes is keyed by NodeKey(kind, file, start_line); the line lives on the
+    # key rather than on the DefNode value.
+    by_name = {node.name: key for key, node in oracle.nodes.items()}
+
+    # "def free_fn" is the first line of the fixture.
+    assert by_name["free_fn"].start_line == 1, by_name["free_fn"]
+    # "class Greeter" is the fifth.
+    assert by_name["Greeter"].start_line == 5, by_name["Greeter"]
+
+
+def test_oracle_on_an_empty_project_returns_no_nodes(tmp_path: Path) -> None:
+    _require_ruby()
+    project = tmp_path / "empty_ruby"
+    project.mkdir()
+    (project / "blank.rb").write_text("# just a comment\n", encoding="utf-8")
+
+    oracle = run_ruby_oracle(project)
+
+    assert not oracle.nodes
+
+
+def test_syntax_error_does_not_crash_the_oracle(tmp_path: Path) -> None:
+    """A malformed file must not abort a whole-corpus run.
+
+    Prism is error-tolerant and still returns a tree, so the oracle should
+    report whatever it recovered rather than raising.
+    """
+    _require_ruby()
+    project = tmp_path / "broken_ruby"
+    project.mkdir()
+    (project / "ok.rb").write_text("def fine\n  1\nend\n", encoding="utf-8")
+    (project / "bad.rb").write_text("def oops\n  unterminated(\n", encoding="utf-8")
+
+    oracle = run_ruby_oracle(project)
+    names = {node.name for node in oracle.nodes.values()}
+
+    # The healthy file's definition still lands.
+    assert "fine" in names, names

--- a/codebase_rag/tests/test_ruby_structure_oracle.py
+++ b/codebase_rag/tests/test_ruby_structure_oracle.py
@@ -140,6 +140,46 @@ def test_oracle_line_numbers_are_one_based(tmp_path: Path) -> None:
     assert by_name["Greeter"].start_line == 5, by_name["Greeter"]
 
 
+def test_multibyte_characters_do_not_shift_line_numbers(tmp_path: Path) -> None:
+    """Prism reports BYTE offsets; a JS string is indexed in UTF-16 units.
+
+    A comment or identifier outside ASCII makes those two disagree, and every
+    span after it drifts by the difference. Ruby source routinely carries
+    non-ASCII in comments and string literals, so this is not an edge case.
+
+    Both ends are asserted, and against a file whose length is known: an
+    end_line past the end of the file is the symptom that shows up first,
+    because the error accumulates across the whole document.
+    """
+    _require_ruby()
+    project = tmp_path / "ruby_multibyte"
+    project.mkdir()
+    # 10 lines. The first carries multibyte characters, so a UTF-16 index
+    # under-counts the bytes Prism reports for everything below it.
+    source = (
+        "# コメント: a multibyte comment\n"
+        "def first_fn\n"
+        "  1\n"
+        "end\n"
+        "\n"
+        "class Café\n"
+        "  def método\n"
+        "    2\n"
+        "  end\n"
+        "end\n"
+    )
+    (project / "mb.rb").write_text(source, encoding="utf-8")
+
+    oracle = run_ruby_oracle(project)
+    spans = {
+        node.name: (key.start_line, node.end_line) for key, node in oracle.nodes.items()
+    }
+
+    assert spans["first_fn"] == (2, 4), spans
+    assert spans["Café"] == (6, 10), spans
+    assert spans["método"] == (7, 9), spans
+
+
 def test_oracle_on_an_empty_project_returns_no_nodes(tmp_path: Path) -> None:
     _require_ruby()
     project = tmp_path / "empty_ruby"

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -473,6 +473,31 @@ LUA_ORACLE_SCRIPT = "lua_ast.js"
 LUA_SCORES_FILENAME = "lua_scores.csv"
 LUA_DIFF_FILENAME = "lua_diff.json"
 
+# Ruby structure eval (issue #1190): cgr nodes graded against Prism, Ruby's
+# official parser. Ruby reaches the graph through the ast-grep structural tier.
+#
+# Ruby MODULES are excluded from the graded set rather than mapped onto Class.
+# cgr has no Module label, so grading them would report a recall miss no
+# implementation could fix; calling a module a Class instead would make ground
+# truth assert something false (modules cannot be instantiated and join the
+# ancestor chain by inclusion, not inheritance) and would score a future Module
+# label as a regression. The exclusion keeps that gap visible and honest.
+# Definitions nested inside a module are still graded — they are real nodes cgr
+# emits.
+RUBY_SUFFIX = ".rb"
+RUBY_SCORED_NODE_KINDS: tuple[cs.NodeLabel, ...] = (
+    cs.NodeLabel.FUNCTION,
+    cs.NodeLabel.METHOD,
+    cs.NodeLabel.CLASS,
+)
+RUBY_SCORED_NODE_KIND_VALUES: frozenset[str] = frozenset(
+    k.value for k in RUBY_SCORED_NODE_KINDS
+)
+RUBY_ORACLE_DIRNAME = "ruby_oracle"
+RUBY_ORACLE_SCRIPT = "ruby_ast.js"
+RUBY_SCORES_FILENAME = "ruby_scores.csv"
+RUBY_DIFF_FILENAME = "ruby_diff.json"
+
 # PHP structure eval: cgr nodes graded against a php-parser oracle.
 PHP_SUFFIX = ".php"
 PHP_SCORED_NODE_KINDS: tuple[cs.NodeLabel, ...] = (

--- a/evals/oracles/__init__.py
+++ b/evals/oracles/__init__.py
@@ -13,6 +13,7 @@ from .go_oracle import go_available, run_go_call_oracle, run_go_oracle
 from .java_oracle import java_available, run_java_call_oracle, run_java_oracle
 from .lua_oracle import lua_oracle_available, run_lua_call_oracle, run_lua_oracle
 from .php_oracle import php_oracle_available, run_php_call_oracle, run_php_oracle
+from .ruby_oracle import ruby_oracle_available, run_ruby_call_oracle, run_ruby_oracle
 from .rust_oracle import run_rust_call_oracle, run_rust_oracle, rust_available
 from .scala_oracle import run_scala_call_oracle, run_scala_oracle, scala_available
 from .typescript_oracle import (
@@ -38,6 +39,9 @@ __all__ = [
     "run_java_call_oracle",
     "run_java_oracle",
     "lua_oracle_available",
+    "ruby_oracle_available",
+    "run_ruby_call_oracle",
+    "run_ruby_oracle",
     "run_lua_call_oracle",
     "run_lua_oracle",
     "php_oracle_available",

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -64,6 +64,10 @@ def ensure_node_deps(oracle_dir: Path) -> None:
                 cwd=str(oracle_dir),
                 capture_output=True,
                 text=True,
+                # Same reason as the oracle run below: npm's output is UTF-8,
+                # and a locale decode would corrupt any non-ASCII path in the
+                # error text raised on a failed install.
+                encoding=cs.ENCODING_UTF8,
                 check=True,
             )
             marker.touch()
@@ -82,6 +86,12 @@ def run_node_oracle_payload(
         [node, str(script), *args],
         capture_output=True,
         text=True,
+        # Node writes UTF-8 JSON. `text=True` alone decodes with the LOCALE
+        # encoding, which is cp1252 on a Windows runner, so any non-ASCII
+        # identifier or path comes back mangled and the payload disagrees with
+        # the source. Reading a name like "Café" then fails far from here, as a
+        # lookup miss rather than as a decode error.
+        encoding=cs.ENCODING_UTF8,
         check=False,
     )
     if proc.returncode != 0:

--- a/evals/oracles/ruby_oracle.py
+++ b/evals/oracles/ruby_oracle.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from codebase_rag import constants as cs
+
+from .. import constants as ec
+from ..types_defs import GraphData, OraclePayload
+from ._common import is_ignored, payload_to_graph, run_node_oracle_payload
+
+_ORACLE_DIR = Path(__file__).parent / ec.RUBY_ORACLE_DIRNAME
+_SCRIPT = _ORACLE_DIR / ec.RUBY_ORACLE_SCRIPT
+_NODE_MODULES = _ORACLE_DIR / ec.NODE_MODULES_DIRNAME
+_CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value})
+
+
+def ruby_oracle_available() -> bool:
+    return (
+        shutil.which(ec.NODE_BIN) is not None and shutil.which(ec.NPM_BIN) is not None
+    )
+
+
+def _run_ruby_oracle_payload(target: Path) -> OraclePayload:
+    return run_node_oracle_payload(_ORACLE_DIR, _SCRIPT, (str(target),))
+
+
+def run_ruby_oracle(target: Path) -> GraphData:
+    return payload_to_graph(_run_ruby_oracle_payload(target))
+
+
+def run_ruby_call_oracle(target: Path) -> tuple[set[tuple[str, str]], frozenset[str]]:
+    # File-level Ruby call sites restricted to first-party callees (simple name
+    # is a declared Function/Method), with the declared name universe so the cgr
+    # side is held to the same set. Mirrors the Go, Rust, Java, TypeScript, Lua
+    # and PHP oracles.
+    payload = _run_ruby_oracle_payload(target)
+    declared = frozenset(
+        rec[ec.ORACLE_KEY_NAME]
+        for rec in payload.get(ec.ORACLE_KEY_NODES, [])
+        if rec.get(ec.ORACLE_KEY_KIND) in _CALLABLE_KINDS
+    )
+    edges = {
+        (call[ec.ORACLE_KEY_FILE], call[ec.ORACLE_KEY_NAME])
+        for call in payload.get(ec.ORACLE_KEY_CALLS, [])
+        if call[ec.ORACLE_KEY_NAME] in declared
+        and not is_ignored(call[ec.ORACLE_KEY_FILE])
+    }
+    return edges, declared

--- a/evals/oracles/ruby_oracle/package-lock.json
+++ b/evals/oracles/ruby_oracle/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "ruby_oracle",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ruby_oracle",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ruby/prism": "^1.9.0"
+      },
+      "bin": {
+        "ruby_oracle": "ruby_ast.js"
+      }
+    },
+    "node_modules/@ruby/prism": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@ruby/prism/-/prism-1.9.0.tgz",
+      "integrity": "sha512-/j+JfP1eA0nCjx6c/8L6K/ENErmsqc6RMAba8rKYNz4RadrT7AW20u4WrjpWYWzdlk6k1YWHxoW9OS68w02+Vw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/evals/oracles/ruby_oracle/package.json
+++ b/evals/oracles/ruby_oracle/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ruby_oracle",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Authoritative Ruby structure oracle for the cgr eval harness",
+  "bin": { "ruby_oracle": "ruby_ast.js" },
+  "dependencies": {
+    "@ruby/prism": "^1.9.0"
+  }
+}

--- a/evals/oracles/ruby_oracle/ruby_ast.js
+++ b/evals/oracles/ruby_oracle/ruby_ast.js
@@ -50,18 +50,30 @@ const calls = [];
 
 // Prism's JS location exposes only `startOffset` and `length` — no line
 // numbers (verified against @ruby/prism 1.9.0: the location object's own keys
-// are exactly ["startOffset", "length"]). Lines are therefore computed from the
-// byte offset against a prefix table built once per file. Reading
+// are exactly ["startOffset", "length"]). Those offsets are in BYTES. Lines are
+// therefore computed from the byte offset against a prefix table built once per
+// file, itself indexed in bytes for the same reason. Reading
 // `location.startLine` yields undefined, and JSON.stringify silently DROPS an
 // undefined value, so the omission surfaces far away as a KeyError on the
 // Python side rather than as an error here.
 //
-// `newlineOffsets` holds the offset of each line start, so the 1-based line for
-// an offset is the count of line starts at or below it.
+// The table is built over the UTF-8 BYTES, not over the JS string. A JS string
+// is indexed in UTF-16 code units, so for any source containing a character
+// outside ASCII the two disagree and every span below that character drifts by
+// the difference — a `def` on line 2 reporting an end_line of 6, or a class in
+// a 10-line file ending at line 11. Ruby routinely carries non-ASCII in
+// comments and string literals, so this is ordinary input rather than an edge
+// case.
+//
+// `starts` holds the byte offset of each line start, so the 1-based line for an
+// offset is the count of line starts at or below it.
 function makeLineLookup(source) {
+  const bytes = Buffer.from(source, "utf8");
   const starts = [0];
-  for (let i = 0; i < source.length; i++) {
-    if (source[i] === "\n") starts.push(i + 1);
+  for (let i = 0; i < bytes.length; i++) {
+    // 0x0A is "\n"; a UTF-8 continuation byte can never collide with it,
+    // since every byte of a multibyte sequence has the high bit set.
+    if (bytes[i] === 0x0a) starts.push(i + 1);
   }
   return (offset) => {
     // Binary search for the last line start <= offset.

--- a/evals/oracles/ruby_oracle/ruby_ast.js
+++ b/evals/oracles/ruby_oracle/ruby_ast.js
@@ -1,0 +1,217 @@
+// Authoritative Ruby structure oracle for the cgr eval harness (issue #1190).
+//
+// Parses every .rb file with Prism, Ruby's official parser, and emits one JSON
+// record per definition in cgr's NodeLabel vocabulary:
+//
+//   DefNode     -> Function (top-level `def`) or Method (inside class/module)
+//   ClassNode   -> Class
+//   ModuleNode  -> NOT EMITTED as a node; see below.
+//
+// Ruby modules are deliberately excluded from the emitted node set rather than
+// mapped onto Class. cgr has no Module label today, so grading modules against
+// one would report a permanent recall miss no implementation could fix. The
+// tempting fix — calling a module a Class — makes the ORACLE assert something
+// false: modules cannot be instantiated, have no superclass, and join the
+// ancestor chain by inclusion rather than inheritance. Ground truth that
+// encodes a known-wrong equivalence is worse than one that reports a real gap,
+// and it would actively fight a later Module label: correct output would start
+// scoring as a regression against this fixture.
+//
+// So a module contributes no node, and the omission is the honest record of a
+// real cgr limitation. Its BODY is still walked, because methods and classes
+// nested inside a module are real definitions cgr does emit; they attach to
+// whatever namespace encloses the module.
+//
+// Containment edges: DEFINES from the enclosing class/module (or the file
+// module, keyed at line 0) to the definition.
+//
+// Prism is error tolerant: a file with a syntax error still yields a tree, so a
+// malformed file in a corpus degrades to whatever was recovered rather than
+// aborting the run.
+//
+// Run: node ruby_ast.js <dir>
+
+const { loadPrism } = require("@ruby/prism");
+const fs = require("fs");
+const path = require("path");
+
+const IGNORED = new Set([".git", "node_modules", "vendor"]);
+const MODULE_LINE = 0;
+
+const KIND_FUNCTION = "Function";
+const KIND_METHOD = "Method";
+const KIND_CLASS = "Class";
+
+const REL_DEFINES = "DEFINES";
+
+const nodes = [];
+const edges = [];
+const calls = [];
+
+// Prism's JS location exposes only `startOffset` and `length` — no line
+// numbers (verified against @ruby/prism 1.9.0: the location object's own keys
+// are exactly ["startOffset", "length"]). Lines are therefore computed from the
+// byte offset against a prefix table built once per file. Reading
+// `location.startLine` yields undefined, and JSON.stringify silently DROPS an
+// undefined value, so the omission surfaces far away as a KeyError on the
+// Python side rather than as an error here.
+//
+// `newlineOffsets` holds the offset of each line start, so the 1-based line for
+// an offset is the count of line starts at or below it.
+function makeLineLookup(source) {
+  const starts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === "\n") starts.push(i + 1);
+  }
+  return (offset) => {
+    // Binary search for the last line start <= offset.
+    let lo = 0;
+    let hi = starts.length - 1;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (starts[mid] <= offset) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo + 1;
+  };
+}
+
+// A constant path (`class Outer::Inner`) names the trailing constant; that is
+// what cgr records as the node's name.
+function constantName(node) {
+  if (!node) return null;
+  if (node.name !== undefined && node.name !== null) return String(node.name);
+  // ConstantPathNode carries the tail in `name` on recent Prism, else in
+  // `child.name`; fall back so a version bump cannot silently yield null.
+  if (node.child && node.child.name) return String(node.child.name);
+  return null;
+}
+
+function spanOf(node, lineAt) {
+  const start = node.location.startOffset;
+  return {
+    line: lineAt(start),
+    end_line: lineAt(start + node.location.length),
+  };
+}
+
+function record(kind, name, file, node, parentRef, lineAt) {
+  const span = spanOf(node, lineAt);
+  nodes.push({
+    kind,
+    name,
+    file,
+    line: span.line,
+    end_line: span.end_line,
+  });
+  edges.push({
+    rel: REL_DEFINES,
+    parent: parentRef,
+    child: { kind, name, file, line: span.line },
+  });
+  return span;
+}
+
+function walk(node, file, parentRef, insideNamespace, lineAt) {
+  if (node === null || typeof node !== "object") return;
+
+  const type = node.constructor && node.constructor.name;
+
+  if (type === "DefNode") {
+    const name = String(node.name);
+    // A `def` inside a class or module is a Method; at file scope it is a
+    // Function. `def self.build` is still a Method of its class.
+    const kind = insideNamespace ? KIND_METHOD : KIND_FUNCTION;
+    const span = record(kind, name, file, node, parentRef, lineAt);
+    // A nested `def` inside a `def` is rare but legal; its parent is the outer
+    // definition, and it stays a Method/Function by the same namespace rule.
+    const selfRef = { kind, name, file, line: span.line };
+    for (const child of node.compactChildNodes()) {
+      walk(child, file, selfRef, insideNamespace, lineAt);
+    }
+    return;
+  }
+
+  if (type === "ClassNode") {
+    const name = constantName(node.constantPath);
+    if (name !== null) {
+      const span = record(KIND_CLASS, name, file, node, parentRef, lineAt);
+      const selfRef = {
+        kind: KIND_CLASS,
+        name,
+        file,
+        line: span.line,
+      };
+      for (const child of node.compactChildNodes()) {
+        walk(child, file, selfRef, true, lineAt);
+      }
+      return;
+    }
+  }
+
+  if (type === "ModuleNode") {
+    // No node emitted (see the header): cgr has no Module label, and calling a
+    // module a Class would put a falsehood in ground truth. The body still
+    // walks so nested classes and methods are captured, and `insideNamespace`
+    // becomes true so a `def` directly inside a module is a Method rather than
+    // a top-level Function — which is what it is, regardless of whether the
+    // module itself is representable.
+    for (const child of node.compactChildNodes()) {
+      walk(child, file, parentRef, true, lineAt);
+    }
+    return;
+  }
+
+  for (const child of node.compactChildNodes()) {
+    walk(child, file, parentRef, insideNamespace, lineAt);
+  }
+}
+
+function collect(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (IGNORED.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collect(full, out);
+    else if (entry.name.endsWith(".rb")) out.push(full);
+  }
+  return out;
+}
+
+async function main() {
+  const root = process.argv[2];
+  if (!root) {
+    process.stderr.write("usage: node ruby_ast.js <dir>\n");
+    process.exit(2);
+  }
+
+  const parse = await loadPrism();
+
+  for (const full of collect(root, [])) {
+    const rel = path.relative(root, full).split(path.sep).join("/");
+    let source;
+    try {
+      source = fs.readFileSync(full, "utf8");
+    } catch {
+      continue;
+    }
+    let result;
+    try {
+      result = parse(source);
+    } catch (err) {
+      // Prism recovers from syntax errors internally; a throw here means the
+      // file could not be parsed at all. Skip it rather than aborting the
+      // whole corpus, and say so on stderr so it is not silent.
+      process.stderr.write(`ruby_oracle: skipped ${rel}: ${err}\n`);
+      continue;
+    }
+    const fileRef = { kind: "Module", name: rel, file: rel, line: MODULE_LINE };
+    walk(result.value, rel, fileRef, false, makeLineLookup(source));
+  }
+
+  process.stdout.write(JSON.stringify({ nodes, edges, calls }));
+}
+
+main().catch((err) => {
+  process.stderr.write(`ruby_oracle: ${err}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
Addresses one item of the first of #1190's four gaps: Ruby had no ground-truth oracle at all, so the ast-grep structural tier it runs on was ungraded.

## Scope, stated up front

#1190 names four gaps (Dart and Ruby oracles; resolved-edge grading beyond Python; qn-level call grading; a FLOWS_TO oracle) and three acceptance bullets. This PR is the Ruby oracle and nothing else, so it uses `Addresses`, not `Fixes`, and the issue stays open.

## What lands

`evals/oracles/ruby_oracle/ruby_ast.js` parses every `.rb` file with Prism, Ruby's official parser, and emits one record per definition in cgr's NodeLabel vocabulary. A top-level `def` is a Function, a `def` inside a class or module is a Method, a `class` is a Class. `evals/oracles/ruby_oracle.py` mirrors the existing `lua_oracle.py` shape.

Prism is authoritative rather than a second guess at the grammar, which is the point of grading a weaker tier against it.

## Ruby modules deliberately emit no node

This is the one judgement call worth reviewing.

cgr has no Module label. Grading Ruby modules against one would report a recall miss no implementation could fix. The tempting alternative — mapping `module` onto Class — makes the **oracle** assert something false: modules cannot be instantiated, have no superclass, and join the ancestor chain by inclusion rather than inheritance. It would also actively fight a future Module label, because correct output would then score as a *regression* against this fixture.

So a module contributes no node, and the omission stands as an honest record of a real cgr limitation. Its body is still walked, so classes and methods nested inside are graded, and `insideNamespace` stays true so a `def` directly inside a module is a Method rather than a top-level Function.

Two tests lock both halves of that: `Outer` absent **and** `Inner`/`deep` present. Asserting only the absence would pass just as well if the module body never parsed, which is the failure this needs to be distinguishable from.

The gap is recorded on #1190 rather than left implicit in the code. Happy to file a separate issue for module-level representation if that is wanted.

## A Prism detail that shaped the code

Prism's JS location object exposes only `startOffset` and `length` — no line numbers, verified against `@ruby/prism` 1.9.0. Lines are computed by binary search over a per-file line-start table.

This is worth knowing because reading `location.startLine` yields `undefined`, and `JSON.stringify` silently drops undefined keys, so the mistake surfaces far away as a `KeyError` on the Python side rather than as an error where it was made.

## Tests

Seven, written before the implementation. Beyond the two module tests above: all definitions found (not just the easy top-level ones), classes reported, one-based line numbers, an empty project, and a file with a syntax error not aborting the corpus — Prism is error-tolerant, so a malformed file should degrade to what was recovered.

Local run: 7 passed. Full unit suite: 7968 passed, 1 pre-existing environmental failure now tracked as #1449.

`node_modules` is gitignored per the existing per-oracle entries; the source and `package-lock.json` are committed, matching lua and php.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Ruby project analysis for discovering functions, methods, and classes.
  - Added Ruby call-relationship analysis for supported evaluation workflows.
  - Added support for nested classes and definitions within modules.
  - Added accurate one-based source line reporting, including files with multibyte characters.

- **Bug Fixes**
  - Added syntax-error recovery so valid Ruby code can still be analyzed.
  - Unreadable or invalid Ruby files are skipped without stopping analysis.
  - Empty Ruby projects now return no analysis nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->