### PR TITLE
test: pin python frontend column conversions to absolute values

### DIFF
--- a/codebase_rag/tests/test_python_frontend.py
+++ b/codebase_rag/tests/test_python_frontend.py
@@ -170,3 +170,28 @@ def test_column_conversions_round_trip() -> None:
     for char_col in range(len(line)):
         byte_col = _char_to_byte_col(line, char_col)
         assert _byte_to_char_col(line, byte_col) == char_col
+
+
+def test_column_conversions_are_absolutely_correct() -> None:
+    """Pin the conversions to reality, not just to each other.
+
+    A round trip only proves the pair is mutually inverse, which two symmetric
+    wrongs also satisfy: replacing BOTH functions with the identity function
+    passes `test_column_conversions_round_trip` unchanged. Identity is wrong
+    here -- every column after the two-byte 'é' diverges by one -- so without an
+    absolute assertion the suite cannot tell a working conversion from no
+    conversion at all.
+    """
+    line = 'x = "café" + f("a")'
+    assert line.index("é") == 8
+
+    # Before the 'é' the two units agree, so these cannot discriminate.
+    assert _char_to_byte_col(line, 8) == 8
+    # After it they must not: char 9 is the 10th byte.
+    assert _char_to_byte_col(line, 9) == 10
+    assert _char_to_byte_col(line, 12) == 13
+    assert _char_to_byte_col(line, 15) == 16
+
+    assert _byte_to_char_col(line, 10) == 9
+    assert _byte_to_char_col(line, 13) == 12
+    assert _byte_to_char_col(line, 16) == 15


### PR DESCRIPTION
## What

Adds one test, `test_column_conversions_are_absolutely_correct`, pinning `_char_to_byte_col` / `_byte_to_char_col` in the Python frontend to absolute values rather than only to each other.

## Why

`test_column_conversions_round_trip` asserts only that the pair is mutually inverse:

```python
for char_col in range(len(line)):
    byte_col = _char_to_byte_col(line, char_col)
    assert _byte_to_char_col(line, byte_col) == char_col
```

Two symmetric wrongs satisfy that. Replacing **both** functions with the identity function passes this test unchanged, and identity is genuinely wrong for the fixture line `'x = "café" + f("a")'` -- every column after the two-byte `é` diverges by one:

```
char  8 -> byte  8    (the é itself; before it the units agree)
char  9 -> byte 10    identity would say 9
char 12 -> byte 13    identity would say 12
char 15 -> byte 16    identity would say 15
```

So the suite could not distinguish a working conversion from no conversion at all.

This matters because `_byte_to_char_col` is on the live path: `frontend.py:132` converts the `ast` byte column to a character column before `script.infer()`, since Jedi reports character columns while `CallSiteKey` and tree-sitter use UTF-8 byte columns. The protocol names that unit explicitly (`parsers/frontends/protocol.py:16-21`).

## Verification

The new test was proven by mutation, not by passing. With both conversions replaced by the identity function:

```
MUTATED  test_column_conversions_round_trip:             PASSED   <- cannot detect the break
MUTATED  test_column_conversions_are_absolutely_correct: FAILED   <- detects it
REAL     test_column_conversions_round_trip:             passed
REAL     test_column_conversions_are_absolutely_correct: passed
```

A test written alongside its subject has never been observed failing, so it pins current behaviour rather than proving correctness. The only way to earn the red is to reintroduce the bug, which is what the mutation above does.

Full file: 10 passed.

## Scope

Test-only; no production change. This does **not** close #1183 -- that issue's Stage 2 (Pyright) is entirely absent and `expression_types` is unimplemented. Context posted at #1183.

Related: the same class of bug was found and fixed in the Ruby oracle (#1450), where Prism reported byte offsets while the line table indexed in UTF-16 units and the existing test passed throughout because its fixture was pure ASCII. Adjacent but distinct from #1454, which gates `subprocess` calls that omit `encoding=`: that catches a decode-time omission, this catches an offset-unit error after a correct decode.

Branched from `main` at `d96e710f`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify accurate character-to-byte and byte-to-character column conversions for lines containing multibyte Unicode characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->