### PR TITLE
feat: indexing-time benchmark on a pinned corpus (#1374 deliverable 4)

### DIFF
--- a/benchmarks/bench_indexing.py
+++ b/benchmarks/bench_indexing.py
@@ -71,13 +71,40 @@ class IndexingMeasurement:
     peak_rss_bytes: int
 
 
+def _proc_peak_rss_bytes() -> int | None:
+    """This process's peak RSS from `/proc/self/status`, or None if unreadable.
+
+    `VmHWM` is per-process and genuinely reset by exec, which `ru_maxrss` is
+    NOT on Linux -- there the child inherits the parent's high-water mark
+    across fork/exec, so a freshly spawned child reports whatever the parent
+    had already peaked at. Measured: a released 192 MiB parent ballast moved
+    the child's reported peak by 201,375,744 bytes.
+
+    Returns None rather than a sentinel so the caller can fall back; absent
+    `/proc` (macOS, Windows) is not the same as "cannot measure".
+    """
+    try:
+        with open("/proc/self/status", encoding=cs.ENCODING_UTF8) as handle:
+            for line in handle:
+                if line.startswith("VmHWM:"):
+                    # "VmHWM:\t  123456 kB"
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
 def _self_peak_rss_bytes() -> int:
     """This process's peak RSS, or `RSS_UNAVAILABLE` where unsupported.
 
-    Only meaningful in the freshly-spawned child, whose high-water mark starts
-    clean. Read in the parent it is the cumulative peak of everything that
-    process has ever done.
+    Only meaningful in the freshly-spawned child. `/proc` is preferred because
+    `VmHWM` is exec-scoped on Linux; `ru_maxrss` is the fallback for platforms
+    with no `/proc` (macOS), where fork/exec does reset the high-water mark and
+    so the value is already child-local.
     """
+    from_proc = _proc_peak_rss_bytes()
+    if from_proc is not None:
+        return from_proc
     if resource is None:
         return RSS_UNAVAILABLE
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * _RSS_SCALE

--- a/benchmarks/bench_indexing.py
+++ b/benchmarks/bench_indexing.py
@@ -1,0 +1,153 @@
+"""Indexing-time benchmark on a pinned corpus (issue #1374, deliverable 4).
+
+The first of the four benchmarks that issue asks for, and deliberately the
+first: it needs no model key and no databases, so it runs in CI and produces a
+README row immediately. The other three (agentic resolved-rate, query latency,
+token cost) all require a live stack or an LLM key.
+
+**What this measures.** The real `GraphUpdater` pipeline -- the same parse,
+definition and call passes production runs -- against an in-memory ingestor
+rather than Memgraph. So the number is honest about parsing and graph
+construction, and excludes database round-trips by construction. That
+exclusion is the point rather than a shortcut: it isolates the cost this
+project controls from the cost of the two databases, which is precisely the
+question the field-test review asked (is the graph worth feeding?), and it is
+what makes the measurement reproducible without infrastructure.
+
+Do not read the result as end-to-end `cgr index` wall-clock. Deliverable 2 in
+#1374 covers the real stack, and that number will be larger.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import resource
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from codebase_rag import constants as cs
+
+# macOS reports ru_maxrss in bytes, Linux in kibibytes. Getting this wrong is a
+# silent factor-of-1024 error in a published table, so it is converted rather
+# than reported raw.
+_RSS_SCALE = 1 if sys.platform == "darwin" else 1024
+
+
+@dataclass(frozen=True)
+class IndexingMeasurement:
+    """One indexing run, with everything needed to reproduce it.
+
+    The provenance fields are not decoration: a timing without its corpus and
+    version is a number nobody can check, and #1374 is explicit that the
+    credibility of the table is the reproducibility of its cells.
+    """
+
+    corpus_name: str
+    corpus_path: str
+    cgr_version: str
+    file_count: int
+    node_count: int
+    edge_count: int
+    duration_seconds: float
+    peak_rss_bytes: int
+
+
+def _peak_rss_bytes() -> int:
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * _RSS_SCALE
+
+
+def _cgr_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("code-graph-rag")
+    except Exception:
+        # A source checkout without an installed distribution still benchmarks;
+        # it just cannot pin a version, and saying so beats inventing one.
+        return "unknown"
+
+
+def measure_indexing(corpus: Path, project_name: str) -> IndexingMeasurement:
+    """Index `corpus` once and report what it cost.
+
+    Raises on a corpus with no indexable files rather than reporting zeroes:
+    "0 files in 0.01s" reads like a very fast index rather than like a
+    benchmark that measured nothing, and it is the published-number version of
+    the silent-smaller-than-truth failure.
+    """
+    # Imported here rather than at module scope so that `--help` and the
+    # dataclass stay usable without paying the parser-loading cost.
+    from evals.cgr_graph import _capture
+
+    corpus = corpus.resolve()
+    rss_before = _peak_rss_bytes()
+
+    start = time.perf_counter()
+    ingestor = _capture(corpus, project_name)
+    duration = time.perf_counter() - start
+
+    # FILE only. cgr emits BOTH a File and a Module node for every parsed
+    # source file, so counting either-or double-counts each one and would have
+    # published a file count twice the truth.
+    file_count = sum(
+        1 for (label, _uid) in ingestor.nodes if label == cs.NodeLabel.FILE.value
+    )
+    if not file_count:
+        raise ValueError(
+            f"no indexable files under {corpus}: refusing to report a benchmark "
+            "that measured nothing"
+        )
+
+    return IndexingMeasurement(
+        corpus_name=corpus.name,
+        corpus_path=str(corpus),
+        cgr_version=_cgr_version(),
+        file_count=file_count,
+        node_count=len(ingestor.nodes),
+        edge_count=len(ingestor.rels),
+        duration_seconds=duration,
+        # The delta would be negative whenever the peak was already set by
+        # earlier work in this process, so report the peak itself.
+        peak_rss_bytes=max(_peak_rss_bytes(), rss_before),
+    )
+
+
+def format_markdown_row(result: IndexingMeasurement) -> str:
+    """One README table row, carrying its own provenance."""
+    mib = result.peak_rss_bytes / (1024 * 1024)
+    return (
+        f"| Indexing time — {result.corpus_name}, {result.file_count} files "
+        f"(cgr {result.cgr_version}) | {result.duration_seconds:.1f}s | "
+        f"{result.node_count} nodes / {result.edge_count} edges | {mib:.0f} MiB |"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("corpus", type=Path, help="repository to index")
+    parser.add_argument(
+        "--project-name",
+        default=None,
+        help="graph project name (defaults to the corpus directory name)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit JSON instead of a table row"
+    )
+    args = parser.parse_args()
+
+    result = measure_indexing(
+        args.corpus, project_name=args.project_name or args.corpus.resolve().name
+    )
+    print(
+        json.dumps(asdict(result), indent=2)
+        if args.json
+        else format_markdown_row(result)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bench_indexing.py
+++ b/benchmarks/bench_indexing.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import resource
+import os
+import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass
@@ -34,6 +35,21 @@ from codebase_rag import constants as cs
 # silent factor-of-1024 error in a published table, so it is converted rather
 # than reported raw.
 _RSS_SCALE = 1 if sys.platform == "darwin" else 1024
+
+# `resource` is Unix-only and this repo runs Windows CI, so an unconditional
+# top-level import makes the module unimportable there -- collection fails
+# before any measurement can run. Absent it, memory is reported as unavailable
+# rather than guessed.
+try:  # pragma: no cover - platform-dependent
+    import resource
+except ModuleNotFoundError:  # pragma: no cover - Windows
+    resource = None  # type: ignore[assignment]
+
+# Sentinel for "this platform cannot report peak memory". Distinct from 0,
+# which would read as "the run used no memory".
+RSS_UNAVAILABLE = -1
+
+_CHILD_ENV_FLAG = "CGR_BENCH_INDEXING_CHILD"
 
 
 @dataclass(frozen=True)
@@ -55,7 +71,15 @@ class IndexingMeasurement:
     peak_rss_bytes: int
 
 
-def _peak_rss_bytes() -> int:
+def _self_peak_rss_bytes() -> int:
+    """This process's peak RSS, or `RSS_UNAVAILABLE` where unsupported.
+
+    Only meaningful in the freshly-spawned child, whose high-water mark starts
+    clean. Read in the parent it is the cumulative peak of everything that
+    process has ever done.
+    """
+    if resource is None:
+        return RSS_UNAVAILABLE
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * _RSS_SCALE
 
 
@@ -71,19 +95,57 @@ def _cgr_version() -> str:
 
 
 def measure_indexing(corpus: Path, project_name: str) -> IndexingMeasurement:
-    """Index `corpus` once and report what it cost.
+    """Index `corpus` once in a fresh subprocess and report what it cost.
+
+    The subprocess is what makes the memory figure meaningful. `ru_maxrss` is
+    a process high-water mark, so measuring in-process attributes any earlier
+    allocation to the indexing run: a released 128 MiB buffer makes a one-file
+    index report 128 MiB. Subtracting two readings does not rescue it either,
+    because once the prior high-water exceeds the run's own peak the
+    difference is zero or negative. Only a new process starts clean.
 
     Raises on a corpus with no indexable files rather than reporting zeroes:
     "0 files in 0.01s" reads like a very fast index rather than like a
     benchmark that measured nothing, and it is the published-number version of
     the silent-smaller-than-truth failure.
     """
+    corpus = corpus.resolve()
+    if os.environ.get(_CHILD_ENV_FLAG):
+        # Already the child: measure directly, and let the peak be this
+        # process's, which is exactly the run's.
+        return _measure_in_this_process(corpus, project_name)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            __spec__.name,
+            str(corpus),
+            "--project-name",
+            project_name,
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        encoding=cs.ENCODING_UTF8,
+        # Handled below: the child's stderr is surfaced in the raised message,
+        # which says more than CalledProcessError's return code alone.
+        check=False,
+        env={**os.environ, _CHILD_ENV_FLAG: "1"},
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    if completed.returncode != 0:
+        raise ValueError(
+            f"benchmark subprocess failed ({completed.returncode}): "
+            f"{completed.stderr.strip()[-2000:]}"
+        )
+    return IndexingMeasurement(**json.loads(completed.stdout))
+
+
+def _measure_in_this_process(corpus: Path, project_name: str) -> IndexingMeasurement:
     # Imported here rather than at module scope so that `--help` and the
     # dataclass stay usable without paying the parser-loading cost.
     from evals.cgr_graph import _capture
-
-    corpus = corpus.resolve()
-    rss_before = _peak_rss_bytes()
 
     start = time.perf_counter()
     ingestor = _capture(corpus, project_name)
@@ -109,19 +171,25 @@ def measure_indexing(corpus: Path, project_name: str) -> IndexingMeasurement:
         node_count=len(ingestor.nodes),
         edge_count=len(ingestor.rels),
         duration_seconds=duration,
-        # The delta would be negative whenever the peak was already set by
-        # earlier work in this process, so report the peak itself.
-        peak_rss_bytes=max(_peak_rss_bytes(), rss_before),
+        # This process was spawned for this one measurement, so its own peak
+        # IS the run's peak -- no baseline to subtract and nothing earlier to
+        # attribute.
+        peak_rss_bytes=_self_peak_rss_bytes(),
     )
 
 
 def format_markdown_row(result: IndexingMeasurement) -> str:
     """One README table row, carrying its own provenance."""
-    mib = result.peak_rss_bytes / (1024 * 1024)
+    if result.peak_rss_bytes == RSS_UNAVAILABLE:
+        # "n/a" rather than 0 MiB: a platform that cannot report memory must
+        # not publish a figure that reads as a measurement.
+        memory = "n/a"
+    else:
+        memory = f"{result.peak_rss_bytes / (1024 * 1024):.0f} MiB"
     return (
         f"| Indexing time — {result.corpus_name}, {result.file_count} files "
         f"(cgr {result.cgr_version}) | {result.duration_seconds:.1f}s | "
-        f"{result.node_count} nodes / {result.edge_count} edges | {mib:.0f} MiB |"
+        f"{result.node_count} nodes / {result.edge_count} edges | {memory} |"
     )
 
 

--- a/benchmarks/bench_indexing.py
+++ b/benchmarks/bench_indexing.py
@@ -121,6 +121,21 @@ def _self_peak_rss_bytes() -> int:
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * _RSS_SCALE
 
 
+def _module_name() -> str:
+    """This module's importable name, for relaunching it with `-m`.
+
+    `__spec__` is None when the file is run directly as a script
+    (`python benchmarks/bench_indexing.py`), so reading `__spec__.name`
+    raises AttributeError before the child is ever spawned -- the benchmark
+    dies on its most obvious invocation. Falling back to the literal keeps
+    both `python -m benchmarks.bench_indexing` and direct execution working.
+    """
+    spec = globals().get("__spec__")
+    if spec is not None and getattr(spec, "name", None):
+        return str(spec.name)
+    return "benchmarks.bench_indexing"
+
+
 def _cgr_version() -> str:
     try:
         from importlib.metadata import version
@@ -157,7 +172,7 @@ def measure_indexing(corpus: Path, project_name: str) -> IndexingMeasurement:
         [
             sys.executable,
             "-m",
-            __spec__.name,
+            _module_name(),
             str(corpus),
             "--project-name",
             project_name,

--- a/benchmarks/bench_indexing.py
+++ b/benchmarks/bench_indexing.py
@@ -97,15 +97,26 @@ def _proc_peak_rss_bytes() -> int | None:
 def _self_peak_rss_bytes() -> int:
     """This process's peak RSS, or `RSS_UNAVAILABLE` where unsupported.
 
-    Only meaningful in the freshly-spawned child. `/proc` is preferred because
-    `VmHWM` is exec-scoped on Linux; `ru_maxrss` is the fallback for platforms
-    with no `/proc` (macOS), where fork/exec does reset the high-water mark and
-    so the value is already child-local.
+    Only meaningful in the freshly-spawned child, and the source depends on
+    the platform because `ru_maxrss` is not child-local everywhere:
+
+    - Linux: `/proc/self/status` `VmHWM`, which IS exec-scoped. If it cannot
+      be read, this reports unavailable rather than falling back --
+      `ru_maxrss` survives fork/exec here, so the fallback would report the
+      parent's history as the child's peak. Measured: a released 192 MiB
+      parent allocation moved the fallback's answer by 199,208,960 bytes for
+      an identical one-file workload.
+    - macOS and other non-Linux Unix: `ru_maxrss`, where fork/exec does reset
+      the high-water mark, so the value is already child-local.
+    - Windows: no `resource` module, so unavailable.
+
+    Reporting unavailable beats reporting a number that is wrong in the
+    direction of "this run used memory it never touched".
     """
     from_proc = _proc_peak_rss_bytes()
     if from_proc is not None:
         return from_proc
-    if resource is None:
+    if resource is None or sys.platform.startswith("linux"):
         return RSS_UNAVAILABLE
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * _RSS_SCALE
 

--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -132,8 +132,12 @@ def test_the_markdown_row_carries_what_was_measured(tmp_path: Path) -> None:
     assert result.corpus_name in row
     assert result.cgr_version in row
     assert str(result.file_count) in row
-    # A pipe-delimited row, so it can be pasted into the README table.
-    assert row.startswith("|") and row.endswith("|")
+    # A pipe-delimited row, so it can be pasted into the README table. Split
+    # rather than combined with `and`: a composite failure cannot say which
+    # end is malformed, and a row missing its trailing pipe renders as broken
+    # markdown in a way the leading-pipe check would not reveal.
+    assert row.startswith("|"), row
+    assert row.endswith("|"), row
 
 
 def test_peak_memory_is_local_to_the_run_not_the_process(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -9,6 +9,7 @@ could not actually take.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -96,3 +97,71 @@ def test_the_markdown_row_carries_what_was_measured(tmp_path: Path) -> None:
     assert str(result.file_count) in row
     # A pipe-delimited row, so it can be pasted into the README table.
     assert row.startswith("|") and row.endswith("|")
+
+
+def test_peak_memory_is_local_to_the_run_not_the_process(tmp_path: Path) -> None:
+    """A prior allocation in this process must not inflate the reported peak.
+
+    `ru_maxrss` is a process high-water mark, so a benchmark reading it
+    directly attributes any earlier allocation to the indexing run. Greptile
+    reproduced exactly that: after a released 128 MiB buffer, a one-file index
+    reported the stale 128 MiB peak.
+
+    The property is INVARIANCE to a prior parent allocation, not an absolute
+    ceiling. An earlier draft asserted `peak < ballast_size` and failed on a
+    correct implementation, because a child that imports the parsers
+    legitimately peaks well above any ballast this test would allocate. That
+    threshold measured "is the run small" when the question is "does the
+    parent's history leak in".
+
+    Allocating and releasing the buffer BETWEEN the two measurements is what
+    gives the test its teeth: in-process `ru_maxrss` would raise the second
+    reading to at least the ballast, while a subprocess measurement is
+    unmoved.
+    """
+    corpus = _write_corpus(tmp_path / "repo", files=1)
+
+    before = measure_indexing(corpus, project_name="bench_fixture")
+
+    ballast = bytearray(192 * 1024 * 1024)
+    ballast_size = len(ballast)
+    del ballast
+
+    after = measure_indexing(corpus, project_name="bench_fixture")
+
+    # Same corpus, same work: the ballast must not show up in the second
+    # reading. Allow generous jitter for allocator noise between two real
+    # indexing runs, but far less than the ballast a leak would contribute.
+    drift = abs(after.peak_rss_bytes - before.peak_rss_bytes)
+    assert drift < ballast_size // 2, (
+        f"peak moved by {drift} bytes across a released {ballast_size}-byte "
+        "parent allocation; the reported peak is tracking the parent process "
+        "rather than the indexing run"
+    )
+
+
+def test_the_benchmark_imports_where_resource_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows has no `resource` module, and this repo runs Windows CI.
+
+    An unconditional top-level `import resource` makes the module unimportable
+    there -- collection fails before any argument handling or measurement.
+    """
+    import builtins
+    import importlib
+
+    real_import = builtins.__import__
+
+    def _no_resource(name, *args, **kwargs):
+        if name == "resource":
+            raise ModuleNotFoundError("No module named 'resource'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_resource)
+    monkeypatch.delitem(sys.modules, "benchmarks.bench_indexing", raising=False)
+    monkeypatch.delitem(sys.modules, "resource", raising=False)
+
+    module = importlib.import_module("benchmarks.bench_indexing")
+
+    assert module.measure_indexing is not None

--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -208,3 +208,51 @@ def test_the_benchmark_imports_where_resource_is_missing(
     module = importlib.import_module("benchmarks.bench_indexing")
 
     assert module.measure_indexing is not None
+
+
+def test_vmhwm_is_parsed_from_proc_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Linux peak comes from VmHWM, parsed in kB and returned in bytes.
+
+    macOS has no /proc, so this path cannot run here and CI Linux is the only
+    place it executes for real -- exactly the gap that let the previous
+    ru_maxrss bug reach CI green on this machine. Parsing a synthetic status
+    file exercises it everywhere.
+    """
+    import benchmarks.bench_indexing as module
+
+    status = tmp_path / "status"
+    status.write_text(
+        "Name:\tpython3\nVmPeak:\t 900000 kB\nVmHWM:\t  123456 kB\nVmRSS:\t 100000 kB\n"
+    )
+
+    real_open = open
+
+    def _fake_open(path, *args, **kwargs):
+        if path == "/proc/self/status":
+            return real_open(status, *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _fake_open)
+
+    assert module._proc_peak_rss_bytes() == 123456 * 1024
+
+
+def test_a_missing_proc_status_falls_back_rather_than_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No /proc is not the same as "cannot measure".
+
+    macOS resets the high-water mark across exec, so ru_maxrss is already
+    child-local there; the fallback must engage rather than reporting the
+    unavailable sentinel and losing a figure the platform can supply.
+    """
+    import benchmarks.bench_indexing as module
+
+    def _no_proc(path, *args, **kwargs):
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr("builtins.open", _no_proc)
+
+    assert module._proc_peak_rss_bytes() is None

--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -260,3 +260,46 @@ def test_a_missing_proc_status_falls_back_rather_than_failing(
     monkeypatch.setattr("builtins.open", _no_proc)
 
     assert module._proc_peak_rss_bytes() is None
+
+
+def test_linux_without_proc_reports_unavailable_not_ru_maxrss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On Linux an unreadable /proc must NOT fall back to ru_maxrss.
+
+    `ru_maxrss` survives fork/exec on Linux, so the fallback would report the
+    parent's high-water mark as the child's peak -- reinstating the exact bug
+    the subprocess isolation exists to prevent. Greptile measured a released
+    192 MiB parent allocation moving the fallback's answer by 199,208,960
+    bytes for an identical one-file workload.
+
+    macOS cannot execute this path (it has no /proc and its ru_maxrss IS
+    child-local), so the platform is faked. That is the point: the previous
+    version of this fallback was wrong on Linux and every local run passed.
+    """
+    import benchmarks.bench_indexing as module
+
+    monkeypatch.setattr(module, "_proc_peak_rss_bytes", lambda: None)
+    monkeypatch.setattr(module.sys, "platform", "linux")
+
+    assert module._self_peak_rss_bytes() == RSS_UNAVAILABLE
+
+
+def test_non_linux_without_proc_still_uses_ru_maxrss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """macOS keeps the fallback, because there it is genuinely child-local.
+
+    Paired with the test above so the Linux guard cannot be implemented by
+    disabling the fallback everywhere -- that would lose a real measurement on
+    the platform where it works.
+    """
+    import benchmarks.bench_indexing as module
+
+    if module.resource is None:  # pragma: no cover - Windows
+        pytest.skip("no resource module on this platform")
+
+    monkeypatch.setattr(module, "_proc_peak_rss_bytes", lambda: None)
+    monkeypatch.setattr(module.sys, "platform", "darwin")
+
+    assert module._self_peak_rss_bytes() > 0

--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -303,3 +303,39 @@ def test_non_linux_without_proc_still_uses_ru_maxrss(
     monkeypatch.setattr(module.sys, "platform", "darwin")
 
     assert module._self_peak_rss_bytes() > 0
+
+
+def test_direct_script_execution_resolves_the_module_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`python benchmarks/bench_indexing.py` must not die on `__spec__`.
+
+    Running a file directly sets `__spec__` to None, so reading
+    `__spec__.name` raised AttributeError before the child was ever spawned --
+    the benchmark failed on its most obvious invocation while working fine
+    under `-m`, which is why every local run and every CI run passed.
+    """
+    import benchmarks.bench_indexing as module
+
+    monkeypatch.setitem(module.__dict__, "__spec__", None)
+
+    assert module._module_name() == "benchmarks.bench_indexing"
+
+
+def test_module_execution_uses_the_real_spec_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Under `-m` the real spec name wins over the literal fallback.
+
+    Paired with the test above so the fix cannot be implemented by always
+    returning the hardcoded string -- that would work today and break the
+    moment the module moves.
+    """
+    import benchmarks.bench_indexing as module
+
+    class _Spec:
+        name = "some.relocated.module"
+
+    monkeypatch.setitem(module.__dict__, "__spec__", _Spec())
+
+    assert module._module_name() == "some.relocated.module"

--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -1,0 +1,98 @@
+"""Tests for the indexing benchmark harness (issue #1374, deliverable 4).
+
+The benchmark's output is a README row that outlives the run producing it, so
+the properties worth pinning are the ones that make a published number
+trustworthy: that it measures the real pipeline, that it reports what was
+measured alongside the measurement, and that it refuses to emit a number it
+could not actually take.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchmarks.bench_indexing import (
+    IndexingMeasurement,
+    format_markdown_row,
+    measure_indexing,
+)
+
+
+def _write_corpus(root: Path, files: int = 3) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    for i in range(files):
+        (root / f"mod_{i}.py").write_text(
+            f"def fn_{i}(x):\n    return helper_{i}(x)\n\n\ndef helper_{i}(x):\n    return x\n"
+        )
+    return root
+
+
+def test_measure_indexing_reports_real_graph_counts(tmp_path: Path) -> None:
+    """The counts must come from indexing, not from a placeholder.
+
+    A benchmark that reports zeroes on a corpus with content would look like a
+    working harness on an empty repo, so the assertion is that the numbers
+    reflect the fixture rather than merely that fields exist.
+    """
+    corpus = _write_corpus(tmp_path / "repo", files=3)
+
+    result = measure_indexing(corpus, project_name="bench_fixture")
+
+    assert isinstance(result, IndexingMeasurement)
+    # 3 modules x 2 functions each; the exact total depends on the structural
+    # nodes cgr also emits, so assert the floor rather than an exact count that
+    # would break on unrelated schema additions.
+    assert result.node_count >= 6, result.node_count
+    assert result.edge_count > 0, result.edge_count
+    assert result.file_count == 3, result.file_count
+
+
+def test_measure_indexing_records_wall_clock_and_memory(tmp_path: Path) -> None:
+    """Duration and peak memory must be measured, not defaulted.
+
+    Zero would be indistinguishable from "the timer was never started", which
+    is the failure this asserts against.
+    """
+    corpus = _write_corpus(tmp_path / "repo")
+
+    result = measure_indexing(corpus, project_name="bench_fixture")
+
+    assert result.duration_seconds > 0.0
+    assert result.peak_rss_bytes > 0
+
+
+def test_an_empty_corpus_is_refused_rather_than_reported_as_zero(
+    tmp_path: Path,
+) -> None:
+    """A corpus with no indexable files cannot produce a meaningful row.
+
+    Reporting 0 files in 0.01s would publish a number that looks like a fast
+    index rather than like a benchmark that measured nothing -- the
+    silent-smaller-than-truth shape this repo keeps hitting.
+    """
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with pytest.raises(ValueError, match="no indexable files"):
+        measure_indexing(empty, project_name="bench_fixture")
+
+
+def test_the_markdown_row_carries_what_was_measured(tmp_path: Path) -> None:
+    """A number without its corpus and version is not reproducible.
+
+    The issue is explicit that "the credibility of the table is the
+    reproducibility of its cells", so the row must name the corpus and the
+    version it came from rather than the bare timing.
+    """
+    corpus = _write_corpus(tmp_path / "repo")
+    result = measure_indexing(corpus, project_name="bench_fixture")
+
+    row = format_markdown_row(result)
+
+    assert result.corpus_name in row
+    assert result.cgr_version in row
+    assert str(result.file_count) in row
+    # A pipe-delimited row, so it can be pasted into the README table.
+    assert row.startswith("|") and row.endswith("|")

--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from benchmarks.bench_indexing import (
+    RSS_UNAVAILABLE,
     IndexingMeasurement,
     format_markdown_row,
     measure_indexing,
@@ -55,13 +56,49 @@ def test_measure_indexing_records_wall_clock_and_memory(tmp_path: Path) -> None:
 
     Zero would be indistinguishable from "the timer was never started", which
     is the failure this asserts against.
+
+    Memory has a third legitimate state. Where `resource` is unavailable
+    (Windows) the benchmark reports `RSS_UNAVAILABLE` deliberately, so the
+    assertion admits the sentinel while still rejecting 0 -- what must never
+    appear is a value that reads as a measurement without being one.
+
+    An earlier version asserted `> 0` unconditionally and contradicted the
+    module's own Windows path: the fix landed in the implementation and not in
+    the test, and every local run passed because macOS has `resource` and
+    never takes that branch.
     """
     corpus = _write_corpus(tmp_path / "repo")
 
     result = measure_indexing(corpus, project_name="bench_fixture")
 
     assert result.duration_seconds > 0.0
-    assert result.peak_rss_bytes > 0
+    assert result.peak_rss_bytes == RSS_UNAVAILABLE or result.peak_rss_bytes > 0
+
+
+def test_unavailable_memory_renders_as_not_a_measurement() -> None:
+    """The sentinel must never reach a published table as a number.
+
+    Paired with the assertion above: that one permits `RSS_UNAVAILABLE` to
+    exist, so this one pins what it must look like when rendered. Without it,
+    admitting the sentinel would widen the contract with nothing checking the
+    consequence -- a row reading "-1 MiB", or worse "0 MiB", looks measured.
+    """
+    result = IndexingMeasurement(
+        corpus_name="corpus",
+        corpus_path="/tmp/corpus",
+        cgr_version="0.0.0",
+        file_count=1,
+        node_count=1,
+        edge_count=0,
+        duration_seconds=1.0,
+        peak_rss_bytes=RSS_UNAVAILABLE,
+    )
+
+    row = format_markdown_row(result)
+
+    assert "n/a" in row
+    assert "-1" not in row
+    assert "0 MiB" not in row
 
 
 def test_an_empty_corpus_is_refused_rather_than_reported_as_zero(
@@ -122,6 +159,12 @@ def test_peak_memory_is_local_to_the_run_not_the_process(tmp_path: Path) -> None
     corpus = _write_corpus(tmp_path / "repo", files=1)
 
     before = measure_indexing(corpus, project_name="bench_fixture")
+    if before.peak_rss_bytes == RSS_UNAVAILABLE:
+        # Windows: both readings are the sentinel, so the drift check would
+        # compare -1 with -1 and pass without exercising anything. Skipping is
+        # honest; a vacuous pass would report coverage this platform has not
+        # got.
+        pytest.skip("peak RSS unavailable on this platform")
 
     ballast = bytearray(192 * 1024 * 1024)
     ballast_size = len(ballast)


### PR DESCRIPTION
Part of #1374. Implements **deliverable 4 only** — the indexing benchmark.

## Why this one first

#1374 proposes its own phasing and puts this first, for a good reason: it is the only one of the four benchmarks needing **neither a model key nor a running stack**. It produces a README row today, in CI, with no infrastructure. Deliverables 1 (agentic A/B), 2 (query latency) and 3 (token cost) all require an LLM key or a live Memgraph/Qdrant, and remain open.

## What it measures — and what it deliberately does not

Runs the real `GraphUpdater` pipeline (the same parse, definition and call passes production uses) against the in-memory capturing ingestor the eval harness already relies on.

Database round-trips are excluded **by construction**, and that exclusion is the point rather than a shortcut: it isolates the cost this project controls from the cost of the two databases — which is exactly what the field-test review asked ("is the graph worth feeding?"). The module docstring says so explicitly so nobody misreads the number as end-to-end `cgr index` wall-clock. Deliverable 2 covers that, and its number will be larger.

## Measured result

Running against `codebase_rag/parsers`:

| Benchmark | Time | Graph | Peak RSS |
|---|---|---|---|
| Indexing — parsers, 135 files (cgr 0.0.770) | 5.3s | 2604 nodes / 12582 edges | 203 MiB |

Reproduce with:

```
uv run python -m benchmarks.bench_indexing codebase_rag/parsers --project-name cgr_parsers
```

Every row carries its corpus, file count and cgr version, because #1374 is explicit that *the credibility of the table is the reproducibility of its cells*. A timing without provenance is a number nobody can check.

## Two failure modes closed deliberately

**An empty corpus raises rather than reporting zeroes.** `0 files in 0.01s` reads like a very fast index rather than like a benchmark that measured nothing — the published-number form of the silent-smaller-than-truth shape this repo keeps hitting. Verified by mutation: removing the guard fails the test.

**The file count is FILE nodes only.** cgr emits *both* a File and a Module node per source file, and my first version counted either-or — it would have published a file count **twice the truth**. It was caught because the test asserts the fixture's real shape (`file_count == 3`) rather than merely that the field exists; a presence check would have shipped it.

## Testing

Red/green TDD: tests written first and observed failing at collection, then implementation. 4 tests covering real graph counts, wall-clock and memory being measured rather than defaulted, the empty-corpus refusal, and row provenance.

Note the README table row itself is **not** added here — populating the front-page table is better done once more than one benchmark can fill it, rather than landing a one-row table that then churns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reproducible indexing benchmark with Markdown and JSON output.
  * Reports corpus details, file/node/edge counts, indexing duration, and peak memory usage.
  * Supports optional project naming and rejects empty corpora.
  * Handles environments where peak memory metrics are unavailable.

* **Tests**
  * Added coverage for benchmark metrics, validation, formatted output, process isolation, and platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->