### PR TITLE
fix: bound frontend helper-tool builds so a wedged toolchain degrades

### DIFF
--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -100,6 +100,10 @@ _BUILD_LOCK = ".build-lock"
 _LOCK_TRIES = 600
 _LOCK_POLL_SECONDS = 0.5
 _RESTORE_TIMEOUT = 600
+# `dotnet build` may restore packages, so it is bounded above a warm rebuild
+# but below the run timeout: a wedged build must degrade to the tree-sitter
+# backbone rather than block indexing (issue #1462).
+_BUILD_TIMEOUT = 600
 _RUN_TIMEOUT = 900
 _DOTNET_ENV = {"DOTNET_CLI_TELEMETRY_OPTOUT": "1", "DOTNET_NOLOGO": "1"}
 _IGNORE_DIRS = frozenset({"bin", "obj", ".git", "node_modules", "vendor", "packages"})
@@ -215,23 +219,31 @@ def _compile_tool(dotnet: str, src: Path, out: Path) -> bool:
     src.mkdir(parents=True, exist_ok=True)
     for name in _TOOL_SOURCES:
         shutil.copy2(_TOOL_SRC / name, src / name)
-    proc = subprocess.run(
-        [
-            dotnet,
-            "build",
-            str(src),
-            "-c",
-            "Release",
-            "-o",
-            str(out),
-            "--verbosity",
-            "quiet",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-        env={**os.environ, **_DOTNET_ENV},
-    )
+    try:
+        proc = subprocess.run(
+            [
+                dotnet,
+                "build",
+                str(src),
+                "-c",
+                "Release",
+                "-o",
+                str(out),
+                "--verbosity",
+                "quiet",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_BUILD_TIMEOUT,
+            env={**os.environ, **_DOTNET_ENV},
+        )
+    except subprocess.TimeoutExpired:
+        # A wedged build degrades exactly like a failed one; the caller falls
+        # back to tree-sitter (issue #1462). Raising would turn a hung
+        # toolchain into a failed index.
+        logger.warning(ls.CSHARP_FRONTEND_BUILD_FAILED)
+        return False
     return proc.returncode == 0
 
 

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -96,6 +96,11 @@ _BUILD_LOCK = ".build-lock"
 # parallel workers run it read-only and never race a shared build output.
 _LOCK_TRIES = 600
 _LOCK_POLL_SECONDS = 0.5
+# `go build` may fetch modules, so it is bounded well above a warm rebuild but
+# far below the run timeout: a wedged build must degrade to the tree-sitter
+# backbone rather than block indexing (issue #1462). Matches the Java
+# frontend's _BUILD_TIMEOUT, which had this from the start.
+_BUILD_TIMEOUT = 300
 _RUN_TIMEOUT = 900
 # GOTOOLCHAIN=local pins the installed toolchain (never a network upgrade);
 # CGO off keeps the binary portable across the machines a shared cache may span.
@@ -160,14 +165,26 @@ def _compile_tool(go: str, src: Path, out: Path) -> bool:
     for name in _TOOL_SOURCES:
         shutil.copy2(_TOOL_SRC / name, src / name)
     out.mkdir(parents=True, exist_ok=True)
-    proc = subprocess.run(
-        [go, "build", "-o", str(out / _BINARY_NAME), "."],
-        cwd=src,
-        capture_output=True,
-        text=True,
-        check=False,
-        env={**os.environ, **_GO_ENV},
-    )
+    try:
+        proc = subprocess.run(
+            [go, "build", "-o", str(out / _BINARY_NAME), "."],
+            cwd=src,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_BUILD_TIMEOUT,
+            env={**os.environ, **_GO_ENV},
+        )
+    except subprocess.TimeoutExpired:
+        # A wedged build degrades exactly like a failed one: the caller falls
+        # back to tree-sitter. Raising here would turn a hung toolchain into a
+        # failed index, which is the opposite of the protocol's invariant.
+        logger.warning(
+            ls.GO_FRONTEND_BUILD_FAILED.format(
+                stderr=f"timed out after {_BUILD_TIMEOUT}s"
+            )
+        )
+        return False
     if proc.returncode != 0:
         logger.warning(ls.GO_FRONTEND_BUILD_FAILED.format(stderr=proc.stderr.strip()))
     return proc.returncode == 0

--- a/codebase_rag/tests/test_frontend_subprocess_timeouts.py
+++ b/codebase_rag/tests/test_frontend_subprocess_timeouts.py
@@ -64,7 +64,13 @@ def _unbounded_run_calls(tree: ast.AST) -> list[int]:
             name = target.id
         if name != "run":
             continue
-        if "timeout" not in {kw.arg for kw in node.keywords if kw.arg}:
+        timeout = next((kw for kw in node.keywords if kw.arg == "timeout"), None)
+        # `timeout=None` is the same as no timeout at all: subprocess treats it
+        # as "wait forever". A presence check would accept it and report the
+        # call bounded, so an explicit literal None counts as unbounded.
+        if timeout is None or (
+            isinstance(timeout.value, ast.Constant) and timeout.value.value is None
+        ):
             found.append(node.lineno)
     return found
 
@@ -116,4 +122,10 @@ def test_the_detector_recognises_bounded_and_unbounded_calls() -> None:
     """
     assert _unbounded_run_calls(ast.parse("subprocess.run(['x'])")) == [1]
     assert _unbounded_run_calls(ast.parse("run(['x'])")) == [1]
+    # `timeout=None` means wait forever, so a presence check is not enough.
+    assert _unbounded_run_calls(ast.parse("subprocess.run(['x'], timeout=None)")) == [1]
     assert _unbounded_run_calls(ast.parse("subprocess.run(['x'], timeout=5)")) == []
+    # A named constant is accepted: the gate cannot evaluate it, and rejecting
+    # every non-literal would make the established `timeout=_RUN_TIMEOUT`
+    # convention unusable.
+    assert _unbounded_run_calls(ast.parse("subprocess.run(['x'], timeout=T)")) == []

--- a/codebase_rag/tests/test_frontend_subprocess_timeouts.py
+++ b/codebase_rag/tests/test_frontend_subprocess_timeouts.py
@@ -1,0 +1,95 @@
+# Gate: every frontend helper-tool subprocess call is bounded (issue #1462).
+#
+# `available()` protects against a toolchain that is ABSENT. It does nothing
+# for one that is present but wedged -- a stale build artifact, a lock, a
+# network-backed module fetch -- and an unbounded `subprocess.run` in a
+# frontend then blocks indexing with no diagnostic and no bound.
+#
+# A gate rather than per-call fixes, because the two offending calls were
+# written alongside six that DID pass a timeout: the convention already
+# existed and was silently not followed, which is exactly the drift a
+# structural assertion catches and a point fix does not.
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FRONTEND_ROOT = _REPO_ROOT / "codebase_rag" / "parsers"
+
+# Frontend packages that shell out to a compiler or language server.
+_FRONTEND_DIRS = (
+    "go_frontend",
+    "java_frontend",
+    "csharp_frontend",
+    "py_frontend",
+    "cpp_frontend",
+)
+
+
+def _unbounded_run_calls(tree: ast.AST) -> list[int]:
+    """Lines of `*.run(...)` calls with no `timeout=`.
+
+    Matches on the `run` attribute rather than on `subprocess.run`
+    specifically, so a module-level `from subprocess import run` is still
+    seen. Over-reporting is the safe direction: a false positive costs one
+    explicit timeout, a false negative costs an unbounded hang.
+    """
+    found: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        name = target.attr if isinstance(target, ast.Attribute) else None
+        if name is None and isinstance(target, ast.Name):
+            name = target.id
+        if name != "run":
+            continue
+        if "timeout" not in {kw.arg for kw in node.keywords if kw.arg}:
+            found.append(node.lineno)
+    return found
+
+
+def test_every_frontend_subprocess_call_is_bounded() -> None:
+    """An unbounded helper-tool call can hang indexing indefinitely.
+
+    The protocol's invariant is that a missing toolchain degrades to the
+    tree-sitter backbone, never worse. A wedged toolchain must degrade the
+    same way, and only a timeout makes that possible.
+    """
+    offenders: list[str] = []
+    for package in _FRONTEND_DIRS:
+        for path in sorted((_FRONTEND_ROOT / package).rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (OSError, SyntaxError):
+                continue
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            offenders.extend(f"{rel}:{line}" for line in _unbounded_run_calls(tree))
+
+    assert not offenders, (
+        "frontend helper-tool calls with no timeout (issue #1462); a wedged "
+        "toolchain blocks indexing with no bound:\n" + "\n".join(offenders)
+    )
+
+
+def test_the_scan_reaches_the_frontend_packages() -> None:
+    """A control: the gate above passes vacuously if it parses nothing.
+
+    An empty file list and a clean tree are indistinguishable in that
+    assertion, which is the failure mode this repo keeps meeting.
+    """
+    seen = [p for d in _FRONTEND_DIRS for p in (_FRONTEND_ROOT / d).rglob("*.py")]
+
+    assert len(seen) >= len(_FRONTEND_DIRS), f"only {len(seen)} files scanned"
+
+
+def test_the_detector_recognises_bounded_and_unbounded_calls() -> None:
+    """A second control: the matcher must fire and stay quiet correctly.
+
+    Proves the gate can fail, rather than being green because its detection
+    is broken.
+    """
+    assert _unbounded_run_calls(ast.parse("subprocess.run(['x'])")) == [1]
+    assert _unbounded_run_calls(ast.parse("run(['x'])")) == [1]
+    assert _unbounded_run_calls(ast.parse("subprocess.run(['x'], timeout=5)")) == []

--- a/codebase_rag/tests/test_frontend_subprocess_timeouts.py
+++ b/codebase_rag/tests/test_frontend_subprocess_timeouts.py
@@ -12,7 +12,9 @@
 from __future__ import annotations
 
 import ast
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _FRONTEND_ROOT = _REPO_ROOT / "codebase_rag" / "parsers"
@@ -129,3 +131,52 @@ def test_the_detector_recognises_bounded_and_unbounded_calls() -> None:
     # every non-literal would make the established `timeout=_RUN_TIMEOUT`
     # convention unusable.
     assert _unbounded_run_calls(ast.parse("subprocess.run(['x'], timeout=T)")) == []
+
+
+def test_a_timed_out_go_build_degrades_rather_than_raising(tmp_path: Path) -> None:
+    """A wedged `go build` must return False, not propagate TimeoutExpired.
+
+    The timeout is only half the fix. Letting TimeoutExpired escape would turn
+    a hung toolchain into a FAILED INDEX, which inverts the protocol's
+    invariant that a missing toolchain degrades to the tree-sitter backbone and
+    never worse.
+    """
+    from codebase_rag.parsers.go_frontend import frontend as gof
+
+    with patch.object(
+        gof.subprocess, "run", side_effect=subprocess.TimeoutExpired("go", 1)
+    ):
+        assert (
+            gof._compile_tool("/usr/bin/go", tmp_path / "src", tmp_path / "out")
+            is False
+        )
+
+
+def test_a_timed_out_dotnet_build_degrades_rather_than_raising(
+    tmp_path: Path,
+) -> None:
+    """The same for `dotnet build`, which restores packages over the network."""
+    from codebase_rag.parsers.csharp_frontend import frontend as csf
+
+    with patch.object(
+        csf.subprocess, "run", side_effect=subprocess.TimeoutExpired("dotnet", 1)
+    ):
+        assert (
+            csf._compile_tool("/usr/bin/dotnet", tmp_path / "s", tmp_path / "o")
+            is False
+        )
+
+
+def test_a_successful_build_still_reports_success(tmp_path: Path) -> None:
+    """The control: without it, a `_compile_tool` hardcoded to False would pass.
+
+    Both assertions above are satisfied by an implementation that never
+    succeeds, so the boundary has to be pinned from the other side too.
+    """
+    from codebase_rag.parsers.go_frontend import frontend as gof
+
+    ok = subprocess.CompletedProcess(["go"], 0, stdout="", stderr="")
+    with patch.object(gof.subprocess, "run", return_value=ok):
+        assert (
+            gof._compile_tool("/usr/bin/go", tmp_path / "src", tmp_path / "out") is True
+        )

--- a/codebase_rag/tests/test_frontend_subprocess_timeouts.py
+++ b/codebase_rag/tests/test_frontend_subprocess_timeouts.py
@@ -26,6 +26,25 @@ _FRONTEND_DIRS = (
     "cpp_frontend",
 )
 
+# Parser helpers that also invoke external language tools but sit directly
+# under `parsers/` rather than in a *_frontend package. Both are bounded today;
+# they are scanned so that STAYS true, which is the point of a gate rather than
+# a sweep. Greptile found them missing by adding an unbounded call to each and
+# observing the test still passed.
+_FRONTEND_FILES = (
+    "java_lombok.py",
+    "stdlib_extractor.py",
+)
+
+
+def _scanned_paths() -> list[Path]:
+    """Every file the gate covers: the frontend packages plus the loose helpers."""
+    paths = [
+        p for d in _FRONTEND_DIRS for p in sorted((_FRONTEND_ROOT / d).rglob("*.py"))
+    ]
+    paths += [_FRONTEND_ROOT / name for name in _FRONTEND_FILES]
+    return paths
+
 
 def _unbounded_run_calls(tree: ast.AST) -> list[int]:
     """Lines of `*.run(...)` calls with no `timeout=`.
@@ -58,14 +77,13 @@ def test_every_frontend_subprocess_call_is_bounded() -> None:
     same way, and only a timeout makes that possible.
     """
     offenders: list[str] = []
-    for package in _FRONTEND_DIRS:
-        for path in sorted((_FRONTEND_ROOT / package).rglob("*.py")):
-            try:
-                tree = ast.parse(path.read_text(encoding="utf-8"))
-            except (OSError, SyntaxError):
-                continue
-            rel = path.relative_to(_REPO_ROOT).as_posix()
-            offenders.extend(f"{rel}:{line}" for line in _unbounded_run_calls(tree))
+    for path in _scanned_paths():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        offenders.extend(f"{rel}:{line}" for line in _unbounded_run_calls(tree))
 
     assert not offenders, (
         "frontend helper-tool calls with no timeout (issue #1462); a wedged "
@@ -79,9 +97,15 @@ def test_the_scan_reaches_the_frontend_packages() -> None:
     An empty file list and a clean tree are indistinguishable in that
     assertion, which is the failure mode this repo keeps meeting.
     """
-    seen = [p for d in _FRONTEND_DIRS for p in (_FRONTEND_ROOT / d).rglob("*.py")]
+    seen = _scanned_paths()
 
     assert len(seen) >= len(_FRONTEND_DIRS), f"only {len(seen)} files scanned"
+    # Every named loose helper must actually exist, or a rename silently
+    # removes it from the gate's coverage and nothing reports the hole.
+    missing = [
+        name for name in _FRONTEND_FILES if not (_FRONTEND_ROOT / name).is_file()
+    ]
+    assert not missing, f"scanned helpers that no longer exist: {missing}"
 
 
 def test_the_detector_recognises_bounded_and_unbounded_calls() -> None:


### PR DESCRIPTION
Fixes #1462, found by CodeRabbit reviewing #1457.

## The defect

`go_frontend:149` and `csharp_frontend:218` called `subprocess.run` with **no timeout**. Both are helper-tool builds — `go build` and `dotnet build` — that may fetch modules or restore packages over the network, so a stale artifact, a held lock or a hung fetch blocked indexing with no bound and no diagnostic.

`available()` protects against a toolchain that is **absent**. It does nothing for one that is present but **wedged**, which is the harder case and the one that produces a support report rather than a clean fallback.

## The part a naive fix would have got wrong

**Adding `timeout=` alone makes this worse.** `TimeoutExpired` propagates, so a hung toolchain becomes a **failed index** rather than a fallback — the exact inversion of the protocol's stated invariant that a missing toolchain degrades to the tree-sitter backbone, never worse.

Both sites now catch it and return `False`, degrading exactly as a build failure already does, with a log line naming which frontend timed out. A silent fallback is indistinguishable from a frontend that ran and found nothing.

So the defect was never "no timeout". It was **no bounded failure path**.

## Why a gate rather than two point fixes

`java_frontend` already had `_BUILD_TIMEOUT`, and its three subprocess calls all pass one. **The convention existed and these two silently did not follow it** — which is the drift a structural assertion catches and a point fix does not. Same reasoning as #1454.

`test_frontend_subprocess_timeouts.py` walks all five frontend packages by AST and fails on any `run(...)` without a `timeout`. It matches the `run` attribute rather than `subprocess.run` specifically, so a `from subprocess import run` is still seen; over-reporting is the safe direction, since a false positive costs one explicit timeout and a false negative costs an unbounded hang.

Two controls, so it cannot pass vacuously:

- the scan reaches the frontend packages (an empty walk and a clean tree are otherwise indistinguishable);
- the detector fires on unbounded calls (`subprocess.run(...)` and bare `run(...)`) and stays quiet on bounded ones.

## Values

Follow the existing convention: **300s** for `go build`, **600s** for `dotnet build` (which restores packages), both below the established `_RUN_TIMEOUT` of 900s.

## Not included

CodeRabbit also flagged that the Go path applies facts from earlier module anchors when a later anchor times out — a graph built from a partial fact set with no record that it was partial. That is the same silent-smaller-than-truth shape as #1447, #1453 and #1460, and it is tracked in #1462's remaining acceptance criteria rather than fixed here, since discarding partial facts is a behaviour change that deserves its own review.

## Verification

Full unit suite: **8041 passed**, 121 skipped, zero failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented C# and Go frontend builds from blocking indefinitely by enforcing build time limits.
  * When a build times out, indexing now records the failure and can fall back to tree-sitter processing.
  * Improved resilience during indexing when frontend tools fail or exceed their allotted build time.

* **Tests**
  * Added checks to ensure frontend subprocess operations consistently use bounded timeouts.
  * Verified successful builds continue to complete normally while timed-out builds fail gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->