### PR TITLE
feat: record per-module frontend degradation instead of hiding it

### DIFF
--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -85,6 +85,11 @@ GO_FRONTEND_PARSE_FAILED = (
     "stdout: {stdout}\nstderr: {stderr}"
 )
 GO_FRONTEND_RUN_FAILED = "Go frontend tool did not finish ({error}); using tree-sitter"
+GO_FRONTEND_ANCHOR_DEGRADED = (
+    "Go frontend tool failed for module anchor {anchor}; that module falls back "
+    "to tree-sitter while the others keep their compiler facts. Recorded in "
+    "degraded_modules so the mixture is not silent."
+)
 GO_FRONTEND_NO_FACTS = (
     "Go frontend produced no facts; every join falls back to tree-sitter. "
     "Tool diagnostics:\n{stderr}"

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -195,22 +195,29 @@ def _build_tool(go: str) -> Path | None:
     return binary if _binary_fresh(binary) else None
 
 
-def _parse_payload(stdout: str, stderr: str = "") -> GoSemanticFacts:
+def _parse_payload(stdout: str, stderr: str = "") -> GoSemanticFacts | None:
+    """Facts from one tool run, or None when the OUTPUT was unusable.
+
+    None rather than empty facts for every failure path below: empty facts is
+    the correct answer for a module the tool analysed and found nothing in, so
+    reusing it for a contract violation makes the two indistinguishable and the
+    degradation invisible (issue #1462).
+    """
     lines = [line for line in stdout.splitlines() if line.strip()]
     if not lines:
         # No output at all: the tool crashed before printing its JSON line.
         logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
-        return _empty_facts()
+        return None
     try:
         payload = json.loads(lines[-1])
     except json.JSONDecodeError:
         logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
-        return _empty_facts()
+        return None
     if not isinstance(payload, dict):
         # Well-formed JSON of the wrong shape (a list or scalar): treat as a
         # tool contract violation and fall back rather than crash indexing.
         logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
-        return _empty_facts()
+        return None
     try:
         facts = GoSemanticFacts(
             call_sites={
@@ -244,7 +251,7 @@ def _parse_payload(stdout: str, stderr: str = "") -> GoSemanticFacts:
         # A malformed fact entry (missing key, non-int position, non-object
         # row) must degrade to tree-sitter, never abort the whole index run.
         logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
-        return _empty_facts()
+        return None
     if (
         not facts.call_sites
         and not facts.external_sites
@@ -321,6 +328,14 @@ def _run_tool_once(binary: Path, module_root: Path) -> GoSemanticFacts | None:
         )
     except (subprocess.SubprocessError, OSError) as error:
         logger.warning(ls.GO_FRONTEND_RUN_FAILED.format(error=error))
+        return None
+    if proc.returncode != 0:
+        # The tool's own exit code was never consulted, so a crashed run whose
+        # stdout happened to parse -- or was simply empty -- looked exactly
+        # like a module with nothing to report (issue #1462).
+        logger.warning(
+            ls.GO_FRONTEND_RUN_FAILED.format(error=f"exit {proc.returncode}")
+        )
         return None
     return _parse_payload(proc.stdout, proc.stderr)
 

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -65,6 +65,20 @@ class GoSemanticFacts(NamedTuple):
     # First-party concrete-type -> first-party interface pairs the compiler
     # proved; the only source of Go IMPLEMENTS edges (no syntactic base list).
     implements: list[GoImplements]
+    # Module anchors whose tool run FAILED (timeout, crash, unparseable
+    # output). A failed anchor drops only its own module to the heuristics,
+    # which is deliberate -- one wedged build must not blind a ten-module repo
+    # -- but the degradation has to be recorded or it is invisible: a module
+    # the tool never analysed is otherwise indistinguishable from one it
+    # analysed and found nothing in, and the graph ends up compiler-accurate
+    # for some modules and heuristic for others with nothing saying which
+    # (issue #1462). Empty on a fully successful run, so a reader can trust it.
+    #
+    # A TUPLE, not a list, and that is why it can carry a default at all: a
+    # NamedTuple default is one shared object, so a mutable `[]` would alias
+    # across every run that omitted it -- the aliasing `_empty_facts` exists to
+    # avoid. An empty tuple is immutable and safe to share.
+    degraded_modules: tuple[str, ...] = ()
 
 
 def _empty_facts() -> GoSemanticFacts:
@@ -284,7 +298,14 @@ def _prefix_facts(facts: GoSemanticFacts, prefix: str) -> GoSemanticFacts:
     )
 
 
-def _run_tool_once(binary: Path, module_root: Path) -> GoSemanticFacts:
+def _run_tool_once(binary: Path, module_root: Path) -> GoSemanticFacts | None:
+    """Facts for one module anchor, or None when the tool run FAILED.
+
+    None rather than empty facts, because they are different facts and the
+    caller must tell them apart: a module the tool analysed and found nothing
+    in yields empty facts and is fine, while a timed-out or crashed run means
+    that module was never analysed at all (issue #1462).
+    """
     try:
         proc = subprocess.run(
             [str(binary), str(module_root)],
@@ -300,7 +321,7 @@ def _run_tool_once(binary: Path, module_root: Path) -> GoSemanticFacts:
         )
     except (subprocess.SubprocessError, OSError) as error:
         logger.warning(ls.GO_FRONTEND_RUN_FAILED.format(error=error))
-        return _empty_facts()
+        return None
     return _parse_payload(proc.stdout, proc.stderr)
 
 
@@ -316,10 +337,20 @@ def run_go_frontend(repo_path: Path) -> GoSemanticFacts:
         logger.warning(ls.GO_FRONTEND_BUILD_FAILED.format(stderr=""))
         return _empty_facts()
     merged = _empty_facts()
+    degraded: list[str] = []
     for anchor in anchors:
         prefix = "" if anchor == repo_path else anchor.relative_to(repo_path).as_posix()
-        facts = _prefix_facts(_run_tool_once(binary, anchor), prefix)
+        raw = _run_tool_once(binary, anchor)
+        if raw is None:
+            # This module drops to the heuristics, and the others keep their
+            # compiler facts -- one wedged build must not blind a ten-module
+            # repo. Recording it is what stops that degradation being
+            # invisible (issue #1462).
+            degraded.append(prefix or ".")
+            logger.warning(ls.GO_FRONTEND_ANCHOR_DEGRADED.format(anchor=anchor))
+            continue
+        facts = _prefix_facts(raw, prefix)
         merged.call_sites.update(facts.call_sites)
         merged.external_sites.update(facts.external_sites)
         merged.implements.extend(facts.implements)
-    return merged
+    return merged._replace(degraded_modules=tuple(degraded))

--- a/codebase_rag/tests/test_go_frontend.py
+++ b/codebase_rag/tests/test_go_frontend.py
@@ -109,11 +109,13 @@ def test_parse_payload_without_sections_yields_empty_facts() -> None:
     assert facts.implements == []
 
 
-def test_parse_payload_non_json_yields_empty_facts() -> None:
-    facts = _parse_payload("panic: boom\n")
-    assert facts.call_sites == {}
-    assert facts.external_sites == set()
-    assert facts.implements == []
+def test_parse_payload_non_json_signals_failure() -> None:
+    # None, not empty facts: empty is the answer for a module the tool
+    # analysed and found nothing in, so reusing it for a contract violation
+    # made the two indistinguishable and the degradation invisible (#1462).
+    # The behaviour this originally guarded -- degrade rather than crash --
+    # is unchanged; only the signal is now distinguishable.
+    assert _parse_payload("panic: boom\n") is None
 
 
 def test_go_frontend_is_registered() -> None:

--- a/codebase_rag/tests/test_go_frontend_degradation_visible.py
+++ b/codebase_rag/tests/test_go_frontend_degradation_visible.py
@@ -129,3 +129,62 @@ def test_a_module_with_no_facts_is_not_recorded_as_degraded(
     facts = run_go_frontend(repo)
 
     assert not facts.degraded_modules, facts.degraded_modules
+
+
+def test_a_crashed_tool_is_recorded_as_degraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-zero exit is a failure, not an empty result.
+
+    The tool's own exit code was never checked, so a crashed run whose stdout
+    happened to parse -- or was simply empty -- looked exactly like a module
+    with nothing to report.
+    """
+    repo = _two_module_repo(tmp_path)
+    _patch_toolchain(monkeypatch)
+
+    def _run(cmd, **_kwargs):
+        if Path(cmd[1]) == repo:
+            return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom")
+        return subprocess.CompletedProcess(cmd, 0, stdout=_PAYLOAD, stderr="")
+
+    monkeypatch.setattr(fe.subprocess, "run", _run)
+
+    facts = run_go_frontend(repo)
+
+    assert facts.degraded_modules, "a crashed tool left no record"
+    assert facts.call_sites, "the surviving module's facts were discarded"
+
+
+@pytest.mark.parametrize(
+    ("stdout", "why"),
+    [
+        ("", "no output at all"),
+        ("not json at all", "unparseable JSON"),
+        ("[1, 2, 3]", "well-formed JSON of the wrong shape"),
+        ('{"calls": [{"file": "s.go"}]}', "a malformed fact entry"),
+    ],
+)
+def test_every_parse_failure_is_recorded_as_degraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, stdout: str, why: str
+) -> None:
+    """Each parse-failure path must degrade visibly, not silently.
+
+    All four returned empty facts, which is the answer for a module that was
+    analysed and had nothing -- so a tool contract violation was indingishable
+    from a quiet success. Parametrised because they are separate returns and
+    fixing one would otherwise leave the rest silent.
+    """
+    repo = _two_module_repo(tmp_path)
+    _patch_toolchain(monkeypatch)
+
+    def _run(cmd, **_kwargs):
+        if Path(cmd[1]) == repo:
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout=_PAYLOAD, stderr="")
+
+    monkeypatch.setattr(fe.subprocess, "run", _run)
+
+    facts = run_go_frontend(repo)
+
+    assert facts.degraded_modules, f"{why} left no record"

--- a/codebase_rag/tests/test_go_frontend_degradation_visible.py
+++ b/codebase_rag/tests/test_go_frontend_degradation_visible.py
@@ -1,0 +1,131 @@
+# A per-module tool failure must be VISIBLE, not merely survivable (#1462).
+#
+# `run_go_frontend` merges facts across every Go module anchor, and a failed
+# anchor drops only its own module to the heuristics -- a deliberate choice
+# (test_go_frontend.py::test_one_failing_module_degrades_only_itself), and the
+# right one: a repo with ten modules and one wedged build should not lose the
+# other nine.
+#
+# What was missing is the record. `_run_tool_once` returned `_empty_facts()` on
+# failure, which is indistinguishable from "this module genuinely has no facts
+# to report", so the resulting graph was compiler-accurate for some modules and
+# heuristic for others with nothing saying which.
+#
+# That is the same distinction the protocol already draws correctly for call
+# sites: `external_sites` exists so "resolved to nothing" and "not analysed"
+# are different facts. This applies it at the module level.
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import codebase_rag.parsers.go_frontend.frontend as fe
+from codebase_rag.parsers.go_frontend import run_go_frontend
+
+_PAYLOAD = json.dumps(
+    {
+        "calls": [
+            {
+                "file": "s.go",
+                "line": 3,
+                "col": 1,
+                "name": "Helper",
+                "tfile": "s.go",
+                "tline": 9,
+                "tcol": 5,
+            }
+        ],
+        "external": [],
+        "implements": [],
+    }
+)
+
+
+def _two_module_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "sub").mkdir(parents=True)
+    (repo / "go.mod").write_text("module example.com/root\n\ngo 1.22\n")
+    (repo / "sub" / "go.mod").write_text("module example.com/sub\n\ngo 1.22\n")
+    return repo
+
+
+def _patch_toolchain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fe.shutil, "which", lambda _name: "/usr/bin/go")
+    monkeypatch.setattr(fe, "_build_tool", lambda _go: Path("/fake/gotypes"))
+
+
+def test_a_failed_anchor_is_recorded_in_the_facts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The surviving module's facts must carry the fact that one module did not.
+
+    Without this, a consumer cannot tell a repository where every module was
+    analysed from one where half the tool runs timed out, and a query that
+    returns fewer results looks like a correct answer about a smaller
+    codebase.
+    """
+    repo = _two_module_repo(tmp_path)
+    _patch_toolchain(monkeypatch)
+
+    def _run(cmd, **_kwargs):
+        if Path(cmd[1]) == repo:
+            raise subprocess.TimeoutExpired(cmd, 1)
+        return subprocess.CompletedProcess(cmd, 0, stdout=_PAYLOAD, stderr="")
+
+    monkeypatch.setattr(fe.subprocess, "run", _run)
+
+    facts = run_go_frontend(repo)
+
+    assert facts.degraded_modules, "a failed anchor left no record"
+    assert facts.call_sites, "the surviving module's facts were discarded"
+
+
+def test_a_fully_successful_run_records_no_degradation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The paired control, and the one that gives the field meaning.
+
+    A field that is always populated says nothing. Asserting only that it is
+    non-empty on failure would pass against an implementation that marked
+    every run degraded.
+    """
+    repo = _two_module_repo(tmp_path)
+    _patch_toolchain(monkeypatch)
+
+    monkeypatch.setattr(
+        fe.subprocess,
+        "run",
+        lambda cmd, **_k: subprocess.CompletedProcess(
+            cmd, 0, stdout=_PAYLOAD, stderr=""
+        ),
+    )
+
+    facts = run_go_frontend(repo)
+
+    assert not facts.degraded_modules, facts.degraded_modules
+
+
+def test_a_module_with_no_facts_is_not_recorded_as_degraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty is not failure -- the distinction the bug erased.
+
+    A module the tool analysed successfully and found nothing in must not be
+    reported as degraded, or the field becomes noise and stops being read.
+    """
+    repo = _two_module_repo(tmp_path)
+    _patch_toolchain(monkeypatch)
+
+    empty = json.dumps({"calls": [], "external": [], "implements": []})
+    monkeypatch.setattr(
+        fe.subprocess,
+        "run",
+        lambda cmd, **_k: subprocess.CompletedProcess(cmd, 0, stdout=empty, stderr=""),
+    )
+
+    facts = run_go_frontend(repo)
+
+    assert not facts.degraded_modules, facts.degraded_modules


### PR DESCRIPTION
Addresses the partial-facts half of #1462. `Addresses`, not `Fixes` — the timeout half is #1463, and this deliberately does **not** implement the issue as written. Explanation below.

## Why not what the issue asked for

#1462's Fix section says *"discard all facts on failure or timeout"*. I implemented that, and it broke an existing test:

```python
def test_one_failing_module_degrades_only_itself(...):
    # A per-module tool failure (timeout, crash) must drop only that
    # module's facts to tree-sitter; the sibling module's facts survive.
```

`test_go_frontend.py:364`, added in `0dc3ca25`. That comment states intent, and the code matches it. **The issue's remedy would reverse a considered decision** — and the failing test would have looked like a test to update rather than a contract being broken, which is the shape of a bad change.

It is also the better decision on the merits: a repository with ten Go modules and one wedged build should not lose the other nine.

## What the complaint actually points at

The defect was never that degradation is per-module. It is that the degradation was **invisible**.

`_run_tool_once` returned `_empty_facts()` on failure — indistinguishable from *"this module was analysed and had nothing to report"*. So the graph came out compiler-accurate for some modules and heuristic for others, with nothing recording which, and a query returning fewer results looks like a correct answer about a smaller codebase.

`GoSemanticFacts` now carries `degraded_modules`, and `_run_tool_once` returns `None` on failure so the caller can tell the two apart.

This is the same distinction the protocol already draws correctly for call sites: `external_sites` exists so *resolved to nothing* and *not analysed* are different facts, spelled as separate collections rather than one ambiguous value.

## One implementation detail worth review

`degraded_modules` is a **tuple, not a list**, and that is why it can carry a default at all. A `NamedTuple` default is a single shared object, so a mutable `[]` would alias across every run that omitted it — precisely the aliasing `_empty_facts` already exists to avoid:

```python
def _empty_facts() -> GoSemanticFacts:
    # A fresh instance per failure path: the maps are handed to mutable
    # processor state, so a shared constant would alias across runs.
```

## The control is what gives the field meaning

Asserting only *"non-empty on failure"* would pass against an implementation that marked **every** run degraded. So:

1. a failed anchor is recorded **and** the surviving module keeps its facts;
2. a fully successful run records **nothing**;
3. a module analysed successfully with no facts is **not** reported as degraded — empty is not failure, which is the distinction the bug erased.

## Verification

All **21** pre-existing Go tests pass, including the one whose contract this preserves. Full unit suite: **8041 passed**, 121 skipped, zero failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Go code analysis now continues when individual modules cannot be analyzed.
  * Results from successfully analyzed modules are preserved instead of being discarded.
  * Modules analyzed without findings are no longer incorrectly reported as degraded.
* **Diagnostics**
  * Added clearer diagnostic information when analysis falls back to an alternate parser for specific modules.
  * Degraded modules are now recorded for improved visibility into partial analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->