### PR TITLE
fix: fingerprint external tool versions, not just the frontend mode

### DIFF
--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -5,6 +5,8 @@
 # grammar wheel versions, and the frontend settings, so a sync can detect the
 # graph was built by a different parser or frontend config.
 import hashlib
+import shutil
+import subprocess
 from importlib import metadata
 from pathlib import Path
 
@@ -14,6 +16,32 @@ from . import constants as cs
 from . import logs as ls
 
 _FILE_HASH_CHUNK_SIZE = 1024 * 1024
+
+# External toolchains whose VERSION changes what a frontend extracts, as
+# (fingerprint key, executable, version argument). The resolved frontend mode
+# already recorded in `_frontend_settings` says which frontend ran; this says
+# what it knew. A Go release with better inference, a Roslyn update resolving
+# an overload differently, or a javac that models a new language feature all
+# change the emitted edges while the mode string is identical (issue #1465).
+#
+# `LOMBOK=` in `_frontend_settings` is the same idea applied to one tool, and
+# is left where it is rather than moved here: it is read from a jar rather
+# than probed by running anything.
+_VERSIONED_TOOLS: tuple[tuple[str, str, str], ...] = (
+    ("GO_VERSION", "go", "version"),
+    ("JAVAC_VERSION", "javac", "-version"),
+    ("DOTNET_VERSION", "dotnet", "--version"),
+)
+
+# Bounded because this runs on every index. A tool that cannot be probed
+# within it cannot be doing useful work either, so the timeout and a missing
+# binary reach the same answer.
+_VERSION_PROBE_TIMEOUT = 10.0
+
+# A toolchain that DISAPPEARED changes extraction as much as one that moved,
+# so absence is recorded rather than omitted -- and it must not collide with
+# any real version string.
+_TOOL_ABSENT = "absent"
 
 
 def _digest_file(path: Path) -> str:
@@ -25,6 +53,51 @@ def _digest_file(path: Path) -> str:
         while chunk := stream.read(_FILE_HASH_CHUNK_SIZE):
             hasher.update(chunk)
     return hasher.hexdigest()
+
+
+def _probe_version(executable: str, argument: str) -> str:
+    """One tool's version string, or `absent` when it cannot be determined.
+
+    Never raises: the fingerprint is computed on every index, so a probe that
+    escaped would turn a missing or wedged toolchain into a failed run. Some
+    tools print their version on stderr (javac before 9), so both streams are
+    considered.
+    """
+    binary = shutil.which(executable)
+    if binary is None:
+        return _TOOL_ABSENT
+    try:
+        proc = subprocess.run(
+            [binary, argument],
+            capture_output=True,
+            text=True,
+            encoding=cs.ENCODING_UTF8,
+            check=False,
+            timeout=_VERSION_PROBE_TIMEOUT,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return _TOOL_ABSENT
+    if proc.returncode != 0:
+        return _TOOL_ABSENT
+    output = (proc.stdout or proc.stderr or "").strip()
+    # First line only: `dotnet --version` is one line, but `go version` and
+    # `javac -version` can carry extra lines on some installs, and a
+    # multi-line value would make the fingerprint sensitive to noise.
+    return output.splitlines()[0].strip() if output else _TOOL_ABSENT
+
+
+def _tool_versions() -> list[str]:
+    """`KEY=version` for each external toolchain, in a stable order.
+
+    Stable order matters as much as the values: the entries are hashed in
+    sequence, so a set or a dict iteration order would make the fingerprint
+    change without the toolchain changing, which invalidates the cache always
+    and costs more than never invalidating it.
+    """
+    return [
+        f"{key}={_probe_version(executable, argument)}"
+        for key, executable, argument in _VERSIONED_TOOLS
+    ]
 
 
 def compute_parser_fingerprint(
@@ -44,6 +117,12 @@ def compute_parser_fingerprint(
     # INHERITS/IMPLEMENTS), so it is part of the parser identity and must
     # trip the staleness warning.
     for entry in _frontend_settings():
+        hasher.update(entry.encode())
+    # The mode above says WHICH frontend ran; these say what it knew. A
+    # compiler upgrade changes the emitted edges with the mode unchanged, so
+    # without this an incremental run reuses a graph the older tool produced
+    # (issue #1465).
+    for entry in _tool_versions():
         hasher.update(entry.encode())
     return hasher.hexdigest()
 

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -7,6 +7,7 @@
 import hashlib
 import shutil
 import subprocess
+from collections.abc import Callable
 from importlib import metadata
 from pathlib import Path
 
@@ -92,29 +93,53 @@ def _probe_version(executable: str, argument: str) -> str:
     return output.splitlines()[0].strip() if output else _TOOL_ABSENT
 
 
-def _active_tools() -> dict[str, bool]:
-    """Whether each tool's frontend is resolved to a mode that USES it.
+def _active_tools(repo_path: Path | None = None) -> dict[str, bool]:
+    """Whether each tool can participate in extraction for THIS repository.
 
-    A tool no frontend can use contributes nothing to extraction, so hashing
-    its version invalidates the graph for a change that cannot affect it --
-    false staleness, which costs more than the drift the version was added to
-    catch (issue #1465 review). Imported lazily, as `_frontend_settings` does,
-    to keep this module free of the parsers package at import time.
+    Two gates, and both are needed. The resolved frontend mode says the
+    frontend could run at all; the repository markers say it can run *here*.
+    Go resolves to `gotypes` whenever a go toolchain exists, so without the
+    second gate a Go upgrade invalidates the graph of a Python-only repo it
+    can extract nothing from -- false staleness, which costs more than the
+    drift the versions were added to catch (issue #1465 review).
+
+    A repo-less call keeps mode gating only, matching `_repo_frontend_inputs`:
+    those callers have no repository to ask, and reporting everything inactive
+    would make their fingerprint disagree with a repo-scoped one for the same
+    toolchain.
+
+    Imported lazily, as `_frontend_settings` does, to keep this module free of
+    the parsers package at import time.
     """
-    from .parsers.csharp_frontend import resolve_csharp_frontend
-    from .parsers.go_frontend import resolve_go_frontend
+    from .parsers.csharp_frontend import find_csharp_project, resolve_csharp_frontend
+    from .parsers.go_frontend import find_go_module, resolve_go_frontend
     from .parsers.java_frontend import resolve_java_frontend
 
+    def _in_repo(probe: Callable[[Path], object | None]) -> bool:
+        # No repository to ask: fall back to mode gating alone rather than
+        # declaring the tool inactive. A probe that raises on a malformed
+        # tree must not abort a fingerprint computed on every index.
+        if repo_path is None:
+            return True
+        try:
+            return probe(repo_path) is not None
+        except OSError:
+            return True
+
     return {
-        "GO_VERSION": resolve_go_frontend() is not cs.GoFrontend.TREESITTER,
+        "GO_VERSION": (
+            resolve_go_frontend() is not cs.GoFrontend.TREESITTER
+            and _in_repo(find_go_module)
+        ),
         "JAVAC_VERSION": resolve_java_frontend() is not cs.JavaFrontend.HEURISTIC,
         "DOTNET_VERSION": (
             resolve_csharp_frontend() is not cs.CSharpFrontend.TREESITTER
+            and _in_repo(find_csharp_project)
         ),
     }
 
 
-def _tool_versions() -> list[str]:
+def _tool_versions(repo_path: Path | None = None) -> list[str]:
     """`KEY=version` for each ACTIVE external toolchain, in a stable order.
 
     Stable order matters as much as the values: the entries are hashed in
@@ -127,7 +152,7 @@ def _tool_versions() -> list[str]:
     those are different states: turning a frontend off changes what is
     extracted and must still trip the warning.
     """
-    active = _active_tools()
+    active = _active_tools(repo_path)
     return [
         f"{key}={_probe_version(executable, argument) if active.get(key) else _TOOL_INACTIVE}"
         for key, executable, argument in _VERSIONED_TOOLS
@@ -156,7 +181,7 @@ def compute_parser_fingerprint(
     # compiler upgrade changes the emitted edges with the mode unchanged, so
     # without this an incremental run reuses a graph the older tool produced
     # (issue #1465).
-    for entry in _tool_versions():
+    for entry in _tool_versions(repo_path):
         hasher.update(entry.encode())
     return hasher.hexdigest()
 

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -43,6 +43,12 @@ _VERSION_PROBE_TIMEOUT = 10.0
 # any real version string.
 _TOOL_ABSENT = "absent"
 
+# Recorded when the tool's frontend is resolved to a mode that cannot use it.
+# Distinct from `absent`: a tool that is installed but unused and one that is
+# missing entirely are different states, and switching a frontend off changes
+# what is extracted just as much as removing its toolchain.
+_TOOL_INACTIVE = "inactive"
+
 
 def _digest_file(path: Path) -> str:
     # compile_commands.json is repository-controlled and can be very large,
@@ -86,16 +92,44 @@ def _probe_version(executable: str, argument: str) -> str:
     return output.splitlines()[0].strip() if output else _TOOL_ABSENT
 
 
+def _active_tools() -> dict[str, bool]:
+    """Whether each tool's frontend is resolved to a mode that USES it.
+
+    A tool no frontend can use contributes nothing to extraction, so hashing
+    its version invalidates the graph for a change that cannot affect it --
+    false staleness, which costs more than the drift the version was added to
+    catch (issue #1465 review). Imported lazily, as `_frontend_settings` does,
+    to keep this module free of the parsers package at import time.
+    """
+    from .parsers.csharp_frontend import resolve_csharp_frontend
+    from .parsers.go_frontend import resolve_go_frontend
+    from .parsers.java_frontend import resolve_java_frontend
+
+    return {
+        "GO_VERSION": resolve_go_frontend() is not cs.GoFrontend.TREESITTER,
+        "JAVAC_VERSION": resolve_java_frontend() is not cs.JavaFrontend.HEURISTIC,
+        "DOTNET_VERSION": (
+            resolve_csharp_frontend() is not cs.CSharpFrontend.TREESITTER
+        ),
+    }
+
+
 def _tool_versions() -> list[str]:
-    """`KEY=version` for each external toolchain, in a stable order.
+    """`KEY=version` for each ACTIVE external toolchain, in a stable order.
 
     Stable order matters as much as the values: the entries are hashed in
     sequence, so a set or a dict iteration order would make the fingerprint
     change without the toolchain changing, which invalidates the cache always
     and costs more than never invalidating it.
+
+    An inactive tool is recorded as `inactive` rather than omitted. Omitting
+    it would make "tool absent" and "frontend disabled" hash identically, and
+    those are different states: turning a frontend off changes what is
+    extracted and must still trip the warning.
     """
+    active = _active_tools()
     return [
-        f"{key}={_probe_version(executable, argument)}"
+        f"{key}={_probe_version(executable, argument) if active.get(key) else _TOOL_INACTIVE}"
         for key, executable, argument in _VERSIONED_TOOLS
     ]
 

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -153,10 +153,13 @@ def _tool_versions(repo_path: Path | None = None) -> list[str]:
     extracted and must still trip the warning.
     """
     active = _active_tools(repo_path)
-    return [
-        f"{key}={_probe_version(executable, argument) if active.get(key) else _TOOL_INACTIVE}"
-        for key, executable, argument in _VERSIONED_TOOLS
-    ]
+    entries: list[str] = []
+    for key, executable, argument in _VERSIONED_TOOLS:
+        value = (
+            _probe_version(executable, argument) if active.get(key) else _TOOL_INACTIVE
+        )
+        entries.append(f"{key}={value}")
+    return entries
 
 
 def compute_parser_fingerprint(

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -126,6 +126,23 @@ def _active_tools(repo_path: Path | None = None) -> dict[str, bool]:
         except OSError:
             return True
 
+    # The probes below are DELIBERATELY the same predicates the frontends use
+    # in their own `applies()` (`frontends/go.py`, `frontends/csharp.py`), so
+    # "tool active" means exactly "this frontend will run against this repo".
+    # That identity is the point, not a coincidence: a fingerprint describes
+    # what produced the graph, so any divergence from the thing that produced
+    # it is a bug by construction.
+    #
+    # Do NOT tighten one side alone. Requiring matching source files here --
+    # a `go.mod` with no `.go` files, say -- looks safe and is the inverse
+    # defect: the frontend still runs, so a toolchain upgrade before someone
+    # adds the first `.go` file would go unrecorded and that file would be
+    # indexed by a compiler the fingerprint does not name. False staleness
+    # costs a re-index; missed staleness costs a silently wrong graph.
+    #
+    # The source-file question is already answered a layer up: the updater
+    # gates on the files it actually parsed, which is why `applies()` only
+    # asks about project markers (see the comment in `frontends/python.py`).
     return {
         "GO_VERSION": (
             resolve_go_frontend() is not cs.GoFrontend.TREESITTER

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -62,13 +62,20 @@ def _digest_file(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def _probe_version(executable: str, argument: str) -> str:
+def _probe_version(executable: str, argument: str, cwd: Path | None = None) -> str:
     """One tool's version string, or `absent` when it cannot be determined.
 
     Never raises: the fingerprint is computed on every index, so a probe that
     escaped would turn a missing or wedged toolchain into a failed run. Some
     tools print their version on stderr (javac before 9), so both streams are
     considered.
+
+    Run from `cwd` when one is given, because Go and .NET SELECT a toolchain
+    from the working directory: a `go.work` or `global.json` can pin a
+    different version, so the same command answers differently depending on
+    where it runs. Probing from the caller's directory would record a
+    toolchain the indexed repository never uses. `None` inherits the caller's
+    cwd rather than inventing one.
     """
     binary = shutil.which(executable)
     if binary is None:
@@ -81,6 +88,7 @@ def _probe_version(executable: str, argument: str) -> str:
             encoding=cs.ENCODING_UTF8,
             check=False,
             timeout=_VERSION_PROBE_TIMEOUT,
+            cwd=None if cwd is None else str(cwd),
         )
     except (subprocess.SubprocessError, OSError):
         return _TOOL_ABSENT
@@ -173,7 +181,9 @@ def _tool_versions(repo_path: Path | None = None) -> list[str]:
     entries: list[str] = []
     for key, executable, argument in _VERSIONED_TOOLS:
         value = (
-            _probe_version(executable, argument) if active.get(key) else _TOOL_INACTIVE
+            _probe_version(executable, argument, repo_path)
+            if active.get(key)
+            else _TOOL_INACTIVE
         )
         entries.append(f"{key}={value}")
     return entries

--- a/codebase_rag/tests/test_fingerprint_tool_versions.py
+++ b/codebase_rag/tests/test_fingerprint_tool_versions.py
@@ -129,3 +129,54 @@ def test_an_inactive_tool_version_does_not_change_the_fingerprint() -> None:
         active_second = pf.compute_parser_fingerprint()
 
     assert active_first != active_second, "an ACTIVE tool's version was ignored"
+
+
+def test_a_tool_is_inactive_when_the_repo_cannot_use_it(tmp_path) -> None:
+    """A Python-only repo must not be invalidated by a Go upgrade.
+
+    Gating on the resolved frontend MODE is not enough: Go resolves to
+    `gotypes` whenever a go toolchain exists, regardless of whether the
+    indexed repository contains a single `go.mod`. Upgrading Go then
+    invalidates the graph of a repo it can extract nothing from.
+
+    Same false-staleness failure as the inactive-mode case, one level down --
+    the mode says the frontend COULD run, `applies()` says whether it can run
+    HERE.
+    """
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    active = pf._active_tools(tmp_path)
+
+    assert not active["GO_VERSION"], "Go counted for a repo with no go.mod"
+    assert not active["DOTNET_VERSION"], "dotnet counted for a repo with no project"
+
+
+def test_a_tool_is_active_when_the_repo_does_use_it(tmp_path) -> None:
+    """The paired control: a repo that DOES contain the language still counts.
+
+    Without it, an implementation that reported every tool inactive would pass
+    the test above and silently stop detecting real toolchain upgrades.
+    """
+    (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.23\n", encoding="utf-8")
+
+    with patch(
+        "codebase_rag.parsers.go_frontend.resolve_go_frontend",
+        return_value=__import__(
+            "codebase_rag.constants", fromlist=["GoFrontend"]
+        ).GoFrontend.GOTYPES,
+    ):
+        active = pf._active_tools(tmp_path)
+
+    assert active["GO_VERSION"], "Go ignored for a repo that has a go.mod"
+
+
+def test_a_repo_less_call_keeps_mode_gating_only(tmp_path) -> None:
+    """`compute_parser_fingerprint()` is called without a repo in places.
+
+    Those calls must stay stable rather than reporting everything inactive,
+    which would make a repo-less fingerprint disagree with a repo-scoped one
+    for the same toolchain.
+    """
+    assert set(pf._active_tools(None)) == {
+        key for key, _exe, _arg in pf._VERSIONED_TOOLS
+    }

--- a/codebase_rag/tests/test_fingerprint_tool_versions.py
+++ b/codebase_rag/tests/test_fingerprint_tool_versions.py
@@ -1,0 +1,77 @@
+# External tool versions belong in the parser fingerprint (issue #1465).
+#
+# The fingerprint exists so a change to what cgr can EXTRACT invalidates the
+# incremental graph. It recorded the resolved frontend mode -- which frontend
+# ran -- but not the version of the tool that frontend drives, which is what
+# it knew. A Go release with better inference, a Roslyn update resolving an
+# overload differently, a libclang that expands a macro it previously could
+# not: each changes the emitted edges while `GO_FRONTEND=gotypes` is identical.
+#
+# `LOMBOK=` was already in the list, so the file agreed with the principle for
+# one tool and simply did not apply it to the others.
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from codebase_rag import parser_fingerprint as pf
+
+_PROBES = "codebase_rag.parser_fingerprint._tool_versions"
+
+
+def test_a_tool_version_change_changes_the_fingerprint() -> None:
+    """Upgrading a compiler must not silently reuse the old graph.
+
+    Asserting the two differ is the whole contract: an incremental run whose
+    fingerprint matches skips the work, so an unchanged fingerprint means the
+    new compiler's output never reaches the graph.
+    """
+    with patch(_PROBES, return_value=["GO_VERSION=go1.22.0"]):
+        before = pf.compute_parser_fingerprint()
+    with patch(_PROBES, return_value=["GO_VERSION=go1.23.0"]):
+        after = pf.compute_parser_fingerprint()
+
+    assert before != after
+
+
+def test_the_fingerprint_is_stable_for_an_unchanged_toolchain() -> None:
+    """The control, and the failure mode that is worse than the bug.
+
+    A fingerprint that changes every run invalidates the cache always, which
+    costs more than never invalidating it. Asserting only that versions change
+    the hash would pass against an implementation that hashed a timestamp.
+    """
+    with patch(_PROBES, return_value=["GO_VERSION=go1.22.0"]):
+        first = pf.compute_parser_fingerprint()
+        second = pf.compute_parser_fingerprint()
+
+    assert first == second
+
+
+def test_an_absent_toolchain_is_distinguishable_from_any_version() -> None:
+    """A toolchain that disappears changes extraction as much as one that moves.
+
+    `absent` must not collide with a version string, or removing a compiler
+    reuses the graph it built.
+    """
+    with patch(_PROBES, return_value=["GO_VERSION=absent"]):
+        without = pf.compute_parser_fingerprint()
+    with patch(_PROBES, return_value=["GO_VERSION=go1.22.0"]):
+        with_go = pf.compute_parser_fingerprint()
+
+    assert without != with_go
+
+
+def test_a_probe_failure_degrades_rather_than_raising() -> None:
+    """The fingerprint is computed on every index; a probe must never abort it.
+
+    A tool that cannot be probed cannot be running, so its absence is the
+    honest answer -- but it has to be reached without an exception escaping.
+    """
+    with patch(
+        "codebase_rag.parser_fingerprint.subprocess.run",
+        side_effect=OSError("no such tool"),
+    ):
+        versions = pf._tool_versions()
+
+    assert versions, "no version entries produced"
+    assert all(entry.endswith("=absent") for entry in versions), versions

--- a/codebase_rag/tests/test_fingerprint_tool_versions.py
+++ b/codebase_rag/tests/test_fingerprint_tool_versions.py
@@ -182,3 +182,38 @@ def test_a_repo_less_call_keeps_mode_gating_only(tmp_path) -> None:
     assert set(pf._active_tools(None)) == {
         key for key, _exe, _arg in pf._VERSIONED_TOOLS
     }
+
+
+def test_the_fingerprint_uses_the_frontends_own_applicability_predicate(
+    tmp_path,
+) -> None:
+    """The fingerprint and `applies()` must agree, and stay agreed.
+
+    A fingerprint describes what produced the graph, so it has to gate on the
+    same question the graph builder asks before running a frontend. The two
+    predicates being identical is deliberate, and a comment saying so is not
+    checkable -- this is.
+
+    Tightening one side alone looks safe and is the inverse defect: a `go.mod`
+    with no `.go` files would report the tool inactive while the frontend still
+    runs, so a toolchain upgrade before the first `.go` file appears goes
+    unrecorded. False staleness costs a re-index; missed staleness costs a
+    silently wrong graph.
+    """
+    from codebase_rag import constants as cs
+    from codebase_rag.parsers.frontends import FRONTENDS
+
+    (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.23\n")
+
+    go_frontend = FRONTENDS[cs.SupportedLanguage.GO]
+    with patch(
+        "codebase_rag.parsers.go_frontend.resolve_go_frontend",
+        return_value=cs.GoFrontend.GOTYPES,
+    ):
+        fingerprint_says = pf._active_tools(tmp_path)["GO_VERSION"]
+
+    assert fingerprint_says is go_frontend.applies(tmp_path), (
+        "the fingerprint's activity predicate diverged from GoFrontend.applies(); "
+        "they must answer the same question or the fingerprint describes a "
+        "different run than the one that happened"
+    )

--- a/codebase_rag/tests/test_fingerprint_tool_versions.py
+++ b/codebase_rag/tests/test_fingerprint_tool_versions.py
@@ -67,11 +67,65 @@ def test_a_probe_failure_degrades_rather_than_raising() -> None:
     A tool that cannot be probed cannot be running, so its absence is the
     honest answer -- but it has to be reached without an exception escaping.
     """
-    with patch(
-        "codebase_rag.parser_fingerprint.subprocess.run",
-        side_effect=OSError("no such tool"),
+    all_active = dict.fromkeys((key for key, _exe, _arg in pf._VERSIONED_TOOLS), True)
+    with (
+        patch.object(pf, "_active_tools", return_value=all_active),
+        patch(
+            "codebase_rag.parser_fingerprint.subprocess.run",
+            side_effect=OSError("no such tool"),
+        ),
     ):
         versions = pf._tool_versions()
 
     assert versions, "no version entries produced"
+    # Every tool forced active, so each one is genuinely probed and each probe
+    # raises: `absent` here is the degradation path, not the inactive marker.
     assert all(entry.endswith("=absent") for entry in versions), versions
+
+
+def test_an_inactive_tool_version_does_not_change_the_fingerprint() -> None:
+    """A tool no frontend uses must not invalidate the graph.
+
+    Greptile proved this by execution: with Java resolved to `heuristic` and
+    C# to `treesitter`, neither executable participates in extraction, yet
+    changing their versions changed the fingerprint and tripped the
+    stale-parser warning.
+
+    That is FALSE staleness -- the failure mode the stability control in this
+    file already warns about, arriving through a different door. A fingerprint
+    that changes when nothing relevant changed invalidates the cache for no
+    reason, which costs more than the drift it was added to catch.
+    """
+    # Every tool inactive, so NOTHING is probed and the varied version can only
+    # reach the fingerprint if an inactive tool is being hashed. Leaving one
+    # tool active would change its value too and prove nothing.
+    none_active = dict.fromkeys((key for key, _exe, _arg in pf._VERSIONED_TOOLS), False)
+    with (
+        patch.object(pf, "_active_tools", return_value=none_active),
+        patch.object(pf, "_probe_version", return_value="17.0.1"),
+    ):
+        first = pf.compute_parser_fingerprint()
+    with (
+        patch.object(pf, "_active_tools", return_value=none_active),
+        patch.object(pf, "_probe_version", return_value="21.0.9"),
+    ):
+        second = pf.compute_parser_fingerprint()
+
+    assert first == second, "an inactive tool's version changed the fingerprint"
+
+    # The paired control: with the SAME tools active, the same version change
+    # must change the fingerprint. Without it this test passes against an
+    # implementation that stopped hashing tool versions entirely.
+    all_active = dict.fromkeys((key for key, _e, _a in pf._VERSIONED_TOOLS), True)
+    with (
+        patch.object(pf, "_active_tools", return_value=all_active),
+        patch.object(pf, "_probe_version", return_value="17.0.1"),
+    ):
+        active_first = pf.compute_parser_fingerprint()
+    with (
+        patch.object(pf, "_active_tools", return_value=all_active),
+        patch.object(pf, "_probe_version", return_value="21.0.9"),
+    ):
+        active_second = pf.compute_parser_fingerprint()
+
+    assert active_first != active_second, "an ACTIVE tool's version was ignored"

--- a/codebase_rag/tests/test_fingerprint_tool_versions.py
+++ b/codebase_rag/tests/test_fingerprint_tool_versions.py
@@ -11,6 +11,7 @@
 # one tool and simply did not apply it to the others.
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import patch
 
 from codebase_rag import parser_fingerprint as pf
@@ -217,3 +218,61 @@ def test_the_fingerprint_uses_the_frontends_own_applicability_predicate(
         "they must answer the same question or the fingerprint describes a "
         "different run than the one that happened"
     )
+
+
+def test_version_probes_run_from_the_indexed_repository(tmp_path) -> None:
+    """Go and .NET select a toolchain from the working directory.
+
+    `go.work` (and .NET's `global.json`) can pin a different toolchain, so the
+    same `go version` command answers differently depending on cwd. Verified
+    directly: a clean directory reports the installed 1.26.6, while one with a
+    `go.work` pinning 1.99.0 tries to download that instead.
+
+    Probing from the caller's cwd therefore records a version the indexed
+    repository would never use, and the fingerprint then describes a toolchain
+    that did not produce the graph -- missed staleness, the expensive
+    direction.
+    """
+    (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.23\n")
+
+    seen: list[object] = []
+
+    def _capture(cmd, **kwargs):
+        seen.append(kwargs.get("cwd"))
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="go version go1.23", stderr=""
+        )
+
+    with (
+        patch.object(pf, "_active_tools", return_value={"GO_VERSION": True}),
+        patch.object(pf.subprocess, "run", _capture),
+    ):
+        pf._tool_versions(tmp_path)
+
+    assert seen, "no probe ran"
+    assert all(cwd == str(tmp_path) for cwd in seen), seen
+
+
+def test_a_repo_less_probe_does_not_force_a_working_directory(tmp_path) -> None:
+    """The control: with no repository, the probe must not invent a cwd.
+
+    Passing a bogus directory would be worse than inheriting the caller's, and
+    asserting only the positive case above would pass against an
+    implementation that hardcoded some path.
+    """
+    seen: list[object] = []
+
+    def _capture(cmd, **kwargs):
+        seen.append(kwargs.get("cwd"))
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="go version go1.23", stderr=""
+        )
+
+    with (
+        patch.object(pf, "_active_tools", return_value={"GO_VERSION": True}),
+        patch.object(pf.subprocess, "run", _capture),
+    ):
+        pf._tool_versions(None)
+
+    assert seen, "no probe ran"
+    assert all(cwd is None for cwd in seen), seen

--- a/codebase_rag/tests/test_fingerprint_tool_versions.py
+++ b/codebase_rag/tests/test_fingerprint_tool_versions.py
@@ -245,6 +245,11 @@ def test_version_probes_run_from_the_indexed_repository(tmp_path) -> None:
 
     with (
         patch.object(pf, "_active_tools", return_value={"GO_VERSION": True}),
+        # `_probe_version` calls shutil.which BEFORE subprocess.run, so without
+        # this the probe short-circuits to `absent` on any machine lacking the
+        # toolchain and the capture never fires -- which is why these passed
+        # locally (go installed) and failed on the macOS runner (go absent).
+        patch.object(pf.shutil, "which", return_value="/usr/bin/go"),
         patch.object(pf.subprocess, "run", _capture),
     ):
         pf._tool_versions(tmp_path)
@@ -270,6 +275,11 @@ def test_a_repo_less_probe_does_not_force_a_working_directory(tmp_path) -> None:
 
     with (
         patch.object(pf, "_active_tools", return_value={"GO_VERSION": True}),
+        # `_probe_version` calls shutil.which BEFORE subprocess.run, so without
+        # this the probe short-circuits to `absent` on any machine lacking the
+        # toolchain and the capture never fires -- which is why these passed
+        # locally (go installed) and failed on the macOS runner (go absent).
+        patch.object(pf.shutil, "which", return_value="/usr/bin/go"),
         patch.object(pf.subprocess, "run", _capture),
     ):
         pf._tool_versions(None)

--- a/codebase_rag/tests/test_fingerprint_tool_versions.py
+++ b/codebase_rag/tests/test_fingerprint_tool_versions.py
@@ -157,7 +157,9 @@ def test_a_tool_is_active_when_the_repo_does_use_it(tmp_path) -> None:
     Without it, an implementation that reported every tool inactive would pass
     the test above and silently stop detecting real toolchain upgrades.
     """
-    (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.23\n", encoding="utf-8")
+    (tmp_path / "go.mod").write_text(
+        "module example.com/x\n\ngo 1.23\n", encoding="utf-8"
+    )
 
     with patch(
         "codebase_rag.parsers.go_frontend.resolve_go_frontend",


### PR DESCRIPTION
Fixes #1465, found by CodeRabbit reviewing #1457.

## The defect

`compute_parser_fingerprint` exists so a change to what cgr can **extract** invalidates the incremental graph. It recorded the resolved frontend mode — *which frontend ran* — but not the version of the tool that frontend drives, which is *what it knew*.

Upgrading `go`, `javac` or `dotnet` therefore left the fingerprint unchanged, and the next index reused a graph the older compiler produced. A Go release with better inference, a Roslyn update resolving an overload differently, a javac modelling a new language feature: each changes the emitted edges while `GO_FRONTEND=gotypes` is byte-identical.

Same silent shape as #1447, #1453, #1460 and #1462 — the graph ends up part old-compiler and part new, with nothing recording the mixture.

## Why this is a gap, not a decision

`LOMBOK={current_lombok_version()}` was **already** in `_frontend_settings`. The file agreed with the principle for one tool and simply did not apply it to the other three. Lombok stays where it is: it is read from a jar rather than probed by running anything.

## Two tests guard failure modes worse than the bug

- **Stability.** A fingerprint that changes every run invalidates the cache *always*, which costs more than never invalidating it. Without this control, an implementation that hashed a timestamp would pass the version-change test.
- **`absent` ≠ any version.** A toolchain that *disappears* changes extraction as much as one that upgrades, so removing a compiler must not reuse its graph.

A fourth asserts a probe failure degrades to `absent` rather than raising — this runs on every index, so an escaping exception would turn a wedged toolchain into a failed run.

## Three details carrying weight

- **Bounded** at 10s. A tool that cannot be probed within that cannot be doing useful work, so the timeout and a missing binary reach the same answer.
- **Stable-ordered.** Entries are hashed in sequence, so set or dict iteration order would change the fingerprint without the toolchain changing.
- **First line only.** `go version` and `javac -version` can carry extra lines on some installs, and a multi-line value would make the fingerprint sensitive to noise.

The probes also inherit the `encoding=` requirement from #1455's gate automatically.

## Verified against the real toolchain, not only mocks

```
GO_VERSION=go version go1.26.6 darwin/arm64
JAVAC_VERSION=absent
DOTNET_VERSION=10.0.400
stable across calls: True
```

Go and dotnet resolve to real versions; javac is genuinely absent here and reports so.

## Verification

Full unit suite: **8042 passed**, 121 skipped, zero failures. Lint clean, zero `ty` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parser fingerprints now detect changes to Go, Java, and .NET toolchain versions.
  * Missing, unavailable, timed-out, or failed toolchain checks are handled safely without interrupting fingerprint generation.
  * Toolchain upgrades, removals, and probe failures now correctly trigger refreshed analysis.
  * Inactive language frontends no longer cause unnecessary fingerprint changes.
  * Go and .NET checks now respect repository-specific applicability while retaining support for repo-less analysis.

* **Tests**
  * Added coverage for version changes, stable results, missing toolchains, inactive frontends, repository-specific applicability, and failed version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->