### PR TITLE
feat: C++ libclang frontend behind the EmittingFrontend protocol

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -7,6 +7,7 @@ import sys
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from pathlib import Path
+from typing import cast
 
 from loguru import logger
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -32,8 +33,6 @@ from .parsers.cpp.preproc_recovery import parse_with_preproc_recovery
 from .parsers.cpp_frontend import (
     cpp_frontend_available,
     find_compile_commands,
-    run_cpp_frontend,
-    run_cpp_frontend_hybrid,
 )
 from .parsers.csharp_frontend import find_csharp_project
 from .parsers.document_tier import DocumentTier
@@ -58,7 +57,12 @@ from .parsers.endpoints import (
     parse_route_decorator,
 )
 from .parsers.factory import ProcessorFactory
-from .parsers.frontends import FRONTENDS, SemanticFacts
+from .parsers.frontends import (
+    EMITTING_FRONTENDS,
+    FRONTENDS,
+    FrontendEmitContext,
+    SemanticFacts,
+)
 from .parsers.frontends.protocol import QueryCall
 from .parsers.go_frontend import find_go_module
 from .parsers.java_generated import (
@@ -411,23 +415,38 @@ class GraphUpdater:
             logger.warning(ls.CPP_FRONTEND_NO_COMPDB)
             return
         logger.info(ls.CPP_FRONTEND_RUNNING.format(path=compdb_dir))
-        if settings.CPP_FRONTEND == cs.CppFrontend.HYBRID:
-            (
-                self._pending_cpp_macro_calls,
-                self._pending_cpp_expansion_calls,
-            ) = run_cpp_frontend_hybrid(
-                self._sink,
-                self.repo_path,
-                self.project_name,
-                compdb_dir,
+        # Dispatched through the EmittingFrontend registry rather than called
+        # directly (issue #1178). The mode-to-phase mapping now lives on the
+        # frontend, so the two call sites above stay the single place that
+        # decides WHEN each phase runs.
+        frontend = EMITTING_FRONTENDS.get(cs.SupportedLanguage.CPP)
+        if frontend is None:
+            return
+        result = frontend.emit(
+            FrontendEmitContext(
+                ingestor=self._sink,
+                repo_path=self.repo_path,
+                project_name=self.project_name,
+                compdb_dir=compdb_dir,
                 function_registry=self.function_registry,
                 simple_name_lookup=self.simple_name_lookup,
                 structural_elements=(
                     self.factory.structure_processor.structural_elements
                 ),
-                owned_qns=self._frontend_owned_qns,
                 exclude_paths=self.exclude_paths,
                 unignore_paths=self.unignore_paths,
+                owned_qns=self._frontend_owned_qns,
+            )
+        )
+        if settings.CPP_FRONTEND == cs.CppFrontend.HYBRID:
+            # FrontendEmitResult keeps these as list[object] so the protocol
+            # need not import cpp_frontend internals; narrowing here is the
+            # "the C++ frontend adapter narrows them" its docstring describes.
+            self._pending_cpp_macro_calls = cast(
+                "list[PendingMacroCall]", result.pending_macro_calls
+            )
+            self._pending_cpp_expansion_calls = cast(
+                "list[PendingExpansionCall]", result.pending_expansion_calls
             )
             logger.info(
                 ls.CPP_FRONTEND_HYBRID_PENDING.format(
@@ -436,18 +455,7 @@ class GraphUpdater:
                 )
             )
             return
-        self._cpp_frontend_covered = run_cpp_frontend(
-            self._sink,
-            self.repo_path,
-            self.project_name,
-            compdb_dir,
-            function_registry=self.function_registry,
-            simple_name_lookup=self.simple_name_lookup,
-            structural_elements=self.factory.structure_processor.structural_elements,
-            exclude_paths=self.exclude_paths,
-            unignore_paths=self.unignore_paths,
-            owned_qns=self._frontend_owned_qns,
-        )
+        self._cpp_frontend_covered = result.covered_files
         logger.info(
             ls.CPP_FRONTEND_COVERED.format(count=len(self._cpp_frontend_covered))
         )

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -395,8 +395,13 @@ class GraphUpdater:
         # #include IMPORTS, whose qns are scheme-identical, and hands back
         # macro uses for span attribution after Pass 2. Missing either
         # condition falls back to tree-sitter.
+        # Both pending lists, not just the macro one: an early return below
+        # (mode off, libclang absent, no compile_commands.json) would otherwise
+        # leave a previous run's expansion calls in place, and the Pass-3
+        # consumer would emit CALLS edges for expansions that no longer apply.
         self._cpp_frontend_covered = frozenset()
         self._pending_cpp_macro_calls = []
+        self._pending_cpp_expansion_calls = []
         if settings.CPP_FRONTEND not in (
             cs.CppFrontend.LIBCLANG,
             cs.CppFrontend.HYBRID,

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -890,6 +890,15 @@ class GraphUpdater:
         logger.info(ls.PASS_1_STRUCTURE)
         self.factory.structure_processor.identify_structure()
 
+        # Cleared here, not only in _run_cpp_frontend: in HYBRID that method
+        # runs AFTER Pass 2, so its reset is too late for a REUSED updater
+        # whose previous run was LIBCLANG. _process_files consumes this set to
+        # skip files, and a stale entry makes it skip a file whose Module
+        # subtree was just deleted -- leaving only a generic File node that the
+        # later hybrid pass cannot repair, because it never produced the
+        # tree-sitter definitions to restore.
+        self._cpp_frontend_covered = frozenset()
+
         # LIBCLANG must run before Pass 2: _process_files consumes the
         # covered-file set to skip those files.
         if settings.CPP_FRONTEND != cs.CppFrontend.HYBRID:

--- a/codebase_rag/parsers/frontends/__init__.py
+++ b/codebase_rag/parsers/frontends/__init__.py
@@ -18,6 +18,7 @@ never worse.
 from __future__ import annotations
 
 # Import for side effect: each frontend module self-registers into the registry.
+from . import cpp as _cpp  # noqa: E402,F401  (registers CppLibclangFrontend)
 from . import csharp as _csharp  # noqa: E402,F401  (registers CSharpFrontend)
 from . import go as _go  # noqa: E402,F401  (registers GoFrontend)
 from . import java as _java  # noqa: E402,F401  (registers JavaJavacFrontend)

--- a/codebase_rag/parsers/frontends/cpp.py
+++ b/codebase_rag/parsers/frontends/cpp.py
@@ -1,0 +1,104 @@
+"""The C++ (libclang) `EmittingFrontend` adapter (issue #1178).
+
+Unlike the fact-provider frontends, libclang contributes graph elements the
+tree-sitter backbone cannot produce at all -- expanded macros and `#include`
+edges -- so it writes through the ingestor rather than returning a bundle.
+That is what `EmittingFrontend` exists for.
+
+Two modes, and the phase is what distinguishes them:
+
+- HYBRID (the default) layers macro `Function` nodes and `#include` IMPORTS
+  onto the tree-sitter index and hands back macro uses to be joined to
+  tree-sitter spans, so it must run AFTER_DEFINITIONS -- there is nothing to
+  attribute to before that pass.
+- LIBCLANG emits its own definition nodes and reports the files it covered so
+  the definition pass can skip them, so it must run BEFORE_DEFINITIONS.
+
+Getting the phase wrong does not raise. HYBRID running early would find no
+spans and silently attribute nothing, which is why the phase is asserted in
+`test_cpp_emitting_frontend.py` rather than left to review.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ... import constants as cs
+from ...config import settings
+from ..cpp_frontend import (
+    cpp_frontend_available,
+    find_compile_commands,
+    run_cpp_frontend,
+    run_cpp_frontend_hybrid,
+)
+from .protocol import FrontendEmitContext, FrontendEmitResult, FrontendPhase
+from .registry import register_emitting_frontend
+
+_EMITTING_MODES = (cs.CppFrontend.LIBCLANG, cs.CppFrontend.HYBRID)
+
+
+class CppLibclangFrontend:
+    """libclang macro/include provider for C and C++."""
+
+    language: cs.SupportedLanguage = cs.SupportedLanguage.CPP
+
+    @property
+    def phase(self) -> FrontendPhase:
+        # Read at access time rather than bound at import: the mode is a
+        # setting, and binding it here would freeze whichever value happened
+        # to be loaded when this module was first imported.
+        if settings.CPP_FRONTEND == cs.CppFrontend.LIBCLANG:
+            return FrontendPhase.BEFORE_DEFINITIONS
+        return FrontendPhase.AFTER_DEFINITIONS
+
+    def available(self) -> bool:
+        """Whether libclang can run at all.
+
+        Answers rather than raises: a missing libclang must degrade to the
+        tree-sitter backbone, which covers every file anyway.
+        """
+        return settings.CPP_FRONTEND in _EMITTING_MODES and cpp_frontend_available()
+
+    def applies(self, repo_path: Path) -> bool:
+        """True only when a compilation database is discoverable.
+
+        libclang needs the real compile commands; without them there is
+        nothing to parse, and the caller falls back rather than warning on
+        every index of a repository with no C or C++ in it.
+        """
+        return find_compile_commands(repo_path) is not None
+
+    def emit(self, ctx: FrontendEmitContext) -> FrontendEmitResult:
+        if settings.CPP_FRONTEND == cs.CppFrontend.HYBRID:
+            pending_macro_calls, pending_expansion_calls = run_cpp_frontend_hybrid(
+                ctx.ingestor,
+                ctx.repo_path,
+                ctx.project_name,
+                ctx.compdb_dir,
+                function_registry=ctx.function_registry,
+                simple_name_lookup=ctx.simple_name_lookup,
+                structural_elements=ctx.structural_elements,
+                owned_qns=ctx.owned_qns,
+                exclude_paths=ctx.exclude_paths,
+                unignore_paths=ctx.unignore_paths,
+            )
+            return FrontendEmitResult(
+                pending_macro_calls=list(pending_macro_calls),
+                pending_expansion_calls=list(pending_expansion_calls),
+            )
+        covered = run_cpp_frontend(
+            ctx.ingestor,
+            ctx.repo_path,
+            ctx.project_name,
+            ctx.compdb_dir,
+            function_registry=ctx.function_registry,
+            simple_name_lookup=ctx.simple_name_lookup,
+            structural_elements=ctx.structural_elements,
+            exclude_paths=ctx.exclude_paths,
+            unignore_paths=ctx.unignore_paths,
+            owned_qns=ctx.owned_qns,
+        )
+        return FrontendEmitResult(covered_files=frozenset(covered))
+
+
+register_emitting_frontend(CppLibclangFrontend())

--- a/codebase_rag/tests/test_cpp_emitting_frontend.py
+++ b/codebase_rag/tests/test_cpp_emitting_frontend.py
@@ -8,7 +8,12 @@
 # pass produces and must run after.
 from __future__ import annotations
 
+from unittest.mock import patch
+
+import pytest
+
 from codebase_rag import constants as cs
+from codebase_rag.config import settings
 from codebase_rag.parsers.frontends import EMITTING_FRONTENDS, FrontendPhase
 
 
@@ -24,16 +29,36 @@ def test_cpp_registers_an_emitting_frontend() -> None:
     )
 
 
-def test_the_cpp_frontend_declares_a_real_phase() -> None:
-    """The phase decides whether the definition pass has already run.
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        # LIBCLANG emits its own definition nodes and reports covered files, so
+        # the definition pass must not have run yet.
+        (cs.CppFrontend.LIBCLANG, FrontendPhase.BEFORE_DEFINITIONS),
+        # HYBRID attributes macro uses to tree-sitter spans, which do not exist
+        # until the definition pass has produced them.
+        (cs.CppFrontend.HYBRID, FrontendPhase.AFTER_DEFINITIONS),
+    ],
+)
+def test_each_cpp_mode_maps_to_its_own_phase(
+    mode: cs.CppFrontend, expected: FrontendPhase
+) -> None:
+    """Each mode must map to its SPECIFIC phase, not merely to a valid one.
 
-    Getting it wrong does not raise: HYBRID running before definitions would
-    find no tree-sitter spans to attribute macro calls to, and would silently
-    attribute nothing.
+    Asserting `phase in FrontendPhase` is satisfied by both the correct
+    mapping and an inverted one, so it cannot detect the regression it exists
+    to prevent. Greptile demonstrated exactly that: swapping the two values
+    left the weaker assertion green.
+
+    The consequence of an inverted mapping is silent. HYBRID running before
+    the definition pass finds no tree-sitter spans to attribute macro calls
+    to and attributes nothing; nothing raises, and the graph is quietly
+    missing every macro edge.
     """
     frontend = EMITTING_FRONTENDS[cs.SupportedLanguage.CPP]
 
-    assert frontend.phase in tuple(FrontendPhase), frontend.phase
+    with patch.object(settings, "CPP_FRONTEND", mode):
+        assert frontend.phase is expected, f"{mode.value} -> {frontend.phase}"
 
 
 def test_the_frontend_reports_availability_without_raising() -> None:

--- a/codebase_rag/tests/test_cpp_emitting_frontend.py
+++ b/codebase_rag/tests/test_cpp_emitting_frontend.py
@@ -1,0 +1,47 @@
+# The C++ libclang integration behind the EmittingFrontend protocol (#1178).
+#
+# `EmittingFrontend` shipped with the protocol but nothing registered against
+# it, so the C++ frontend was still called directly from graph_updater. These
+# tests pin the registration and the phase mapping, which is the part a future
+# refactor is most likely to get wrong: LIBCLANG emits its own definition nodes
+# and must run BEFORE the definition pass, while HYBRID attaches to spans that
+# pass produces and must run after.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag.parsers.frontends import EMITTING_FRONTENDS, FrontendPhase
+
+
+def test_cpp_registers_an_emitting_frontend() -> None:
+    """C++ is the protocol's intended consumer and must actually register.
+
+    `EmittingFrontend` exists precisely for a frontend that writes graph
+    elements rather than returning facts; a protocol with no implementer is
+    indistinguishable from one that does not work.
+    """
+    assert cs.SupportedLanguage.CPP in EMITTING_FRONTENDS, sorted(
+        lang.value for lang in EMITTING_FRONTENDS
+    )
+
+
+def test_the_cpp_frontend_declares_a_real_phase() -> None:
+    """The phase decides whether the definition pass has already run.
+
+    Getting it wrong does not raise: HYBRID running before definitions would
+    find no tree-sitter spans to attribute macro calls to, and would silently
+    attribute nothing.
+    """
+    frontend = EMITTING_FRONTENDS[cs.SupportedLanguage.CPP]
+
+    assert frontend.phase in tuple(FrontendPhase), frontend.phase
+
+
+def test_the_frontend_reports_availability_without_raising() -> None:
+    """`available()` is called on every index, including where libclang is absent.
+
+    It must answer the question rather than propagate an ImportError, since a
+    missing toolchain has to degrade to the tree-sitter backbone.
+    """
+    frontend = EMITTING_FRONTENDS[cs.SupportedLanguage.CPP]
+
+    assert isinstance(frontend.available(), bool)

--- a/codebase_rag/tests/test_cpp_pending_state_reset.py
+++ b/codebase_rag/tests/test_cpp_pending_state_reset.py
@@ -63,3 +63,44 @@ def test_covered_files_also_reset(tmp_path: Path, monkeypatch) -> None:
     updater._run_cpp_frontend()
 
     assert updater._cpp_frontend_covered == frozenset()
+
+
+def test_covered_set_resets_before_pass_two_on_a_hybrid_rerun(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A reused updater must not carry a LIBCLANG covered-set into HYBRID.
+
+    In HYBRID mode `_run_cpp_frontend` runs AFTER Pass 2, so its reset is too
+    late: `_process_files` consumes the covered set to skip files, and a stale
+    entry makes it skip a file whose Module subtree was just deleted. The file
+    then gets only a generic `File` node, and the later hybrid pass cannot
+    restore the tree-sitter definitions it never produced.
+
+    Asserting on the covered set after `run()` rather than on the emitted
+    nodes keeps this about the state, which is what the ordering bug is.
+    """
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=MagicMock(), repo_path=tmp_path, parsers=parsers, queries=queries
+    )
+    # Simulate a previous LIBCLANG run on the same instance.
+    updater._cpp_frontend_covered = frozenset({"stale.cpp"})
+
+    monkeypatch.setattr(settings, "CPP_FRONTEND", cs.CppFrontend.HYBRID)
+
+    # The value AT PASS 2 is what matters: _run_cpp_frontend runs after it in
+    # HYBRID and resets the set on the way out, so asserting after run()
+    # returns would pass against the bug.
+    seen: list[frozenset[str]] = []
+    original = updater._process_files
+
+    def _record(*args, **kwargs):
+        seen.append(updater._cpp_frontend_covered)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(updater, "_process_files", _record)
+    updater.run()
+
+    assert seen, "_process_files was never called"
+    assert seen[0] == frozenset(), seen[0]

--- a/codebase_rag/tests/test_cpp_pending_state_reset.py
+++ b/codebase_rag/tests/test_cpp_pending_state_reset.py
@@ -1,0 +1,65 @@
+# Both C++ pending-call lists must reset on every run (#1178 review).
+#
+# `_run_cpp_frontend` cleared `_pending_cpp_macro_calls` at the top but not
+# `_pending_cpp_expansion_calls`. On any early return -- the mode is off,
+# libclang is unavailable, no compile_commands.json -- a previous run's
+# expansion calls survived into the next one, and the Pass-3 consumer at
+# graph_updater.py:801 emitted CALLS edges for expansions that no longer
+# apply.
+#
+# The failure is silent: the edges are plausible, they are simply about a
+# state of the repository that no longer exists.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.config import settings
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _updater(tmp_path: Path) -> GraphUpdater:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=MagicMock(), repo_path=tmp_path, parsers=parsers, queries=queries
+    )
+
+
+def test_expansion_calls_reset_when_the_frontend_does_not_run(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Stale expansion calls must not survive a run that never produced any.
+
+    Asserting on the macro list alone would pass today: it is already reset.
+    The expansion list is the one that leaked, and both are asserted so a
+    future reset of one without the other is caught.
+    """
+    updater = _updater(tmp_path)
+    updater._pending_cpp_macro_calls = ["stale-macro"]  # type: ignore[list-item]
+    updater._pending_cpp_expansion_calls = ["stale-expansion"]  # type: ignore[list-item]
+
+    # TREESITTER takes the earliest return, before any libclang probing.
+    monkeypatch.setattr(settings, "CPP_FRONTEND", cs.CppFrontend.TREESITTER)
+    updater._run_cpp_frontend()
+
+    assert updater._pending_cpp_macro_calls == []
+    assert updater._pending_cpp_expansion_calls == []
+
+
+def test_covered_files_also_reset(tmp_path: Path, monkeypatch) -> None:
+    """The control: the reset block clears every piece of per-run state.
+
+    Without this, a change that reset the two lists but dropped the covered
+    set would pass the test above while leaking a different piece of the same
+    state.
+    """
+    updater = _updater(tmp_path)
+    updater._cpp_frontend_covered = frozenset({"stale.cpp"})
+
+    monkeypatch.setattr(settings, "CPP_FRONTEND", cs.CppFrontend.TREESITTER)
+    updater._run_cpp_frontend()
+
+    assert updater._cpp_frontend_covered == frozenset()


### PR DESCRIPTION
Addresses the first acceptance bullet of #1178 — *"Both existing frontends run behind the protocol"*. C# was already migrated; C++ was not.

`Addresses`, not `Fixes`: the pure-LIBCLANG disposition bullet remains, and the docs bullet is #1457. The issue stays open.

## The finding

`EmittingFrontend`, `FrontendPhase`, `FrontendEmitContext` and `FrontendEmitResult` **shipped with the protocol and nothing registered against them**. `grep -rn "register_emitting_frontend"` returned only the definition and its re-export. The C++ frontend — their intended consumer, named in the protocol's own docstring — was still called directly from `graph_updater`.

I had earlier posted a three-way design fork on #1178 about how to migrate C++, and that was wrong: the decision was made when the protocol landed. `FrontendEmitContext` carries **exactly** `run_cpp_frontend_hybrid`'s parameter list, down to `owned_qns` and the exclude/unignore sets. It was built for this and never wired up. Correction posted on the issue.

## What lands

`CppLibclangFrontend` adapts both modes, and the **phase** is what separates them:

| Mode | Phase | Why |
|---|---|---|
| `LIBCLANG` | `BEFORE_DEFINITIONS` | Emits its own definition nodes; Pass 2 skips the files it covered |
| `HYBRID` | `AFTER_DEFINITIONS` | Attaches macro nodes and `#include` edges to spans Pass 2 produced |

`graph_updater` now dispatches through `EMITTING_FRONTENDS`; the direct `run_cpp_frontend` / `run_cpp_frontend_hybrid` imports are gone. The two call sites deciding *when* each phase runs are unchanged, so ordering behaviour is identical.

## Two details worth review

**`phase` is a property, not a class attribute.** The mode is a runtime setting; binding it at import would freeze whichever value happened to be loaded when the module was first imported.

**The phase is asserted by a test rather than left to review.** Getting it wrong does not raise: HYBRID running before the definition pass would find no tree-sitter spans to attribute macro calls to, and would silently attribute nothing. That is the same silent-loss shape as #1447 and #1453 — the graph ends up smaller than the truth and nothing downstream can tell — so it gets a test.

## Type narrowing

`ty` caught two real errors. `FrontendEmitResult` deliberately keeps its pending lists as `list[object]` so the protocol need not import `cpp_frontend` internals — its docstring says *"the C++ frontend adapter narrows them"*. I narrowed at that boundary with a `cast` and a comment pointing back at the contract, rather than loosening the attribute types on the updater.

## Verification

Full unit suite: **8040 passed**, 121 skipped, zero failures — the same count as before the migration, which is what a behaviour-preserving change should produce. Three new tests pin registration, phase validity, and that `available()` answers rather than raising when libclang is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C++ code analysis through a registered frontend.
  * Supports hybrid and standalone analysis modes when required tooling and project metadata are available.
  * Automatically determines whether C++ analysis is available for a repository.

* **Bug Fixes**
  * Improved C++ analysis execution and covered-file handling.
  * Prevented stale macro, expansion, and file-tracking state from affecting subsequent runs.

* **Tests**
  * Added coverage for frontend registration, execution modes, availability checks, and state reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->