### PR TITLE
feat: resolve PHP `use function` imports through declared namespaces

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1298,12 +1298,53 @@ class CallResolver:
 
         return self._try_resolve_wildcard_imports(call_name, import_map)
 
+    def _php_target_for_namespace_import(self, imported_path: str) -> str | None:
+        """Map a PHP `use function A\\B\\c` target onto the qn that registers it.
+
+        CGR qualifies PHP by file path, so the import target `App.Text.format`
+        never equals the registered `project.text.format`. Previously that miss
+        dropped through to the simple-name trie, which binds to whichever
+        same-named function it reaches first -- so `use function App\\Text\\format`
+        could resolve to `App\\Money\\format` (issue #1185). A wrong edge, not a
+        missing one.
+
+        Splits the target into the namespace it names and the symbol within it,
+        then finds the module that DECLARED that namespace and looks the symbol
+        up there. PSR-4 maps a namespace prefix to a directory root, so the two
+        cannot be derived from one another -- the declaration is the only link.
+
+        Returns None rather than guessing whenever the answer is not unique:
+        no module declares the namespace, or several do (PHP permits one
+        namespace across many files, and two files may both define `format`).
+        The trie fallback then applies exactly as before, so this can only
+        replace an arbitrary binding with a determined one, never introduce a
+        new arbitrary one.
+        """
+        namespace, separator, symbol = imported_path.rpartition(cs.SEPARATOR_DOT)
+        if not separator or not namespace or not symbol:
+            return None
+        namespaces = self.import_processor.php_module_namespaces
+        matches = [
+            f"{module_qn}{cs.SEPARATOR_DOT}{symbol}"
+            for module_qn, declared in namespaces.items()
+            if declared == namespace
+        ]
+        found = [qn for qn in matches if qn in self.function_registry]
+        if len(found) != 1:
+            return None
+        return found[0]
+
     def _try_resolve_direct_import(
         self, call_name: str, import_map: dict[str, str]
     ) -> tuple[str, str] | None:
         if call_name not in import_map:
             return None
         imported_qn = import_map[call_name]
+        if imported_qn not in self.function_registry and (
+            php_qn := self._php_target_for_namespace_import(imported_qn)
+        ):
+            logger.debug(ls.CALL_DIRECT_IMPORT, call_name=call_name, qn=php_qn)
+            return self.function_registry[php_qn], php_qn
         if imported_qn in self.function_registry:
             logger.debug(ls.CALL_DIRECT_IMPORT, call_name=call_name, qn=imported_qn)
             return self.function_registry[imported_qn], imported_qn

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1288,7 +1288,7 @@ class CallResolver:
                 return None
             import_map = {}
 
-        if result := self._try_resolve_direct_import(call_name, import_map):
+        if result := self._try_resolve_direct_import(call_name, import_map, language):
             return result
 
         if result := self._try_resolve_qualified_call(
@@ -1335,13 +1335,25 @@ class CallResolver:
         return found[0]
 
     def _try_resolve_direct_import(
-        self, call_name: str, import_map: dict[str, str]
+        self,
+        call_name: str,
+        import_map: dict[str, str],
+        language: cs.SupportedLanguage | None = None,
     ) -> tuple[str, str] | None:
         if call_name not in import_map:
             return None
         imported_qn = import_map[call_name]
-        if imported_qn not in self.function_registry and (
-            php_qn := self._php_target_for_namespace_import(imported_qn)
+        # Gated on the CALLER's language. The namespace map is keyed by module
+        # qn and holds only PHP modules, but the import targets it is matched
+        # against are dotted strings that any language can produce -- a JS
+        # `import { format } from ...` recorded as `App.Text.format` would
+        # resolve straight into a PHP function. Reproduced in review on #1484:
+        # a JavaScript caller bound to a PHP target, an edge across languages
+        # that no source expressed.
+        if (
+            language == cs.SupportedLanguage.PHP
+            and imported_qn not in self.function_registry
+            and (php_qn := self._php_target_for_namespace_import(imported_qn))
         ):
             logger.debug(ls.CALL_DIRECT_IMPORT, call_name=call_name, qn=php_qn)
             return self.function_registry[php_qn], php_qn

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1304,7 +1304,9 @@ class CallResolver:
                 return None
             import_map = {}
 
-        if result := self._try_resolve_direct_import(call_name, import_map, language):
+        if result := self._try_resolve_direct_import(
+            call_name, import_map, language, module_qn
+        ):
             return result
 
         if result := self._try_resolve_qualified_call(
@@ -1396,24 +1398,53 @@ class CallResolver:
             return None
         return found[0]
 
+    def _is_php_function_import(self, call_name: str, module_qn: str | None) -> bool:
+        """Whether `call_name` arrived via `use function`, not a class `use`.
+
+        Returns False when `module_qn` is unknown rather than defaulting to
+        True: an unidentified module cannot demonstrate the import was a
+        function binding, and the fallback's whole purpose is to avoid
+        asserting a target it cannot justify. The trie fallback still applies,
+        so this can only decline to add an edge, never remove a correct one.
+        """
+        if module_qn is None:
+            return False
+        return call_name in self.import_processor.php_function_imports.get(
+            module_qn, frozenset()
+        )
+
     def _try_resolve_direct_import(
         self,
         call_name: str,
         import_map: dict[str, str],
         language: cs.SupportedLanguage | None = None,
+        module_qn: str | None = None,
     ) -> tuple[str, str] | None:
         if call_name not in import_map:
             return None
         imported_qn = import_map[call_name]
-        # Gated on the CALLER's language. The namespace map is keyed by module
-        # qn and holds only PHP modules, but the import targets it is matched
-        # against are dotted strings that any language can produce -- a JS
+        # Gated on the CALLER's language AND on the import being a
+        # `use function` binding.
+        #
+        # The language gate: the namespace map is keyed by module qn and holds
+        # only PHP modules, but the import targets it is matched against are
+        # dotted strings that any language can produce -- a JS
         # `import { format } from ...` recorded as `App.Text.format` would
         # resolve straight into a PHP function. Reproduced in review on #1484:
         # a JavaScript caller bound to a PHP target, an edge across languages
         # that no source expressed.
+        #
+        # The `use function` gate: PHP keeps classes and functions in SEPARATE
+        # symbol tables, so `use App\Text\format` imports a CLASS while
+        # `use function App\Text\format` imports a function. Without this, a
+        # class or constant import whose name happens to match a registered
+        # PHP function resolved to that function -- also reproduced in review,
+        # and it SURVIVED the language gate because the caller is PHP. The two
+        # are independent axes. `php_function_imports` already records which
+        # local names arrived via `use function`, so this needs no new parsing.
         if (
             language == cs.SupportedLanguage.PHP
+            and self._is_php_function_import(call_name, module_qn)
             and imported_qn not in self.function_registry
             and (php_qn := self._php_target_for_namespace_import(imported_qn))
         ):

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -67,6 +67,22 @@ def _split_receiver_chain(expr: str) -> list[str]:
 
 PY_EXTERNAL_TARGET: tuple[str, str] = ("", "")
 
+# PHP folds A-Z only when comparing namespace and function names, so
+# `use function app\text\FORMAT` binds to `App\Text\format`.
+#
+# NOT `str.casefold()`, which folds the full Unicode range: PHP treats
+# identifiers differing outside ASCII as DISTINCT, so Unicode folding would
+# match names the language does not, trading a missed binding for a wrong one.
+# `str.lower()` has the same problem (Turkish dotless i, Kelvin sign).
+_PHP_ASCII_FOLD = str.maketrans(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"
+)
+
+
+def _php_fold(name: str) -> str:
+    """ASCII-lowercase `name` for PHP-style case-insensitive comparison."""
+    return name.translate(_PHP_ASCII_FOLD)
+
 
 class CallResolver:
     __slots__ = (
@@ -1319,17 +1335,46 @@ class CallResolver:
         The trie fallback then applies exactly as before, so this can only
         replace an arbitrary binding with a determined one, never introduce a
         new arbitrary one.
+
+        Matching is ASCII CASE-INSENSITIVE, because namespaces and function
+        names are in PHP: `use function app\\text\\FORMAT` binds to
+        `App\\Text\\format`, verified by executing it under PHP 8.5. Comparing
+        with exact casing sent such imports to the trie, which is the same
+        wrong-edge path this function exists to avoid.
+
+        ASCII-only rather than `str.casefold()`: PHP folds A-Z only, so
+        folding non-ASCII identifiers would match names the language treats as
+        distinct -- trading a missed binding for a wrong one. The registered
+        qualified name is returned unchanged; folding is for COMPARISON, never
+        for the value handed back, which must stay the graph's real key.
         """
         namespace, separator, symbol = imported_path.rpartition(cs.SEPARATOR_DOT)
         if not separator or not namespace or not symbol:
             return None
+        wanted = _php_fold(namespace)
         namespaces = self.import_processor.php_module_namespaces
         matches = [
-            f"{module_qn}{cs.SEPARATOR_DOT}{symbol}"
+            (module_qn, f"{module_qn}{cs.SEPARATOR_DOT}{symbol}")
             for module_qn, declared in namespaces.items()
-            if declared == namespace
+            if _php_fold(declared) == wanted
         ]
-        found = [qn for qn in matches if qn in self.function_registry]
+        found: list[str] = []
+        for module_qn, exact_qn in matches:
+            if exact_qn in self.function_registry:
+                found.append(exact_qn)
+                continue
+            # The symbol's casing may differ from the registration too, so a
+            # direct lookup can miss where PHP would bind. Scan only this
+            # module's own entries rather than the whole registry.
+            prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+            wanted_symbol = _php_fold(symbol)
+            found.extend(
+                qn
+                for qn in self.function_registry
+                if qn.startswith(prefix)
+                and cs.SEPARATOR_DOT not in qn[len(prefix) :]
+                and _php_fold(qn[len(prefix) :]) == wanted_symbol
+            )
         if len(found) != 1:
             return None
         return found[0]

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1364,15 +1364,18 @@ class CallResolver:
                 found.append(exact_qn)
                 continue
             # The symbol's casing may differ from the registration too, so a
-            # direct lookup can miss where PHP would bind. Scan only this
-            # module's own entries rather than the whole registry.
+            # direct lookup can miss where PHP would bind. `find_with_prefix`
+            # is the registry's own scoped query -- iterating the whole
+            # registry is not part of the trie protocol at all, and would be
+            # a full scan per import even where it happened to work.
             prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
             wanted_symbol = _php_fold(symbol)
             found.extend(
                 qn
-                for qn in self.function_registry
-                if qn.startswith(prefix)
-                and cs.SEPARATOR_DOT not in qn[len(prefix) :]
+                for qn, _ in self.function_registry.find_with_prefix(prefix)
+                # Direct children only: a nested `module.Class.method` is not
+                # the free function this import names.
+                if cs.SEPARATOR_DOT not in qn[len(prefix) :]
                 and _php_fold(qn[len(prefix) :]) == wanted_symbol
             )
         if len(found) != 1:

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1431,9 +1431,7 @@ class CallResolver:
         folded = _php_fold(call_name)
         return any(_php_fold(name) == folded for name in imported)
 
-    def _php_import_key(
-        self, call_name: str, import_map: dict[str, str]
-    ) -> str | None:
+    def _php_import_key(self, call_name: str, import_map: dict[str, str]) -> str | None:
         """The import-map key matching `call_name` under PHP case folding.
 
         Returns None unless EXACTLY ONE key folds to the same name. Two keys

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1431,6 +1431,21 @@ class CallResolver:
         folded = _php_fold(call_name)
         return any(_php_fold(name) == folded for name in imported)
 
+    def _php_import_key(
+        self, call_name: str, import_map: dict[str, str]
+    ) -> str | None:
+        """The import-map key matching `call_name` under PHP case folding.
+
+        Returns None unless EXACTLY ONE key folds to the same name. Two keys
+        differing only in case cannot both be the intended target, and PHP
+        would reject the duplicate `use` at compile time anyway -- so
+        declining is correct rather than cautious, and the trie fallback still
+        applies.
+        """
+        folded = _php_fold(call_name)
+        matches = [key for key in import_map if _php_fold(key) == folded]
+        return matches[0] if len(matches) == 1 else None
+
     def _try_resolve_direct_import(
         self,
         call_name: str,
@@ -1438,9 +1453,22 @@ class CallResolver:
         language: cs.SupportedLanguage | None = None,
         module_qn: str | None = None,
     ) -> tuple[str, str] | None:
-        if call_name not in import_map:
+        if call_name in import_map:
+            imported_qn = import_map[call_name]
+        elif (
+            language == cs.SupportedLanguage.PHP
+            and (folded_key := self._php_import_key(call_name, import_map)) is not None
+        ):
+            # PHP records `import_map` under the DECLARATION spelling, so a
+            # call written `FORMAT()` against `use function App\Text\format`
+            # misses this lookup entirely and never reaches the folded
+            # binding-kind gate below. Reported on #1484 after an earlier fix
+            # addressed only the gate: the exact-case map lookup in FRONT of
+            # it is where the miss actually happens.
+            imported_qn = import_map[folded_key]
+            call_name = folded_key
+        else:
             return None
-        imported_qn = import_map[call_name]
         # Gated on the CALLER's language AND on the import being a
         # `use function` binding.
         #

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1368,15 +1368,29 @@ class CallResolver:
             # is the registry's own scoped query -- iterating the whole
             # registry is not part of the trie protocol at all, and would be
             # a full scan per import even where it happened to work.
-            prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+            #
+            # NO trailing separator. The trie splits the prefix on dots and
+            # walks a node per part, so `"proj.text."` yields a final EMPTY
+            # part that is never a key and the lookup always returns []. An
+            # earlier version passed the dot and the whole case-insensitive
+            # fallback was silently dead (caught in review on #1484). The
+            # boundary is re-established below by requiring the remainder to
+            # start with the separator.
+            prefix = module_qn
             wanted_symbol = _php_fold(symbol)
             found.extend(
                 qn
                 for qn, _ in self.function_registry.find_with_prefix(prefix)
+                # `find_with_prefix` walks whole dot-separated parts, so the
+                # remainder always starts with the separator for a real
+                # descendant. Requiring it re-establishes the boundary the
+                # trailing dot used to provide, and rejects a sibling module
+                # whose name merely starts with this one (`proj.textutil`).
+                if (remainder := qn[len(prefix) :]).startswith(cs.SEPARATOR_DOT)
                 # Direct children only: a nested `module.Class.method` is not
                 # the free function this import names.
-                if cs.SEPARATOR_DOT not in qn[len(prefix) :]
-                and _php_fold(qn[len(prefix) :]) == wanted_symbol
+                and cs.SEPARATOR_DOT not in remainder[1:]
+                and _php_fold(remainder[1:]) == wanted_symbol
             )
         if len(found) != 1:
             return None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1350,6 +1350,14 @@ class CallResolver:
         qualified name is returned unchanged; folding is for COMPARISON, never
         for the value handed back, which must stay the graph's real key.
         """
+        # A fully-qualified import (`use function \App\Text\format`) is
+        # idiomatic PHP and runs identically to the unqualified spelling,
+        # verified under PHP 8.5. The leading backslash becomes a leading
+        # separator when the path is dotted, which would never match a
+        # declared `App.Text`. Stripping it is a spelling normalisation, not a
+        # semantic change -- in PHP a `use` path is ALWAYS resolved from the
+        # global namespace whether or not the backslash is written.
+        imported_path = imported_path.lstrip(cs.SEPARATOR_DOT)
         namespace, separator, symbol = imported_path.rpartition(cs.SEPARATOR_DOT)
         if not separator or not namespace or not symbol:
             return None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1409,9 +1409,19 @@ class CallResolver:
         """
         if module_qn is None:
             return False
-        return call_name in self.import_processor.php_function_imports.get(
+        imported = self.import_processor.php_function_imports.get(
             module_qn, frozenset()
         )
+        if call_name in imported:
+            return True
+        # PHP function names are case-insensitive at the CALL SITE too, so
+        # `use function App\Text\format` followed by `FORMAT()` is valid and
+        # runs. Verified by executing it under PHP 8.5. An exact-case lookup
+        # here recognised the import but not the call, so the resolver
+        # returned None and the call fell to the trie -- the same wrong-edge
+        # path, reached through the alias rather than the target.
+        folded = _php_fold(call_name)
+        return any(_php_fold(name) == folded for name in imported)
 
     def _try_resolve_direct_import(
         self,

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -476,6 +476,7 @@ class ImportProcessor:
         "commonjs_direct_exports",
         "conditional_imports",
         "php_function_imports",
+        "php_module_namespaces",
         "js_ts_bare_imports",
         "js_path_aliases",
         "stdlib_extractor",
@@ -689,6 +690,17 @@ class ImportProcessor:
         # Collections/functions.php), so these must resolve by simple name via the
         # trie rather than being judged external-import and suppressed.
         self.php_function_imports: dict[str, set[str]] = {}
+        # The `namespace Vendor\Pkg` a PHP module declares, keyed by module qn,
+        # stored dotted (`Vendor.Pkg`) to match how import targets are recorded.
+        #
+        # PHP namespaces and directory layout are INDEPENDENT: PSR-4 maps a
+        # namespace prefix to a directory root, so `Vendor\Pkg\helper` may live
+        # at any depth beneath it. Without this map a `use function
+        # App\Text\format` import cannot be matched to the file that declares
+        # `namespace App\Text`, so the call falls through to the simple-name
+        # trie and binds to whichever same-named function it reaches first --
+        # a WRONG edge rather than a missing one (issue #1185).
+        self.php_module_namespaces: dict[str, str] = {}
         # Local names brought in by a JS/TS import with a NON-STANDARD scheme
         # (`ext:deno_node/y`; see _has_aliased_scheme), keyed by module. Such a
         # specifier aliases first-party code but does not resolve to a file-path
@@ -870,6 +882,9 @@ class ImportProcessor:
         # Reset per-module PHP use-function state too, so a re-index that drops a
         # `use function` import does not leave a stale exemption behind.
         self.php_function_imports.pop(module_qn, None)
+        # A re-index that removes or edits the `namespace` declaration must not
+        # leave the old namespace bound to this module.
+        self.php_module_namespaces.pop(module_qn, None)
         self.js_ts_bare_imports.pop(module_qn, None)
 
         try:
@@ -899,7 +914,7 @@ class ImportProcessor:
                 case cs.SupportedLanguage.LUA:
                     self._parse_lua_imports(captures, module_qn)
                 case cs.SupportedLanguage.PHP:
-                    self._parse_php_imports(captures, module_qn)
+                    self._parse_php_imports(captures, module_qn, root_node)
                 case cs.SupportedLanguage.CSHARP:
                     self._parse_csharp_imports(captures, module_qn)
                 case cs.SupportedLanguage.DART:
@@ -4050,7 +4065,46 @@ class ImportProcessor:
         }
     )
 
-    def _parse_php_imports(self, captures: dict, module_qn: str) -> None:
+    def _record_php_namespace(self, root_node: Node, module_qn: str) -> None:
+        """Bind this module to the `namespace` it declares, if any.
+
+        Walked from the root rather than read from the imports query, because
+        that query captures `namespace_use_declaration` only -- the `use`
+        statements -- and never `namespace_definition`. Widening the query
+        would change its capture contract for every consumer; this reads the
+        one node it needs.
+
+        Only TOP-LEVEL declarations count. PHP permits braced namespace blocks
+        and even several per file, but a nested or repeated declaration does
+        not identify "the namespace of this module", which is the only
+        question this map answers. Recording the first top-level one and
+        stopping is therefore deliberate rather than a simplification: a file
+        with two namespace blocks has no single answer, and guessing one would
+        produce exactly the confident-wrong binding this whole change exists
+        to remove.
+        """
+        for child in root_node.children:
+            if child.type != cs.TS_PHP_NAMESPACE_DEFINITION:
+                continue
+            name_node = child.child_by_field_name(cs.TS_FIELD_NAME)
+            if name_node is None or not name_node.text:
+                # `namespace { ... }` -- the explicit GLOBAL namespace. It has
+                # no name, and binding it to "" would make every unqualified
+                # lookup match it.
+                return
+            declared = safe_decode_with_fallback(name_node)
+            if not declared:
+                return
+            self.php_module_namespaces[module_qn] = declared.replace(
+                "\\", cs.SEPARATOR_DOT
+            )
+            return
+
+    def _parse_php_imports(
+        self, captures: dict, module_qn: str, root_node: Node | None = None
+    ) -> None:
+        if root_node is not None:
+            self._record_php_namespace(root_node, module_qn)
         all_imports = captures.get(cs.CAPTURE_IMPORT, []) + captures.get(
             cs.CAPTURE_IMPORT_FROM, []
         )

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -4105,9 +4105,7 @@ class ImportProcessor:
         declared = safe_decode_with_fallback(name_node)
         if not declared:
             return
-        self.php_module_namespaces[module_qn] = declared.replace(
-            "\\", cs.SEPARATOR_DOT
-        )
+        self.php_module_namespaces[module_qn] = declared.replace("\\", cs.SEPARATOR_DOT)
 
     def _parse_php_imports(
         self, captures: dict, module_qn: str, root_node: Node | None = None

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -4074,31 +4074,40 @@ class ImportProcessor:
         would change its capture contract for every consumer; this reads the
         one node it needs.
 
-        Only TOP-LEVEL declarations count. PHP permits braced namespace blocks
-        and even several per file, but a nested or repeated declaration does
-        not identify "the namespace of this module", which is the only
-        question this map answers. Recording the first top-level one and
-        stopping is therefore deliberate rather than a simplification: a file
-        with two namespace blocks has no single answer, and guessing one would
-        produce exactly the confident-wrong binding this whole change exists
-        to remove.
+        A file with SEVERAL top-level namespace blocks records NOTHING. PHP
+        permits `namespace A { } namespace B { }` in one file, and this map
+        answers "which namespace is this module", which such a file has no
+        single answer to. An earlier version recorded the first block and
+        called that deliberate; review reproduced the consequence (#1484): with
+        `App\\First` recorded and both blocks' functions living in the same
+        module qn, an import of `App\\First\\helper` resolved to the `helper`
+        defined in `App\\Second` -- a confident wrong binding, which is the
+        exact failure this whole change exists to remove.
+
+        Recording nothing sends those files to the trie fallback, which is
+        where they were before this feature existed. Strictly no worse than
+        the status quo, and unlike a first-block guess it never asserts an
+        answer it does not have.
         """
-        for child in root_node.children:
-            if child.type != cs.TS_PHP_NAMESPACE_DEFINITION:
-                continue
-            name_node = child.child_by_field_name(cs.TS_FIELD_NAME)
-            if name_node is None or not name_node.text:
-                # `namespace { ... }` -- the explicit GLOBAL namespace. It has
-                # no name, and binding it to "" would make every unqualified
-                # lookup match it.
-                return
-            declared = safe_decode_with_fallback(name_node)
-            if not declared:
-                return
-            self.php_module_namespaces[module_qn] = declared.replace(
-                "\\", cs.SEPARATOR_DOT
-            )
+        declarations = [
+            child
+            for child in root_node.children
+            if child.type == cs.TS_PHP_NAMESPACE_DEFINITION
+        ]
+        if len(declarations) != 1:
             return
+        name_node = declarations[0].child_by_field_name(cs.TS_FIELD_NAME)
+        if name_node is None or not name_node.text:
+            # `namespace { ... }` -- the explicit GLOBAL namespace. It has no
+            # name, and binding it to "" would make every unqualified lookup
+            # match it.
+            return
+        declared = safe_decode_with_fallback(name_node)
+        if not declared:
+            return
+        self.php_module_namespaces[module_qn] = declared.replace(
+            "\\", cs.SEPARATOR_DOT
+        )
 
     def _parse_php_imports(
         self, captures: dict, module_qn: str, root_node: Node | None = None

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -23,23 +23,29 @@ from unittest.mock import MagicMock
 import pytest
 
 from codebase_rag import constants as cs
+from codebase_rag.function_registry import FunctionRegistryTrie
 from codebase_rag.tests.conftest import get_relationships, run_updater
+from codebase_rag.types_defs import NodeType
 
 SKIP = "php"
 
 
-class _FakeRegistry(dict):
-    """A registry double carrying the trie method the resolver actually calls.
+def _registry(entries: dict[str, str]) -> FunctionRegistryTrie:
+    """A REAL registry trie, not a stand-in.
 
-    A plain dict passed as `function_registry` HID a real defect: the earlier
-    implementation iterated the registry directly, which a dict supports and
-    `FunctionRegistryTrieProtocol` does not. The tests went green against an
-    interface production never provides -- the mirror-test failure, where the
-    double is more permissive than the real object.
+    A `dict` double hid two defects in this file already: it iterates (the
+    protocol does not), and its `startswith` prefix matching accepts a
+    trailing separator where the trie's part-wise walk returns nothing. Both
+    passed the tests and failed in production.
+
+    The trie is cheap to construct, so there is no reason to approximate it --
+    and a double that is more permissive than the real object makes the suite
+    green against an interface production never provides.
     """
-
-    def find_with_prefix(self, prefix: str) -> list[tuple[str, str]]:
-        return [(qn, kind) for qn, kind in self.items() if qn.startswith(prefix)]
+    trie = FunctionRegistryTrie()
+    for qn in entries:
+        trie[qn] = NodeType.FUNCTION
+    return trie
 
 
 def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
@@ -154,7 +160,7 @@ def test_an_ambiguous_namespace_target_resolves_to_nothing(tmp_path: Path) -> No
     resolver.import_processor = SimpleNamespace(
         php_module_namespaces={"proj.one": "App.Text", "proj.two": "App.Text"}
     )
-    resolver.function_registry = _FakeRegistry(
+    resolver.function_registry = _registry(
         {
             "proj.one.format": "Function",
             "proj.two.format": "Function",
@@ -169,7 +175,7 @@ def test_an_ambiguous_namespace_target_resolves_to_nothing(tmp_path: Path) -> No
 
     # The paired positive: with ONE candidate it resolves, so the None above is
     # the ambiguity guard rather than the helper being inert.
-    resolver.function_registry = _FakeRegistry({"proj.one.format": "Function"})
+    resolver.function_registry = _registry({"proj.one.format": "Function"})
     assert (
         resolver._php_target_for_namespace_import("App.Text.format")
         == "proj.one.format"
@@ -258,7 +264,7 @@ def test_a_mixed_case_import_resolves_like_php_does(tmp_path: Path) -> None:
         php_module_namespaces={"proj.text": "App.Text"},
         commonjs_direct_exports={},
     )
-    resolver.function_registry = _FakeRegistry({"proj.text.format": "Function"})
+    resolver.function_registry = _registry({"proj.text.format": "Function"})
 
     for target in (
         "App.Text.format",  # exact
@@ -323,7 +329,7 @@ def test_a_non_php_caller_never_resolves_through_php_namespaces(
         # must carry it or the test fails on the fixture rather than the guard.
         commonjs_direct_exports={},
     )
-    resolver.function_registry = _FakeRegistry({"proj.text.format": "Function"})
+    resolver.function_registry = _registry({"proj.text.format": "Function"})
     import_map = {"format": "App.Text.format"}
 
     for language in (

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -350,6 +350,47 @@ def test_a_call_through_a_use_function_alias_is_case_insensitive(
     )
 
 
+def test_two_import_keys_differing_only_in_case_resolve_to_nothing(
+    tmp_path: Path,
+) -> None:
+    """Ambiguous folded keys must decline rather than pick one.
+
+    Found by mutation: dropping the `len(matches) == 1` guard from
+    `_php_import_key` left all 14 other tests passing, because no fixture had
+    two keys folding to the same name.
+
+    PHP rejects a duplicate `use` at compile time, so this state should not
+    arise from valid source -- but the map is built by our own parser, and
+    "cannot happen" is exactly what the guard is for. Picking `matches[0]`
+    would resolve to whichever key iteration reached first: an arbitrary
+    binding, which is the defect this whole change removes.
+    """
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.text": "App.Text", "proj.money": "App.Money"},
+        commonjs_direct_exports={},
+        php_function_imports={"proj.caller": {"format", "FORMAT"}},
+    )
+    resolver.function_registry = _registry(
+        {"proj.text.format": "Function", "proj.money.format": "Function"}
+    )
+
+    assert (
+        resolver._try_resolve_direct_import(
+            "Format",
+            {"format": "App.Text.format", "FORMAT": "App.Money.format"},
+            cs.SupportedLanguage.PHP,
+            "proj.caller",
+        )
+        is None
+    ), (
+        "two import keys folding to the same name resolved to one of them; "
+        "neither can be shown to be intended, so the import cannot say which"
+    )
+
+
 def test_a_fully_qualified_import_resolves(tmp_path: Path) -> None:
     """`use function \\App\\Text\\format` (leading backslash) must resolve.
 

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -28,6 +28,20 @@ from codebase_rag.tests.conftest import get_relationships, run_updater
 SKIP = "php"
 
 
+class _FakeRegistry(dict):
+    """A registry double carrying the trie method the resolver actually calls.
+
+    A plain dict passed as `function_registry` HID a real defect: the earlier
+    implementation iterated the registry directly, which a dict supports and
+    `FunctionRegistryTrieProtocol` does not. The tests went green against an
+    interface production never provides -- the mirror-test failure, where the
+    double is more permissive than the real object.
+    """
+
+    def find_with_prefix(self, prefix: str) -> list[tuple[str, str]]:
+        return [(qn, kind) for qn, kind in self.items() if qn.startswith(prefix)]
+
+
 def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
     return {
         (str(call.args[0][2]), str(call.args[2][2]))
@@ -140,10 +154,12 @@ def test_an_ambiguous_namespace_target_resolves_to_nothing(tmp_path: Path) -> No
     resolver.import_processor = SimpleNamespace(
         php_module_namespaces={"proj.one": "App.Text", "proj.two": "App.Text"}
     )
-    resolver.function_registry = {
-        "proj.one.format": "Function",
-        "proj.two.format": "Function",
-    }
+    resolver.function_registry = _FakeRegistry(
+        {
+            "proj.one.format": "Function",
+            "proj.two.format": "Function",
+        }
+    )
 
     assert resolver._php_target_for_namespace_import("App.Text.format") is None, (
         "an import naming a namespace declared by TWO modules that both define "
@@ -153,7 +169,7 @@ def test_an_ambiguous_namespace_target_resolves_to_nothing(tmp_path: Path) -> No
 
     # The paired positive: with ONE candidate it resolves, so the None above is
     # the ambiguity guard rather than the helper being inert.
-    resolver.function_registry = {"proj.one.format": "Function"}
+    resolver.function_registry = _FakeRegistry({"proj.one.format": "Function"})
     assert (
         resolver._php_target_for_namespace_import("App.Text.format")
         == "proj.one.format"
@@ -242,7 +258,7 @@ def test_a_mixed_case_import_resolves_like_php_does(tmp_path: Path) -> None:
         php_module_namespaces={"proj.text": "App.Text"},
         commonjs_direct_exports={},
     )
-    resolver.function_registry = {"proj.text.format": "Function"}
+    resolver.function_registry = _FakeRegistry({"proj.text.format": "Function"})
 
     for target in (
         "App.Text.format",  # exact
@@ -251,7 +267,9 @@ def test_a_mixed_case_import_resolves_like_php_does(tmp_path: Path) -> None:
         "App.Text.FORMAT",  # symbol folded
         "app.text.FORMAT",  # both, the reported case
     ):
-        assert resolver._php_target_for_namespace_import(target) == "proj.text.format", (
+        assert (
+            resolver._php_target_for_namespace_import(target) == "proj.text.format"
+        ), (
             f"{target!r} did not resolve; PHP treats namespace and function "
             "names as case-insensitive, so this import is valid and binds"
         )
@@ -305,7 +323,7 @@ def test_a_non_php_caller_never_resolves_through_php_namespaces(
         # must carry it or the test fails on the fixture rather than the guard.
         commonjs_direct_exports={},
     )
-    resolver.function_registry = {"proj.text.format": "Function"}
+    resolver.function_registry = _FakeRegistry({"proj.text.format": "Function"})
     import_map = {"format": "App.Text.format"}
 
     for language in (

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -240,6 +240,78 @@ def test_a_reindex_replaces_the_recorded_namespace(tmp_path: Path) -> None:
     )
 
 
+def test_a_class_use_does_not_resolve_to_a_php_function(tmp_path: Path) -> None:
+    """`use App\\Text\\format` is a CLASS import and must not bind a function.
+
+    PHP keeps classes and functions in separate symbol tables: `use X` imports
+    a class, `use function X` imports a function. Without the distinction, a
+    class or constant import whose name happens to match a registered PHP
+    function resolved to that function.
+
+    Reproduced in review on #1484, and it survived the caller-language guard
+    because the caller IS PHP -- the language gate and the binding-kind gate
+    are independent axes, and covering one said nothing about the other.
+
+    `php_function_imports` already records which local names arrived via
+    `use function`, so the distinction needs no new parsing.
+    """
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.text": "App.Text"},
+        commonjs_direct_exports={},
+        # The caller imported the name, but NOT via `use function`.
+        php_function_imports={"proj.caller": set()},
+    )
+    resolver.function_registry = _registry({"proj.text.format": "Function"})
+    import_map = {"format": "App.Text.format"}
+
+    assert (
+        resolver._try_resolve_direct_import(
+            "format", import_map, cs.SupportedLanguage.PHP, "proj.caller"
+        )
+        is None
+    ), (
+        "a class-style `use App\\Text\\format` resolved to the PHP FUNCTION "
+        "`format`; PHP holds classes and functions in separate symbol tables, "
+        "so this is an edge the source never expressed"
+    )
+
+    # The paired positive: recording it as a `use function` binding DOES
+    # resolve, so the None above is the binding-kind gate rather than the
+    # fallback being switched off.
+    resolver.import_processor.php_function_imports = {"proj.caller": {"format"}}
+    assert resolver._try_resolve_direct_import(
+        "format", import_map, cs.SupportedLanguage.PHP, "proj.caller"
+    ) == (NodeType.FUNCTION, "proj.text.format")
+
+
+def test_an_unknown_caller_module_does_not_resolve(tmp_path: Path) -> None:
+    """No `module_qn` means the binding kind cannot be shown, so decline.
+
+    Defaulting to True when the module is unknown would reinstate the class-use
+    defect wherever the caller module is not threaded through. Declining costs
+    only the trie fallback, which is where such calls went before this feature.
+    """
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.text": "App.Text"},
+        commonjs_direct_exports={},
+        php_function_imports={"proj.caller": {"format"}},
+    )
+    resolver.function_registry = _registry({"proj.text.format": "Function"})
+
+    assert (
+        resolver._try_resolve_direct_import(
+            "format", {"format": "App.Text.format"}, cs.SupportedLanguage.PHP, None
+        )
+        is None
+    )
+
+
 def test_a_mixed_case_import_resolves_like_php_does(tmp_path: Path) -> None:
     """`use function app\\text\\FORMAT` binds to `App\\Text\\format`.
 
@@ -328,6 +400,8 @@ def test_a_non_php_caller_never_resolves_through_php_namespaces(
         # The non-PHP path falls through to the commonjs lookup, so the double
         # must carry it or the test fails on the fixture rather than the guard.
         commonjs_direct_exports={},
+        # `use function` bindings, which the PHP path now requires.
+        php_function_imports={"proj.caller": {"format"}},
     )
     resolver.function_registry = _registry({"proj.text.format": "Function"})
     import_map = {"format": "App.Text.format"}
@@ -339,15 +413,18 @@ def test_a_non_php_caller_never_resolves_through_php_namespaces(
         None,
     ):
         assert (
-            resolver._try_resolve_direct_import("format", import_map, language) is None
+            resolver._try_resolve_direct_import(
+                "format", import_map, language, "proj.caller"
+            )
+            is None
         ), (
             f"a {language} caller resolved through the PHP namespace map to a "
             "PHP function; the fallback must be gated on the caller's language"
         )
 
     assert resolver._try_resolve_direct_import(
-        "format", import_map, cs.SupportedLanguage.PHP
-    ) == ("Function", "proj.text.format"), (
+        "format", import_map, cs.SupportedLanguage.PHP, "proj.caller"
+    ) == (NodeType.FUNCTION, "proj.text.format"), (
         "the PHP caller stopped resolving too, so the guard disabled the "
         "feature rather than scoping it"
     )

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -218,6 +218,68 @@ def test_a_reindex_replaces_the_recorded_namespace(tmp_path: Path) -> None:
     )
 
 
+def test_a_mixed_case_import_resolves_like_php_does(tmp_path: Path) -> None:
+    """`use function app\\text\\FORMAT` binds to `App\\Text\\format`.
+
+    PHP namespaces and function names are case-insensitive. Verified by
+    executing it under PHP 8.5 rather than taken from documentation:
+
+        namespace App\\Text; function format(...)
+        use function app\\text\\FORMAT;  ->  prints "formatted:x"
+
+    Exact-case comparison sent such imports to the simple-name trie, which is
+    the same wrong-edge path this feature exists to avoid -- a valid import
+    silently binding to an unrelated same-named function.
+
+    Covers BOTH halves independently: the namespace differing in case, and the
+    symbol differing in case. An implementation folding only one would satisfy
+    a test that varied both together.
+    """
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.text": "App.Text"},
+        commonjs_direct_exports={},
+    )
+    resolver.function_registry = {"proj.text.format": "Function"}
+
+    for target in (
+        "App.Text.format",  # exact
+        "app.text.format",  # namespace folded
+        "APP.TEXT.format",  # namespace folded, upper
+        "App.Text.FORMAT",  # symbol folded
+        "app.text.FORMAT",  # both, the reported case
+    ):
+        assert resolver._php_target_for_namespace_import(target) == "proj.text.format", (
+            f"{target!r} did not resolve; PHP treats namespace and function "
+            "names as case-insensitive, so this import is valid and binds"
+        )
+
+
+def test_the_case_fold_is_ascii_only(tmp_path: Path) -> None:
+    """Folding must not reach beyond A-Z.
+
+    PHP folds ASCII only, so identifiers differing outside that range are
+    DISTINCT. `str.casefold()` or `str.lower()` would match names the language
+    does not -- trading a missed binding for a WRONG one, which is the
+    direction that matters here.
+
+    The Kelvin sign folds to plain `k` under Unicode rules and must not match.
+    """
+    from codebase_rag.parsers.call_resolver import _php_fold
+
+    assert _php_fold("App.Text") == "app.text"
+    assert _php_fold("FORMAT") == "format"
+
+    kelvin = "\u212a"  # KELVIN SIGN; casefolds to "k" under Unicode
+    assert _php_fold(kelvin) != "k", (
+        "the fold reached beyond ASCII; PHP would treat these identifiers as "
+        "distinct, so matching them creates an edge the language does not"
+    )
+    assert kelvin.casefold() == "k", "control: Unicode folding DOES match here"
+
+
 def test_a_non_php_caller_never_resolves_through_php_namespaces(
     tmp_path: Path,
 ) -> None:

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -316,14 +316,19 @@ def test_a_call_through_a_use_function_alias_is_case_insensitive(
         php_function_imports={"proj.caller": {"format"}},
     )
     resolver.function_registry = _registry({"proj.text.format": "Function"})
-    # Both spellings are in the import map, because the call-name capture
-    # records the call AS WRITTEN. What varies here is whether the resolver
-    # recognises the alias when the CASE differs from the `use function`
-    # spelling -- a spelling absent from the map fails at an earlier layer
-    # and would test something else.
-    import_map = {"format": "App.Text.format", "FORMAT": "App.Text.format"}
+    # PRODUCTION SHAPE: the import map is keyed by the DECLARATION spelling
+    # only. Verified against the import processor -- `use function
+    # App\\Text\\format` records exactly {'format': ...}, whatever casing the
+    # call later uses.
+    #
+    # An earlier version of this test seeded BOTH spellings, which production
+    # never produces. That made the assertion pass against a fixture the
+    # system cannot generate, hiding the fact that the exact-case map lookup
+    # in front of the folded gate is where the miss actually happens
+    # (unreachable-fixture defect, reported on #1484).
+    import_map = {"format": "App.Text.format"}
 
-    for spelling in ("format", "FORMAT"):
+    for spelling in ("format", "FORMAT", "Format"):
         assert resolver._try_resolve_direct_import(
             spelling, import_map, cs.SupportedLanguage.PHP, "proj.caller"
         ) == (NodeType.FUNCTION, "proj.text.format"), (

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -17,6 +17,7 @@
 # implementation and the current path-based one disagree. A fixture with one
 # `format()` would pass under both.
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -214,6 +215,109 @@ def test_a_reindex_replaces_the_recorded_namespace(tmp_path: Path) -> None:
     assert "proj.svc" not in processor.php_module_namespaces, (
         "removing the `namespace` declaration left "
         f"{processor.php_module_namespaces.get('proj.svc')!r} bound"
+    )
+
+
+def test_a_non_php_caller_never_resolves_through_php_namespaces(
+    tmp_path: Path,
+) -> None:
+    """The namespace fallback is gated on the CALLER being PHP.
+
+    The map holds only PHP modules, but the import targets matched against it
+    are dotted strings any language can produce. A JS `import { format }`
+    recorded as `App.Text.format` would resolve straight into a PHP function
+    -- an edge ACROSS languages that no source expressed, and a new class of
+    wrong edge introduced by the fix itself.
+
+    Reproduced in review on #1484: a JavaScript caller bound to a PHP target.
+
+    Asserts a non-PHP language resolves to nothing AND that PHP still does, so
+    the guard is a language gate rather than the path being switched off.
+    """
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.text": "App.Text"},
+        # The non-PHP path falls through to the commonjs lookup, so the double
+        # must carry it or the test fails on the fixture rather than the guard.
+        commonjs_direct_exports={},
+    )
+    resolver.function_registry = {"proj.text.format": "Function"}
+    import_map = {"format": "App.Text.format"}
+
+    for language in (
+        cs.SupportedLanguage.JS,
+        cs.SupportedLanguage.TS,
+        cs.SupportedLanguage.PYTHON,
+        None,
+    ):
+        assert (
+            resolver._try_resolve_direct_import("format", import_map, language) is None
+        ), (
+            f"a {language} caller resolved through the PHP namespace map to a "
+            "PHP function; the fallback must be gated on the caller's language"
+        )
+
+    assert resolver._try_resolve_direct_import(
+        "format", import_map, cs.SupportedLanguage.PHP
+    ) == ("Function", "proj.text.format"), (
+        "the PHP caller stopped resolving too, so the guard disabled the "
+        "feature rather than scoping it"
+    )
+
+
+def test_a_file_with_several_namespace_blocks_records_nothing(
+    tmp_path: Path,
+) -> None:
+    """Two top-level blocks have no single answer, so none is recorded.
+
+    PHP allows `namespace A { } namespace B { }` in one file. Both blocks'
+    functions land in the SAME module qn, so recording the first makes an
+    import of `A\\helper` resolve to the `helper` defined in B.
+
+    Reproduced in review on #1484 -- `App.First` recorded, resolution returned
+    the `App.Second` function.
+
+    Recording nothing sends such files to the trie fallback, exactly where
+    they were before this feature existed: no worse than the status quo, and
+    unlike a first-block guess it never asserts an answer it does not have.
+    """
+    from tree_sitter import QueryCursor
+
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    language = cs.SupportedLanguage.PHP
+    if language not in parsers:
+        pytest.skip("php grammar not installed")
+
+    source = b"""<?php
+namespace App\\First {
+    function helper(): int { return 1; }
+}
+namespace App\\Second {
+    function helper(): int { return 2; }
+}
+"""
+    tree = parsers[language].parse(source)
+    processor = ImportProcessor(repo_path=tmp_path, project_name="proj")
+    cursor = QueryCursor(queries[language]["imports"])
+
+    processor.parse_imports(
+        root_node=tree.root_node,
+        module_qn="proj.multi",
+        language=language,
+        queries=queries,
+        pre_captures=cursor.captures(tree.root_node),
+    )
+
+    recorded = processor.php_module_namespaces.get("proj.multi")
+    assert recorded is None, (
+        f"a file with two top-level namespace blocks recorded {recorded!r}; "
+        "both blocks' functions share one module qn, so an import naming that "
+        "namespace can bind to a function defined in the OTHER block"
     )
 
 

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -287,6 +287,64 @@ def test_a_class_use_does_not_resolve_to_a_php_function(tmp_path: Path) -> None:
     ) == (NodeType.FUNCTION, "proj.text.format")
 
 
+def test_a_call_through_a_use_function_alias_is_case_insensitive(
+    tmp_path: Path,
+) -> None:
+    """`use function App\\Text\\format` then calling `FORMAT()` must resolve.
+
+    PHP function names are case-insensitive at the CALL SITE, not only in the
+    import path. Verified by executing it under PHP 8.5:
+
+        namespace App\\Text; function format(...)
+        use function App\\Text\\format;
+        echo FORMAT("x");        // prints F:x
+
+    An exact-case membership test recognised the IMPORT but not the CALL, so
+    the resolver declined and the call fell through to the simple-name trie --
+    the same wrong-edge path, reached through the alias instead of the target.
+
+    Distinct from the mixed-case import test: that one varies the spelling of
+    the imported PATH, this one varies the spelling of the CALL. Two axes of
+    the same case-insensitivity, and covering one said nothing about the other.
+    """
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.text": "App.Text"},
+        commonjs_direct_exports={},
+        php_function_imports={"proj.caller": {"format"}},
+    )
+    resolver.function_registry = _registry({"proj.text.format": "Function"})
+    # Both spellings are in the import map, because the call-name capture
+    # records the call AS WRITTEN. What varies here is whether the resolver
+    # recognises the alias when the CASE differs from the `use function`
+    # spelling -- a spelling absent from the map fails at an earlier layer
+    # and would test something else.
+    import_map = {"format": "App.Text.format", "FORMAT": "App.Text.format"}
+
+    for spelling in ("format", "FORMAT"):
+        assert resolver._try_resolve_direct_import(
+            spelling, import_map, cs.SupportedLanguage.PHP, "proj.caller"
+        ) == (NodeType.FUNCTION, "proj.text.format"), (
+            f"calling the alias as {spelling!r} did not resolve; PHP function "
+            "names are case-insensitive at the call site, so this call is "
+            "valid and runs"
+        )
+
+    # The control: a name that was never imported must still decline, so the
+    # fold is case-insensitivity rather than accepting anything.
+    assert (
+        resolver._try_resolve_direct_import(
+            "unrelated",
+            {"unrelated": "App.Text.format"},
+            cs.SupportedLanguage.PHP,
+            "proj.caller",
+        )
+        is None
+    )
+
+
 def test_an_unknown_caller_module_does_not_resolve(tmp_path: Path) -> None:
     """No `module_qn` means the binding kind cannot be shown, so decline.
 

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -1,0 +1,347 @@
+# PHP namespace-aware qualification (issue #1185, stage 1).
+#
+# CGR qualifies PHP functions by FILE PATH and ignores the `namespace`
+# declaration, which `parsers/call_resolver.py` records as the repo's only
+# `LIMITATION:` comment. In modern PHP the namespace and the directory layout
+# are independent -- PSR-4 maps a namespace PREFIX to a directory, so
+# `Vendor\Pkg\helper` may live anywhere under the mapped root, and a global
+# helper commonly declares `namespace Illuminate\Support` from
+# `Collections/functions.php`.
+#
+# The consequence is not a missing edge but a WRONG one: two same-named
+# functions in different namespaces are indistinguishable by file path alone,
+# so a call binds to whichever the trie happens to reach first.
+#
+# The fixtures below deliberately give the two candidates the SAME simple name
+# in DIFFERENT namespaces, because that is the only shape where a correct
+# implementation and the current path-based one disagree. A fixture with one
+# `format()` would pass under both.
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+SKIP = "php"
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(call.args[0][2]), str(call.args[2][2]))
+        for call in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+def test_a_namespaced_call_binds_to_its_own_namespace(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """`use App\\Text\\format;` must bind to App\\Text, not to a same-named sibling.
+
+    Two files declare `format()` in different namespaces. The caller imports
+    exactly one of them. Path-based qualification cannot tell them apart, so
+    the call resolves by simple name and may reach either.
+
+    Asserts the (source, target) PAIR rather than that some CALLS edge exists:
+    an edge to the wrong `format` is the actual defect, and a test asserting
+    only "a call was recorded" passes against it.
+    """
+    project = temp_repo / "php_ns"
+    project.mkdir()
+
+    (project / "text.php").write_text(
+        encoding="utf-8",
+        data="""<?php
+namespace App\\Text;
+
+function format(string $s): string {
+    return trim($s);
+}
+""",
+    )
+
+    (project / "money.php").write_text(
+        encoding="utf-8",
+        data="""<?php
+namespace App\\Money;
+
+function format(int $cents): string {
+    return (string) $cents;
+}
+""",
+    )
+
+    (project / "caller.php").write_text(
+        encoding="utf-8",
+        data="""<?php
+namespace App\\Report;
+
+use function App\\Text\\format;
+
+function render(string $raw): string {
+    return format($raw);
+}
+""",
+    )
+
+    run_updater(project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _calls(mock_ingestor)
+    callers = {(src, dst) for src, dst in pairs if src.endswith("render")}
+
+    assert callers, f"no CALLS edge from render at all; pairs={sorted(pairs)}"
+
+    # Asserted on the MODULE the target lives in, not on namespace text in the
+    # qn. Qualified names stay path-based by design -- the namespace is held in
+    # a side map (`php_module_namespaces`) and used to RESOLVE the import,
+    # rather than folded into every PHP qn, which would rewrite the identity of
+    # every existing PHP node in the graph.
+    #
+    # `text.php` declares `namespace App\Text` and `money.php` declares
+    # `namespace App\Money`, so which module the edge lands in is exactly the
+    # question, and the two are distinguishable.
+    assert any(dst.endswith("text.format") for _, dst in callers), (
+        "render() did not resolve to the `format` in the module declaring "
+        "namespace App\\Text; the `use function App\\Text\\format` import was "
+        f"not honoured. edges={sorted(callers)}"
+    )
+    assert not any(dst.endswith("money.format") for _, dst in callers), (
+        "render() resolved to the `format` in the App\\Money module, which it "
+        "never imported -- a WRONG edge rather than a missing one. "
+        f"edges={sorted(callers)}"
+    )
+
+
+def test_an_ambiguous_namespace_target_resolves_to_nothing(tmp_path: Path) -> None:
+    """Two modules in ONE namespace both defining the symbol must not be guessed.
+
+    PHP allows a namespace to span any number of files, so a namespace may be
+    declared by several. If more than one of them defines the symbol, the
+    import alone cannot say which is meant -- and picking the first would
+    reintroduce exactly the arbitrary binding this change removes, only with
+    more confidence behind it.
+
+    Found by mutation: relaxing the uniqueness check from `len(found) != 1` to
+    "take the first match" left every other test in this file passing, because
+    no other fixture has two candidates inside ONE namespace.
+
+    Exercises the resolver helper directly with a registry holding both
+    candidates. Going through the updater would assert on whichever edge the
+    trie fallback then produced, which is not the question -- the question is
+    whether the IMPORT resolution claims a unique answer it does not have.
+    """
+    from types import SimpleNamespace
+
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.one": "App.Text", "proj.two": "App.Text"}
+    )
+    resolver.function_registry = {
+        "proj.one.format": "Function",
+        "proj.two.format": "Function",
+    }
+
+    assert resolver._php_target_for_namespace_import("App.Text.format") is None, (
+        "an import naming a namespace declared by TWO modules that both define "
+        "the symbol was resolved to one of them; with two equally valid "
+        "candidates the import cannot say which is meant"
+    )
+
+    # The paired positive: with ONE candidate it resolves, so the None above is
+    # the ambiguity guard rather than the helper being inert.
+    resolver.function_registry = {"proj.one.format": "Function"}
+    assert (
+        resolver._php_target_for_namespace_import("App.Text.format")
+        == "proj.one.format"
+    )
+
+
+def test_a_reindex_replaces_the_recorded_namespace(tmp_path: Path) -> None:
+    """Re-parsing a module must not leave its OLD namespace bound.
+
+    `parse_imports` is called again whenever a file changes. Without the
+    per-module reset, editing `namespace App\\Text` to `namespace App\\Money`
+    would leave both bound -- and since resolution matches on the declared
+    namespace, imports naming the OLD one would keep resolving to this module
+    forever.
+
+    Found by mutation: dropping the `php_module_namespaces.pop(module_qn)` line
+    left every other test passing, because none of them parses the same module
+    twice. Incremental re-index is the normal path in a running cgr, so the
+    untested case is the common one.
+    """
+    from tree_sitter import QueryCursor
+
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    language = cs.SupportedLanguage.PHP
+    if language not in parsers:
+        pytest.skip("php grammar not installed")
+
+    processor = ImportProcessor(repo_path=tmp_path, project_name="proj")
+
+    def parse(source: bytes) -> None:
+        tree = parsers[language].parse(source)
+        cursor = QueryCursor(queries[language]["imports"])
+        processor.parse_imports(
+            root_node=tree.root_node,
+            module_qn="proj.svc",
+            language=language,
+            queries=queries,
+            pre_captures=cursor.captures(tree.root_node),
+        )
+
+    parse(b"<?php\nnamespace App\\Text;\nfunction f(): int { return 1; }\n")
+    assert processor.php_module_namespaces["proj.svc"] == "App.Text"
+
+    parse(b"<?php\nnamespace App\\Money;\nfunction f(): int { return 1; }\n")
+
+    assert processor.php_module_namespaces["proj.svc"] == "App.Money", (
+        "after re-parsing with a changed `namespace` declaration the module is "
+        "still bound to "
+        f"{processor.php_module_namespaces['proj.svc']!r}; imports naming the "
+        "old namespace would keep resolving here"
+    )
+
+    # And a module whose namespace declaration is REMOVED must unbind, not
+    # keep the last one it ever had.
+    parse(b"<?php\nfunction f(): int { return 1; }\n")
+    assert "proj.svc" not in processor.php_module_namespaces, (
+        "removing the `namespace` declaration left "
+        f"{processor.php_module_namespaces.get('proj.svc')!r} bound"
+    )
+
+
+def test_the_global_namespace_block_is_not_recorded(tmp_path: Path) -> None:
+    """`namespace { ... }` names nothing and must bind nothing.
+
+    PHP's braced form with no name declares the GLOBAL namespace. Recording it
+    as the empty string would make `""` the module's namespace, and the
+    namespace part of any unqualified import target is also `""` -- so every
+    such lookup would match this module.
+
+    Found by mutation: removing the empty-name guard left all other tests
+    passing, since no other fixture uses the braced global form.
+    """
+    from tree_sitter import QueryCursor
+
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    language = cs.SupportedLanguage.PHP
+    if language not in parsers:
+        pytest.skip("php grammar not installed")
+
+    source = b"""<?php
+namespace {
+    function helper(): int { return 1; }
+}
+"""
+    tree = parsers[language].parse(source)
+    processor = ImportProcessor(repo_path=tmp_path, project_name="proj")
+    cursor = QueryCursor(queries[language]["imports"])
+
+    processor.parse_imports(
+        root_node=tree.root_node,
+        module_qn="proj.global",
+        language=language,
+        queries=queries,
+        pre_captures=cursor.captures(tree.root_node),
+    )
+
+    recorded = processor.php_module_namespaces.get("proj.global")
+    assert recorded is None, (
+        "the unnamed `namespace { }` global block was recorded as "
+        f"{recorded!r}; an empty namespace matches every unqualified import "
+        "target, so this module would capture all of them"
+    )
+
+
+def test_the_namespace_declaration_is_captured_for_the_module(tmp_path: Path) -> None:
+    """The `namespace` a module declares must be recorded, dotted.
+
+    The narrower precondition of the test above, pinned separately so a
+    failure says WHICH half broke: without the declaration nothing can bind an
+    import target to a file, and the resolution test could only pass by luck
+    of the trie.
+
+    Exercises the import processor directly rather than the whole updater,
+    because this is a statement about one map and the end-to-end path is
+    already covered above.
+    """
+    from tree_sitter import QueryCursor
+
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    language = cs.SupportedLanguage.PHP
+    if language not in parsers:
+        pytest.skip("php grammar not installed")
+
+    source = b"""<?php
+namespace Vendor\\Pkg\\Sub;
+
+function helper(): int { return 1; }
+"""
+    tree = parsers[language].parse(source)
+    processor = ImportProcessor(repo_path=tmp_path, project_name="proj")
+    cursor = QueryCursor(queries[language]["imports"])
+
+    processor.parse_imports(
+        root_node=tree.root_node,
+        module_qn="proj.svc",
+        language=language,
+        queries=queries,
+        pre_captures=cursor.captures(tree.root_node),
+    )
+
+    assert processor.php_module_namespaces.get("proj.svc") == "Vendor.Pkg.Sub", (
+        "the `namespace Vendor\\Pkg\\Sub` declaration was not recorded, so an "
+        "import target naming that namespace cannot be matched to this module "
+        f"(issue #1185). map={processor.php_module_namespaces}"
+    )
+
+
+def test_a_file_with_no_namespace_records_nothing(tmp_path: Path) -> None:
+    """A control: absence must stay absent rather than binding to "".
+
+    An empty-string namespace would compare equal to the namespace part of any
+    unqualified import target, making every such lookup match this module --
+    turning the fix into a new source of confident wrong edges.
+    """
+    from tree_sitter import QueryCursor
+
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    language = cs.SupportedLanguage.PHP
+    if language not in parsers:
+        pytest.skip("php grammar not installed")
+
+    source = b"""<?php
+function helper(): int { return 1; }
+"""
+    tree = parsers[language].parse(source)
+    processor = ImportProcessor(repo_path=tmp_path, project_name="proj")
+    cursor = QueryCursor(queries[language]["imports"])
+
+    processor.parse_imports(
+        root_node=tree.root_node,
+        module_qn="proj.plain",
+        language=language,
+        queries=queries,
+        pre_captures=cursor.captures(tree.root_node),
+    )
+
+    assert "proj.plain" not in processor.php_module_namespaces, (
+        "a file with no `namespace` declaration was bound to a namespace "
+        f"anyway: {processor.php_module_namespaces}"
+    )

--- a/codebase_rag/tests/test_php_namespace_qualification.py
+++ b/codebase_rag/tests/test_php_namespace_qualification.py
@@ -345,6 +345,53 @@ def test_a_call_through_a_use_function_alias_is_case_insensitive(
     )
 
 
+def test_a_fully_qualified_import_resolves(tmp_path: Path) -> None:
+    """`use function \\App\\Text\\format` (leading backslash) must resolve.
+
+    A fully-qualified import is idiomatic PHP and runs identically to the
+    unqualified spelling -- verified by executing it under PHP 8.5, which
+    prints `B:x`. In PHP a `use` path is ALWAYS resolved from the global
+    namespace, so the backslash is emphasis rather than a different meaning.
+
+    The import processor dots the path, so the backslash becomes a LEADING
+    separator: the recorded target is `.App.Text.format`, which never matches
+    a declared `App.Text`.
+
+    Found by probing this function's contract axes directly rather than
+    waiting for review to surface a fourth one -- the previous three
+    (import-path case, binding kind, call-site case) each arrived that way.
+    """
+    from codebase_rag.parsers.call_resolver import CallResolver
+
+    resolver = object.__new__(CallResolver)
+    resolver.import_processor = SimpleNamespace(
+        php_module_namespaces={"proj.text": "App.Text"},
+        commonjs_direct_exports={},
+        php_function_imports={"proj.caller": {"format"}},
+    )
+    resolver.function_registry = _registry({"proj.text.format": "Function"})
+
+    assert resolver._try_resolve_direct_import(
+        "format",
+        {"format": ".App.Text.format"},
+        cs.SupportedLanguage.PHP,
+        "proj.caller",
+    ) == (NodeType.FUNCTION, "proj.text.format"), (
+        "a fully-qualified `use function \\App\\Text\\format` did not resolve; "
+        "the leading separator from the backslash was compared against a "
+        "namespace declared without one"
+    )
+
+    # The control: the unqualified spelling still resolves, so the strip is a
+    # normalisation rather than something that only works with a backslash.
+    assert resolver._try_resolve_direct_import(
+        "format",
+        {"format": "App.Text.format"},
+        cs.SupportedLanguage.PHP,
+        "proj.caller",
+    ) == (NodeType.FUNCTION, "proj.text.format")
+
+
 def test_an_unknown_caller_module_does_not_resolve(tmp_path: Path) -> None:
     """No `module_qn` means the binding kind cannot be shown, so decline.
 


### PR DESCRIPTION
Addresses #1185 — **stage 1 only**. Stages 2 and 3 (php-parser `NameResolver` facts) remain open on the issue, matching how #105 tracks its two Scala stages.

## The defect

CGR qualifies PHP by file path and ignored the `namespace` declaration, so a `use function App\Text\format` import could never match the registered `project.text.format`. The miss fell through to the simple-name trie, which binds to whichever same-named function it reaches first:

```
before: ('php_ns.caller.render', 'php_ns.money.format')   ← never imported
after:  ('php_ns.caller.render', 'php_ns.text.format')
```

A **wrong** edge rather than a missing one. The graph gained a relationship the source never expressed, and nothing downstream could tell — a missing edge is visibly absent, a wrong edge is silently confident.

This is the repo's only `LIMITATION:` comment (`call_resolver.py`).

## Why not fold namespaces into qualified names

That would rewrite the identity of every existing PHP node in the graph, turning a resolution fix into a graph migration — and identity changes break incremental update, dead-code reachability, and every stored reference at once. PSR-4 also makes namespace and directory independent, so the qn could not be derived from the path even in principle.

Instead the declaration goes into a side map (`php_module_namespaces`, module qn → dotted namespace) consulted at import resolution: split the target into namespace and symbol, find the module *declaring* that namespace, look the symbol up there. Blast radius stays at the resolution step.

## Refusing to guess

`_php_target_for_namespace_import` returns `None` whenever the answer is not unique — no module declares the namespace, or several do and more than one defines the symbol. The trie fallback then applies exactly as before, so this can only replace an arbitrary binding with a determined one, never introduce a new arbitrary one.

Only top-level declarations are recorded, and the unnamed `namespace { }` global block is skipped: binding it to `""` would match the namespace part of every unqualified import target.

## Verification

Five alternative implementations. **Two initially passed** and are now covered:

| alternative | before | after |
|---|---|---|
| disable the fix entirely | caught | caught |
| take FIRST match, not unique | **5 passed** | caught |
| ignore the namespace match | caught | caught |
| record the empty namespace | 5 passed | *not a gap — see below* |
| drop the per-module reset | **5 passed** | caught |

The re-index gap is the one worth naming: no test parsed the same module twice, so **incremental re-index — the normal path in a running cgr — was untested**. Editing a file's `namespace` would have left both the old and new bound forever.

The empty-namespace alternative I investigated rather than "fixed". Removing either guard alone changes nothing because two guards enforce it redundantly; removing **both** makes the test fail. The behaviour is covered and the guards are defence-in-depth, so adding a test there would have produced a green assertion that cannot distinguish the implementations.

RED proven before the fix, then re-proven after: disabling the resolution fails exactly one test.

PHP and import suites: **554 passed, 2 skipped** — the skips are `torch` and Xdebug, both missing optional deps unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PHP namespaced function import resolution, including case-insensitive matching.
  * Imports now bind to the correct namespaced function when similarly named functions exist elsewhere.
  * Ambiguous or unavailable namespace matches remain unresolved instead of linking to an arbitrary function.
  * Re-indexing correctly updates or removes outdated namespace information.
  * Prevented non-PHP code and class-style imports from incorrectly resolving to PHP functions.
  * Improved handling of files containing multiple or global namespace blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->