### PR TITLE
docs: narrow the stale PHP LIMITATION comment

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1192,12 +1192,20 @@ class CallResolver:
         # `namespace Illuminate\Support` from Collections/functions.php). Treating
         # it as external would suppress the simple-name trie fallback that a bare
         # PHP call already relies on, dropping the call; leave it to the trie.
-        # LIMITATION: cgr qualifies PHP functions by file path and does not track
-        # the `namespace` declaration, so a genuinely external
-        # `use function Vendor\pkg\helper` cannot be told apart from a
-        # path-mismatched first-party one; both defer to the trie, as a bare
-        # `helper()` call already does. Precise disambiguation would need
-        # systemic PHP namespace tracking.
+        # NARROWED (#1185 stage 1): the `namespace` declaration IS now tracked,
+        # in `import_processor.php_module_namespaces`, and
+        # `_php_target_for_namespace_import` uses it to bind a `use function`
+        # import to the module declaring that namespace. So a first-party
+        # target whose namespace is declared somewhere in the repo resolves
+        # rather than deferring.
+        #
+        # What remains: a target whose namespace NO indexed module declares is
+        # still indistinguishable here from a first-party one the resolver
+        # could not place, and both defer to the trie exactly as a bare
+        # `helper()` call does. That is a smaller gap than the original
+        # comment described, and deferring stays the right behaviour for it --
+        # treating it as external would suppress the trie fallback and drop
+        # the call.
         php_imports = self.import_processor.php_function_imports.get(module_qn)
         if php_imports and call_name in php_imports:
             return False


### PR DESCRIPTION
Follow-up to #1484.

## The problem

That PR made this comment false. It says cgr *"does not track the `namespace` declaration"* — which stopped being true the moment #1484 merged: `php_module_namespaces` records it, and `_php_target_for_namespace_import` binds through it.

The comment lives in `_is_external_import`, a **different code path** from the one the fix touched, so it survived the change and now asserts the opposite of code a few hundred lines away.

A comment contradicting its own module is worse than no comment — it is exactly the artifact a reader trusts when deciding whether a capability exists. It was also the comment I cited as motivation when opening #1185, so leaving it would misdirect the next person twice over.

## Narrowed, not deleted

A real gap remains and is worth naming: a target whose namespace **no indexed module declares** is still indistinguishable from a first-party one the resolver could not place, and both defer to the trie. Deferring stays correct there — treating it as external would suppress the trie fallback and drop the call.

## Verified rather than reasoned

```
declared namespace (App.Text)  -> ('Function', 'proj.text.format')
UNdeclared namespace (Vendor)  -> None   (defers to the trie)
```

Comment-only change; no behaviour is touched.

Noted for completeness: `ty check` fails in this fresh worktree on unresolvable optional imports (`numpy`, `qdrant_client`, `pymilvus`). Zero of those errors are in the changed file — same worktree-venv gap seen on #1484, which passed once the extras were installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation for PHP `use function` imports and namespace resolution.
  * Documented how unresolved namespace targets continue to use simple-name matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->