### PR TITLE
test: guard node properties against the protobuf schema

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -348,6 +348,8 @@ SCHEMA_OPTIONAL_SUFFIX = "?"
 NODE_PROJECT = NodeLabel.PROJECT
 
 KEY_PARAMETERS = "parameters"
+# Declared Markdown front-matter, as sorted "key=value" entries (issue #1448).
+KEY_FRONT_MATTER = "front_matter"
 KEY_DECORATORS = "decorators"
 # Target-module qn candidates of `#[cfg(test)] mod NAME;` declarations in a
 # Rust file, stored on the DECLARING module's node (issue #1010). The

--- a/codebase_rag/parsers/document_tier.py
+++ b/codebase_rag/parsers/document_tier.py
@@ -55,6 +55,78 @@ _MAX_HEADING_LEVEL = 6
 
 DOCUMENT_EXTENSIONS: frozenset[str] = frozenset({".md", ".markdown"})
 
+# YAML front-matter delimiter. The grammar exposes the whole block as a
+# `minus_metadata` node, but its contents are opaque -- tree-sitter-markdown
+# does not parse YAML -- so the pairs are read here.
+_FRONT_MATTER_FENCE = "---"
+
+# Property names a document may NOT declare, because the ingestion layer owns
+# them. A front-matter `path:` would otherwise overwrite the node's real path
+# and break every consumer that resolves a Module back to a file.
+_RESERVED_FRONT_MATTER_KEYS: frozenset[str] = frozenset(
+    {
+        cs.KEY_QUALIFIED_NAME,
+        cs.KEY_NAME,
+        cs.KEY_PATH,
+        cs.KEY_ABSOLUTE_PATH,
+        cs.KEY_START_LINE,
+        cs.KEY_END_LINE,
+        cs.KEY_HEADING_LEVEL,
+    }
+)
+
+
+def parse_front_matter(text: str) -> dict[str, str]:
+    """Read declared YAML front-matter into flat string properties.
+
+    Deliberately NOT a YAML parser. Only top-level `key: value` scalars are
+    read; nested structures, lists and multi-line values are skipped rather
+    than flattened, because a graph node property is a scalar and inventing a
+    representation for a list would be a schema decision this issue does not
+    have (#1448).
+
+    Declared metadata, not inferred: #1448 lists five other bullets that need
+    design decisions about inference and unprompted edits, and this one is
+    separable precisely because it reads what the author wrote.
+
+    Refuses rather than guesses in three cases, each of which would otherwise
+    put non-metadata into node properties:
+
+    - no opening fence on the FIRST line (a `---` elsewhere is a horizontal
+      rule or a setext underline, not front-matter)
+    - no closing fence (an unterminated block would swallow the document)
+    - a reserved key that the ingestion layer owns
+
+    A single malformed line is skipped rather than discarding the block:
+    front-matter is hand-written, so a stray line is likelier than a wholly
+    invalid block, and the valid pairs around it still carry meaning.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != _FRONT_MATTER_FENCE:
+        return {}
+    closing = next(
+        (
+            i
+            for i in range(1, len(lines))
+            if lines[i].strip() == _FRONT_MATTER_FENCE
+        ),
+        None,
+    )
+    if closing is None:
+        return {}
+    found: dict[str, str] = {}
+    for line in lines[1:closing]:
+        key, separator, value = line.partition(":")
+        if not separator:
+            continue
+        # `partition` splits at the FIRST colon only, so a value containing
+        # further colons (`url: https://x/y`) survives intact.
+        name = key.strip()
+        if not name or name in _RESERVED_FRONT_MATTER_KEYS:
+            continue
+        found[name] = value.strip().strip("\"'")
+    return found
+
 # Link grammar nodes. `inline_link` is ``[text](target)``; the destination sits
 # in a `link_destination` child. Reference-style links (``[text][label]``) name
 # a definition elsewhere and carry no destination of their own, so they are not
@@ -476,7 +548,22 @@ class DocumentTier:
             logger.warning("markdown parse failed for {}: {}", file_path, exc)
             return
 
-        module_qn = self._emit_module(file_path, structural_elements)
+        # Declared front-matter becomes Module properties (issue #1448).
+        # Decoded leniently: a document with an invalid byte should still be
+        # indexed, and its metadata is a bonus rather than a precondition.
+        declared = parse_front_matter(source.decode("utf-8", errors="replace"))
+        # Emitted as ONE declared `front_matter` property holding "key=value"
+        # entries, not as a property per key. The graph's node schema is a
+        # fixed property list audited on every ingest, so arbitrary keys would
+        # be undocumented properties -- the audit catches exactly that, and it
+        # is right to: a document could otherwise define any node property it
+        # liked, including ones a future schema wants for something else.
+        front_matter = (
+            {cs.KEY_FRONT_MATTER: [f"{k}={v}" for k, v in sorted(declared.items())]}
+            if declared
+            else None
+        )
+        module_qn = self._emit_module(file_path, structural_elements, front_matter)
         relative_path = cached_relative_path(file_path, self._repo_path).as_posix()
         absolute_path = cached_resolve_posix(file_path)
 
@@ -585,7 +672,10 @@ class DocumentTier:
         return resolved.as_posix()
 
     def _emit_module(
-        self, file_path: Path, structural_elements: dict[Path, str | None]
+        self,
+        file_path: Path,
+        structural_elements: dict[Path, str | None],
+        front_matter: dict[str, str] | None = None,
     ) -> str:
         return emit_flat_module(
             self._ingestor,
@@ -597,6 +687,7 @@ class DocumentTier:
             # would merge "guide.md" and "guide.markdown" onto one Module
             # node and merge their same-named sections with it.
             distinguish_suffix=True,
+            extra_properties=front_matter,
         )
 
     def _emit_section(

--- a/codebase_rag/parsers/document_tier.py
+++ b/codebase_rag/parsers/document_tier.py
@@ -31,6 +31,7 @@ from urllib.parse import unquote
 from loguru import logger
 
 from .. import constants as cs
+from ..types_defs import PropertyDict
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from .flat_module import emit_flat_module
 
@@ -105,11 +106,7 @@ def parse_front_matter(text: str) -> dict[str, str]:
     if not lines or lines[0].strip() != _FRONT_MATTER_FENCE:
         return {}
     closing = next(
-        (
-            i
-            for i in range(1, len(lines))
-            if lines[i].strip() == _FRONT_MATTER_FENCE
-        ),
+        (i for i in range(1, len(lines)) if lines[i].strip() == _FRONT_MATTER_FENCE),
         None,
     )
     if closing is None:
@@ -126,6 +123,7 @@ def parse_front_matter(text: str) -> dict[str, str]:
             continue
         found[name] = value.strip().strip("\"'")
     return found
+
 
 # Link grammar nodes. `inline_link` is ``[text](target)``; the destination sits
 # in a `link_destination` child. Reference-style links (``[text][label]``) name
@@ -675,7 +673,7 @@ class DocumentTier:
         self,
         file_path: Path,
         structural_elements: dict[Path, str | None],
-        front_matter: dict[str, str] | None = None,
+        front_matter: PropertyDict | None = None,
     ) -> str:
         return emit_flat_module(
             self._ingestor,

--- a/codebase_rag/parsers/document_tier.py
+++ b/codebase_rag/parsers/document_tier.py
@@ -113,8 +113,25 @@ def parse_front_matter(text: str) -> dict[str, str]:
         return {}
     found: dict[str, str] = {}
     for line in lines[1:closing]:
+        # INDENTED lines belong to a parent key, not to the document. Taking
+        # them would hoist `child: v` under `parent:` to top level, inventing
+        # a declaration the author never made at that level -- and the value
+        # would be indistinguishable from a real top-level one.
+        if line[:1] in {" ", "\t"}:
+            continue
+        # A comment declares nothing. `# note: x` would otherwise become the
+        # key "# note".
+        if line.lstrip().startswith("#"):
+            continue
         key, separator, value = line.partition(":")
         if not separator:
+            continue
+        # A key with an EMPTY value opens a nested block or a list
+        # (`parent:` / `tags:`) rather than declaring a scalar. Recording it
+        # as an empty string would assert the author declared it empty, which
+        # is a different claim from declaring a structure this parser does
+        # not represent.
+        if not value.strip():
             continue
         # `partition` splits at the FIRST colon only, so a value containing
         # further colons (`url: https://x/y`) survives intact.

--- a/codebase_rag/parsers/flat_module.py
+++ b/codebase_rag/parsers/flat_module.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .. import constants as cs
+from ..types_defs import PropertyDict
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 
 if TYPE_CHECKING:
@@ -27,7 +28,7 @@ def emit_flat_module(
     file_path: Path,
     structural_elements: dict[Path, str | None],
     distinguish_suffix: bool = False,
-    extra_properties: dict[str, str] | None = None,
+    extra_properties: PropertyDict | None = None,
 ) -> str:
     """Emit a file's Module node and its containment edge; return its qn.
 
@@ -47,7 +48,7 @@ def emit_flat_module(
         # hierarchy to every consumer that splits a qn on it.
         parts[-1] = f"{parts[-1]}_{relative_path.suffix.lstrip(cs.SEPARATOR_DOT)}"
     module_qn = cs.SEPARATOR_DOT.join([project_name, *parts])
-    module_props: dict[str, object] = {
+    module_props: PropertyDict = {
         cs.KEY_QUALIFIED_NAME: module_qn,
         cs.KEY_NAME: file_path.name,
         cs.KEY_PATH: relative_path.as_posix(),

--- a/codebase_rag/parsers/flat_module.py
+++ b/codebase_rag/parsers/flat_module.py
@@ -27,6 +27,7 @@ def emit_flat_module(
     file_path: Path,
     structural_elements: dict[Path, str | None],
     distinguish_suffix: bool = False,
+    extra_properties: dict[str, str] | None = None,
 ) -> str:
     """Emit a file's Module node and its containment edge; return its qn.
 
@@ -46,15 +47,18 @@ def emit_flat_module(
         # hierarchy to every consumer that splits a qn on it.
         parts[-1] = f"{parts[-1]}_{relative_path.suffix.lstrip(cs.SEPARATOR_DOT)}"
     module_qn = cs.SEPARATOR_DOT.join([project_name, *parts])
-    ingestor.ensure_node_batch(
-        cs.NodeLabel.MODULE,
-        {
-            cs.KEY_QUALIFIED_NAME: module_qn,
-            cs.KEY_NAME: file_path.name,
-            cs.KEY_PATH: relative_path.as_posix(),
-            cs.KEY_ABSOLUTE_PATH: cached_resolve_posix(file_path),
-        },
-    )
+    module_props: dict[str, object] = {
+        cs.KEY_QUALIFIED_NAME: module_qn,
+        cs.KEY_NAME: file_path.name,
+        cs.KEY_PATH: relative_path.as_posix(),
+        cs.KEY_ABSOLUTE_PATH: cached_resolve_posix(file_path),
+    }
+    if extra_properties:
+        # Caller-declared properties, currently Markdown front-matter
+        # (issue #1448). Applied AFTER the identity fields and filtered by the
+        # caller, so a declared `path:` cannot overwrite the node's real path.
+        module_props.update(extra_properties)
+    ingestor.ensure_node_batch(cs.NodeLabel.MODULE, module_props)
     ingestor.ensure_relationship_batch(
         _parent_ref(repo_path, project_name, relative_path.parent, structural_elements),
         cs.RelationshipType.CONTAINS_MODULE,

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -1,0 +1,171 @@
+# Markdown front-matter as declared metadata (issue #1448, metadata bullet).
+#
+# #1448 lists six remaining criteria, five of which need design decisions that
+# have not been made -- where an inferred purpose comes from, what "related"
+# means for synchronisation, whether the agent may edit files unprompted.
+#
+# Metadata tagging is the exception, and the reason it is separable is worth
+# stating: front-matter is DECLARED, not inferred, so "inference can be
+# silently wrong" does not apply; and reading it writes nothing, so the
+# unprompted-edit question does not arise.
+#
+# The grammar already exposes it. `tree-sitter-markdown` parses
+#
+#     ---
+#     purpose: planning
+#     ---
+#
+# to a `minus_metadata` node, which `document_tier` currently ignores.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.parsers.document_tier import parse_front_matter
+
+
+class TestParsing:
+    """What the parser accepts and, more importantly, what it refuses."""
+
+    def test_simple_scalar_keys(self) -> None:
+        assert parse_front_matter(
+            "---\npurpose: planning\nscope: service-X\n---\n"
+        ) == {"purpose": "planning", "scope": "service-X"}
+
+    def test_values_keep_internal_colons(self) -> None:
+        """`url: https://x/y` must not split at the second colon.
+
+        Splitting on every colon would truncate the value to `https`, which is
+        wrong in a way that looks plausible -- the key is right and the value
+        is a real string, so nothing downstream reports it.
+        """
+        assert parse_front_matter("---\nurl: https://example.com/a\n---\n") == {
+            "url": "https://example.com/a"
+        }
+
+    def test_quotes_are_stripped_from_values(self) -> None:
+        assert parse_front_matter('---\ntitle: "My Plan"\nk: \'v\'\n---\n') == {
+            "title": "My Plan",
+            "k": "v",
+        }
+
+    def test_a_document_without_front_matter_yields_nothing(self) -> None:
+        """The common case: most Markdown has no front-matter at all.
+
+        Returning an empty mapping rather than raising, because absence is
+        normal here and an exception would make every ordinary document a
+        parse failure.
+        """
+        assert parse_front_matter("# Title\n\nBody.\n") == {}
+
+    def test_a_delimiter_line_alone_is_not_front_matter(self) -> None:
+        """`---` as a horizontal rule or setext underline must not open a block.
+
+        A setext heading underlines with `---`, so a document beginning with a
+        title in that style would otherwise have its body swallowed as
+        metadata.
+        """
+        assert parse_front_matter("Title\n---\n\nBody.\n") == {}
+
+    def test_an_unterminated_block_yields_nothing(self) -> None:
+        """No closing delimiter means the block never ends.
+
+        Treating the rest of the file as metadata would put arbitrary prose
+        into node properties. Refusing is the conservative reading, and it is
+        also what a YAML parser would do.
+        """
+        assert parse_front_matter("---\npurpose: planning\n\n# Title\n") == {}
+
+    def test_lines_without_a_colon_are_skipped_not_fatal(self) -> None:
+        """One malformed line must not discard the whole block.
+
+        Front-matter is hand-written, so a stray line is likelier than a
+        wholly invalid block. The valid pairs around it still carry meaning.
+        """
+        assert parse_front_matter(
+            "---\npurpose: planning\nnot a pair\nscope: x\n---\n"
+        ) == {"purpose": "planning", "scope": "x"}
+
+    def test_an_empty_key_is_refused(self) -> None:
+        """`: value` names nothing and must not become a property.
+
+        An empty-string key would collide with any other empty-string key and
+        is not addressable by a consumer.
+        """
+        assert parse_front_matter("---\n: orphan\npurpose: p\n---\n") == {
+            "purpose": "p"
+        }
+
+
+class TestIngestion:
+    """The declared metadata must reach the Module node."""
+
+    def test_front_matter_becomes_module_properties(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """A Module node carries its declared front-matter.
+
+        Asserted on the node the graph actually emits rather than on the
+        parser alone: a correct parser whose output is never attached would
+        satisfy every test in the class above and change nothing observable.
+        """
+        from codebase_rag.tests.conftest import run_updater
+        from codebase_rag.types_defs import NodeType
+
+        project = temp_repo / "md_fm"
+        project.mkdir()
+        (project / "plan.md").write_text(
+            "---\npurpose: planning\nscope: service-X\n---\n\n# Plan\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        run_updater(project, mock_ingestor)
+
+        modules = [
+            call.args[1]
+            for call in mock_ingestor.ensure_node_batch.call_args_list
+            if call.args[0] == NodeType.MODULE
+            and str(call.args[1].get("qualified_name", "")).endswith("plan_md")
+        ]
+
+        assert modules, "no Module node emitted for plan.md"
+        props = modules[0]
+
+        # ONE declared property holding sorted "key=value" entries, not a
+        # property per key. The graph's node schema is a fixed property list
+        # audited on every ingest -- arbitrary keys would be undocumented
+        # properties, and a document could otherwise define any node property
+        # it liked. The audit caught this design when it was wrong.
+        assert props.get("front_matter") == ["purpose=planning", "scope=service-X"], (
+            props
+        )
+
+    def test_a_document_without_front_matter_gains_no_properties(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The control: absence must stay absent.
+
+        Emitting empty-string properties for every ordinary document would
+        make "has no declared purpose" indistinguishable from "declares an
+        empty purpose", and would write a property onto every Markdown node
+        in every repository.
+        """
+        from codebase_rag.tests.conftest import run_updater
+        from codebase_rag.types_defs import NodeType
+
+        project = temp_repo / "md_plain"
+        project.mkdir()
+        (project / "notes.md").write_text("# Notes\n\nBody.\n", encoding="utf-8")
+
+        run_updater(project, mock_ingestor)
+
+        modules = [
+            call.args[1]
+            for call in mock_ingestor.ensure_node_batch.call_args_list
+            if call.args[0] == NodeType.MODULE
+            and str(call.args[1].get("qualified_name", "")).endswith("notes_md")
+        ]
+
+        assert modules, "no Module node emitted for notes.md"
+        props = modules[0]
+        assert "front_matter" not in props, props

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -122,6 +122,35 @@ class TestParsing:
             "---\npurpose: planning\nnot a pair\nscope: x\n---\n"
         ) == {"purpose": "planning", "scope": "x"}
 
+    def test_a_nested_key_is_not_hoisted_to_the_top_level(self) -> None:
+        """`child:` under `parent:` must not become a top-level declaration.
+
+        The worst of the three: hoisting produced `{"parent": "", "child":
+        "v"}`, so a nested key became indistinguishable from one the author
+        declared at the top level. The docstring said "top-level scalars
+        only" while the code took every line with a colon -- the contract and
+        the implementation disagreed (reported on #1488).
+        """
+        assert parse_front_matter(
+            "---\nparent:\n  child: v\npurpose: p\n---\n"
+        ) == {"purpose": "p"}
+
+    def test_a_comment_line_declares_nothing(self) -> None:
+        """`# note: x` would otherwise become the key `# note`."""
+        assert parse_front_matter("---\n# note: x\npurpose: p\n---\n") == {
+            "purpose": "p"
+        }
+
+    def test_a_key_opening_a_structure_is_skipped(self) -> None:
+        """`tags:` with no value opens a list, and is not an empty scalar.
+
+        Recording `{"tags": ""}` asserts the author declared it empty, which
+        is a different claim from declaring a structure this parser does not
+        represent. The distinction matters because a consumer cannot tell the
+        two apart after the fact.
+        """
+        assert parse_front_matter("---\ntags:\n  - a\n  - b\n---\n") == {}
+
     def test_an_empty_key_is_refused(self) -> None:
         """`: value` names nothing and must not become a property.
 

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -67,6 +67,38 @@ class TestParsing:
         """
         assert parse_front_matter("Title\n---\n\nBody.\n") == {}
 
+    def test_a_fenced_block_below_the_first_line_is_not_front_matter(self) -> None:
+        """Front-matter must open on line 1; a later fenced pair is prose.
+
+        Found by mutation: removing the `lines[0]` check left all 10 tests
+        passing, because the existing delimiter test uses a document with no
+        CLOSING fence -- so the unterminated-block guard caught it and the
+        position guard was never exercised.
+
+        This document has a well-formed fenced pair further down, which a
+        position-blind parser reads as metadata. It is a horizontal rule
+        around a quote, and its contents are body text.
+        """
+        assert parse_front_matter(
+            "# Title\n\n---\npurpose: not-metadata\n---\n\nBody.\n"
+        ) == {}
+
+    def test_a_reserved_key_cannot_overwrite_an_identity_property(self) -> None:
+        """A document may not declare `path:` or `qualified_name:`.
+
+        Found by mutation: dropping the reserved-key check changed nothing,
+        because no fixture declared one. Without it a document could rename
+        its own node or point it at another file, and every consumer that
+        resolves a Module back to a file would follow the document's claim
+        rather than the filesystem.
+
+        The surrounding valid pairs still survive, so one hostile or mistaken
+        key does not discard the rest.
+        """
+        assert parse_front_matter(
+            "---\npath: /etc/passwd\nqualified_name: other.module\npurpose: p\n---\n"
+        ) == {"purpose": "p"}
+
     def test_an_unterminated_block_yields_nothing(self) -> None:
         """No closing delimiter means the block never ends.
 

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -70,18 +70,19 @@ class TestParsing:
     def test_a_fenced_block_below_the_first_line_is_not_front_matter(self) -> None:
         """Front-matter must open on line 1; a later fenced pair is prose.
 
-        Found by mutation: removing the `lines[0]` check left all 10 tests
-        passing, because the existing delimiter test uses a document with no
-        CLOSING fence -- so the unterminated-block guard caught it and the
-        position guard was never exercised.
+        Found by mutation, in two rounds. Removing the `lines[0]` check left
+        all tests passing; my first replacement fixture ALSO left it passing,
+        because its pairs sat after the first fence found, so a position-blind
+        scan read a blank line and returned nothing either way. The fixture
+        was written to describe the defect rather than to separate the two
+        implementations.
 
-        This document has a well-formed fenced pair further down, which a
-        position-blind parser reads as metadata. It is a horizontal rule
-        around a quote, and its contents are body text.
+        The discriminating shape needs a `key: value` on line 2 and a fence on
+        line 3. This is a setext heading -- `Title` underlined with `---` --
+        which is exactly the realistic case: a position-blind parser reads the
+        line between as metadata and swallows body text into node properties.
         """
-        assert parse_front_matter(
-            "# Title\n\n---\npurpose: not-metadata\n---\n\nBody.\n"
-        ) == {}
+        assert parse_front_matter("Title\nkey: swallowed\n---\n\nBody.\n") == {}
 
     def test_a_reserved_key_cannot_overwrite_an_identity_property(self) -> None:
         """A document may not declare `path:` or `qualified_name:`.

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -18,8 +18,11 @@
 # to a `minus_metadata` node, which `document_tier` currently ignores.
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 from codebase_rag.parsers.document_tier import parse_front_matter
 
@@ -131,7 +134,22 @@ class TestParsing:
 
 
 class TestIngestion:
-    """The declared metadata must reach the Module node."""
+    """The declared metadata must reach the Module node.
+
+    Guarded on the grammar, unlike `TestParsing` above. These two index a
+    fixture through the real updater, so without `tree_sitter_markdown` no
+    Module node is emitted at all and both fail with "no Module node emitted"
+    -- a missing optional dependency reported as a product defect.
+
+    The parser tests are deliberately NOT guarded: they are pure string
+    handling and must run on the base install, which is where the contract
+    they pin is easiest to break unnoticed.
+    """
+
+    pytestmark = pytest.mark.skipif(
+        importlib.util.find_spec("tree_sitter_markdown") is None,
+        reason="markdown grammar ships in the treesitter-full extra",
+    )
 
     def test_front_matter_becomes_module_properties(
         self, temp_repo: Path, mock_ingestor: MagicMock

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -131,9 +131,9 @@ class TestParsing:
         only" while the code took every line with a colon -- the contract and
         the implementation disagreed (reported on #1488).
         """
-        assert parse_front_matter(
-            "---\nparent:\n  child: v\npurpose: p\n---\n"
-        ) == {"purpose": "p"}
+        assert parse_front_matter("---\nparent:\n  child: v\npurpose: p\n---\n") == {
+            "purpose": "p"
+        }
 
     def test_a_comment_line_declares_nothing(self) -> None:
         """`# note: x` would otherwise become the key `# note`."""

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -44,7 +44,7 @@ class TestParsing:
         }
 
     def test_quotes_are_stripped_from_values(self) -> None:
-        assert parse_front_matter('---\ntitle: "My Plan"\nk: \'v\'\n---\n') == {
+        assert parse_front_matter("---\ntitle: \"My Plan\"\nk: 'v'\n---\n") == {
             "title": "My Plan",
             "k": "v",
         }

--- a/codebase_rag/tests/test_protobuf_node_property_parity.py
+++ b/codebase_rag/tests/test_protobuf_node_property_parity.py
@@ -18,6 +18,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
+from typing import Any
 
 from codebase_rag.types_defs import NODE_SCHEMAS
 from codec import schema_pb2 as pb
@@ -130,16 +132,16 @@ def _proto_fields(label: str) -> set[str] | None:
     return None if message is None else {field.name for field in message.fields}
 
 
-def test_every_declared_property_is_exported_or_declared_unexported() -> None:
-    """Default-deny: a new property must be exported or explicitly excluded.
+def _unexported_properties(schemas: Iterable[Any]) -> list[str]:
+    """Declared properties with no proto field and no exemption.
 
-    Reading the generated DESCRIPTORS rather than the `.proto` text, because a
-    text search answers "does this name appear in the file" -- which a comment
-    or an unrelated message satisfies -- and the question is "does this message
-    carry this field".
+    Extracted so a test can run the REAL comparison over a stand-in schema.
+    An inline copy inside a test would be a mirror -- mutating this function
+    would leave the copy passing, which is what the first attempt at covering
+    the missing-message branch actually did (#1491).
     """
     undeclared: list[str] = []
-    for schema in NODE_SCHEMAS:
+    for schema in schemas:
         label = schema.label.value
         fields = _proto_fields(label)
         if fields is None:
@@ -157,6 +159,18 @@ def test_every_declared_property_is_exported_or_declared_unexported() -> None:
         for prop in sorted(_declared_properties(schema.properties)):
             if prop not in fields and prop not in allowed:
                 undeclared.append(f"{label}.{prop}")
+    return undeclared
+
+
+def test_every_declared_property_is_exported_or_declared_unexported() -> None:
+    """Default-deny: a new property must be exported or explicitly excluded.
+
+    Reading the generated DESCRIPTORS rather than the `.proto` text, because a
+    text search answers "does this name appear in the file" -- which a comment
+    or an unrelated message satisfies -- and the question is "does this message
+    carry this field".
+    """
+    undeclared = _unexported_properties(NODE_SCHEMAS)
 
     assert not undeclared, (
         f"{len(undeclared)} node propert(ies) are declared in NODE_SCHEMAS but "
@@ -189,6 +203,20 @@ def test_a_label_without_a_proto_message_is_reported() -> None:
     # The paired positive: a real label resolves, so the None above is the
     # absence rather than the helper being inert.
     assert _proto_fields("Module") is not None
+
+    # And the COMPARISON must act on that None rather than skipping. Asserting
+    # on `_proto_fields` alone left the silent-skip revert PASSING, because no
+    # real label lacks a message -- so that assertion cannot reach the branch
+    # it is about. Calls the real function; an inline copy would be a mirror.
+    class _StandInSchema:
+        class label:  # noqa: N801 - mimics the NodeSchema attribute shape
+            value = "NoSuchNodeLabel"
+
+        properties = "{qualified_name: string}"
+
+    assert _unexported_properties([_StandInSchema()]) == [
+        "NoSuchNodeLabel (no proto message at all)"
+    ], "a label with no proto message must be reported, not skipped"
 
 
 def test_the_unexported_list_names_only_real_absences() -> None:

--- a/codebase_rag/tests/test_protobuf_node_property_parity.py
+++ b/codebase_rag/tests/test_protobuf_node_property_parity.py
@@ -1,0 +1,208 @@
+# Guards node properties in NODE_SCHEMAS against codec/schema.proto (#1490).
+#
+# The sibling `test_protobuf_relationship_parity.py` guards the relationship
+# ENUM. Nothing guarded node PROPERTIES, and the failure mode is the same
+# shape: a property added to `NODE_SCHEMAS` is written at ingestion and read by
+# queries, but silently dropped on protobuf export. No error, no warning -- the
+# exported index is simply missing a field the schema says exists.
+#
+# Found while adding `Module.front_matter` (#1488): review flagged that it
+# would not survive export, and checking whether an existing guard would have
+# caught it turned up dozens of other properties in the same position. So the
+# specific finding was an instance of a general gap.
+#
+# DEFAULT-DENY, deliberately. An inventory of "properties to check" cannot fail
+# for the property nobody remembered to list -- the same inversion the MCP lock
+# guard needed in #1475. Here every declared property must either have a proto
+# field or be named in `_NOT_EXPORTED` below, so forgetting fails.
+from __future__ import annotations
+
+import re
+
+from codebase_rag.types_defs import NODE_SCHEMAS
+from codec import schema_pb2 as pb
+
+# Properties that exist in NODE_SCHEMAS and deliberately have no proto field.
+#
+# This is a RECORD OF THE CURRENT STATE, not an endorsement of it. Every entry
+# was measured against the generated descriptors when this test was written;
+# none has been reviewed for whether it SHOULD be exported. #1490 carries that
+# question.
+#
+# The value of listing them is that the set is now closed: a new absence fails
+# this test and has to be argued for explicitly, rather than joining the pile
+# unnoticed. Removing an entry (by adding the proto field) is always safe;
+# adding one should be a deliberate decision with a reason.
+_NOT_EXPORTED: dict[str, frozenset[str]] = {
+    "Project": frozenset({"root_path"}),
+    "Package": frozenset({"absolute_path"}),
+    "Folder": frozenset({"absolute_path"}),
+    "File": frozenset({"absolute_path"}),
+    "Module": frozenset(
+        {"absolute_path", "end_line", "front_matter", "start_line"}
+    ),
+    "Class": frozenset({"absolute_path", "modifiers", "path", "start_col"}),
+    "Function": frozenset(
+        {
+            "absolute_path",
+            "is_macro",
+            "modifiers",
+            "name_start_col",
+            "name_start_line",
+            "path",
+            "start_col",
+        }
+    ),
+    "Method": frozenset(
+        {
+            "absolute_path",
+            "is_exported",
+            "is_property",
+            "modifiers",
+            "name_start_col",
+            "name_start_line",
+            "overrides_external",
+            "path",
+            "start_col",
+        }
+    ),
+    "Interface": frozenset(
+        {
+            "decorators",
+            "docstring",
+            "end_line",
+            "is_exported",
+            "modifiers",
+            "start_col",
+            "start_line",
+        }
+    ),
+    "Enum": frozenset(
+        {
+            "decorators",
+            "docstring",
+            "end_line",
+            "is_exported",
+            "modifiers",
+            "start_col",
+            "start_line",
+        }
+    ),
+    "Type": frozenset(
+        {
+            "absolute_path",
+            "decorators",
+            "docstring",
+            "end_line",
+            "is_exported",
+            "modifiers",
+            "path",
+            "start_col",
+            "start_line",
+        }
+    ),
+    "Union": frozenset(
+        {
+            "absolute_path",
+            "decorators",
+            "docstring",
+            "end_line",
+            "is_exported",
+            "modifiers",
+            "path",
+            "start_col",
+            "start_line",
+        }
+    ),
+    "ModuleInterface": frozenset({"absolute_path", "module_type"}),
+    "ModuleImplementation": frozenset({"absolute_path", "module_type"}),
+}
+
+# `{name: type, other: type?}` -> {"name", "other"}
+_PROPERTY_NAME = re.compile(r"(\w+):")
+
+
+def _declared_properties(schema_text: str) -> set[str]:
+    return set(_PROPERTY_NAME.findall(schema_text))
+
+
+def _proto_fields(label: str) -> set[str] | None:
+    """Field names of the proto message for `label`, or None if absent."""
+    message = pb.DESCRIPTOR.message_types_by_name.get(label)
+    return None if message is None else {field.name for field in message.fields}
+
+
+def test_every_declared_property_is_exported_or_declared_unexported() -> None:
+    """Default-deny: a new property must be exported or explicitly excluded.
+
+    Reading the generated DESCRIPTORS rather than the `.proto` text, because a
+    text search answers "does this name appear in the file" -- which a comment
+    or an unrelated message satisfies -- and the question is "does this message
+    carry this field".
+    """
+    undeclared: list[str] = []
+    for schema in NODE_SCHEMAS:
+        label = schema.label.value
+        fields = _proto_fields(label)
+        if fields is None:
+            continue
+        allowed = _NOT_EXPORTED.get(label, frozenset())
+        for prop in sorted(_declared_properties(schema.properties)):
+            if prop not in fields and prop not in allowed:
+                undeclared.append(f"{label}.{prop}")
+
+    assert not undeclared, (
+        f"{len(undeclared)} node propert(ies) are declared in NODE_SCHEMAS but "
+        "have no field in codec/schema.proto and are not listed in "
+        "_NOT_EXPORTED:\n"
+        + "\n".join(undeclared)
+        + "\n\nAdd the proto field and regenerate the bindings, or add the "
+        "property to _NOT_EXPORTED with a reason (issue #1490)."
+    )
+
+
+def test_the_unexported_list_names_only_real_absences() -> None:
+    """A control: an entry that IS exported must be removed from the list.
+
+    Without this the allow-list only grows. A property gains a proto field,
+    its entry here becomes a lie, and the next reader cannot tell which
+    entries are current -- the same staleness that makes an unmaintained
+    exclusion list worse than none.
+    """
+    stale: list[str] = []
+    for label, properties in _NOT_EXPORTED.items():
+        fields = _proto_fields(label)
+        if fields is None:
+            continue
+        stale.extend(f"{label}.{prop}" for prop in sorted(properties & fields))
+
+    assert not stale, (
+        f"{len(stale)} entr(ies) in _NOT_EXPORTED now HAVE a proto field and "
+        "should be removed:\n" + "\n".join(stale)
+    )
+
+
+def test_the_unexported_list_names_only_declared_properties() -> None:
+    """A second control: the list may not name properties that do not exist.
+
+    A renamed or removed property would leave an entry that suppresses
+    nothing, and a future property reusing that name would be silently
+    exempted from the check above.
+    """
+    declared_by_label = {
+        schema.label.value: _declared_properties(schema.properties)
+        for schema in NODE_SCHEMAS
+    }
+
+    unknown: list[str] = []
+    for label, properties in _NOT_EXPORTED.items():
+        declared = declared_by_label.get(label)
+        if declared is None:
+            unknown.append(f"{label} (no such node schema)")
+            continue
+        unknown.extend(f"{label}.{prop}" for prop in sorted(properties - declared))
+
+    assert not unknown, (
+        f"{len(unknown)} entr(ies) in _NOT_EXPORTED do not name a declared "
+        "property:\n" + "\n".join(unknown)
+    )

--- a/codebase_rag/tests/test_protobuf_node_property_parity.py
+++ b/codebase_rag/tests/test_protobuf_node_property_parity.py
@@ -38,9 +38,7 @@ _NOT_EXPORTED: dict[str, frozenset[str]] = {
     "Package": frozenset({"absolute_path"}),
     "Folder": frozenset({"absolute_path"}),
     "File": frozenset({"absolute_path"}),
-    "Module": frozenset(
-        {"absolute_path", "end_line", "front_matter", "start_line"}
-    ),
+    "Module": frozenset({"absolute_path", "end_line", "front_matter", "start_line"}),
     "Class": frozenset({"absolute_path", "modifiers", "path", "start_col"}),
     "Function": frozenset(
         {

--- a/codebase_rag/tests/test_protobuf_node_property_parity.py
+++ b/codebase_rag/tests/test_protobuf_node_property_parity.py
@@ -143,6 +143,15 @@ def test_every_declared_property_is_exported_or_declared_unexported() -> None:
         label = schema.label.value
         fields = _proto_fields(label)
         if fields is None:
+            # A node label with NO proto message at all exports nothing, which
+            # is a larger loss than a single missing property. Skipping it here
+            # would let a whole label slip through the check written to catch
+            # exactly this -- the inventory-fails-open shape (#1490).
+            #
+            # Unreachable today: every label has a message. That is a fact
+            # about the current proto, not a promise, so the branch is
+            # reported rather than assumed away.
+            undeclared.append(f"{label} (no proto message at all)")
             continue
         allowed = _NOT_EXPORTED.get(label, frozenset())
         for prop in sorted(_declared_properties(schema.properties)):
@@ -157,6 +166,29 @@ def test_every_declared_property_is_exported_or_declared_unexported() -> None:
         + "\n\nAdd the proto field and regenerate the bindings, or add the "
         "property to _NOT_EXPORTED with a reason (issue #1490)."
     )
+
+
+def test_a_label_without_a_proto_message_is_reported() -> None:
+    """A whole missing message must fail, not be skipped.
+
+    The guard originally did `if fields is None: continue`, so a node label
+    with no proto message at all passed silently -- exporting nothing, which
+    is a larger loss than any single absent property. That is the
+    inventory-fails-open shape the test exists to prevent, reproduced inside
+    the test itself (reported on #1491).
+
+    Exercised through `_proto_fields` on a label the proto does not carry,
+    since every real label currently has a message. Unreachable today is a
+    fact about the current proto, not a promise.
+    """
+    assert _proto_fields("NoSuchNodeLabel") is None, (
+        "a label absent from the proto must report None, so the caller can "
+        "distinguish it from a message that exists with no matching fields"
+    )
+
+    # The paired positive: a real label resolves, so the None above is the
+    # absence rather than the helper being inert.
+    assert _proto_fields("Module") is not None
 
 
 def test_the_unexported_list_names_only_real_absences() -> None:

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -843,7 +843,7 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     ),
     NodeSchema(
         NodeLabel.MODULE,
-        "{qualified_name: string, name: string, path: string, absolute_path: string, flow_covered: boolean?, generated: boolean?, generator: string?, start_line: int?, end_line: int?, decorators: list[string]?, rust_cfg_test_mods: list[string]?, rust_ungated_mods: list[string]?}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, flow_covered: boolean?, generated: boolean?, generator: string?, start_line: int?, end_line: int?, decorators: list[string]?, rust_cfg_test_mods: list[string]?, rust_ungated_mods: list[string]?, front_matter: list[string]?}",
     ),
     NodeSchema(
         NodeLabel.CLASS,


### PR DESCRIPTION
Fixes #1490

## The gap

`NODE_SCHEMAS` and `codec/schema.proto` declare node properties independently, and nothing checked they agree. A property added to the schema is written at ingestion, read by queries, and **silently dropped on export** — no error, no warning.

The sibling `test_protobuf_relationship_parity.py` guards the relationship *enum* for exactly this failure mode. The node side had no equivalent.

Measured across 14 node labels — the absences are real, verified against the generated descriptors rather than by grepping the proto text:

```
Project.root_path            Module.front_matter       Class.modifiers
Class.path                   Function.is_macro         Function.name_start_line
Method.overrides_external    Interface.docstring       Type.start_line   …
```

## How it surfaced

Review on #1488 flagged that `Module.front_matter` would not survive export. Checking whether an existing guard would have caught it turned up dozens of properties in the same position — so the specific finding was an instance of a general gap, and fixing only the instance would have left the mechanism intact.

## Default-deny

An inventory of "properties to check" cannot fail for the property nobody remembered to list — the same inversion the MCP lock guard needed in #1475. Every declared property must have a proto field **or** be named in `_NOT_EXPORTED`.

`_NOT_EXPORTED` records the **current state**, measured. No entry has been reviewed for whether it *should* be exported; #1490 carries that question. The value is that the set is now closed: a 26th absence fails this test and has to be argued for.

## Two controls keep the list honest

- An entry that gains a proto field must be **removed** — otherwise the list only grows and a reader cannot tell which entries are current.
- An entry naming a property that does not exist is **rejected** — otherwise a renamed property leaves an exemption that silently covers whatever later reuses the name.

## Verification

| mutation | result |
|---|---|
| drop `front_matter` from the allow-list | fails the default-deny test |
| add an already-exported property to the list | fails the staleness control |
| add a nonexistent property to the list | fails the existence control |

Each fails exactly one test. Scope is the guard only — adding proto fields for the existing absences needs someone to decide, per label, whether each belongs in the export, and I would be guessing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading YAML front matter from Markdown documents.
  * Preserves valid metadata as sorted `key=value` entries on the document record.
  * Ignores unsupported, reserved, malformed, or empty metadata entries.
* **Bug Fixes**
  * Prevents declared metadata from overwriting core document properties.
* **Tests**
  * Added coverage for front-matter parsing, ingestion, and property schema consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->