### PR TITLE
docs: say what add-grammar does NOT do (#1368)

### DIFF
--- a/docs/advanced/adding-languages.md
+++ b/docs/advanced/adding-languages.md
@@ -50,21 +50,36 @@ Everything above is derived from the grammar's own `tree-sitter.json` and
 `node-types.json`. Anything that depends on what the language *means* is not,
 and cannot be, inferred from those files.
 
-A grammar added this way gets **definitions and calls**. It does not get a
-`LanguageHandler`, and several capabilities live there:
+A grammar added this way gets **definitions and calls**. Everything below the
+line needs language-specific code that someone has written:
 
-| Derived from the grammar | Needs a language handler |
+| Derived from the grammar | Needs language-specific code |
 |---|---|
 | Functions, methods, classes | Inheritance (`extends`, `with`, mixins) |
 | Modules and files | Import resolution and aliasing |
 | Call sites | Qualified-name construction rules |
 
-Measured example: Scala shipped with its node types wired and no handler. It
-produced classes, objects, traits, methods, modules and CALLS edges — and
-**no inheritance edges at all**, because `extends A with B` is a grammar
-production nothing had been taught to read. Its imports resolved to nothing
-for every form. Both took reading the grammar and deciding what the
-constructs mean; neither is in `node-types.json`.
+That code does not have to be a `LanguageHandler`. C# and Dart use the base
+handler and still emit inheritance and import edges, through dedicated
+extraction paths (`split_csharp_bases` and `extract_dart_parent_classes` in
+`class_ingest/parent_extraction.py`; `_parse_csharp_imports` and
+`_parse_dart_imports` in `import_processor.py`). A handler is one place such
+code lives, not the only one.
+
+What matters is that **somebody wrote it for that language**. `add-grammar`
+does not, and cannot: the shape of an `extends` clause or an import alias is
+not in `node-types.json`.
+
+Measured example, since fixed: Scala **used to be** in exactly this state —
+node types wired, no language-specific extraction. It produced classes,
+objects, traits, methods, modules and CALLS edges, and **no inheritance edges
+at all**, because `extends A with B` is a grammar production nothing had been
+taught to read. Its imports resolved to nothing for every form.
+
+Closing those gaps meant reading the grammar and deciding what the constructs
+mean — that `with` introduces mixins, that `import a.{B => C}` binds `C` and
+not `B`. None of it is in `node-types.json`, which is why the gap existed for
+as long as it did and why nothing reported it.
 
 **The failure is silent.** A partially-supported language produces a graph,
 not an error. Queries return fewer results rather than reporting that a
@@ -72,11 +87,16 @@ relationship kind is missing, so nothing tells you the graph is thinner than
 the code.
 
 So treat `add-grammar` as *"parse this language"*, not *"support this
-language"*. If you need inheritance or import edges, the language needs a
-handler in `codebase_rag/parsers/handlers/` — see
-[Adding a Language Frontend](../architecture/language-frontends.md) and the
-[support matrix](../architecture/language-support.md) for what each shipped
-language actually provides.
+language"*. If you need inheritance or import edges, someone has to write the
+language-specific extraction — in a handler under
+`codebase_rag/parsers/handlers/`, or in the per-language branches of
+`class_ingest/parent_extraction.py` and `import_processor.py`, as C# and Dart
+do.
+
+The [support matrix](../architecture/language-support.md) is the authority on
+what each shipped language actually provides; the presence or absence of a
+handler is not. For compiler-backed facts on top of the Tree-sitter
+backbone, see [Adding a Language Frontend](../architecture/language-frontends.md).
 
 ## Example: Adding C# Support
 

--- a/docs/advanced/adding-languages.md
+++ b/docs/advanced/adding-languages.md
@@ -44,6 +44,40 @@ When you add a language, the tool automatically:
 4. **Updates Configuration**: Adds the language to `codebase_rag/language_spec.py`
 5. **Enables Parsing**: Makes the language available for codebase analysis (the grammar itself is compiled on first use by the parser loader)
 
+## What does NOT happen automatically
+
+Everything above is derived from the grammar's own `tree-sitter.json` and
+`node-types.json`. Anything that depends on what the language *means* is not,
+and cannot be, inferred from those files.
+
+A grammar added this way gets **definitions and calls**. It does not get a
+`LanguageHandler`, and several capabilities live there:
+
+| Derived from the grammar | Needs a language handler |
+|---|---|
+| Functions, methods, classes | Inheritance (`extends`, `with`, mixins) |
+| Modules and files | Import resolution and aliasing |
+| Call sites | Qualified-name construction rules |
+
+Measured example: Scala shipped with its node types wired and no handler. It
+produced classes, objects, traits, methods, modules and CALLS edges — and
+**no inheritance edges at all**, because `extends A with B` is a grammar
+production nothing had been taught to read. Its imports resolved to nothing
+for every form. Both took reading the grammar and deciding what the
+constructs mean; neither is in `node-types.json`.
+
+**The failure is silent.** A partially-supported language produces a graph,
+not an error. Queries return fewer results rather than reporting that a
+relationship kind is missing, so nothing tells you the graph is thinner than
+the code.
+
+So treat `add-grammar` as *"parse this language"*, not *"support this
+language"*. If you need inheritance or import edges, the language needs a
+handler in `codebase_rag/parsers/handlers/` — see
+[Adding a Language Frontend](../architecture/language-frontends.md) and the
+[support matrix](../architecture/language-support.md) for what each shipped
+language actually provides.
+
 ## Example: Adding C# Support
 
 ```bash


### PR DESCRIPTION
Relates to #1368, and lands the part of it that is true **whichever way that issue is decided**.

## The problem

`docs/advanced/adding-languages.md` lists five things that happen automatically, ending with:

> **Enables Parsing**: Makes the language available for codebase analysis

and mentions no limitation anywhere — **zero** occurrences of "handler", "limitation" or "does not" across 99 lines. It reads as *"you now support this language"*.

The page names `ruby` and `kotlin` as examples. Both have **open issues requesting support** (#118, #1233). That gap is stated by the repo itself.

## What `add-grammar` actually produces

Definitions and calls — everything derivable from the grammars own `tree-sitter.json` and `node-types.json`. It does not produce a `LanguageHandler`; `codebase_rag/tools/language.py` contains no reference to one. Inheritance, import resolution and qualified-name rules live there.

**Measured example, from this repo:** Scala shipped with node types wired and no handler. The result produced classes, objects, traits, methods, modules and CALLS edges — and **no inheritance edges at all**, plus no import resolution for any form. Neither is inferable from `node-types.json`; both took reading the grammar and deciding what the constructs mean.

## Why it is worth documenting rather than leaving implicit

**The failure is silent.** A partially-supported language produces a graph, not an error. Queries return fewer results, with nothing reporting that a whole relationship kind is absent — so the graph is thinner than the code and nothing says so.

## What this deliberately does not claim

Handler-less does **not** mean unsupported. C# and Dart have no handler entry and are `FULL` in the support matrix, because they compensate through frontends and dedicated extraction paths.

So the page points at the [support matrix](docs/architecture/language-support.md) for what each language actually provides, rather than implying a rule that would be wrong for two of them. Both added cross-references were checked to resolve.

Docs-only; no code paths change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that language-specific extraction may be implemented through language handlers or dedicated language-specific paths.
  * Updated C# and Dart examples to reflect their extraction approaches.
  * Revised the Scala example to note that previous extraction gaps have been addressed, including mixins and import aliasing.
  * Directed readers to the support matrix as the authoritative source for language capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->