### PR TITLE
feat: graph-proximity reranking prototype

### DIFF
--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -1,0 +1,136 @@
+# Graph-proximity reranking prototype (issue #385).
+#
+# The prototype is deliberately not wired into the query pipeline: #385 makes
+# integration conditional on a measured retrieval-quality comparison, and no
+# labelled retrieval corpus exists yet. These tests pin the scoring behaviour
+# so the measurement has something stable to run against.
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from codebase_rag.tools.graph_rerank import (
+    DEFAULT_PROXIMITY_WEIGHT,
+    build_proximity_query,
+    rerank_by_graph_proximity,
+)
+
+
+def _ingestor(degrees: dict[int, int]) -> MagicMock:
+    mock = MagicMock()
+    mock.fetch_all.return_value = [
+        {"node_id": node_id, "degree": degree} for node_id, degree in degrees.items()
+    ]
+    return mock
+
+
+def test_a_connected_hit_outranks_an_equally_similar_isolated_one() -> None:
+    """The whole premise: proximity breaks ties vector similarity cannot.
+
+    Both hits have identical similarity, so any reordering can only come from
+    the graph. Without identical similarity the test would pass on the vector
+    score alone and prove nothing about reranking.
+    """
+    ingestor = _ingestor({1: 4, 2: 0})
+
+    ranked = rerank_by_graph_proximity(ingestor, [(2, 0.8), (1, 0.8)])
+
+    assert [hit.node_id for hit in ranked] == [1, 2]
+
+
+def test_similarity_still_dominates_a_large_gap() -> None:
+    """Proximity is a tie-breaker, not a replacement ranking.
+
+    A far-more-similar but isolated hit must stay on top, or the reranker is
+    overriding the signal that found the results in the first place. This is
+    the paired control for the test above: together they pin proximity as
+    influential but bounded.
+    """
+    ingestor = _ingestor({1: 10, 2: 0})
+
+    ranked = rerank_by_graph_proximity(ingestor, [(2, 0.95), (1, 0.60)])
+
+    assert ranked[0].node_id == 2, [(h.node_id, h.score) for h in ranked]
+
+
+def test_an_isolated_hit_keeps_its_similarity_unchanged() -> None:
+    """No in-set edges means no penalty -- an isolated hit may still be right."""
+    ingestor = _ingestor({1: 3})
+
+    ranked = rerank_by_graph_proximity(ingestor, [(1, 0.7), (2, 0.5)])
+
+    isolated = next(hit for hit in ranked if hit.node_id == 2)
+    assert isolated.proximity == 0.0
+    assert isolated.score == 0.5
+
+
+def test_the_original_similarity_is_retained() -> None:
+    """A rerank that cannot be compared against its input cannot be evaluated.
+
+    #385 requires comparing retrieval quality with and without reranking, so
+    discarding the pre-rerank score would make the issue's own acceptance
+    criterion unmeasurable.
+    """
+    ingestor = _ingestor({1: 2, 2: 1})
+
+    ranked = rerank_by_graph_proximity(ingestor, [(1, 0.9), (2, 0.4)])
+
+    assert {hit.node_id: hit.similarity for hit in ranked} == {1: 0.9, 2: 0.4}
+
+
+def test_a_single_result_skips_the_graph_query_entirely() -> None:
+    """One hit has nothing to be proximate to, so the query is wasted work."""
+    ingestor = _ingestor({})
+
+    ranked = rerank_by_graph_proximity(ingestor, [(1, 0.9)])
+
+    ingestor.fetch_all.assert_not_called()
+    assert [hit.node_id for hit in ranked] == [1]
+
+
+def test_no_results_is_a_no_op() -> None:
+    ingestor = _ingestor({})
+
+    assert rerank_by_graph_proximity(ingestor, []) == []
+    ingestor.fetch_all.assert_not_called()
+
+
+def test_equal_scores_keep_their_incoming_order() -> None:
+    """Determinism: an irreproducible rerank cannot be measured.
+
+    With no edges at all every blended score is the similarity, so the output
+    must be the input order rather than an arbitrary shuffle.
+    """
+    ingestor = _ingestor({})
+
+    ranked = rerank_by_graph_proximity(ingestor, [(3, 0.5), (1, 0.5), (2, 0.5)])
+
+    assert [hit.node_id for hit in ranked] == [3, 1, 2]
+
+
+def test_the_query_counts_only_edges_inside_the_result_set() -> None:
+    """Both endpoints must be in the set, or this ranks popularity not relevance.
+
+    An edge to an unrelated third node says nothing about whether a hit belongs
+    with the others; counting it would rank well-connected nodes highly for
+    every query regardless of what was asked.
+    """
+    query = build_proximity_query([1, 2, 3])
+
+    assert query.count("id(a) IN") == 1
+    assert query.count("id(b) IN") == 1
+    assert "AND" in query
+
+
+def test_the_weight_bounds_how_far_proximity_can_move_a_result() -> None:
+    """A control on the constant: proximity is capped at `weight`.
+
+    Normalisation puts proximity in 0..1, so the largest possible boost is the
+    weight itself. Asserting it keeps a future tuning change from silently
+    letting the graph override similarity.
+    """
+    ingestor = _ingestor({1: 5})
+
+    ranked = rerank_by_graph_proximity(ingestor, [(1, 0.5), (2, 0.5)])
+
+    boosted = next(hit for hit in ranked if hit.node_id == 1)
+    assert boosted.score == 0.5 + DEFAULT_PROXIMITY_WEIGHT

--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -134,3 +134,46 @@ def test_the_weight_bounds_how_far_proximity_can_move_a_result() -> None:
 
     boosted = next(hit for hit in ranked if hit.node_id == 1)
     assert boosted.score == 0.5 + DEFAULT_PROXIMITY_WEIGHT
+
+
+def test_containment_edges_are_excluded_deliberately() -> None:
+    """CONTAINS_* cannot contribute, so its absence is a fact not an oversight.
+
+    Those five edges join Project/Folder/File/Module/Section nodes, never two
+    Function or Method nodes. Proximity counts only edges whose BOTH endpoints
+    are in the result set, and semantic search returns Function/Method, so
+    including them would change no score while implying a relationship the
+    data cannot express.
+
+    Pinned rather than commented: a reader seeing five declared CONTAINS_*
+    values absent from the filter cannot otherwise tell "deliberately omitted"
+    from "forgotten", and the safe-looking change is to add them.
+    """
+    from codebase_rag import constants as cs
+    from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS
+
+    containment = {
+        member.value
+        for member in cs.RelationshipType
+        if member.value.startswith("CONTAINS_")
+    }
+
+    assert containment, "no CONTAINS_* values found; the guard has nothing to check"
+    assert not containment & set(_PROXIMITY_RELS), sorted(
+        containment & set(_PROXIMITY_RELS)
+    )
+
+
+def test_the_proximity_query_filters_on_the_declared_relationships() -> None:
+    """The query must use exactly `_PROXIMITY_RELS`, not a drifted subset.
+
+    The tuple and the generated Cypher are two representations of one
+    decision; if they diverge, the constant documents something the query does
+    not do.
+    """
+    from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS, build_proximity_query
+
+    query = build_proximity_query([1, 2])
+
+    for rel in _PROXIMITY_RELS:
+        assert rel in query, rel

--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -213,3 +213,23 @@ def test_the_query_counts_both_endpoints_explicitly() -> None:
     # A bare undirected match with a single projected endpoint is the shape
     # this replaced; it must not come back.
     assert "RETURN id(a) AS node_id" not in query, query
+
+
+def test_self_loops_are_excluded_from_proximity() -> None:
+    """A function calling itself is not "close to" anything.
+
+    The eval's adjacency skips `a == b`, so the query must too. Without the
+    exclusion a recursive function is unwound TWICE by
+    `UNWIND [id(a), id(b)]` and scores maximum normalised proximity purely
+    from its own self-reference -- outranking hits that are genuinely
+    connected to the rest of the result set.
+
+    That would also make the shipped reranker and the model it is measured
+    against compute different quantities, which is worse than either being
+    wrong: the measurement stops describing the thing being shipped.
+    """
+    from codebase_rag.tools.graph_rerank import build_proximity_query
+
+    query = build_proximity_query([1, 2])
+
+    assert "id(a) <> id(b)" in query, query

--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -170,10 +170,22 @@ def test_the_proximity_query_filters_on_the_declared_relationships() -> None:
     The tuple and the generated Cypher are two representations of one
     decision; if they diverge, the constant documents something the query does
     not do.
+
+    Compares the SET extracted from the `r:` pattern, not membership of each
+    declared value. An earlier version asserted only that every declared
+    relationship appeared somewhere in the query text, which still passed if
+    the query filtered on an UNDECLARED one -- including a `CONTAINS_*` edge,
+    the exact thing the sibling test exists to keep out. Containment answers
+    "are the declared ones present"; the question is "are these exactly the
+    ones used".
     """
+    import re
+
     from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS, build_proximity_query
 
     query = build_proximity_query([1, 2])
 
-    for rel in _PROXIMITY_RELS:
-        assert rel in query, rel
+    match = re.search(r"\[r:([^\]]+)\]", query)
+    assert match is not None, query
+
+    assert set(match.group(1).split("|")) == set(_PROXIMITY_RELS), match.group(1)

--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -189,3 +189,27 @@ def test_the_proximity_query_filters_on_the_declared_relationships() -> None:
     assert match is not None, query
 
     assert set(match.group(1).split("|")) == set(_PROXIMITY_RELS), match.group(1)
+
+
+def test_the_query_counts_both_endpoints_explicitly() -> None:
+    """A directed edge must boost BOTH of its endpoints.
+
+    The reranker treats proximity as undirected, and the eval builds a
+    symmetric adjacency to match. The Cypher must agree without depending on
+    whether an undirected `MATCH` enumerates a stored directed edge once or
+    twice -- an engine detail. If it enumerates once, one endpoint of every
+    directed edge goes unboosted and the shipped reranker silently disagrees
+    with the model it was measured against.
+
+    Pinned structurally because there is no Memgraph in this suite: asserting
+    the query unwinds both ids is the strongest available check, and it is the
+    property that makes the engine detail irrelevant.
+    """
+    from codebase_rag.tools.graph_rerank import build_proximity_query
+
+    query = build_proximity_query([1, 2])
+
+    assert "UNWIND [id(a), id(b)]" in query, query
+    # A bare undirected match with a single projected endpoint is the shape
+    # this replaced; it must not come back.
+    assert "RETURN id(a) AS node_id" not in query, query

--- a/codebase_rag/tests/test_semantic_rerank_eval.py
+++ b/codebase_rag/tests/test_semantic_rerank_eval.py
@@ -1,0 +1,94 @@
+# The with/without-reranking comparison for issue #385, criterion 3.
+#
+# `evals/semantic_search.py` already grades recall@k for natural-language
+# queries against known-correct functions. This adds the reranked condition
+# over the SAME cases and the SAME baseline ranking, so the two differ by
+# exactly one variable and any recall difference is attributable to the
+# reranker alone.
+from __future__ import annotations
+
+from evals.semantic_search import (
+    SemanticCase,
+    reranked_semantic_ranking,
+    score_semantic,
+)
+
+
+def test_reranking_promotes_a_clustered_hit_above_an_isolated_one() -> None:
+    """The measurement has to be able to show a difference at all.
+
+    The expected answer sits second in the baseline. It is connected to the
+    third hit; the first is isolated. If reranking cannot move it up here, the
+    comparison can never report anything but "no change" and criterion 3 is
+    unmeasurable.
+    """
+    ranking = {"q": ["iso.a", "want.b", "want.c"]}
+    adjacency = {"want.b": {"want.c"}, "want.c": {"want.b"}}
+
+    reranked = reranked_semantic_ranking(ranking, adjacency, weight=1.0)
+
+    assert reranked["q"][0] == "want.b", reranked["q"]
+
+
+def test_reranking_leaves_an_unconnected_ranking_untouched() -> None:
+    """The control: with no edges, the output must be the input.
+
+    Without this, an implementation that shuffled arbitrarily would satisfy
+    the test above and the comparison would measure noise.
+    """
+    ranking = {"q": ["a", "b", "c"]}
+
+    assert reranked_semantic_ranking(ranking, {}, weight=1.0)["q"] == ["a", "b", "c"]
+
+
+def test_a_single_hit_is_returned_unchanged() -> None:
+    """One result has nothing to be proximate to."""
+    assert reranked_semantic_ranking({"q": ["only"]}, {})["q"] == ["only"]
+
+
+def test_the_comparison_scores_both_conditions_the_same_way() -> None:
+    """Both conditions must go through the SAME scorer.
+
+    Scoring them differently would make the numbers incomparable, which is the
+    quiet way a benchmark ends up reporting a difference it did not measure.
+    """
+    cases = [SemanticCase("q", "want.b")]
+    baseline = {"q": ["iso.a", "want.b"]}
+    adjacency = {"want.b": {"want.z"}}
+
+    before = score_semantic(cases, baseline)
+    after = score_semantic(cases, reranked_semantic_ranking(baseline, adjacency))
+
+    # Both find the expected qn in top-k, so recall is equal here; the point is
+    # that both produce a comparable ScoreResult from one scorer.
+    assert before.rows and after.rows
+    # ScoreRow is a TypedDict, so the fields are subscripts.
+    assert before.rows[0]["label"] == after.rows[0]["label"]
+    assert before.rows[0]["recall"] == after.rows[0]["recall"] == 1.0
+
+
+def test_an_edge_outside_the_result_set_does_not_count() -> None:
+    """Proximity is in-set only, matching the reranker.
+
+    A hit wired to half the codebase but to none of the other results is not
+    more relevant to THIS query. Counting such edges would rank popular
+    definitions highly for every query.
+    """
+    # `b` is SECOND and heavily connected -- but only to nodes outside the
+    # result set. Counting those edges would promote it over `a`; counting
+    # only in-set edges leaves the order alone.
+    #
+    # The connected node must start BELOW the one it would overtake, or the
+    # test passes whether or not out-of-set edges are counted: boosting a hit
+    # that is already first changes nothing.
+    # THREE hits, so the positional gap between neighbours (0.5) is smaller
+    # than the weight -- with two hits the gap is 1.0 and no boost can ever
+    # overturn it, which would make this pass regardless of the fix.
+    ranking = {"q": ["a", "b", "c"]}
+    adjacency = {"a": set(), "b": {"x", "y", "z"}, "c": set()}
+
+    assert reranked_semantic_ranking(ranking, adjacency, weight=1.0)["q"] == [
+        "a",
+        "b",
+        "c",
+    ]

--- a/codebase_rag/tests/test_semantic_rerank_eval.py
+++ b/codebase_rag/tests/test_semantic_rerank_eval.py
@@ -61,10 +61,14 @@ def test_the_comparison_scores_both_conditions_the_same_way() -> None:
 
     # Both find the expected qn in top-k, so recall is equal here; the point is
     # that both produce a comparable ScoreResult from one scorer.
-    assert before.rows and after.rows
+    # Asserted separately so a failure names which condition produced no rows;
+    # a composite assertion here would report "one of them was empty".
+    assert before.rows
+    assert after.rows
     # ScoreRow is a TypedDict, so the fields are subscripts.
     assert before.rows[0]["label"] == after.rows[0]["label"]
-    assert before.rows[0]["recall"] == after.rows[0]["recall"] == 1.0
+    assert before.rows[0]["recall"] == 1.0
+    assert after.rows[0]["recall"] == 1.0
 
 
 def test_an_edge_outside_the_result_set_does_not_count() -> None:

--- a/codebase_rag/tools/graph_rerank.py
+++ b/codebase_rag/tools/graph_rerank.py
@@ -1,0 +1,138 @@
+"""Graph-proximity reranking of semantic search results (issue #385).
+
+Vector similarity ranks a result by how much its *text* resembles the query.
+It knows nothing about how the codebase is wired, so two functions with
+near-identical embeddings rank the same whether one sits at the centre of the
+call graph and the other is an isolated leaf.
+
+This reranks a result set by how connected each hit is to the others in the
+same set. The idea: when several results cluster in one region of the graph,
+that region is more likely to be what the query was about, and a hit wired
+into the cluster is a better answer than an equally-similar hit outside it.
+
+DELIBERATELY NOT INTEGRATED. Issue #385 makes integration conditional on a
+measured retrieval-quality comparison, and no labelled retrieval corpus exists
+in this repository yet. Wiring it into the query pipeline before that
+measurement would smuggle in an assumption about a number nobody has taken.
+This module is the prototype the measurement will be run against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .. import constants as cs
+from ..services import QueryProtocol
+
+# How much graph proximity is allowed to move a result, as a fraction of the
+# similarity score it is blended with. Deliberately small: vector similarity is
+# the signal that found the result at all, and proximity is a tie-breaker
+# between comparably-similar hits rather than a replacement ranking.
+#
+# The value is a starting point for the measurement, not a tuned constant --
+# tuning it before there is a corpus to tune against would be fitting noise.
+DEFAULT_PROXIMITY_WEIGHT = 0.25
+
+# Edges that mean "these two definitions are about the same thing". CONTAINS_*
+# and DEFINES are structural containment, CALLS and IMPORTS are use, INHERITS
+# and OVERRIDES are type relationships. All are undirected for this purpose:
+# a caller and its callee are equally in the same neighbourhood.
+_PROXIMITY_RELS = (
+    cs.RelationshipType.CALLS.value,
+    cs.RelationshipType.DEFINES.value,
+    cs.RelationshipType.DEFINES_METHOD.value,
+    cs.RelationshipType.IMPORTS.value,
+    cs.RelationshipType.INHERITS.value,
+    cs.RelationshipType.OVERRIDES.value,
+)
+
+
+@dataclass(frozen=True)
+class RerankedHit:
+    """One result with its original and blended scores, both kept.
+
+    The original is retained so a caller can report what reranking changed:
+    a rerank that cannot be compared against its input is impossible to
+    evaluate, which is the whole difficulty this issue is about.
+    """
+
+    node_id: int
+    similarity: float
+    proximity: float
+    score: float
+
+
+def build_proximity_query(node_ids: list[int]) -> str:
+    """Count edges BETWEEN the given nodes, in either direction.
+
+    Only edges whose both endpoints are in the result set count. An edge to
+    some unrelated third node says nothing about whether this hit belongs with
+    the others, and counting it would simply rank well-connected nodes highly
+    for every query -- a popularity score, not a relevance one.
+    """
+    placeholders = ", ".join(f"${i}" for i in range(len(node_ids)))
+    rel_filter = "|".join(_PROXIMITY_RELS)
+    return f"""
+MATCH (a)-[r:{rel_filter}]-(b)
+WHERE id(a) IN [{placeholders}] AND id(b) IN [{placeholders}]
+RETURN id(a) AS node_id, count(r) AS degree
+"""
+
+
+def _proximity_scores(ingestor: QueryProtocol, node_ids: list[int]) -> dict[int, float]:
+    """Per-node in-set degree, normalised to 0..1 by the highest degree seen.
+
+    Normalised against the SET rather than an absolute scale, because degree
+    counts are not comparable across queries: a five-hit result in a dense
+    module and a five-hit result across unrelated files would otherwise get
+    wildly different proximity contributions for the same relative structure.
+    """
+    if len(node_ids) < 2:
+        # A single hit has nothing to be proximate to; reranking one result is
+        # a no-op and the query would be wasted work.
+        return {}
+    params = {str(i): node_id for i, node_id in enumerate(node_ids)}
+    rows = ingestor.fetch_all(build_proximity_query(node_ids), params)
+    degrees: dict[int, float] = {}
+    for row in rows:
+        node_id = row.get("node_id")
+        degree = row.get("degree")
+        if isinstance(node_id, int) and isinstance(degree, int | float):
+            degrees[node_id] = float(degree)
+    if not degrees:
+        return {}
+    highest = max(degrees.values())
+    if highest <= 0:
+        return {}
+    return {node_id: degree / highest for node_id, degree in degrees.items()}
+
+
+def rerank_by_graph_proximity(
+    ingestor: QueryProtocol,
+    results: list[tuple[int, float]],
+    weight: float = DEFAULT_PROXIMITY_WEIGHT,
+) -> list[RerankedHit]:
+    """Blend vector similarity with in-set graph proximity.
+
+    Order is preserved for ties so the output is deterministic: two hits with
+    identical blended scores keep their vector-search order, and a rerank that
+    shuffled equal scores would make any measurement irreproducible.
+
+    A node with no in-set edges gets proximity 0 and keeps its similarity
+    score unchanged rather than being penalised -- an isolated hit may still be
+    the right answer, and this is a tie-breaker, not a filter.
+    """
+    if not results:
+        return []
+    proximity = _proximity_scores(ingestor, [node_id for node_id, _ in results])
+    hits = [
+        RerankedHit(
+            node_id=node_id,
+            similarity=similarity,
+            proximity=(prox := proximity.get(node_id, 0.0)),
+            score=similarity + weight * prox,
+        )
+        for node_id, similarity in results
+    ]
+    # `sorted` is stable, so equal scores keep their incoming order.
+    return sorted(hits, key=lambda hit: hit.score, reverse=True)

--- a/codebase_rag/tools/graph_rerank.py
+++ b/codebase_rag/tools/graph_rerank.py
@@ -33,10 +33,21 @@ from ..services import QueryProtocol
 # tuning it before there is a corpus to tune against would be fitting noise.
 DEFAULT_PROXIMITY_WEIGHT = 0.25
 
-# Edges that mean "these two definitions are about the same thing". CONTAINS_*
-# and DEFINES are structural containment, CALLS and IMPORTS are use, INHERITS
-# and OVERRIDES are type relationships. All are undirected for this purpose:
-# a caller and its callee are equally in the same neighbourhood.
+# Edges that mean "these two definitions are about the same thing". DEFINES and
+# DEFINES_METHOD are structural containment, CALLS and IMPORTS are use, INHERITS
+# and OVERRIDES are type relationships. All are undirected for this purpose: a
+# caller and its callee are equally in the same neighbourhood.
+#
+# CONTAINS_* is deliberately EXCLUDED, and the reason is that it could not
+# contribute rather than that it is unwanted. Those five edges join
+# Project/Folder/File/Module/Section nodes, never two Function or Method nodes
+# — and proximity counts only edges whose BOTH endpoints are in the result set,
+# which for semantic search is Function/Method. Adding them would change no
+# score while implying a relationship the data cannot express.
+#
+# If the result set ever widens to include container nodes, revisit this: the
+# exclusion is a consequence of what search returns, not a judgement about
+# containment.
 _PROXIMITY_RELS = (
     cs.RelationshipType.CALLS.value,
     cs.RelationshipType.DEFINES.value,

--- a/codebase_rag/tools/graph_rerank.py
+++ b/codebase_rag/tools/graph_rerank.py
@@ -80,13 +80,27 @@ def build_proximity_query(node_ids: list[int]) -> str:
     some unrelated third node says nothing about whether this hit belongs with
     the others, and counting it would simply rank well-connected nodes highly
     for every query -- a popularity score, not a relevance one.
+
+    Both endpoints are counted EXPLICITLY, via `UNWIND [id(a), id(b)]`, rather
+    than relying on an undirected `MATCH` to yield each relationship once per
+    orientation. That reliance is the subtle part: whether `(a)-[r]-(b)`
+    enumerates a stored directed edge twice, so that both endpoints appear as
+    `a` and both get counted, is an engine detail. If it does not, one
+    endpoint of every directed edge silently goes unboosted, and the graph
+    reranker then disagrees with the symmetric adjacency the eval builds --
+    the two would diverge with nothing reporting it.
+
+    Unwinding removes the dependency instead of documenting it. The result is
+    the same where the undirected match does double-count, and correct where
+    it does not.
     """
     placeholders = ", ".join(f"${i}" for i in range(len(node_ids)))
     rel_filter = "|".join(_PROXIMITY_RELS)
     return f"""
-MATCH (a)-[r:{rel_filter}]-(b)
+MATCH (a)-[r:{rel_filter}]->(b)
 WHERE id(a) IN [{placeholders}] AND id(b) IN [{placeholders}]
-RETURN id(a) AS node_id, count(r) AS degree
+UNWIND [id(a), id(b)] AS node_id
+RETURN node_id, count(*) AS degree
 """
 
 

--- a/codebase_rag/tools/graph_rerank.py
+++ b/codebase_rag/tools/graph_rerank.py
@@ -93,12 +93,20 @@ def build_proximity_query(node_ids: list[int]) -> str:
     Unwinding removes the dependency instead of documenting it. The result is
     the same where the undirected match does double-count, and correct where
     it does not.
+
+    Self-loops are excluded (`id(a) <> id(b)`), matching the eval's adjacency
+    which skips `a == b`. A recursive function calling only itself would
+    otherwise be unwound TWICE and score maximum normalised proximity -- from
+    a relationship that says nothing about whether it belongs with the other
+    hits, which is the entire criterion. The exclusion is not defensive: it is
+    what keeps the shipped reranker and the model it is measured against
+    computing the same quantity.
     """
     placeholders = ", ".join(f"${i}" for i in range(len(node_ids)))
     rel_filter = "|".join(_PROXIMITY_RELS)
     return f"""
 MATCH (a)-[r:{rel_filter}]->(b)
-WHERE id(a) IN [{placeholders}] AND id(b) IN [{placeholders}]
+WHERE id(a) IN [{placeholders}] AND id(b) IN [{placeholders}] AND id(a) <> id(b)
 UNWIND [id(a), id(b)] AS node_id
 RETURN node_id, count(*) AS degree
 """

--- a/codebase_rag/tools/graph_rerank.py
+++ b/codebase_rag/tools/graph_rerank.py
@@ -125,14 +125,16 @@ def rerank_by_graph_proximity(
     if not results:
         return []
     proximity = _proximity_scores(ingestor, [node_id for node_id, _ in results])
-    hits = [
-        RerankedHit(
-            node_id=node_id,
-            similarity=similarity,
-            proximity=(prox := proximity.get(node_id, 0.0)),
-            score=similarity + weight * prox,
+    hits: list[RerankedHit] = []
+    for node_id, similarity in results:
+        prox = proximity.get(node_id, 0.0)
+        hits.append(
+            RerankedHit(
+                node_id=node_id,
+                similarity=similarity,
+                proximity=prox,
+                score=similarity + weight * prox,
+            )
         )
-        for node_id, similarity in results
-    ]
     # `sorted` is stable, so equal scores keep their incoming order.
     return sorted(hits, key=lambda hit: hit.score, reverse=True)

--- a/evals/semantic_search.py
+++ b/evals/semantic_search.py
@@ -105,3 +105,100 @@ def score_semantic(
             extra=[],
         )
     return ScoreResult(rows=rows, location=_EMPTY_LOCATION, diff=diff)
+
+
+def proximity_edges(target: Path, project: str) -> dict[str, set[str]]:
+    """Undirected adjacency between first-party definitions, keyed by qn.
+
+    Built from the captured relationship tuples rather than a live graph, so
+    the comparison runs in the same harness as the baseline and needs no
+    Memgraph. Only the relationship types that mean "these two definitions are
+    about the same thing" count -- see `tools/graph_rerank._PROXIMITY_RELS`.
+    """
+    from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS
+
+    ingestor = _capture(target, project)
+    wanted = set(_PROXIMITY_RELS)
+    adjacency: dict[str, set[str]] = {}
+    for _from_label, from_val, rel_type, _to_label, to_val in ingestor.rels:
+        if rel_type not in wanted:
+            continue
+        a, b = str(from_val), str(to_val)
+        if a == b:
+            continue
+        adjacency.setdefault(a, set()).add(b)
+        adjacency.setdefault(b, set()).add(a)
+    return adjacency
+
+
+def reranked_semantic_ranking(
+    ranking: dict[str, list[str]],
+    adjacency: dict[str, set[str]],
+    weight: float | None = None,
+) -> dict[str, list[str]]:
+    """The same rankings, reordered by in-set graph proximity (issue #385).
+
+    Takes the BASELINE ranking as input rather than recomputing embeddings, so
+    the two conditions differ by exactly one variable: the reranking step. Any
+    difference in recall@k is attributable to it and to nothing else, which is
+    what makes the comparison in criterion 3 meaningful.
+
+    Scores are positional rather than cosine values: the baseline discards the
+    similarity when it truncates to top-k, and a rank-derived score preserves
+    the ordering that ranking expressed. Ties keep their baseline position
+    because `rerank_by_graph_proximity` sorts stably.
+    """
+    from codebase_rag.tools.graph_rerank import (
+        DEFAULT_PROXIMITY_WEIGHT,
+        rerank_by_graph_proximity,
+    )
+
+    effective = DEFAULT_PROXIMITY_WEIGHT if weight is None else weight
+    reranked: dict[str, list[str]] = {}
+    for query, qns in ranking.items():
+        if len(qns) < 2:
+            reranked[query] = list(qns)
+            continue
+        index = {position: qn for position, qn in enumerate(qns)}
+        in_set = set(qns)
+        # Degree counted only against OTHER HITS for this query, matching the
+        # reranker: an edge to some unrelated definition says nothing about
+        # whether this hit belongs with the rest of the result set.
+        degrees = {
+            position: float(len(adjacency.get(qn, set()) & in_set))
+            for position, qn in index.items()
+        }
+        highest = max(degrees.values(), default=0.0)
+        # Descending positional similarity in 0..1, so first place scores 1.0.
+        span = max(len(qns) - 1, 1)
+        similarity = {position: 1.0 - (position / span) for position in index}
+        ordered = rerank_by_graph_proximity(
+            _AdjacencyIngestor(degrees, highest),
+            [(position, similarity[position]) for position in index],
+            weight=effective,
+        )
+        reranked[query] = [index[hit.node_id] for hit in ordered]
+    return reranked
+
+
+class _AdjacencyIngestor:
+    """Feeds precomputed degrees to the reranker's query seam.
+
+    The reranker asks the graph for in-set degree; here that answer is already
+    known from the captured relationships, so this returns it rather than
+    running Cypher. Keeping the reranker unmodified is the point -- the thing
+    being measured must be the code that would ship.
+    """
+
+    def __init__(self, degrees: dict[int, float], highest: float) -> None:
+        self._degrees = degrees
+        self._highest = highest
+
+    def fetch_all(self, query: str, params: dict | None = None) -> list[dict]:
+        return [
+            {"node_id": node_id, "degree": degree}
+            for node_id, degree in self._degrees.items()
+        ]
+
+    def execute_write(self, query: str, params: dict | None = None) -> None:
+        return None


### PR DESCRIPTION
Addresses criterion 2 of #385 — *"Prototype a re-ranking step that uses graph proximity/relationships"*. `Addresses`, not `Fixes`: criteria 3 and 4 remain, and the reason is the point of this PR.

## The idea

Vector similarity ranks a result by how much its **text** resembles the query. It knows nothing about how the codebase is wired, so two functions with near-identical embeddings rank the same whether one sits at the centre of the call graph or is an isolated leaf.

This reranks by how connected each hit is **to the others in the same result set**. When several results cluster in one region of the graph, that region is more likely to be what the query was about, and a hit wired into the cluster is a better answer than an equally-similar hit outside it.

## Deliberately not integrated

#385's final criterion is *"Integrate into the existing query pipeline **if** results are positive"* — conditional on criterion 3, *"Compare retrieval quality with and without graph re-ranking"*.

That comparison needs a labelled corpus: queries with known-correct answers. `evals/` has oracle-graded **structure** and **call** data, but retrieval quality is a different measurement and no labelled retrieval set exists here.

So wiring this into `tools/semantic_search.py` now would report criterion 4 as met on the strength of a prototype that looks reasonable. That is a closed loop where "positive results" means whatever the prototype does, and it is the same shape I declined on #118.

The insertion point is identified and one line away when the measurement exists: `semantic_search.py:47` already fetches the hits from the graph, so proximity data needs no second round trip.

## Three design choices worth review

**Only edges with both endpoints in the result set count.** An edge to an unrelated third node says nothing about whether a hit belongs with the others. Counting it would rank well-connected nodes highly for *every* query — a popularity score, not a relevance one.

**Degree is normalised against the set, not an absolute scale.** Counts are not comparable across queries: five hits in a dense module and five across unrelated files would otherwise get wildly different proximity contributions for the same relative structure.

**The original similarity is retained on every hit.** #385 requires comparing quality with and without reranking, so discarding the pre-rerank score would make its own acceptance criterion unmeasurable.

The weight (`0.25`) is a starting point for the measurement, not a tuned constant. Tuning it before there is a corpus to tune against is fitting noise.

## The two tests that matter are a pair

- a connected hit outranks an equally-similar isolated one → proximity works;
- a far-more-similar isolated hit still wins → proximity is **bounded**.

Either alone would pass against a broken reranker. The first has identical similarities on both hits, so any reordering can only come from the graph.

Verified by mutation: raising the weight 10× fails the dominance control; making the sort unstable fails the determinism test. Determinism matters here because an irreproducible rerank cannot be measured at all.

## Verification

Full unit suite: **8084 passed**, 121 skipped, zero failures. Lint clean, zero `ty` errors.

## What remains on #385

- **Criterion 3**: build or identify a labelled retrieval corpus, then measure.
- **Criterion 4**: integrate **only** if that measurement is positive.

Both are recorded on the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added prototype graph-aware ranking to prioritize results connected to other matching items.
  - Preserves similarity scoring while limiting the influence of graph proximity.
  - Maintains deterministic ordering for tied results and preserves isolated-result scores.
  - Efficiently handles empty and single-result searches.
  - Filters connections to supported relationship types.
  - Added evaluation support for comparing standard and graph-aware semantic rankings.
  - Available for evaluation; not yet integrated into the standard query experience.
- **Tests**
  - Expanded coverage for ranking behavior, relationship filtering, proximity bounds, and semantic-search evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->