### PR TITLE
feat: report a measured frame resolution rate on traceback correlation

### DIFF
--- a/codebase_rag/crash_correlation.py
+++ b/codebase_rag/crash_correlation.py
@@ -285,6 +285,15 @@ def explain_traceback(
         flow_gaps=graph.flow_gaps,
         resolution=FrameResolutionRate(
             total=len(contexts),
+            # Keyed on `qualified_name`, NOT on `unresolved_reason is None`.
+            # Today the two agree, because every failure path in
+            # `FrameResolver.resolve` records a reason before returning None.
+            # But `_resolve_stack` derives the reason with
+            # `next(iter(stats.unresolved), None)`, so a future failure path
+            # that forgets to record one would yield reason=None with no
+            # qualified name -- and the other predicate would then count an
+            # unresolvable frame as resolved. The qualified name is what the
+            # rate is ABOUT; the reason is diagnostic text alongside it.
             resolved=sum(1 for frame in contexts if frame.qualified_name is not None),
         ),
     )

--- a/codebase_rag/crash_correlation.py
+++ b/codebase_rag/crash_correlation.py
@@ -75,11 +75,43 @@ class FrameContext(NamedTuple):
     flow_sources: tuple[str, ...]
 
 
+class FrameResolutionRate(NamedTuple):
+    """How much of a traceback the graph could actually anchor (issue #227).
+
+    Named for the frames it counts rather than "resolution stats", because
+    `trace.resolution.ResolutionStats` is already imported here and counts
+    something else entirely -- the resolver's internal attempts for ONE frame.
+    Shadowing it silently broke `_resolve_stack`.
+
+    Per-frame ``unresolved_reason`` says WHICH frames failed to resolve; this
+    says HOW MANY, which is what decides whether a report is worth acting on.
+    A stack where one frame in three resolved and one where all three did are
+    different artefacts, and without the aggregate they read alike.
+    """
+
+    total: int
+    resolved: int
+
+    @property
+    def rate(self) -> float:
+        """Resolved frames over ALL frames, 0.0 when there are none.
+
+        The denominator is every frame in the traceback, including those
+        outside the repository. Dividing by the resolved count instead would
+        report 1.0 for every report ever produced, and skipping unresolved
+        frames would hide exactly the gap this measures. An empty stack
+        resolves nothing, so it scores 0.0 rather than a vacuous 1.0 -- the
+        same trap as an average over no cases.
+        """
+        return self.resolved / self.total if self.total else 0.0
+
+
 class TracebackReport(NamedTuple):
     exception_type: str
     exception_message: str
     frames: tuple[FrameContext, ...]
     flow_gaps: tuple[str, ...]
+    resolution: FrameResolutionRate
 
 
 class RootCause(NamedTuple):
@@ -251,6 +283,10 @@ def explain_traceback(
         exception_message=parsed.exception_message,
         frames=tuple(contexts),
         flow_gaps=graph.flow_gaps,
+        resolution=FrameResolutionRate(
+            total=len(contexts),
+            resolved=sum(1 for frame in contexts if frame.qualified_name is not None),
+        ),
     )
 
 

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -531,6 +531,13 @@ class MCPToolsRegistry:
             "exception_message": report.exception_message,
             "frames": [frame._asdict() for frame in report.frames],
             "flow_gaps": list(report.flow_gaps),
+            # `rate` is a property, so `_asdict()` omits it; mapped explicitly
+            # because the ratio is the number the caller acts on (issue #227).
+            "resolution": {
+                "total": report.resolution.total,
+                "resolved": report.resolution.resolved,
+                "rate": report.resolution.rate,
+            },
         }
 
     async def rank_root_causes(self, traceback_text: str) -> dict:

--- a/codebase_rag/tests/test_crash_correlation.py
+++ b/codebase_rag/tests/test_crash_correlation.py
@@ -143,6 +143,89 @@ def test_explain_resolves_frames_and_attaches_neighbourhood(tmp_path):
     assert report.flow_gaps == ()
 
 
+def test_explain_reports_a_measured_resolution_rate(tmp_path):
+    """Criterion 1 of #227: the rate must be measured, not left to the caller.
+
+    Per-frame `unresolved_reason` already says WHICH frames failed; the
+    aggregate says HOW MANY, which is the number the criterion asks for and
+    the one an agent needs to judge whether a report is worth acting on. A
+    report where one frame in three resolved is a different artefact from one
+    where all three did, and nothing distinguished them.
+    """
+    fetch_all = _fetch_all_for(flow_edges=[])
+    report = explain_traceback(fetch_all, _P, tmp_path, _crash_text(tmp_path))
+
+    assert report.resolution.total == 3
+    assert report.resolution.resolved == 3
+    assert report.resolution.rate == 1.0
+
+
+def test_resolution_rate_counts_only_the_frames_that_resolved(tmp_path):
+    """A partially-resolved stack must not report a perfect rate.
+
+    Pinned as exact counts AND the ratio. Asserting only `rate < 1.0` would
+    pass for any wrong denominator -- counting resolved frames over resolved
+    frames, or skipping unresolved ones entirely, both of which are the
+    plausible mistakes here and both of which return 1.0 or a rate over a
+    denominator that hides the gap.
+    """
+    text = (
+        "Traceback (most recent call last):\n"
+        '  File "/usr/lib/python3.12/site-packages/lib.py", line 5, in call\n'
+        "    fn()\n"
+        f'  File "{(tmp_path / "app" / "service.py").as_posix()}", line 10, in handle\n'
+        "    return cfg.timeout\n"
+        "AttributeError: 'NoneType' object has no attribute 'timeout'\n"
+    )
+    fetch_all = _fetch_all_for(flow_edges=[])
+
+    report = explain_traceback(fetch_all, _P, tmp_path, text)
+
+    assert report.resolution.total == 2
+    assert report.resolution.resolved == 1
+    assert report.resolution.rate == 0.5
+
+
+def test_resolution_rate_of_a_frameless_traceback_is_zero_not_one(tmp_path):
+    """total == 0 must score 0.0, exercising the empty branch itself.
+
+    The test below covers "frames exist, none resolved". It does NOT cover
+    "no frames at all", because its fixture has total == 1 so the `if
+    self.total` guard is always taken -- measured: mutating the empty case to
+    return 1.0 left that test green. A frameless traceback is the only input
+    that runs the branch, and an exception raised with no stack produces one.
+    """
+    text = "Traceback (most recent call last):\nRuntimeError: boom\n"
+    fetch_all = _fetch_all_for(flow_edges=[])
+
+    report = explain_traceback(fetch_all, _P, tmp_path, text)
+
+    assert report.resolution.total == 0
+    assert report.resolution.resolved == 0
+    assert report.resolution.rate == 0.0
+
+
+def test_resolution_rate_of_an_unresolvable_stack_is_zero_not_one(tmp_path):
+    """Frames present, none resolved: 0.0 over a real denominator.
+
+    Distinct from the frameless case above -- here `total` is non-zero, so
+    this exercises the division rather than the empty guard.
+    """
+    text = (
+        "Traceback (most recent call last):\n"
+        '  File "/usr/lib/python3.12/site-packages/lib.py", line 5, in call\n'
+        "    fn()\n"
+        "RuntimeError: boom\n"
+    )
+    fetch_all = _fetch_all_for(flow_edges=[])
+
+    report = explain_traceback(fetch_all, _P, tmp_path, text)
+
+    assert report.resolution.total == 1
+    assert report.resolution.resolved == 0
+    assert report.resolution.rate == 0.0
+
+
 def test_explain_marks_out_of_repo_frames_with_a_reason(tmp_path):
     text = (
         "Traceback (most recent call last):\n"

--- a/codebase_rag/tests/test_crash_correlation.py
+++ b/codebase_rag/tests/test_crash_correlation.py
@@ -168,12 +168,33 @@ def test_resolution_rate_counts_only_the_frames_that_resolved(tmp_path):
     frames, or skipping unresolved ones entirely, both of which are the
     plausible mistakes here and both of which return 1.0 or a rate over a
     denominator that hides the gap.
+
+    The ratio is 2/5, chosen because it collides with NOTHING. The obvious
+    fixture is one library frame and one repo frame, giving 0.5 -- and at
+    `total=2, resolved=1` six formulas all produce 0.5: the correct one,
+    `1 - resolved/total` (the INVERTED rate, which reports failure while
+    looking like success), `unresolved/total`, `1/total`,
+    `resolved/(resolved+1)` and a hardcoded `resolved/2`. The assertion would
+    hold for five wrong implementations.
+
+    2/5 is also not 1/3, which still collides with `1/total`. Other tests here
+    do catch these collectively, via the fully-resolved and nothing-resolved
+    cases -- but a guard that discriminates only with help from its siblings
+    loses its coverage the moment one is weakened, and nothing records which
+    test was load-bearing.
     """
+    src = (tmp_path / "app" / "service.py").as_posix()
     text = (
         "Traceback (most recent call last):\n"
         '  File "/usr/lib/python3.12/site-packages/lib.py", line 5, in call\n'
         "    fn()\n"
-        f'  File "{(tmp_path / "app" / "service.py").as_posix()}", line 10, in handle\n'
+        '  File "/usr/lib/python3.12/json/decoder.py", line 9, in decode\n'
+        "    raise err\n"
+        '  File "/usr/lib/python3.12/json/__init__.py", line 3, in loads\n'
+        "    return _default_decoder.decode(s)\n"
+        f'  File "{src}", line 16, in dispatch\n'
+        "    return handle(cfg)\n"
+        f'  File "{src}", line 10, in handle\n'
         "    return cfg.timeout\n"
         "AttributeError: 'NoneType' object has no attribute 'timeout'\n"
     )
@@ -181,9 +202,9 @@ def test_resolution_rate_counts_only_the_frames_that_resolved(tmp_path):
 
     report = explain_traceback(fetch_all, _P, tmp_path, text)
 
-    assert report.resolution.total == 2
-    assert report.resolution.resolved == 1
-    assert report.resolution.rate == 0.5
+    assert report.resolution.total == 5
+    assert report.resolution.resolved == 2
+    assert report.resolution.rate == 0.4
 
 
 def test_resolution_counts_the_qualified_name_not_the_absence_of_a_reason(

--- a/codebase_rag/tests/test_crash_correlation.py
+++ b/codebase_rag/tests/test_crash_correlation.py
@@ -186,6 +186,62 @@ def test_resolution_rate_counts_only_the_frames_that_resolved(tmp_path):
     assert report.resolution.rate == 0.5
 
 
+def test_resolution_counts_the_qualified_name_not_the_absence_of_a_reason(
+    tmp_path, monkeypatch
+):
+    """A frame with neither a qn nor a reason counts as UNRESOLVED.
+
+    Keying `resolved` on `unresolved_reason is None` instead passes every
+    other test in this file -- measured. The two predicates agree today
+    because every failure path in `FrameResolver.resolve` records a reason
+    before returning None, so this condition is not reachable through the
+    shipped resolver.
+
+    Pinned anyway, and as BEHAVIOUR rather than as an early return, because
+    "unreachable" describes the current resolver and not a promise:
+    `_resolve_stack` derives the reason with `next(iter(stats.unresolved),
+    None)`, so one future failure path that forgets to record makes it real.
+    The resolver is patched to BE that future path, so the assertion runs
+    through `explain_traceback` and covers the line that picks the predicate
+    -- asserting over a hand-built `FrameResolutionRate` would pin arithmetic
+    production never executes.
+    """
+    from codebase_rag.crash_correlation import FrameResolver as _FR
+
+    real_resolve = _FR.resolve
+
+    def resolve_without_recording(self, frame, stats):
+        match = real_resolve(self, frame, stats)
+        if match is None:
+            # The future failure path: returns None, records nothing.
+            stats.unresolved.clear()
+        return match
+
+    monkeypatch.setattr(_FR, "resolve", resolve_without_recording)
+
+    text = (
+        "Traceback (most recent call last):\n"
+        '  File "/usr/lib/python3.12/site-packages/lib.py", line 5, in call\n'
+        "    fn()\n"
+        f'  File "{(tmp_path / "app" / "service.py").as_posix()}", line 10, in handle\n'
+        "    return cfg.timeout\n"
+        "AttributeError: 'NoneType' object has no attribute 'timeout'\n"
+    )
+    report = explain_traceback(_fetch_all_for(flow_edges=[]), _P, tmp_path, text)
+
+    outside = report.frames[0]
+    assert outside.qualified_name is None
+    assert outside.unresolved_reason is None, "fixture did not reach the case"
+
+    assert report.resolution.resolved == 1, (
+        "a frame with no qualified name was counted as resolved because it "
+        "carried no unresolved_reason; the rate must count what the graph "
+        "actually anchored"
+    )
+    assert report.resolution.total == 2
+    assert report.resolution.rate == 0.5
+
+
 def test_resolution_rate_of_a_frameless_traceback_is_zero_not_one(tmp_path):
     """total == 0 must score 0.0, exercising the empty branch itself.
 

--- a/codebase_rag/tests/test_mcp_crash_correlation.py
+++ b/codebase_rag/tests/test_mcp_crash_correlation.py
@@ -90,6 +90,22 @@ async def test_explain_traceback_returns_resolved_frames(tmp_path):
     assert qns == [f"{project}.app.service.dispatch", f"{project}.app.service.handle"]
 
 
+async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
+    """The measurement must reach the caller, not just exist in the report.
+
+    `explain_traceback` builds its response field by field, so a stat added to
+    `TracebackReport` is silently dropped here unless it is mapped across. A
+    measurement the MCP surface does not return is indistinguishable from one
+    that was never computed -- the defect Greptile caught on #1478, where a
+    cutoff-aware scorer existed and nothing invoked it.
+    """
+    registry = _registry(tmp_path)
+
+    result = await registry.explain_traceback(traceback_text=_crash_text(tmp_path))
+
+    assert result["resolution"] == {"total": 2, "resolved": 2, "rate": 1.0}
+
+
 async def test_rank_root_causes_returns_ranked_candidates(tmp_path):
     registry = _registry(tmp_path)
     project = derive_project_name(tmp_path)

--- a/codebase_rag/tests/test_mcp_crash_correlation.py
+++ b/codebase_rag/tests/test_mcp_crash_correlation.py
@@ -105,11 +105,12 @@ async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
     passed all four tests before this fixture gained a library frame. The
     illustrative case and the discriminating case are different cases.
 
-    TWO unresolvable frames rather than one, so the ratio is 1/3 rather than
-    1/2. At `total=2, resolved=1` the correct `resolved/total` collides
-    numerically with `1 - resolved/total`, `unresolved/total`,
-    `resolved/(resolved+1)` and `1/total` -- all five yield 0.5, so the
-    assertion would hold for four wrong formulas. 1/3 separates them.
+    The ratio is 2/5, which collides with nothing. At `total=2, resolved=1`
+    six formulas all yield 0.5 -- the correct one, the INVERTED
+    `1 - resolved/total`, `unresolved/total`, `1/total`,
+    `resolved/(resolved+1)` and a hardcoded `resolved/2` -- so the assertion
+    would hold for five wrong implementations. 1/3 is better but still
+    collides with `1/total`.
     """
     registry = _registry(tmp_path)
     src = (tmp_path / "app" / "service.py").as_posix()
@@ -119,6 +120,10 @@ async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
         "    fn()\n"
         '  File "/usr/lib/python3.12/json/decoder.py", line 9, in decode\n'
         "    raise err\n"
+        '  File "/usr/lib/python3.12/json/__init__.py", line 3, in loads\n'
+        "    return _default_decoder.decode(s)\n"
+        f'  File "{src}", line 16, in dispatch\n'
+        "    return handle(cfg)\n"
         f'  File "{src}", line 10, in handle\n'
         "    return cfg.timeout\n"
         "AttributeError: 'NoneType' object has no attribute 'timeout'\n"
@@ -126,7 +131,7 @@ async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
 
     result = await registry.explain_traceback(traceback_text=text)
 
-    assert result["resolution"] == {"total": 3, "resolved": 1, "rate": 1 / 3}
+    assert result["resolution"] == {"total": 5, "resolved": 2, "rate": 0.4}
 
 
 async def test_rank_root_causes_returns_ranked_candidates(tmp_path):

--- a/codebase_rag/tests/test_mcp_crash_correlation.py
+++ b/codebase_rag/tests/test_mcp_crash_correlation.py
@@ -98,12 +98,27 @@ async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
     measurement the MCP surface does not return is indistinguishable from one
     that was never computed -- the defect Greptile caught on #1478, where a
     cutoff-aware scorer existed and nothing invoked it.
+
+    A PARTIALLY resolved stack, deliberately. The obvious fixture is the
+    fully-resolved one used by the tests above, and with `total == resolved`
+    a mapping that swaps the two keys is invisible -- measured: the swap
+    passed all four tests before this fixture gained the library frame. The
+    illustrative case and the discriminating case are different cases.
     """
     registry = _registry(tmp_path)
+    src = (tmp_path / "app" / "service.py").as_posix()
+    text = (
+        "Traceback (most recent call last):\n"
+        '  File "/usr/lib/python3.12/site-packages/lib.py", line 5, in call\n'
+        "    fn()\n"
+        f'  File "{src}", line 10, in handle\n'
+        "    return cfg.timeout\n"
+        "AttributeError: 'NoneType' object has no attribute 'timeout'\n"
+    )
 
-    result = await registry.explain_traceback(traceback_text=_crash_text(tmp_path))
+    result = await registry.explain_traceback(traceback_text=text)
 
-    assert result["resolution"] == {"total": 2, "resolved": 2, "rate": 1.0}
+    assert result["resolution"] == {"total": 2, "resolved": 1, "rate": 0.5}
 
 
 async def test_rank_root_causes_returns_ranked_candidates(tmp_path):

--- a/codebase_rag/tests/test_mcp_crash_correlation.py
+++ b/codebase_rag/tests/test_mcp_crash_correlation.py
@@ -102,8 +102,14 @@ async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
     A PARTIALLY resolved stack, deliberately. The obvious fixture is the
     fully-resolved one used by the tests above, and with `total == resolved`
     a mapping that swaps the two keys is invisible -- measured: the swap
-    passed all four tests before this fixture gained the library frame. The
+    passed all four tests before this fixture gained a library frame. The
     illustrative case and the discriminating case are different cases.
+
+    TWO unresolvable frames rather than one, so the ratio is 1/3 rather than
+    1/2. At `total=2, resolved=1` the correct `resolved/total` collides
+    numerically with `1 - resolved/total`, `unresolved/total`,
+    `resolved/(resolved+1)` and `1/total` -- all five yield 0.5, so the
+    assertion would hold for four wrong formulas. 1/3 separates them.
     """
     registry = _registry(tmp_path)
     src = (tmp_path / "app" / "service.py").as_posix()
@@ -111,6 +117,8 @@ async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
         "Traceback (most recent call last):\n"
         '  File "/usr/lib/python3.12/site-packages/lib.py", line 5, in call\n'
         "    fn()\n"
+        '  File "/usr/lib/python3.12/json/decoder.py", line 9, in decode\n'
+        "    raise err\n"
         f'  File "{src}", line 10, in handle\n'
         "    return cfg.timeout\n"
         "AttributeError: 'NoneType' object has no attribute 'timeout'\n"
@@ -118,7 +126,7 @@ async def test_explain_traceback_exposes_the_resolution_rate_over_mcp(tmp_path):
 
     result = await registry.explain_traceback(traceback_text=text)
 
-    assert result["resolution"] == {"total": 2, "resolved": 1, "rate": 0.5}
+    assert result["resolution"] == {"total": 3, "resolved": 1, "rate": 1 / 3}
 
 
 async def test_rank_root_causes_returns_ranked_candidates(tmp_path):


### PR DESCRIPTION
Closes the last open acceptance criterion on #227.

## What was missing

Three of the four criteria were already met on `main` — I counted them against the checklist rather than estimating:

| Criterion | State |
|---|---|
| `rank_root_causes` places the planted defect in the top 3 | ✅ `test_rank_places_the_flow_writer_in_the_top_candidates` |
| Both tools exposed via MCP with tests | ✅ `test_mcp_crash_correlation.py` |
| Graceful degradation when `FLOWS_TO` is absent | ✅ `test_rank_degrades_to_calls_only_when_flow_is_absent` |
| **Python traceback resolves with a measured resolution rate** | ❌ **this PR** |

`FrameContext.unresolved_reason` already said *which* frames failed to resolve. Nothing said *how many*. A stack where one frame in three resolved and one where all three did produced reports that read alike, which is the number an agent needs to judge whether a report is worth acting on.

## The change

`FrameResolutionRate(total, resolved)` on `TracebackReport`, with `rate` as a property, mapped explicitly across the MCP boundary.

**Named `FrameResolutionRate`, not `ResolutionStats`** — `trace.resolution.ResolutionStats` is already imported in that module and counts something else (one frame's resolver attempts). My first version shadowed it and silently broke `_resolve_stack`; the type error surfaced it immediately.

**Mapped explicitly in `mcp/tools.py`** because that handler builds its response field by field and `rate` is a property, so `_asdict()` omits it. A measurement the MCP surface does not return is indistinguishable from one never computed — the defect Greptile caught on #1478.

## Mutation proof, including one my own test missed

Red proven first: all three tests failed with `AttributeError` before the implementation existed. Then each named alternative:

```
rate over RESOLVED (always 1.0)       -> test_..._counts_only_the_frames_that_resolved  FAILED
MCP drops the field                   -> test_..._exposes_the_resolution_rate_over_mcp  FAILED
vacuous 1.0 for an empty stack        -> 3 passed   NOT CAUGHT
```

The third **survived**, and its docstring claimed to guard exactly that case. The fixture had `total == 1`, so the `if self.total` guard was always taken and the empty branch never ran — a test asserting a property its fixture cannot reach.

Confirmed the branch is reachable (a frameless traceback yields `total == 0`) and added `test_resolution_rate_of_a_frameless_traceback_is_zero_not_one`. Re-verified: the vacuous-1.0 mutation now fails, and only that test.

## Checks

`ruff check` and `ruff format` clean. 20 passed across both crash-correlation test files. `ty` reports the same 2 diagnostics as `main`, neither in a touched file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added traceback resolution statistics showing total frames, resolved frames, and resolution rate.
  * Included resolution details in crash explanation results.
  * Resolution rates now support fully, partially, and unsuccessfully resolved tracebacks.

* **Bug Fixes**
  * Correctly reports a 0.0 resolution rate for empty or entirely unresolved tracebacks.
  * Ensures unresolved frames are not mistakenly counted as resolved.

* **Tests**
  * Added coverage for resolution statistics across common traceback scenarios and crash explanation responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->