### PR TITLE
fix: dispatch EMITTING_FRONTENDS generically by phase

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -61,6 +61,7 @@ from .parsers.frontends import (
     EMITTING_FRONTENDS,
     FRONTENDS,
     FrontendEmitContext,
+    FrontendPhase,
     SemanticFacts,
 )
 from .parsers.frontends.protocol import QueryCall
@@ -385,6 +386,49 @@ class GraphUpdater:
         self.finding_analyzer = FindingAnalyzer(
             self._sink, self.repo_path, self.capture
         )
+
+    def _run_emitting_frontends(self, phase: FrontendPhase) -> None:
+        """Run every registered emitting frontend declaring this phase.
+
+        C++ is dispatched by `_run_cpp_frontend`, which owns the mode gating
+        and the compile-database discovery its two modes need, so it is skipped
+        here to avoid running it twice (issue #1460).
+
+        A frontend that is unavailable or does not apply is skipped rather than
+        failing the run: a missing toolchain must degrade to the tree-sitter
+        backbone, which covers every file anyway.
+        """
+        for language, frontend in EMITTING_FRONTENDS.items():
+            if language == cs.SupportedLanguage.CPP:
+                continue
+            if frontend.phase != phase:
+                continue
+            try:
+                if not frontend.available() or not frontend.applies(self.repo_path):
+                    continue
+            except Exception:
+                logger.warning(ls.EMITTING_FRONTEND_PROBE_FAILED.format(lang=language))
+                continue
+            result = frontend.emit(
+                FrontendEmitContext(
+                    ingestor=self._sink,
+                    repo_path=self.repo_path,
+                    project_name=self.project_name,
+                    compdb_dir=self.repo_path,
+                    function_registry=self.function_registry,
+                    simple_name_lookup=self.simple_name_lookup,
+                    structural_elements=(
+                        self.factory.structure_processor.structural_elements
+                    ),
+                    exclude_paths=self.exclude_paths,
+                    unignore_paths=self.unignore_paths,
+                    owned_qns=self._frontend_owned_qns,
+                )
+            )
+            # Covered files union across frontends: each one reports the files
+            # it fully owns, and the definition pass must skip all of them.
+            if result.covered_files:
+                self._cpp_frontend_covered |= result.covered_files
 
     def _run_cpp_frontend(self) -> None:
         # Optional libclang C++ pre-pass when a compile_commands.json is
@@ -903,6 +947,7 @@ class GraphUpdater:
         # covered-file set to skip those files.
         if settings.CPP_FRONTEND != cs.CppFrontend.HYBRID:
             self._run_cpp_frontend()
+        self._run_emitting_frontends(FrontendPhase.BEFORE_DEFINITIONS)
 
         # The C# Roslyn frontend must run before Pass 2: it produces a
         # base-classification oracle that split_csharp_bases consults while
@@ -952,6 +997,7 @@ class GraphUpdater:
         # it and vanish until a forced rebuild.
         if settings.CPP_FRONTEND == cs.CppFrontend.HYBRID:
             self._run_cpp_frontend()
+        self._run_emitting_frontends(FrontendPhase.AFTER_DEFINITIONS)
 
         corrected = self.factory.definition_processor.resolve_deferred_cpp_methods()
         if corrected:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -14,6 +14,10 @@ PASS_2_FILES = (
 PASS_3_CALLS = "--- Pass 3: Processing Function Calls from AST Cache ---"
 PASS_4_EMBEDDINGS = "--- Pass 4: Generating semantic embeddings ---"
 CPP_FRONTEND_RUNNING = "--- C/C++ libclang frontend: {path} ---"
+EMITTING_FRONTEND_PROBE_FAILED = (
+    "Emitting frontend for {lang} raised while probing availability; skipping "
+    "it and falling back to tree-sitter for that language."
+)
 CPP_FRONTEND_UNAVAILABLE = (
     "C/C++ libclang frontend enabled but libclang is unavailable; using "
     "tree-sitter only (no macro Function nodes or #include IMPORTS). "

--- a/codebase_rag/tests/test_emitting_frontend_dispatch.py
+++ b/codebase_rag/tests/test_emitting_frontend_dispatch.py
@@ -145,3 +145,39 @@ def test_a_frontend_that_does_not_apply_is_not_invoked(
 
     assert not frontend.emitted
     assert "marker.from.frontend" not in _emitted_qns(mock)
+
+
+def test_a_frontend_whose_probe_raises_is_skipped(tmp_path: Path, monkeypatch) -> None:
+    """A raising `available()` must not fail the whole index.
+
+    The protocol's invariant is that a missing toolchain degrades to the
+    tree-sitter backbone, never worse. A frontend whose PROBE throws -- a
+    broken install, a permissions error reading a marker -- would otherwise
+    take the entire run down with it, which is the opposite of degrading.
+
+    Asserting the other frontends still run is what makes this meaningful:
+    a dispatch loop that swallowed the exception and then stopped iterating
+    would satisfy "no crash" while silently dropping every later frontend.
+    """
+    raiser = _RecordingFrontend(
+        cs.SupportedLanguage.RUST, FrontendPhase.AFTER_DEFINITIONS
+    )
+    raiser.available = lambda: (_ for _ in ()).throw(  # type: ignore[method-assign]
+        RuntimeError("broken install")
+    )
+    survivor = _RecordingFrontend(
+        cs.SupportedLanguage.JAVA, FrontendPhase.AFTER_DEFINITIONS
+    )
+
+    patched = dict(EMITTING_FRONTENDS)
+    patched[raiser.language] = raiser
+    patched[survivor.language] = survivor
+    monkeypatch.setattr(
+        "codebase_rag.graph_updater.EMITTING_FRONTENDS", patched, raising=False
+    )
+
+    mock = _index(tmp_path)
+
+    assert not raiser.emitted, "a raising probe should skip its frontend"
+    assert survivor.emitted, "one broken frontend stopped the others running"
+    assert "marker.from.frontend" in _emitted_qns(mock)

--- a/codebase_rag/tests/test_emitting_frontend_dispatch.py
+++ b/codebase_rag/tests/test_emitting_frontend_dispatch.py
@@ -1,0 +1,147 @@
+# Generic dispatch of EMITTING_FRONTENDS by declared phase (issue #1460).
+#
+# The registry is keyed by language and reads as a general mechanism, but the
+# graph builder looked up one hardcoded key, so a frontend registered for any
+# other language was silently never called -- registration succeeded, emit()
+# never ran, and its nodes were simply absent with nothing to diagnose.
+#
+# These tests register a dummy frontend and assert its marker node REACHES the
+# graph. Asserting only that indexing does not crash passes against the broken
+# behaviour, which is the whole failure mode: nothing errors.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.frontends import (
+    EMITTING_FRONTENDS,
+    FrontendEmitContext,
+    FrontendEmitResult,
+    FrontendPhase,
+)
+
+_MARKER_LABEL = cs.NodeLabel.MODULE.value
+
+
+class _RecordingFrontend:
+    """A minimal emitting frontend that writes one identifiable node."""
+
+    def __init__(self, language: cs.SupportedLanguage, phase: FrontendPhase) -> None:
+        self.language = language
+        self.phase = phase
+        self.emitted = False
+
+    def available(self) -> bool:
+        return True
+
+    def applies(self, repo_path: Path) -> bool:
+        return True
+
+    def emit(self, ctx: FrontendEmitContext) -> FrontendEmitResult:
+        self.emitted = True
+        ctx.ingestor.ensure_node_batch(
+            _MARKER_LABEL, {cs.KEY_QUALIFIED_NAME: "marker.from.frontend"}
+        )
+        return FrontendEmitResult()
+
+
+def _index(tmp_path: Path) -> MagicMock:
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return mock
+
+
+def _emitted_qns(mock: MagicMock) -> set[str]:
+    return {
+        str(call.args[1].get(cs.KEY_QUALIFIED_NAME))
+        for call in mock.ensure_node_batch.call_args_list
+        if str(call.args[0]) == _MARKER_LABEL
+    }
+
+
+def _register(monkeypatch, frontend: _RecordingFrontend) -> None:
+    patched = dict(EMITTING_FRONTENDS)
+    patched[frontend.language] = frontend
+    monkeypatch.setattr(
+        "codebase_rag.graph_updater.EMITTING_FRONTENDS", patched, raising=False
+    )
+
+
+def test_a_registered_frontend_for_any_language_is_invoked(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Registration must be sufficient, for a language other than C++.
+
+    The previous lookup was `EMITTING_FRONTENDS.get(SupportedLanguage.CPP)`,
+    so this frontend was never called and its node never written. Nothing
+    raised, which is why the assertion is on the emitted node rather than on
+    the absence of an exception.
+    """
+    frontend = _RecordingFrontend(
+        cs.SupportedLanguage.RUST, FrontendPhase.AFTER_DEFINITIONS
+    )
+    _register(monkeypatch, frontend)
+
+    mock = _index(tmp_path)
+
+    assert frontend.emitted, "emit() was never called"
+    assert "marker.from.frontend" in _emitted_qns(mock)
+
+
+def test_a_before_definitions_frontend_is_invoked(tmp_path: Path, monkeypatch) -> None:
+    """Both phases dispatch, not just the one C++ happens to use by default.
+
+    A dispatch loop wired into only one call site would pass the test above
+    and silently drop every frontend declaring the other phase.
+    """
+    frontend = _RecordingFrontend(
+        cs.SupportedLanguage.RUST, FrontendPhase.BEFORE_DEFINITIONS
+    )
+    _register(monkeypatch, frontend)
+
+    mock = _index(tmp_path)
+
+    assert frontend.emitted, "emit() was never called"
+    assert "marker.from.frontend" in _emitted_qns(mock)
+
+
+def test_an_unavailable_frontend_is_not_invoked(tmp_path: Path, monkeypatch) -> None:
+    """`available()` gates the call, so a missing toolchain degrades quietly.
+
+    The paired negative: without it, a dispatch loop that ignored availability
+    would pass both tests above while crashing on every machine lacking the
+    tool.
+    """
+    frontend = _RecordingFrontend(
+        cs.SupportedLanguage.RUST, FrontendPhase.AFTER_DEFINITIONS
+    )
+    frontend.available = lambda: False  # type: ignore[method-assign]
+    _register(monkeypatch, frontend)
+
+    mock = _index(tmp_path)
+
+    assert not frontend.emitted
+    assert "marker.from.frontend" not in _emitted_qns(mock)
+
+
+def test_a_frontend_that_does_not_apply_is_not_invoked(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`applies()` gates it too: no project file, no run."""
+    frontend = _RecordingFrontend(
+        cs.SupportedLanguage.RUST, FrontendPhase.AFTER_DEFINITIONS
+    )
+    frontend.applies = lambda repo_path: False  # type: ignore[method-assign]
+    _register(monkeypatch, frontend)
+
+    mock = _index(tmp_path)
+
+    assert not frontend.emitted
+    assert "marker.from.frontend" not in _emitted_qns(mock)


### PR DESCRIPTION
Fixes #1460. Stacked on #1459 — that PR registers the C++ frontend, this one makes the registry actually dispatch. Base is `feat/cpp-emitting-frontend`; retarget to `main` once #1459 merges.

## How this was found

Greptile reviewed #1457 (the frontend docs) by **executing the checklist rather than reading it**: it registered a phase-tagged emitting frontend, ran the real graph-build path, and confirmed the emitter was never invoked and its marker node never written.

That is a defect in the code, not the doc. #1457 now carries a warning; this fixes the underlying gap.

## The defect

`EMITTING_FRONTENDS` is keyed by language and reads as a general mechanism. It was not:

```python
frontend = EMITTING_FRONTENDS.get(cs.SupportedLanguage.CPP)
```

One hardcoded key. A frontend registered for any other language was **silently never called** — registration succeeded, `available()` and `applies()` were never consulted, `emit()` never ran, its nodes were simply absent. Nothing errored.

`FrontendPhase` had the same problem one level up: declared on every emitting frontend and read by nothing, with ordering coming from two hardcoded `settings.CPP_FRONTEND` checks.

Same silent-loss shape as #1447 and #1453 — the graph ends up smaller than the truth and nothing downstream can distinguish that from a repository which genuinely lacked those elements.

## Three choices worth review

**C++ is explicitly skipped in the generic loop.** It owns the mode gating and compile-database discovery its two modes need, so dispatching it here as well would run it twice. #1459's behaviour is byte-identical.

**`available()` and `applies()` are wrapped.** A frontend whose *probe* raises would otherwise fail the whole index, and the protocol's invariant is that a missing toolchain degrades to the tree-sitter backbone — never worse.

**`covered_files` unions rather than overwrites**, since each frontend reports the files it owns and the definition pass must skip all of them.

## The tests assert the node reaches the graph

Not that indexing did not crash — **nothing crashed before either**, which was the entire failure mode. A test asserting the absence of an exception passes against the broken behaviour.

The two negative tests are paired controls: without them, a dispatch loop that ignored `available()` would pass both positives while breaking every machine lacking the tool.

Red first, and the red had the right shape: both positives failed (`emit() was never called`), both negatives passed.

## Verification

Full unit suite: **8044 passed**, 121 skipped, zero failures — 8040 plus the four new tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for language frontends running at different processing phases.
  * Registered frontends can contribute results before and after definition processing.
  * Automatically falls back to tree-sitter when a frontend is unavailable or not applicable.

* **Bug Fixes**
  * Improved handling of frontend probe failures with clear warnings and continued processing.

* **Tests**
  * Added coverage for frontend dispatch across languages, phases, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->