### PR TITLE
fix: make semantic recall@k order-sensitive so reranking can be measured

### DIFF
--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -209,7 +209,11 @@ def test_the_query_counts_both_endpoints_explicitly() -> None:
 
     query = build_proximity_query([1, 2])
 
-    assert "UNWIND [id(a), id(b)]" in query, query
+    # Both endpoints reach the UNWIND, via the normalised (low, high) pair the
+    # distinct-type counting in #1477 introduced. What matters is that neither
+    # endpoint is dropped, not which expression names them.
+    assert "UNWIND [low, high]" in query, query
+    assert "AS low" in query and "AS high" in query, query
     # A bare undirected match with a single projected endpoint is the shape
     # this replaced; it must not come back.
     assert "RETURN id(a) AS node_id" not in query, query
@@ -235,7 +239,7 @@ def test_self_loops_are_excluded_from_proximity() -> None:
     assert "id(a) <> id(b)" in query, query
 
 
-# --- the shipped query and the eval's adjacency must agree (issue #1474) ----
+# --- the shipped query and the eval's adjacency must agree (issue #1477) ----
 #
 # The three bugs fixed in review on #1467 -- one endpoint of a directed edge
 # going uncounted, self-loops being double-counted, and the CONTAINS_*
@@ -260,11 +264,14 @@ def _degrees_via_shipped_semantics(
     Mirrors `build_proximity_query` clause for clause over tuples:
     `MATCH (a)-[r:REL]->(b)` filtered to `_PROXIMITY_RELS`, both endpoints in
     the node-id list, `id(a) <> id(b)`, then `UNWIND [id(a), id(b)]` counting
-    each endpoint once per surviving edge.
+    each endpoint once per DISTINCT relationship TYPE joining the pair
+    (issue #1477).
     """
     from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS
 
-    degrees: dict[str, int] = {}
+    # (unordered pair) -> the distinct counted types joining it, matching the
+    # query's `count(DISTINCT type(r))` per pair.
+    kinds: dict[tuple[str, str], set[str]] = {}
     for source, rel_type, target in rels:
         if rel_type not in _PROXIMITY_RELS:
             continue
@@ -272,8 +279,12 @@ def _degrees_via_shipped_semantics(
             continue
         if source == target:  # id(a) <> id(b)
             continue
-        for endpoint in (source, target):  # UNWIND [id(a), id(b)]
-            degrees[endpoint] = degrees.get(endpoint, 0) + 1
+        kinds.setdefault(tuple(sorted((source, target))), set()).add(rel_type)
+
+    degrees: dict[str, int] = {}
+    for (left, right), types in kinds.items():
+        for endpoint in (left, right):  # UNWIND [id(a), id(b)]
+            degrees[endpoint] = degrees.get(endpoint, 0) + len(types)
     return degrees
 
 
@@ -282,24 +293,32 @@ def _degrees_via_eval_adjacency(
 ) -> dict[str, int]:
     """In-set degree the way `evals.semantic_search.proximity_edges` does.
 
-    That helper builds an undirected adjacency SET keyed by qualified name;
-    `reranked_semantic_ranking` then counts `adjacency[qn] & in_set`.
+    That helper builds an undirected adjacency keyed by qualified name whose
+    values are the distinct counted relationship TYPES joining the pair;
+    `reranked_semantic_ranking` then sums those over in-set neighbours
+    (issue #1477).
     """
     from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS
 
-    adjacency: dict[str, set[str]] = {}
+    adjacency: dict[str, dict[str, set[str]]] = {}
     for source, rel_type, target in rels:
         if rel_type not in _PROXIMITY_RELS:
             continue
         if source == target:
             continue
-        adjacency.setdefault(source, set()).add(target)
-        adjacency.setdefault(target, set()).add(source)
-    return {
-        qn: len(adjacency.get(qn, set()) & in_set)
-        for qn in in_set
-        if adjacency.get(qn, set()) & in_set
-    }
+        adjacency.setdefault(source, {}).setdefault(target, set()).add(rel_type)
+        adjacency.setdefault(target, {}).setdefault(source, set()).add(rel_type)
+
+    degrees: dict[str, int] = {}
+    for qn in in_set:
+        total = sum(
+            len(types)
+            for neighbour, types in adjacency.get(qn, {}).items()
+            if neighbour in in_set
+        )
+        if total:
+            degrees[qn] = total
+    return degrees
 
 
 def test_directed_edges_boost_both_endpoints_in_both_implementations() -> None:
@@ -382,30 +401,13 @@ def test_the_two_implementations_agree_over_a_mixed_graph() -> None:
     assert set(shipped) == in_set, shipped
 
 
-def test_a_multi_edge_pair_is_a_known_divergence() -> None:
-    """Two nodes joined by SEVERAL counted edges are scored differently.
+def test_distinct_relationship_types_between_one_pair_each_count() -> None:
+    """Two DIFFERENT relationship types joining a pair count as two (#1477).
 
-    Found by the comparison above rather than by inspection, which is the
-    point of comparing implementations at all. The shipped Cypher counts
-    EDGES -- `UNWIND` yields both endpoints once per matching relationship --
-    while `proximity_edges` builds a SET of neighbours, so every extra edge
-    between the same pair collapses to one.
-
-    A pair joined by both CALLS and OVERRIDES therefore contributes twice the
-    proximity in shipped code and once in the model that measures it.
-    Normalisation hides this while one pair dominates; it surfaces as soon as
-    a multi-edge pair competes with a single-edge one. Measured over
-    a-b (two edges) and b-c (one edge):
-
-        shipped: a=0.67  b=1.0  c=0.33
-        eval:    a=0.5   b=1.0  c=0.5
-
-    Pinned rather than fixed: which count is CORRECT is a question about the
-    proximity model (is a pair that both calls and overrides "closer" than one
-    that only calls?), not about this metric change, and answering it inside
-    an eval-scoring fix would ship a silent behaviour change to the reranker.
-    Tracked in issue #1477; this test fails the moment either side changes, so
-    the divergence cannot widen unnoticed.
+    An override that calls up -- `Child.handle` calling `super().handle()` --
+    carries both CALLS and OVERRIDES between the same pair. Those are two
+    genuinely different relationships, not one observed twice, so the pair is
+    more strongly associated than one joined by either alone.
     """
     rels = [("a", "CALLS", "b"), ("a", "OVERRIDES", "b")]
     in_set = {"a", "b"}
@@ -413,10 +415,44 @@ def test_a_multi_edge_pair_is_a_known_divergence() -> None:
     shipped = _degrees_via_shipped_semantics(rels, in_set)
     evaluated = _degrees_via_eval_adjacency(rels, in_set)
 
+    assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
     assert shipped == {"a": 2, "b": 2}, shipped
-    assert evaluated == {"a": 1, "b": 1}, evaluated
-    assert shipped != evaluated, (
-        "the multi-edge divergence is gone; if it was fixed deliberately, "
-        "fold this pair back into test_the_two_implementations_agree_over_a_"
-        "mixed_graph and delete this test"
-    )
+
+
+def test_the_same_relationship_type_repeated_counts_once() -> None:
+    """One relationship observed twice is not a stronger association (#1477).
+
+    A caller invoking a callee on two lines emits two CALLS edges. Counting
+    both would make proximity depend on how many times a function happens to
+    call another, so a callee invoked in a loop body and once after it would
+    outrank one invoked once from otherwise identical structure.
+
+    Measured on this repo, this is the DOMINANT multi-edge shape: 285 of 1115
+    adjacent pairs across three subtrees, and all 51 multi-CALLS pairs in
+    `codebase_rag/tools` were same-direction repeats with zero mutual.
+    """
+    rels = [("a", "CALLS", "b"), ("a", "CALLS", "b"), ("a", "CALLS", "b")]
+    in_set = {"a", "b"}
+
+    shipped = _degrees_via_shipped_semantics(rels, in_set)
+    evaluated = _degrees_via_eval_adjacency(rels, in_set)
+
+    assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
+    assert shipped == {"a": 1, "b": 1}, shipped
+
+
+def test_repeated_and_distinct_types_are_told_apart() -> None:
+    """The two multi-edge families must not collapse into each other.
+
+    Without this, counting distinct types could be replaced by "count 1 per
+    pair" and both tests above would still pass -- an implementation that
+    discards the OVERRIDES signal entirely.
+    """
+    repeated = [("a", "CALLS", "b"), ("a", "CALLS", "b")]
+    distinct = [("a", "CALLS", "b"), ("a", "OVERRIDES", "b")]
+    in_set = {"a", "b"}
+
+    assert _degrees_via_shipped_semantics(repeated, in_set) == {"a": 1, "b": 1}
+    assert _degrees_via_shipped_semantics(distinct, in_set) == {"a": 2, "b": 2}
+    assert _degrees_via_eval_adjacency(repeated, in_set) == {"a": 1, "b": 1}
+    assert _degrees_via_eval_adjacency(distinct, in_set) == {"a": 2, "b": 2}

--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -350,14 +350,20 @@ def test_a_self_loop_contributes_nothing_in_both_implementations() -> None:
     evaluated = _degrees_via_eval_adjacency(rels, in_set)
 
     assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
-    assert "rec" not in shipped, shipped
+    # Pinned absolutely, not only as "rec is absent". Agreement between the two
+    # mirrors is satisfied by a SHARED error -- multiplying both by a constant
+    # keeps them equal and keeps `rec` absent, so both halves of the weaker
+    # assertion hold while every degree is wrong. Verified: scaling both
+    # mirrors by 7 left this test green before the absolute pin was added.
+    assert shipped == {"a": 1, "b": 1}, shipped
 
 
 def test_containment_edges_change_no_degree_in_either_implementation() -> None:
     """CONTAINS_* is excluded from the shipped query; the eval must match.
 
-    Pinned by comparison rather than by asserting the constant, so that adding
-    a relationship type to one path and not the other fails here.
+    Pinned by comparison AND absolutely. Comparison alone catches a change to
+    one path only; the absolute value is what catches a change to BOTH, which
+    agreement cannot see -- two mirrors sharing an error agree perfectly.
     """
     rels = [
         ("mod", "CONTAINS_FILE", "a"),
@@ -370,7 +376,7 @@ def test_containment_edges_change_no_degree_in_either_implementation() -> None:
     evaluated = _degrees_via_eval_adjacency(rels, in_set)
 
     assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
-    assert "mod" not in shipped, shipped
+    assert shipped == {"a": 1, "b": 1}, shipped
 
 
 def test_the_two_implementations_agree_over_a_mixed_graph() -> None:
@@ -380,9 +386,10 @@ def test_the_two_implementations_agree_over_a_mixed_graph() -> None:
     containment edge, and an unrelated relationship type. Any single-path
     change to the proximity model breaks the equality.
 
-    At most ONE counted edge joins any pair here -- see
-    `test_a_multi_edge_pair_is_a_known_divergence` for why that restriction is
-    load-bearing rather than incidental.
+    At most ONE counted edge joins any pair here, so every in-set node has
+    degree exactly 2 -- one per other in-set node. See
+    `test_distinct_relationship_types_between_one_pair_each_count` for the
+    multi-type case that restriction excludes.
     """
     rels = [
         ("a", "CALLS", "b"),
@@ -398,10 +405,12 @@ def test_the_two_implementations_agree_over_a_mixed_graph() -> None:
     evaluated = _degrees_via_eval_adjacency(rels, in_set)
 
     assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
-    # Every in-set node is connected to both others by at least one counted
-    # edge, so none may be missing -- an empty result would satisfy the
-    # equality above while measuring nothing.
-    assert set(shipped) == in_set, shipped
+    # Pinned to VALUES, not membership. `set(shipped) == in_set` rules out the
+    # empty result but survives any error that scales every degree, because
+    # scaling changes no key -- and a shared scaling error also survives the
+    # equality above. Only absolute values distinguish the two mirrors being
+    # right from the two mirrors being wrong together.
+    assert shipped == {"a": 2, "b": 2, "c": 2}, shipped
 
 
 def test_distinct_relationship_types_between_one_pair_each_count() -> None:

--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -213,7 +213,10 @@ def test_the_query_counts_both_endpoints_explicitly() -> None:
     # distinct-type counting in #1477 introduced. What matters is that neither
     # endpoint is dropped, not which expression names them.
     assert "UNWIND [low, high]" in query, query
-    assert "AS low" in query and "AS high" in query, query
+    # Asserted separately so a failure names WHICH endpoint alias went
+    # missing; a composite assertion reports only that one of them did.
+    assert "AS low" in query, query
+    assert "AS high" in query, query
     # A bare undirected match with a single projected endpoint is the shape
     # this replaced; it must not come back.
     assert "RETURN id(a) AS node_id" not in query, query

--- a/codebase_rag/tests/test_graph_rerank.py
+++ b/codebase_rag/tests/test_graph_rerank.py
@@ -233,3 +233,190 @@ def test_self_loops_are_excluded_from_proximity() -> None:
     query = build_proximity_query([1, 2])
 
     assert "id(a) <> id(b)" in query, query
+
+
+# --- the shipped query and the eval's adjacency must agree (issue #1474) ----
+#
+# The three bugs fixed in review on #1467 -- one endpoint of a directed edge
+# going uncounted, self-loops being double-counted, and the CONTAINS_*
+# exclusion being unpinned -- were all DIVERGENCES between the shipped Cypher
+# and the adjacency model the eval scores it against, rather than freestanding
+# errors. Nothing caught them because nothing compared the two implementations,
+# only each one against its own expectations.
+#
+# `build_proximity_query` is pinned structurally above because this suite has
+# no Memgraph. These execute the query's SEMANTICS over the same relationship
+# tuples `evals.semantic_search.proximity_edges` consumes, and assert both
+# arrive at the same in-set degrees. A divergence in either direction fails
+# here rather than silently making the measurement describe different code
+# from the code that ships.
+
+
+def _degrees_via_shipped_semantics(
+    rels: list[tuple[str, str, str]], in_set: set[str]
+) -> dict[str, int]:
+    """In-set degree the way the shipped Cypher computes it.
+
+    Mirrors `build_proximity_query` clause for clause over tuples:
+    `MATCH (a)-[r:REL]->(b)` filtered to `_PROXIMITY_RELS`, both endpoints in
+    the node-id list, `id(a) <> id(b)`, then `UNWIND [id(a), id(b)]` counting
+    each endpoint once per surviving edge.
+    """
+    from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS
+
+    degrees: dict[str, int] = {}
+    for source, rel_type, target in rels:
+        if rel_type not in _PROXIMITY_RELS:
+            continue
+        if source not in in_set or target not in in_set:
+            continue
+        if source == target:  # id(a) <> id(b)
+            continue
+        for endpoint in (source, target):  # UNWIND [id(a), id(b)]
+            degrees[endpoint] = degrees.get(endpoint, 0) + 1
+    return degrees
+
+
+def _degrees_via_eval_adjacency(
+    rels: list[tuple[str, str, str]], in_set: set[str]
+) -> dict[str, int]:
+    """In-set degree the way `evals.semantic_search.proximity_edges` does.
+
+    That helper builds an undirected adjacency SET keyed by qualified name;
+    `reranked_semantic_ranking` then counts `adjacency[qn] & in_set`.
+    """
+    from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS
+
+    adjacency: dict[str, set[str]] = {}
+    for source, rel_type, target in rels:
+        if rel_type not in _PROXIMITY_RELS:
+            continue
+        if source == target:
+            continue
+        adjacency.setdefault(source, set()).add(target)
+        adjacency.setdefault(target, set()).add(source)
+    return {
+        qn: len(adjacency.get(qn, set()) & in_set)
+        for qn in in_set
+        if adjacency.get(qn, set()) & in_set
+    }
+
+
+def test_directed_edges_boost_both_endpoints_in_both_implementations() -> None:
+    """The directed-endpoint bug, caught by comparison rather than by inspection.
+
+    `a` CALLS `b` and nothing else. Both must gain degree 1. Projecting only
+    `id(a)` -- the shape this replaced -- would leave `b` at 0 in the shipped
+    path while the eval's symmetric adjacency still reports 1.
+    """
+    rels = [("a", "CALLS", "b")]
+    in_set = {"a", "b"}
+
+    shipped = _degrees_via_shipped_semantics(rels, in_set)
+    evaluated = _degrees_via_eval_adjacency(rels, in_set)
+
+    assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
+    assert shipped == {"a": 1, "b": 1}
+
+
+def test_a_self_loop_contributes_nothing_in_both_implementations() -> None:
+    """A recursive function scores zero proximity, not maximum, in both paths."""
+    rels = [("rec", "CALLS", "rec"), ("a", "CALLS", "b")]
+    in_set = {"rec", "a", "b"}
+
+    shipped = _degrees_via_shipped_semantics(rels, in_set)
+    evaluated = _degrees_via_eval_adjacency(rels, in_set)
+
+    assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
+    assert "rec" not in shipped, shipped
+
+
+def test_containment_edges_change_no_degree_in_either_implementation() -> None:
+    """CONTAINS_* is excluded from the shipped query; the eval must match.
+
+    Pinned by comparison rather than by asserting the constant, so that adding
+    a relationship type to one path and not the other fails here.
+    """
+    rels = [
+        ("mod", "CONTAINS_FILE", "a"),
+        ("mod", "CONTAINS_FILE", "b"),
+        ("a", "CALLS", "b"),
+    ]
+    in_set = {"mod", "a", "b"}
+
+    shipped = _degrees_via_shipped_semantics(rels, in_set)
+    evaluated = _degrees_via_eval_adjacency(rels, in_set)
+
+    assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
+    assert "mod" not in shipped, shipped
+
+
+def test_the_two_implementations_agree_over_a_mixed_graph() -> None:
+    """One fixture exercising every divergence at once.
+
+    Directed edges in both orientations, a self-loop, an out-of-set edge, a
+    containment edge, and an unrelated relationship type. Any single-path
+    change to the proximity model breaks the equality.
+
+    At most ONE counted edge joins any pair here -- see
+    `test_a_multi_edge_pair_is_a_known_divergence` for why that restriction is
+    load-bearing rather than incidental.
+    """
+    rels = [
+        ("a", "CALLS", "b"),
+        ("b", "CALLS", "c"),
+        ("c", "CALLS", "a"),
+        ("a", "CALLS", "a"),
+        ("a", "CALLS", "outside"),
+        ("mod", "CONTAINS_FILE", "a"),
+    ]
+    in_set = {"a", "b", "c"}
+
+    shipped = _degrees_via_shipped_semantics(rels, in_set)
+    evaluated = _degrees_via_eval_adjacency(rels, in_set)
+
+    assert shipped == evaluated, f"shipped={shipped} eval={evaluated}"
+    # Every in-set node is connected to both others by at least one counted
+    # edge, so none may be missing -- an empty result would satisfy the
+    # equality above while measuring nothing.
+    assert set(shipped) == in_set, shipped
+
+
+def test_a_multi_edge_pair_is_a_known_divergence() -> None:
+    """Two nodes joined by SEVERAL counted edges are scored differently.
+
+    Found by the comparison above rather than by inspection, which is the
+    point of comparing implementations at all. The shipped Cypher counts
+    EDGES -- `UNWIND` yields both endpoints once per matching relationship --
+    while `proximity_edges` builds a SET of neighbours, so every extra edge
+    between the same pair collapses to one.
+
+    A pair joined by both CALLS and OVERRIDES therefore contributes twice the
+    proximity in shipped code and once in the model that measures it.
+    Normalisation hides this while one pair dominates; it surfaces as soon as
+    a multi-edge pair competes with a single-edge one. Measured over
+    a-b (two edges) and b-c (one edge):
+
+        shipped: a=0.67  b=1.0  c=0.33
+        eval:    a=0.5   b=1.0  c=0.5
+
+    Pinned rather than fixed: which count is CORRECT is a question about the
+    proximity model (is a pair that both calls and overrides "closer" than one
+    that only calls?), not about this metric change, and answering it inside
+    an eval-scoring fix would ship a silent behaviour change to the reranker.
+    Tracked in issue #1477; this test fails the moment either side changes, so
+    the divergence cannot widen unnoticed.
+    """
+    rels = [("a", "CALLS", "b"), ("a", "OVERRIDES", "b")]
+    in_set = {"a", "b"}
+
+    shipped = _degrees_via_shipped_semantics(rels, in_set)
+    evaluated = _degrees_via_eval_adjacency(rels, in_set)
+
+    assert shipped == {"a": 2, "b": 2}, shipped
+    assert evaluated == {"a": 1, "b": 1}, evaluated
+    assert shipped != evaluated, (
+        "the multi-edge divergence is gone; if it was fixed deliberately, "
+        "fold this pair back into test_the_two_implementations_agree_over_a_"
+        "mixed_graph and delete this test"
+    )

--- a/codebase_rag/tests/test_semantic_rerank_eval.py
+++ b/codebase_rag/tests/test_semantic_rerank_eval.py
@@ -8,13 +8,20 @@
 from __future__ import annotations
 
 from itertools import permutations
+from pathlib import Path
+from unittest import mock
 
+import pytest
+import typer
+
+from evals import constants as ec
 from evals.semantic_search import (
     SemanticCase,
     reranked_semantic_ranking,
     score_semantic,
     score_semantic_mrr,
 )
+from evals.types_defs import LocationStats, ScoreResult, ScoreRow
 
 
 def test_reranking_promotes_a_clustered_hit_above_an_isolated_one() -> None:
@@ -26,7 +33,7 @@ def test_reranking_promotes_a_clustered_hit_above_an_isolated_one() -> None:
     unmeasurable.
     """
     ranking = {"q": ["iso.a", "want.b", "want.c"]}
-    adjacency = {"want.b": {"want.c"}, "want.c": {"want.b"}}
+    adjacency = {"want.b": {"want.c": {"CALLS"}}, "want.c": {"want.b": {"CALLS"}}}
 
     reranked = reranked_semantic_ranking(ranking, adjacency, weight=1.0)
 
@@ -57,7 +64,7 @@ def test_the_comparison_scores_both_conditions_the_same_way() -> None:
     """
     cases = [SemanticCase("q", "want.b")]
     baseline = {"q": ["iso.a", "want.b"]}
-    adjacency = {"want.b": {"want.z"}}
+    adjacency = {"want.b": {"want.z": {"CALLS"}}}
 
     before = score_semantic(cases, baseline)
     after = score_semantic(cases, reranked_semantic_ranking(baseline, adjacency))
@@ -97,7 +104,11 @@ def test_an_edge_outside_the_result_set_does_not_count() -> None:
     # than the weight -- with two hits the gap is 1.0 and no boost can ever
     # overturn it, which would make this pass regardless of the fix.
     ranking = {"q": ["a", "b", "c"]}
-    adjacency = {"a": set(), "b": {"x", "y", "z"}, "c": set()}
+    adjacency: dict[str, dict[str, set[str]]] = {
+        "a": {},
+        "b": {"x": {"CALLS"}, "y": {"CALLS"}, "z": {"CALLS"}},
+        "c": {},
+    }
 
     assert reranked_semantic_ranking(ranking, adjacency, weight=1.0)["q"] == [
         "a",
@@ -175,9 +186,9 @@ def test_reranking_that_demotes_the_answer_scores_worse_end_to_end() -> None:
     baseline = {"q": ["cl.a", "want", "cl.b", "cl.c"]}
     # Every hit except `want` is wired to the others, so all three outrank it.
     adjacency = {
-        "cl.a": {"cl.b", "cl.c"},
-        "cl.b": {"cl.a", "cl.c"},
-        "cl.c": {"cl.a", "cl.b"},
+        "cl.a": {"cl.b": {"CALLS"}, "cl.c": {"CALLS"}},
+        "cl.b": {"cl.a": {"CALLS"}, "cl.c": {"CALLS"}},
+        "cl.c": {"cl.a": {"CALLS"}, "cl.b": {"CALLS"}},
     }
 
     reranked = reranked_semantic_ranking(baseline, adjacency, weight=1.0)
@@ -251,3 +262,151 @@ def test_mrr_averages_across_cases() -> None:
 def test_mrr_over_no_cases_is_zero() -> None:
     """No cases means no evidence, not a perfect score."""
     assert score_semantic_mrr([], {"q": ["a"]}) == 0.0
+
+
+def test_the_eval_reranker_counts_distinct_types_not_neighbours() -> None:
+    """The PRODUCTION eval path must weigh a multi-type pair more (#1477).
+
+    `test_graph_rerank.py` compares two local mirrors of the two proximity
+    models. That catches a divergence between the models but says nothing
+    about `reranked_semantic_ranking` itself, so reverting THIS function to
+    presence-only counting left every test in that module green. The guard has
+    to run the shipped code.
+
+    `mid` and `low` are both adjacent to one in-set neighbour, but `mid`'s edge
+    carries two distinct types (an override that calls up). Counting
+    neighbours scores them equally and stable sort keeps the baseline order;
+    counting distinct types promotes `mid`.
+
+    weight=2.0 rather than 1.0: `mid` sits last, so it starts 0.5 of
+    positional similarity behind `low`, and its proximity advantage after
+    normalisation is also 0.5. At weight 1.0 those cancel exactly and stable
+    sort keeps `low` ahead -- the test would then pass for BOTH counting
+    models, which is the defect this whole issue is about.
+    """
+    ranking = {"q": ["top", "low", "mid"]}
+    adjacency: dict[str, dict[str, set[str]]] = {
+        "mid": {"top": {"CALLS", "OVERRIDES"}},
+        "top": {"mid": {"CALLS", "OVERRIDES"}},
+        "low": {"top": {"CALLS"}},
+    }
+
+    reranked = reranked_semantic_ranking(ranking, adjacency, weight=2.0)
+
+    assert reranked["q"].index("mid") < reranked["q"].index("low"), (
+        f"{reranked['q']}: a pair joined by two distinct relationship types "
+        "did not outrank one joined by a single type, so the eval is counting "
+        "neighbours rather than distinct types"
+    )
+
+
+def test_a_negative_cutoff_is_rejected_rather_than_sliced() -> None:
+    """`hits[:-1]` is "all but the last", not a top-k window.
+
+    Left unguarded, a negative k reports a plausible-looking number from a
+    nonsensical window -- the same class of quietly-wrong measurement this
+    metric exists to prevent (CodeRabbit, #1478).
+    """
+    cases = [SemanticCase("q", "want")]
+    ranking = {"q": ["iso.a", "want", "iso.c"]}
+
+    for k in (-1, -3):
+        with pytest.raises(ValueError, match="non-negative"):
+            score_semantic(cases, ranking, k=k)
+        with pytest.raises(ValueError, match="non-negative"):
+            score_semantic_mrr(cases, ranking, k=k)
+
+
+def test_a_zero_cutoff_retrieves_nothing() -> None:
+    """k=0 is a valid empty window, distinct from an invalid negative one."""
+    cases = [SemanticCase("q", "want")]
+    ranking = {"q": ["want"]}
+
+    assert score_semantic(cases, ranking, k=0).rows[0]["recall"] == 0.0
+    assert score_semantic_mrr(cases, ranking, k=0) == 0.0
+
+
+# --- the entry point must actually use the new measurements (#1478) ---------
+#
+# Greptile's P1 on #1478: adding a cutoff-aware scorer and an order-sensitive
+# metric changes nothing if the eval's entry path still calls the default
+# full-ranking recall. A capability nothing invokes is indistinguishable from
+# one that was never added.
+
+
+def test_the_cli_scores_both_conditions_at_the_cutoff() -> None:
+    """`main` must pass its cutoff into scoring and score BOTH conditions.
+
+    Asserted by capturing what the scorers were called with, rather than by
+    reading the printed table: a table showing two rows proves the rows were
+    rendered, not that the reranked condition was scored at the cutoff.
+    """
+    from evals import semantic_search
+
+    seen_recall: list[int | None] = []
+    seen_mrr: list[int | None] = []
+    rankings: list[dict[str, list[str]]] = []
+
+    def fake_ranking(
+        target: object, project: str, queries: list[str], top_k: int
+    ) -> dict[str, list[str]]:
+        # Deeper than the cutoff, or reranking has nothing to demote from.
+        assert top_k > ec.SEMANTIC_TOP_K, top_k
+        return {query: ["a", "b", "c", "d"] for query in queries}
+
+    def fake_score(
+        cases: object, ranking: dict[str, list[str]], k: int | None = None
+    ) -> ScoreResult:
+        seen_recall.append(k)
+        rankings.append(ranking)
+        return ScoreResult(
+            rows=[
+                ScoreRow(
+                    category="retrieval",
+                    label=ec.SEMANTIC_LABEL,
+                    tp=1,
+                    fp=0,
+                    fn=0,
+                    precision=1.0,
+                    recall=1.0,
+                    f1=1.0,
+                )
+            ],
+            location=LocationStats(0, 0, 0, 0.0, 0),
+            diff={},
+        )
+
+    def fake_mrr(
+        cases: object, ranking: dict[str, list[str]], k: int | None = None
+    ) -> float:
+        seen_mrr.append(k)
+        return 1.0
+
+    with mock.patch.multiple(
+        semantic_search,
+        cgr_semantic_ranking=fake_ranking,
+        proximity_edges=lambda *_a, **_kw: {},
+        score_semantic=fake_score,
+        score_semantic_mrr=fake_mrr,
+    ):
+        semantic_search.main(target=Path("codebase_rag"), top_k=ec.SEMANTIC_TOP_K)
+
+    # Both conditions, both metrics, all at the cutoff -- not the default None.
+    assert seen_recall == [ec.SEMANTIC_TOP_K, ec.SEMANTIC_TOP_K], seen_recall
+    assert seen_mrr == [ec.SEMANTIC_TOP_K, ec.SEMANTIC_TOP_K], seen_mrr
+    assert len(rankings) == 2, "only one condition was scored"
+
+
+def test_the_cli_rejects_a_retain_that_leaves_nothing_to_demote() -> None:
+    """retain=1 truncates at the cutoff, reintroducing #1474 at the call site.
+
+    With no candidates below k, no reranking can move a hit across the cutoff
+    and the comparison reports no difference whatever the reranker does.
+    """
+    from evals import semantic_search
+
+    with pytest.raises(typer.BadParameter, match="demote from"):
+        semantic_search.main(target=Path("codebase_rag"), retain=1)
+
+    with pytest.raises(typer.BadParameter, match="at least 1"):
+        semantic_search.main(target=Path("codebase_rag"), top_k=0)

--- a/codebase_rag/tests/test_semantic_rerank_eval.py
+++ b/codebase_rag/tests/test_semantic_rerank_eval.py
@@ -7,10 +7,13 @@
 # reranker alone.
 from __future__ import annotations
 
+from itertools import permutations
+
 from evals.semantic_search import (
     SemanticCase,
     reranked_semantic_ranking,
     score_semantic,
+    score_semantic_mrr,
 )
 
 
@@ -59,16 +62,21 @@ def test_the_comparison_scores_both_conditions_the_same_way() -> None:
     before = score_semantic(cases, baseline)
     after = score_semantic(cases, reranked_semantic_ranking(baseline, adjacency))
 
-    # Both find the expected qn in top-k, so recall is equal here; the point is
-    # that both produce a comparable ScoreResult from one scorer.
     # Asserted separately so a failure names which condition produced no rows;
     # a composite assertion here would report "one of them was empty".
     assert before.rows
     assert after.rows
     # ScoreRow is a TypedDict, so the fields are subscripts.
     assert before.rows[0]["label"] == after.rows[0]["label"]
-    assert before.rows[0]["recall"] == 1.0
-    assert after.rows[0]["recall"] == 1.0
+    # Nothing is demoted out of top-k here, so equal recall is the CORRECT
+    # answer rather than the metric failing to look. The earlier version of
+    # this test asserted both were 1.0 and offered that as evidence the
+    # comparison worked -- but a membership scorer returns 1.0 for every
+    # permutation, so the assertion held whether or not the metric could see
+    # order at all. That is the defect in #1474 written into its own guard.
+    # `test_demoting_the_expected_answer_out_of_top_k_costs_recall` is what
+    # distinguishes the two implementations; this one only fixes the scorer.
+    assert before.rows[0]["recall"] == after.rows[0]["recall"]
 
 
 def test_an_edge_outside_the_result_set_does_not_count() -> None:
@@ -96,3 +104,150 @@ def test_an_edge_outside_the_result_set_does_not_count() -> None:
         "b",
         "c",
     ]
+
+
+# --- #1474: the metric must be able to see order ---------------------------
+#
+# A reranker returns a PERMUTATION of the candidate list. Membership is
+# invariant under permutation, so a membership-based recall@k scores the
+# baseline and the reranked condition identically for every input -- by
+# construction, not by coincidence. The tests below are the ones that fail
+# against that scorer; without them the fix could be deleted and every other
+# test in this file would still pass.
+
+
+def test_demoting_the_expected_answer_out_of_top_k_costs_recall() -> None:
+    """The measurement #1474 exists for: position must change the score.
+
+    Both rankings contain the expected answer, so a membership scorer returns
+    1.0 for each and this assertion fails. Only a scorer that truncates to k
+    before checking can tell the two apart.
+    """
+    cases = [SemanticCase("q", "want")]
+    kept = {"q": ["want", "iso.a", "iso.c"]}
+    demoted = {"q": ["iso.a", "iso.c", "want"]}
+
+    kept_recall = score_semantic(cases, kept, k=2).rows[0]["recall"]
+    demoted_recall = score_semantic(cases, demoted, k=2).rows[0]["recall"]
+
+    assert kept_recall > demoted_recall, (
+        f"recall@2 scored a demoted-out-of-top-k hit ({demoted_recall}) the same "
+        f"as one held at rank 1 ({kept_recall}); the metric is order-insensitive "
+        "and reranking cannot be measured with it"
+    )
+    assert demoted_recall == 0.0
+
+
+def test_recall_at_k_is_not_invariant_across_permutations() -> None:
+    """Pin the general property, not just the one pair above.
+
+    Scoring every permutation of a fixed candidate set proves the metric
+    responds to ORDER. A membership scorer produces one distinct value here;
+    an order-sensitive one produces more than one.
+    """
+    cases = [SemanticCase("q", "want")]
+    scores = {
+        score_semantic(cases, {"q": list(perm)}, k=2).rows[0]["recall"]
+        for perm in permutations(["iso.a", "want", "iso.c"])
+    }
+
+    assert len(scores) > 1, (
+        f"every permutation scored the same ({scores}); recall@k discards the "
+        "ordering that reranking exists to change"
+    )
+
+
+def test_reranking_that_demotes_the_answer_scores_worse_end_to_end() -> None:
+    """Acceptance criterion 1, through the real reranker rather than by hand.
+
+    `want` starts SECOND and is isolated. The hits around it form a connected
+    cluster, so proximity reranking promotes them and pushes `want` out of the
+    top k=2. That must cost recall, or the comparison on #385 is measuring
+    nothing.
+
+    Four hits rather than three, because positional similarity spreads over
+    `len - 1`: with three the gap between neighbours is 0.5 and a maximally
+    boosted last-place hit only TIES the isolated one, which stable sort then
+    leaves in place. The fixture has to make the demoted hit lose outright,
+    not tie.
+    """
+    cases = [SemanticCase("q", "want")]
+    baseline = {"q": ["cl.a", "want", "cl.b", "cl.c"]}
+    # Every hit except `want` is wired to the others, so all three outrank it.
+    adjacency = {
+        "cl.a": {"cl.b", "cl.c"},
+        "cl.b": {"cl.a", "cl.c"},
+        "cl.c": {"cl.a", "cl.b"},
+    }
+
+    reranked = reranked_semantic_ranking(baseline, adjacency, weight=1.0)
+    assert reranked["q"][-1] == "want", reranked["q"]
+
+    before = score_semantic(cases, baseline, k=2).rows[0]["recall"]
+    after = score_semantic(cases, reranked, k=2).rows[0]["recall"]
+
+    assert after < before, (
+        f"reranking demoted the expected answer out of top-2 but recall did not "
+        f"move ({before} -> {after})"
+    )
+
+
+def test_k_defaults_to_scoring_the_whole_ranking() -> None:
+    """Omitting k must preserve the published numbers.
+
+    The existing eval truncates upstream in `cgr_semantic_ranking`, so callers
+    that already pass a top-k list must keep scoring exactly as before.
+    """
+    cases = [SemanticCase("q", "want")]
+    ranking = {"q": ["iso.a", "iso.c", "want"]}
+
+    assert score_semantic(cases, ranking).rows[0]["recall"] == 1.0
+    assert score_semantic(cases, ranking, k=None).rows[0]["recall"] == 1.0
+
+
+def test_mrr_rewards_a_higher_rank() -> None:
+    """The order-sensitive instrument: position is the measurement.
+
+    Unlike recall@k, MRR distinguishes rank 1 from rank 2 even when both are
+    inside k, so it can measure a promotion that does not cross the cutoff.
+    """
+    cases = [SemanticCase("q", "want")]
+
+    first = score_semantic_mrr(cases, {"q": ["want", "iso.a", "iso.c"]})
+    second = score_semantic_mrr(cases, {"q": ["iso.a", "want", "iso.c"]})
+    third = score_semantic_mrr(cases, {"q": ["iso.a", "iso.c", "want"]})
+
+    assert first == 1.0
+    assert second == 0.5
+    assert third == 1 / 3
+    assert first > second > third
+
+
+def test_mrr_scores_a_missing_answer_zero() -> None:
+    """An answer that never appears has no reciprocal rank."""
+    cases = [SemanticCase("q", "want")]
+
+    assert score_semantic_mrr(cases, {"q": ["iso.a", "iso.c"]}) == 0.0
+    assert score_semantic_mrr(cases, {}) == 0.0
+
+
+def test_mrr_respects_k() -> None:
+    """A hit below the cutoff is not retrievable, so it scores zero."""
+    cases = [SemanticCase("q", "want")]
+    ranking = {"q": ["iso.a", "iso.c", "want"]}
+
+    assert score_semantic_mrr(cases, ranking, k=2) == 0.0
+    assert score_semantic_mrr(cases, ranking, k=3) == 1 / 3
+
+
+def test_mrr_averages_across_cases() -> None:
+    """The headline is a mean over cases, so one perfect and one missing is 0.5."""
+    cases = [SemanticCase("q1", "a"), SemanticCase("q2", "b")]
+    ranking = {"q1": ["a"], "q2": ["z"]}
+
+    assert score_semantic_mrr(cases, ranking) == 0.5
+
+
+def test_mrr_over_no_cases_is_zero() -> None:
+    """No cases means no evidence, not a perfect score."""
+    assert score_semantic_mrr([], {"q": ["a"]}) == 0.0

--- a/codebase_rag/tests/test_semantic_rerank_eval.py
+++ b/codebase_rag/tests/test_semantic_rerank_eval.py
@@ -300,6 +300,43 @@ def test_the_eval_reranker_counts_distinct_types_not_neighbours() -> None:
     )
 
 
+def test_eval_proximity_keeps_separating_above_two_types() -> None:
+    """Degree is PROPORTIONAL to in-set connection, with no ceiling.
+
+    The test above states only that a multi-type pair is weighed "more". That
+    is satisfied by any implementation which distinguishes 1 from 2 and then
+    stops -- capping the degree at 2 passes every other test in this file,
+    because no other fixture contains a node above degree 2.
+
+    An understated property is the default failure: a docstring explains why a
+    test exists, and the minimal reason is usually narrower than the contract
+    the code implements. A well-fixtured test for the narrow property guards
+    less than the code does. Found by checking the stated property against the
+    code's DEFINING behaviour rather than checking the fixture against the
+    stated property.
+
+    `hub` reaches three in-set neighbours; `rival` reaches one by two distinct
+    types. Uncapped they are 3 and 2 and separate; capped at 2 they are equal
+    and stable sort keeps the baseline order.
+    """
+    ranking = {"q": ["rival", "hub", "n1", "n2", "n3"]}
+    adjacency: dict[str, dict[str, set[str]]] = {
+        "hub": {"n1": {"CALLS"}, "n2": {"CALLS"}, "n3": {"CALLS"}},
+        "n1": {"hub": {"CALLS"}, "rival": {"CALLS", "OVERRIDES"}},
+        "n2": {"hub": {"CALLS"}},
+        "n3": {"hub": {"CALLS"}},
+        "rival": {"n1": {"CALLS", "OVERRIDES"}},
+    }
+
+    reranked = reranked_semantic_ranking(ranking, adjacency, weight=2.0)
+
+    assert reranked["q"].index("hub") < reranked["q"].index("rival"), (
+        f"{reranked['q']}: a node with in-set degree 3 did not outrank one "
+        "with degree 2, so proximity stops distinguishing above two types "
+        "rather than scaling with how connected a hit is"
+    )
+
+
 def test_a_negative_cutoff_is_rejected_rather_than_sliced() -> None:
     """`hits[:-1]` is "all but the last", not a top-k window.
 

--- a/codebase_rag/tools/graph_rerank.py
+++ b/codebase_rag/tools/graph_rerank.py
@@ -101,14 +101,37 @@ def build_proximity_query(node_ids: list[int]) -> str:
     hits, which is the entire criterion. The exclusion is not defensive: it is
     what keeps the shipped reranker and the model it is measured against
     computing the same quantity.
+
+    Each pair contributes once per DISTINCT relationship type, not once per
+    edge (issue #1477). Two functions where one calls the other on three lines
+    carry three CALLS edges, but that is one relationship observed three
+    times: counting them separately would make proximity depend on how often a
+    caller happens to invoke a callee, so a callee invoked in a loop body and
+    again after it would outrank one invoked once from identical structure.
+    Measured on this repo, that shape is the common one -- 285 of 1115
+    adjacent pairs across three subtrees.
+
+    Distinct TYPES are still counted separately, because they are separate
+    relationships: an override that calls up (`super().handle()`) carries both
+    CALLS and OVERRIDES, and is genuinely more strongly associated than a pair
+    joined by either alone. `collect(DISTINCT type(r))` per pair before the
+    UNWIND is what draws that line.
     """
     placeholders = ", ".join(f"${i}" for i in range(len(node_ids)))
     rel_filter = "|".join(_PROXIMITY_RELS)
+    # Normalise each edge to an unordered (low, high) pair FIRST, so `a CALLS b`
+    # and `b OVERRIDES a` land on the same pair and their types are deduplicated
+    # together. Counting distinct types per ordered pair would miss that, and
+    # the two orientations would each contribute their own count.
     return f"""
 MATCH (a)-[r:{rel_filter}]->(b)
 WHERE id(a) IN [{placeholders}] AND id(b) IN [{placeholders}] AND id(a) <> id(b)
-UNWIND [id(a), id(b)] AS node_id
-RETURN node_id, count(*) AS degree
+WITH CASE WHEN id(a) < id(b) THEN id(a) ELSE id(b) END AS low,
+     CASE WHEN id(a) < id(b) THEN id(b) ELSE id(a) END AS high,
+     type(r) AS kind
+WITH low, high, count(DISTINCT kind) AS kind_count
+UNWIND [low, high] AS node_id
+RETURN node_id, sum(kind_count) AS degree
 """
 
 

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -262,6 +262,23 @@ SEMANTIC_DIFF_PREFIX = "semantic:"
 SEMANTIC_LABEL = "recall-at-k"
 SEMANTIC_CASE_REPR = "{query} => {expected}"
 SEMANTIC_TITLE = "cgr semantic-search eval: query->function recall@k"
+SEMANTIC_RECALL_COLUMN = "recall"
+
+# Query -> expected qualified name, over DEFAULT_TARGET (`codebase_rag`).
+# Each query must map UNAMBIGUOUSLY to one function, or the case grades the
+# fixture rather than the retriever. Kept here rather than in a test module so
+# the CLI entry point and the tests score the same corpus; a benchmark whose
+# cases live only in its test cannot be run.
+SEMANTIC_CASES: tuple[tuple[str, str], ...] = (
+    (
+        "count edges between nodes in the result set for reranking",
+        "codebase_rag.tools.graph_rerank.build_proximity_query",
+    ),
+    (
+        "blend vector similarity with graph proximity to reorder hits",
+        "codebase_rag.tools.graph_rerank.rerank_by_graph_proximity",
+    ),
+)
 
 # Static CALLS eval: function-level call recall. The oracle resolves only
 # unambiguous direct calls (a bare-name call to a function reachable via a

--- a/evals/semantic_search.py
+++ b/evals/semantic_search.py
@@ -80,17 +80,39 @@ def cgr_semantic_ranking(
     return ranking
 
 
+def _rank_of(expected_qn: str, hits: list[str], k: int | None) -> int | None:
+    """1-based rank of `expected_qn` within the top k, or None if absent.
+
+    Truncating HERE rather than upstream is what makes the score respond to
+    order: a reranker returns a permutation, and membership in the full list
+    is invariant under permutation (issue #1474).
+    """
+    considered = hits if k is None else hits[:k]
+    try:
+        return considered.index(expected_qn) + 1
+    except ValueError:
+        return None
+
+
 def score_semantic(
-    cases: list[SemanticCase], ranking: dict[str, list[str]]
+    cases: list[SemanticCase], ranking: dict[str, list[str]], k: int | None = None
 ) -> ScoreResult:
     # recall@k: a case is a hit when its expected function is in the query's
     # top-k. Modelled as a set of satisfied cases vs all cases, so precision is
     # 1.0 by construction and the headline number is recall.
+    #
+    # `k` truncates before the membership check so that a hit demoted out of
+    # the top k genuinely costs recall. Without it any reranker scores exactly
+    # as the baseline for every input -- not approximately, but by
+    # construction, since reordering cannot change what a list contains
+    # (issue #1474). `k=None` scores the whole ranking, which is what callers
+    # that already truncated upstream in `cgr_semantic_ranking` want; it keeps
+    # the published retrieval numbers comparable.
     oracle = {(case.query, case.expected_qn) for case in cases}
     hits = {
         (case.query, case.expected_qn)
         for case in cases
-        if case.expected_qn in ranking.get(case.query, [])
+        if _rank_of(case.expected_qn, ranking.get(case.query, []), k) is not None
     }
     rows: list[ScoreRow] = []
     diff: dict[str, DiffBucket] = {}
@@ -105,6 +127,33 @@ def score_semantic(
             extra=[],
         )
     return ScoreResult(rows=rows, location=_EMPTY_LOCATION, diff=diff)
+
+
+def score_semantic_mrr(
+    cases: list[SemanticCase], ranking: dict[str, list[str]], k: int | None = None
+) -> float:
+    """Mean reciprocal rank of the expected function over all cases.
+
+    The order-sensitive counterpart to `score_semantic` (issue #1474). Where
+    recall@k asks only whether the answer survived the cutoff, MRR measures
+    WHERE it landed, so a promotion from rank 3 to rank 2 registers even
+    though it crosses no boundary. That makes it the instrument for ranking
+    work: position is the quantity being measured rather than a property the
+    metric discards.
+
+    A case whose answer is absent (or below k) contributes 0.0 rather than
+    being skipped, so adding an unretrievable case lowers the mean instead of
+    quietly leaving it unchanged. No cases means no evidence, which scores 0.0
+    rather than a vacuous 1.0.
+    """
+    if not cases:
+        return 0.0
+    total = 0.0
+    for case in cases:
+        rank = _rank_of(case.expected_qn, ranking.get(case.query, []), k)
+        if rank is not None:
+            total += 1.0 / rank
+    return total / len(cases)
 
 
 def proximity_edges(target: Path, project: str) -> dict[str, set[str]]:

--- a/evals/semantic_search.py
+++ b/evals/semantic_search.py
@@ -6,7 +6,12 @@
 # graph, so it tests cgr's embedding + ranking pipeline; the Qdrant ANN layer
 # only approximates this same ranking.
 from pathlib import Path
-from typing import NamedTuple
+from typing import Annotated, NamedTuple
+
+import typer
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
 
 from codebase_rag import constants as cs
 
@@ -14,6 +19,8 @@ from . import constants as ec
 from .cgr_graph import _capture
 from .score import _prf
 from .types_defs import DiffBucket, LocationStats, ScoreResult, ScoreRow
+
+console = Console()
 
 _FUNCTION = cs.NodeLabel.FUNCTION.value
 _METHOD = cs.NodeLabel.METHOD.value
@@ -86,7 +93,14 @@ def _rank_of(expected_qn: str, hits: list[str], k: int | None) -> int | None:
     Truncating HERE rather than upstream is what makes the score respond to
     order: a reranker returns a permutation, and membership in the full list
     is invariant under permutation (issue #1474).
+
+    A negative `k` is rejected rather than passed to the slice. `hits[:-1]`
+    means "all but the last", so a negative cutoff would silently score a
+    ranking against a nonsensical window and report a plausible-looking number
+    -- the failure this metric exists to stop (CodeRabbit, #1478).
     """
+    if k is not None and k < 0:
+        raise ValueError(f"k must be non-negative, got {k}")
     considered = hits if k is None else hits[:k]
     try:
         return considered.index(expected_qn) + 1
@@ -156,33 +170,39 @@ def score_semantic_mrr(
     return total / len(cases)
 
 
-def proximity_edges(target: Path, project: str) -> dict[str, set[str]]:
+def proximity_edges(target: Path, project: str) -> dict[str, dict[str, set[str]]]:
     """Undirected adjacency between first-party definitions, keyed by qn.
 
     Built from the captured relationship tuples rather than a live graph, so
     the comparison runs in the same harness as the baseline and needs no
     Memgraph. Only the relationship types that mean "these two definitions are
     about the same thing" count -- see `tools/graph_rerank._PROXIMITY_RELS`.
+
+    Each neighbour maps to the DISTINCT relationship types joining the pair,
+    not merely to its presence (issue #1477). The shipped query counts one per
+    distinct type, so recording only "is adjacent" would under-count the
+    override-that-calls-up shape (CALLS + OVERRIDES) and make the eval measure
+    a different quantity from the reranker it grades.
     """
     from codebase_rag.tools.graph_rerank import _PROXIMITY_RELS
 
     ingestor = _capture(target, project)
     wanted = set(_PROXIMITY_RELS)
-    adjacency: dict[str, set[str]] = {}
+    adjacency: dict[str, dict[str, set[str]]] = {}
     for _from_label, from_val, rel_type, _to_label, to_val in ingestor.rels:
         if rel_type not in wanted:
             continue
         a, b = str(from_val), str(to_val)
         if a == b:
             continue
-        adjacency.setdefault(a, set()).add(b)
-        adjacency.setdefault(b, set()).add(a)
+        adjacency.setdefault(a, {}).setdefault(b, set()).add(rel_type)
+        adjacency.setdefault(b, {}).setdefault(a, set()).add(rel_type)
     return adjacency
 
 
 def reranked_semantic_ranking(
     ranking: dict[str, list[str]],
-    adjacency: dict[str, set[str]],
+    adjacency: dict[str, dict[str, set[str]]],
     weight: float | None = None,
 ) -> dict[str, list[str]]:
     """The same rankings, reordered by in-set graph proximity (issue #385).
@@ -212,9 +232,17 @@ def reranked_semantic_ranking(
         in_set = set(qns)
         # Degree counted only against OTHER HITS for this query, matching the
         # reranker: an edge to some unrelated definition says nothing about
-        # whether this hit belongs with the rest of the result set.
+        # whether this hit belongs with the rest of the result set. Summed over
+        # DISTINCT relationship types per neighbour, which is what the shipped
+        # query's `count(DISTINCT kind)` produces (issue #1477).
         degrees = {
-            position: float(len(adjacency.get(qn, set()) & in_set))
+            position: float(
+                sum(
+                    len(kinds)
+                    for neighbour, kinds in adjacency.get(qn, {}).items()
+                    if neighbour in in_set
+                )
+            )
             for position, qn in index.items()
         }
         highest = max(degrees.values(), default=0.0)
@@ -251,3 +279,75 @@ class _AdjacencyIngestor:
 
     def execute_write(self, query: str, params: dict | None = None) -> None:
         return None
+
+
+def main(
+    target: Annotated[
+        Path, typer.Option(help="cgr source to evaluate semantic retrieval for.")
+    ] = Path(ec.DEFAULT_TARGET),
+    project_name: Annotated[str, typer.Option(help="cgr project name.")] = "",
+    top_k: Annotated[int, typer.Option(help="Cutoff for recall@k and MRR.")] = (
+        ec.SEMANTIC_TOP_K
+    ),
+    retain: Annotated[
+        int,
+        typer.Option(
+            help="Candidates kept before reranking, as a multiple of top_k. "
+            "Must exceed 1 or reranking has nothing to demote from."
+        ),
+    ] = 3,
+) -> None:
+    """Score semantic retrieval with and without graph-proximity reranking.
+
+    Reports recall@k and MRR for both conditions. The reranked condition is
+    scored through the SAME scorer at the SAME cutoff, so the two differ by one
+    variable and any gap is attributable to reranking alone (issue #385).
+
+    Candidates are retained DEEPER than `top_k` and truncated at scoring time.
+    Truncating before reranking would leave it nothing to demote from, and the
+    comparison would report no difference regardless of what reranking did --
+    which is the defect in issue #1474, reintroduced at the call site.
+    """
+    if top_k < 1:
+        raise typer.BadParameter(f"top_k must be at least 1, got {top_k}")
+    if retain < 2:
+        raise typer.BadParameter(
+            f"retain must be at least 2 or reranking has no candidates to "
+            f"demote from, got {retain}"
+        )
+
+    target = target.resolve()
+    project = project_name or target.name
+    cases = [SemanticCase(query, expected) for query, expected in ec.SEMANTIC_CASES]
+    queries = [case.query for case in cases]
+    logger.info("Ranking {} queries against {}", len(queries), target)
+    baseline = cgr_semantic_ranking(target, project, queries, top_k * retain)
+    adjacency = proximity_edges(target, project)
+    reranked = reranked_semantic_ranking(baseline, adjacency)
+
+    table = Table(title=ec.SEMANTIC_TITLE)
+    table.add_column("condition")
+    table.add_column(f"recall@{top_k}", justify="right")
+    table.add_column("MRR", justify="right")
+    for label, ranking in (("baseline", baseline), ("reranked", reranked)):
+        rows = score_semantic(cases, ranking, k=top_k).rows
+        recall = rows[0][ec.SEMANTIC_RECALL_COLUMN] if rows else 0.0
+        table.add_row(
+            label,
+            f"{recall:.4f}",
+            f"{score_semantic_mrr(cases, ranking, k=top_k):.4f}",
+        )
+    console.print(table)
+
+    # A comparison where nothing moved measures nothing; say so rather than
+    # letting an unchanged number read as "reranking made no difference".
+    changed = sum(1 for query in baseline if baseline[query] != reranked.get(query))
+    if not changed:
+        console.print(
+            "[yellow]Reranking changed no ordering, so the two rows above are "
+            "the same measurement twice rather than a comparison.[/yellow]"
+        )
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
Closes #1474.

## The defect

`score_semantic` scored recall@k by **membership**. A reranker returns a *permutation*, and membership is invariant under permutation, so the baseline and reranked conditions scored identically for every input — by construction, not by coincidence.

Reproduced before any fix:

```
=== all permutations of a 3-hit list containing the expected answer ===
  ('iso.a', 'want', 'iso.c') -> recall 1.0
  ('iso.a', 'iso.c', 'want') -> recall 1.0
  ('want', 'iso.a', 'iso.c') -> recall 1.0
  ('want', 'iso.c', 'iso.a') -> recall 1.0
  ('iso.c', 'iso.a', 'want') -> recall 1.0
  ('iso.c', 'want', 'iso.a') -> recall 1.0

  expected kept at rank 1 : recall 1.0
  expected demoted to rank 3 (out of top 2): recall 1.0
```

## The fix

Both remedies the issue lists, since they are not exclusive:

* `score_semantic(cases, ranking, k=None)` truncates **before** the membership check, so a hit demoted out of the top k genuinely costs recall. `k=None` scores the whole ranking, preserving every existing call site and the published retrieval numbers.
* `score_semantic_mrr(cases, ranking, k=None)` is the order-sensitive instrument: it measures *where* the answer landed, so a promotion that crosses no cutoff still registers.

## The old guard asserted the bug

`test_the_comparison_scores_both_conditions_the_same_way` asserted `before.recall == 1.0` and `after.recall == 1.0` and offered that as evidence the comparison worked. A membership scorer returns 1.0 for every permutation, so the assertion held whether or not the metric could see order at all — the defect written into its own guard. It now asserts the two are *equal* (correct, since nothing crosses the cutoff there) and points at the test that actually distinguishes the implementations.

## Mutation proof

Green is not evidence for tests written after a fix. Reverting `score_semantic` to the membership check:

```
FAILED test_demoting_the_expected_answer_out_of_top_k_costs_recall
FAILED test_recall_at_k_is_not_invariant_across_permutations
FAILED test_reranking_that_demotes_the_answer_scores_worse_end_to_end
3 failed, 11 passed
```

with the message `reranking demoted the expected answer out of top-2 but recall did not move (1.0 -> 1.0)`. The other 11 still pass, so the guards are specific to this defect.

## Divergence guard, and a fourth divergence found

The three bugs fixed in review on #1467 were all divergences between the shipped Cypher and the adjacency model the eval scores it against. Nothing caught them because the existing tests pin the query *text* and the adjacency *shape* separately, each against its own expectations, with nothing comparing the two.

This adds tests that execute both paths over one fixture and assert equal in-set degrees. Writing them immediately surfaced a **fourth** divergence: the shipped Cypher counts *edges* (`UNWIND` yields both endpoints once per relationship) while `proximity_edges` builds a *set* of neighbours, so a pair joined by both `CALLS` and `OVERRIDES` contributes 2 in shipped code and 1 in the model measuring it. Verified against the real `_proximity_scores`:

```
shipped: a=0.67  b=1.0  c=0.33
eval:    a=0.5   b=1.0  c=0.5
```

Pinned as a known divergence rather than fixed here — which count is correct is a question about the proximity model, and answering it inside a metric fix would ship a silent behaviour change to the reranker. Filed as #1477.

## #385 re-measurement

Run on the fixed metric, retaining candidates deeper than k so reranking has somewhere to demote from:

```
condition     recall@k       MRR
baseline        1.0000    1.0000
reranked        1.0000    0.8333

  weight  recall@3       MRR
    0.05    1.0000    1.0000
    0.10    1.0000    1.0000
    0.25    1.0000    0.8333
    0.50    1.0000    0.8333
    1.00    1.0000    0.8333
```

Order changed on 3/3 queries, so the deltas measure something rather than reporting an inert comparison.

This is a **first measurement of post-#1467 code, not a correction of the retracted one**. Three correctness bugs were fixed after that measurement and the metric has changed, so two variables moved; the old number is void rather than superseded.

**Two caveats, both limiting:** the fixture's baseline is already perfect (MRR 1.0), so it can detect harm but never improvement — this is evidence against reranking helping *here*, not evidence it helps nowhere. And three cases on one synthetic repo is thin. What it does establish is that the instrument now moves, which is what #1474 was for. Note also that recall@k alone still reports `+0.0000`: all three answers stayed inside the top 3, and only MRR sees the demotion from rank 1 to rank 2 — the concrete argument for adding the order-sensitive metric rather than only truncating.

## Checks

`ruff check` clean, `ruff format --check` clean, 35 passed across the three affected test files. `ty` reports 2 diagnostics, both pre-existing on `main` (identical with these changes stashed, neither in a touched file).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line workflow for evaluating semantic search.
  * Added baseline and graph-reranked scoring with recall@k and MRR.
  * Added configurable result cutoffs and validation for evaluation settings.
  * Added shared semantic evaluation cases for consistent scoring.

* **Bug Fixes**
  * Improved proximity ranking to count distinct relationship types accurately while ignoring repeated edges of the same type.
  * Added support for negative and zero cutoff validation.

* **Tests**
  * Expanded coverage for relationship types, cutoff behavior, CLI scoring, and invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 2 — `8838d16c`

All three findings from the first round are addressed, and the scope grew to close #1477 as well.

### Greptile P1: the entry path did not use the new measurements

Correct, and the most important of the three. `k` and MRR existed but nothing invoked them, so the eval still ran the order-blind default — a capability nothing calls is indistinguishable from one never added.

There was no eval *workflow* to wire into: `semantic_search.py` had no `main`, unlike its siblings (`module_calls.py`, `flow_ground_truth.py`) which each expose `typer.run(main)`. Added one following that convention. It scores **both** conditions through the same scorer at the same cutoff, and retains candidates deeper than `top_k` so reranking has somewhere to demote from — truncating first would reintroduce #1474 at the call site.

Two guards on the entry point itself: `retain < 2` and `top_k < 1` are rejected with reasons, and the command says so explicitly when reranking changed no ordering, so an unchanged number cannot read as "reranking made no difference."

`SEMANTIC_CASES` moved into `evals/constants.py` (they previously lived only in a test module — a benchmark whose cases live only in its test cannot be run).

### CodeRabbit: negative `k` silently sliced

Correct. `hits[:-1]` means "all but the last", so a negative cutoff scored a nonsensical window and returned a plausible-looking number. Now raises `ValueError`, with tests covering `-1`/`-3` and confirming `k=0` remains a *valid* empty window.

### CodeRabbit: wrong issue reference

Correct, my slip — that block is #1477, not #1474. Fixed.

## Also closes #1477

The known-divergence pin is gone; both paths now agree. Measured on real code before choosing the semantics rather than guessing, across three subtrees (1115 adjacent pairs):

```
                                 pairs   repeated-same-type   distinct-types
codebase_rag/tools                 187                   48               21
codebase_rag/parsers/io_access     179                   94                0
evals                              749                  143               13
TOTAL                             1115                  285               34
```

Two distinct families, and only one was a judgement call:

* **285 pairs (25.6%)** are the *same* type repeated — a caller invoking a callee on three lines. All 51 multi-`CALLS` pairs in `codebase_rag/tools` were same-direction repeats, **zero mutual**. Counting these separately makes proximity depend on how often a caller happens to invoke a callee, which is indefensible under either model.
* **34 pairs (3.0%)** carry genuinely distinct types — the override that calls up (`super().handle()` is both `CALLS` and `OVERRIDES`). Credit to @vscode-link-terminal-scheme for isolating that case; verified through the real updater.

So both paths now count **distinct relationship types per pair**. This differs from *both* previous implementations: the shipped query over-counted the 25.6%, the eval under-counted the 3.0%.

## Mutation proof

The first mutation run exposed a real gap in my own tests: reverting the **eval-side production code** to presence-only counting left all 20 tests in `test_graph_rerank.py` green, because those compare two local *mirrors* of the models rather than the shipped functions. Added `test_the_eval_reranker_counts_distinct_types_not_neighbours`, which runs `reranked_semantic_ranking` itself. Re-verified:

```
mutation (eval counts neighbours, not distinct types) -> FAILED  (was: 20 passed)
mutation (shipped mirror counts edges again)          -> 7 failed
unmutated                                             -> 42 passed
```

## Checks

`ruff check` clean, `ruff format` clean, 42 passed. `ty` reports the same 2 diagnostics as `main` — verified pre-existing by stashing these changes and re-running; neither is in a touched file.