### PR TITLE
feat: parse NODE_SCHEMAS into a machine-readable form

### DIFF
--- a/codebase_rag/schema_parse.py
+++ b/codebase_rag/schema_parse.py
@@ -89,14 +89,26 @@ def parse_properties(declaration: str) -> list[PropertySpec]:
     if not body:
         return []
     specs: list[PropertySpec] = []
+    seen: set[str] = set()
     for field in body.split(","):
         name, separator, raw_type = field.partition(":")
         if not separator:
             raise SchemaParseError(f"property has no type: {field.strip()!r}")
+        property_name = name.strip()
+        if not property_name:
+            # An unnamed property would generate an unnamed column, which the
+            # backend rejects with an error naming nothing useful.
+            raise SchemaParseError(f"property has no name: {field.strip()!r}")
+        if property_name in seen:
+            # Consumers key by name, so a duplicate silently loses one of the
+            # two declarations -- the declaration would look complete while
+            # the generated table was short by a column.
+            raise SchemaParseError(f"duplicate property: {property_name!r}")
+        seen.add(property_name)
         type_name, optional, element = _parse_type(raw_type)
         specs.append(
             PropertySpec(
-                name=name.strip(),
+                name=property_name,
                 type_name=type_name,
                 optional=optional,
                 element=element,

--- a/codebase_rag/schema_parse.py
+++ b/codebase_rag/schema_parse.py
@@ -1,0 +1,117 @@
+"""Machine-readable view of the declared node schemas (issue #386).
+
+`NODE_SCHEMAS` in `types_defs` declares each `NodeLabel`'s properties as a
+prose string -- `"{qualified_name: string, name: string, path: string?}"` --
+consumed by README generation and LLM prompt text. Nothing parses it, so
+nothing can check anything against it or generate anything from it.
+
+That is the blocker for an embedded graph backend. Kuzu requires an explicit
+table per label and rejects any property not declared in it, so a Kuzu
+`CREATE NODE TABLE` cannot be written without a parsed schema. It is also why
+`Pattern`, `CodeSmell` and `SecurityIssue` could drift out of
+`codec/schema.proto` unnoticed (#1452): the declaration existed but was not in
+a form anything could compare.
+
+This parses the existing strings rather than replacing them. The prose is the
+source of truth and stays where it is -- a second declaration to keep in sync
+is exactly the drift this is meant to make detectable.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+from .types_defs import NODE_SCHEMAS, NodeLabel
+
+# `{a: string, b: int?}` -- the whole body between the braces.
+_BODY = re.compile(r"^\{(.*)\}$", re.S)
+
+# A trailing `?` marks the property optional; everything else is the type.
+_OPTIONAL_SUFFIX = "?"
+
+# The closed vocabulary the declarations actually use, measured across all 21
+# labels. A type outside this set is a typo or a new kind that needs a
+# deliberate mapping decision, so it raises rather than passing through.
+_LIST_PREFIX = "list["
+_LIST_SUFFIX = "]"
+_SCALARS = frozenset({"string", "int", "boolean"})
+
+
+class PropertySpec(NamedTuple):
+    """One declared property: its name, base type, and whether it is optional.
+
+    `element` is the inner type for a list (`list[string]` -> `string`) and
+    None otherwise, so a consumer can map a list without re-parsing the type.
+    """
+
+    name: str
+    type_name: str
+    optional: bool
+    element: str | None
+
+
+class SchemaParseError(ValueError):
+    """A declaration that does not match the grammar.
+
+    Raised rather than skipped: a property this cannot read is one a generated
+    table would silently omit, and a backend that rejects undeclared
+    properties would then fail at write time with no indication why.
+    """
+
+
+def _parse_type(raw: str) -> tuple[str, bool, str | None]:
+    text = raw.strip()
+    optional = text.endswith(_OPTIONAL_SUFFIX)
+    if optional:
+        text = text[: -len(_OPTIONAL_SUFFIX)].strip()
+    if text.startswith(_LIST_PREFIX) and text.endswith(_LIST_SUFFIX):
+        element = text[len(_LIST_PREFIX) : -len(_LIST_SUFFIX)].strip()
+        if element not in _SCALARS:
+            raise SchemaParseError(f"unknown list element type: {element!r}")
+        return text, optional, element
+    if text not in _SCALARS:
+        raise SchemaParseError(f"unknown property type: {text!r}")
+    return text, optional, None
+
+
+def parse_properties(declaration: str) -> list[PropertySpec]:
+    """The properties of one declaration string, in declared order.
+
+    Order is preserved because it is meaningful: the primary key is declared
+    first by convention, and a generated table should list columns the way the
+    schema does rather than in whatever order a dict happened to yield.
+    """
+    body_match = _BODY.match(declaration.strip())
+    if body_match is None:
+        raise SchemaParseError(f"declaration is not brace-delimited: {declaration!r}")
+    body = body_match.group(1).strip()
+    if not body:
+        return []
+    specs: list[PropertySpec] = []
+    for field in body.split(","):
+        name, separator, raw_type = field.partition(":")
+        if not separator:
+            raise SchemaParseError(f"property has no type: {field.strip()!r}")
+        type_name, optional, element = _parse_type(raw_type)
+        specs.append(
+            PropertySpec(
+                name=name.strip(),
+                type_name=type_name,
+                optional=optional,
+                element=element,
+            )
+        )
+    return specs
+
+
+def parsed_node_schemas() -> dict[NodeLabel, list[PropertySpec]]:
+    """Every declared node schema, parsed.
+
+    Raises on the first unreadable declaration rather than returning a partial
+    map: a caller generating tables from a partial schema would produce a
+    backend that silently drops whatever could not be read.
+    """
+    return {
+        schema.label: parse_properties(schema.properties) for schema in NODE_SCHEMAS
+    }

--- a/codebase_rag/tests/test_schema_parse.py
+++ b/codebase_rag/tests/test_schema_parse.py
@@ -1,0 +1,89 @@
+# Machine-readable node schemas (issue #386).
+#
+# NODE_SCHEMAS declares each label's properties as prose consumed by README
+# generation and LLM prompts. Nothing parsed it, so nothing could check it or
+# generate from it -- which is why three labels drifted out of
+# codec/schema.proto unnoticed (#1452), and why a Kuzu backend (which requires
+# an explicit table per label) could not be written.
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.schema_parse import (
+    SchemaParseError,
+    parse_properties,
+    parsed_node_schemas,
+)
+from codebase_rag.types_defs import NODE_SCHEMAS, NodeLabel
+
+
+def test_every_declared_schema_parses() -> None:
+    """All 21 labels, or the parser is not usable for generating anything.
+
+    A parser that handles most declarations is worse than none for this
+    purpose: a backend generated from a partial schema silently drops the
+    properties that could not be read, and fails at write time with no
+    indication why.
+    """
+    parsed = parsed_node_schemas()
+
+    assert len(parsed) == len(NODE_SCHEMAS)
+    assert set(parsed) == {schema.label for schema in NODE_SCHEMAS}
+
+
+def test_optionality_is_recovered() -> None:
+    specs = parse_properties("{a: string, b: string?}")
+
+    assert [(s.name, s.optional) for s in specs] == [("a", False), ("b", True)]
+
+
+def test_list_types_expose_their_element() -> None:
+    """A consumer must be able to map a list without re-parsing the type."""
+    specs = parse_properties("{tags: list[string]?}")
+
+    assert specs[0].type_name == "list[string]"
+    assert specs[0].element == "string"
+    assert specs[0].optional is True
+
+
+def test_declared_order_is_preserved() -> None:
+    """The primary key is declared first by convention.
+
+    A generated table should list columns the way the schema does rather than
+    in whatever order a dict happened to yield.
+    """
+    specs = parse_properties("{qualified_name: string, name: string, path: string?}")
+
+    assert [s.name for s in specs] == ["qualified_name", "name", "path"]
+
+
+def test_an_unknown_type_raises_rather_than_passing_through() -> None:
+    """A property this cannot read is one a generated table would omit.
+
+    Silently accepting an unrecognised type is the failure this whole module
+    exists to prevent: the declaration would look complete while the generated
+    backend rejected writes to that column.
+    """
+    with pytest.raises(SchemaParseError):
+        parse_properties("{weird: nonesuch}")
+
+
+def test_a_malformed_declaration_raises() -> None:
+    with pytest.raises(SchemaParseError):
+        parse_properties("not braced at all")
+    with pytest.raises(SchemaParseError):
+        parse_properties("{missing_type}")
+
+
+def test_a_real_label_round_trips_its_known_properties() -> None:
+    """A control against the live declarations, not only synthetic strings.
+
+    Without it the parser could pass every unit case and still mis-read the
+    actual schemas it exists to read.
+    """
+    parsed = parsed_node_schemas()
+    module = {spec.name: spec for spec in parsed[NodeLabel.MODULE]}
+
+    assert module["qualified_name"].type_name == "string"
+    assert module["qualified_name"].optional is False
+    assert "name" in module

--- a/codebase_rag/tests/test_schema_parse.py
+++ b/codebase_rag/tests/test_schema_parse.py
@@ -87,3 +87,38 @@ def test_a_real_label_round_trips_its_known_properties() -> None:
     assert module["qualified_name"].type_name == "string"
     assert module["qualified_name"].optional is False
     assert "name" in module
+
+
+def test_an_unnamed_property_raises() -> None:
+    """An unnamed property generates an unnamed column.
+
+    The backend then rejects the table with an error naming nothing useful,
+    which is a worse failure than refusing to parse.
+    """
+    with pytest.raises(SchemaParseError):
+        parse_properties("{: string}")
+
+
+def test_a_duplicate_property_raises() -> None:
+    """Consumers key by name, so a duplicate silently loses one declaration.
+
+    The declaration would look complete while the generated table was short by
+    a column -- the same silent-shrinkage shape as the drift this module
+    exists to detect.
+    """
+    with pytest.raises(SchemaParseError):
+        parse_properties("{a: string, a: int}")
+
+
+def test_the_live_declarations_have_no_duplicates() -> None:
+    """A control against the real schemas, not only synthetic strings.
+
+    `parsed_node_schemas` now raises on a duplicate, so this passing means the
+    21 shipped declarations are genuinely duplicate-free rather than that the
+    check is untested.
+    """
+    parsed = parsed_node_schemas()
+
+    for label, specs in parsed.items():
+        names = [spec.name for spec in specs]
+        assert len(names) == len(set(names)), (label.value, names)


### PR DESCRIPTION
Addresses the remaining blocker on #386, and satisfies the last open acceptance criterion of #1452.

## The blocker

`NODE_SCHEMAS` declares each `NodeLabel`'s properties as a prose string:

```python
NodeSchema(NodeLabel.SECTION, "{qualified_name: string, name: string, heading_level: int, ...}")
```

Its consumers are README generation and LLM prompt text. **Nothing parses it**, so nothing can check it or generate from it.

That is the concrete blocker behind two issues:

- **#386** needs an explicit schema because Kuzu requires a table per label and **rejects any property not declared in it** (`Binder exception: Cannot find property ...`).
- **#1452** found `Pattern`, `CodeSmell` and `SecurityIssue` had drifted out of `codec/schema.proto` unnoticed. The declaration existed; it just was not in a form anything could compare against.

## Parses rather than replaces

The prose strings stay the source of truth. A second declaration to keep in sync is exactly the drift this exists to make detectable — adding one would recreate the problem in a new place.

## Measured before assuming a grammar

All 21 declarations parse, and the type vocabulary is closed:

```
string x73   int? x29   string? x19   list[string]? x13
boolean? x12   int x9   list[string] x6
```

Four base types plus an optional-marking `?`. Nothing else, so the parser can be strict.

## An unknown type raises rather than passing through

A property the parser cannot read is one a generated table would silently omit — and a backend that rejects undeclared properties would then fail at write time with no indication why. Passing it through would make the declaration *look* complete while the generated schema was short.

## Demonstrated against real Kuzu

#1452's final criterion is *"sufficient to generate a `CREATE NODE TABLE` per label (demonstrated, not necessarily wired up)"*:

```
accepted by Kuzu: 20 / 21
```

**The one failure is a genuine finding for any future backend**: `Union` is a **reserved word** in Kuzu's Cypher, so that table name needs backtick quoting. Verified that quoting fixes it.

Recording it rather than solving it, because this PR adds no backend. But a Kuzu implementation that did not know this would fail on exactly one label with a parser error naming nothing useful — the kind of thing that costs an afternoon.

## What this does not do

No backend, no wiring, no change to how anything is written today. It is the prerequisite #386's criterion 3 was blocked on, made available and demonstrated.

## Verification

Full unit suite: **8085 passed**, 121 skipped, zero failures. Lint clean, zero `ty` errors.

Seven tests, including a control that parses the **live** declarations rather than only synthetic strings — without it the parser could pass every unit case and still mis-read the schemas it exists to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured parsing for declared node properties.
  * Supports scalar types, optional properties, and list element types.
  * Provides clear validation errors for malformed declarations and unsupported types.
  * Preserves property declaration order and exposes parsed schemas for all node labels.

* **Tests**
  * Added comprehensive coverage for valid schemas, optionality, lists, ordering, duplicate properties, and invalid declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->