### PR TITLE
fix: report a rejected API key as an auth error, not a count failure

### DIFF
--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -87,6 +87,10 @@ FIELD_ENDPOINT = "endpoint"
 ANTHROPIC_COUNT_TOKENS_URL = "https://api.anthropic.com/v1/messages/count_tokens"
 ANTHROPIC_API_VERSION = "2023-06-01"
 ANTHROPIC_HEADER_API_KEY = "x-api-key"
+
+# HTTP statuses meaning the credential was REJECTED. Retrying cannot help,
+# so these are reported differently from transient failures (issue #1493).
+HTTP_AUTH_FAILURE_STATUSES: frozenset[int] = frozenset({401, 403})
 ANTHROPIC_HEADER_VERSION = "anthropic-version"
 HEADER_CONTENT_TYPE = "content-type"
 CONTENT_TYPE_JSON = "application/json"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -147,6 +147,11 @@ EMBEDDING_SNIPPET_FAILED = (
 )
 EMBEDDING_BATCH_COMPUTE_FAILED = "Failed to embed batch of {count}: {error}"
 CONTEXT_TOKEN_COUNT_FAILED = "Context token count failed: {error}"
+# A rejected credential, distinct from a transient failure: the user must
+# change something, so it is warned rather than logged at debug (issue #1493).
+CONTEXT_TOKEN_COUNT_AUTH_FAILED = (
+    "Context token counting disabled for this session: {error}"
+)
 NO_SOURCE_FOR = "No source code found for {name}"
 EMBEDDINGS_COMPLETE = "Successfully generated {count} semantic embeddings"
 EMBEDDING_GENERATION_FAILED = "Failed to generate semantic embeddings: {error}"

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -876,11 +876,26 @@ async def _refresh_context_tokens(messages: list[ModelMessage]) -> None:
     if config.provider != cs.Provider.ANTHROPIC or not config.api_key:
         return
     try:
-        from .services.anthropic_token_counter import count_anthropic_context
+        from .services.anthropic_token_counter import (
+            TokenCountAuthError,
+            count_anthropic_context,
+        )
 
         count = await count_anthropic_context(config.api_key, config.model_id, messages)
         app_context.session.context_tokens = count
+    except TokenCountAuthError as e:
+        # A rejected key recurs on EVERY refresh and silently disables the
+        # token counter for the whole session, so debug is the wrong level:
+        # the user has to change something and would otherwise never know
+        # (issue #1493). Warned once per session rather than per refresh --
+        # the counter runs in the background on each turn, and repeating an
+        # unactionable-until-restart message would bury the rest of the log.
+        if not app_context.session.token_auth_warned:
+            app_context.session.token_auth_warned = True
+            logger.warning(ls.CONTEXT_TOKEN_COUNT_AUTH_FAILED.format(error=e))
     except Exception as e:
+        # Transient failures stay at debug. The next refresh probably works,
+        # and a background retry is not something the user must act on.
         logger.debug(ls.CONTEXT_TOKEN_COUNT_FAILED.format(error=e))
 
 

--- a/codebase_rag/models.py
+++ b/codebase_rag/models.py
@@ -21,6 +21,11 @@ class SessionState:
     cancelled: bool = False
     permission_mode: PermissionMode = PermissionMode.NORMAL
     context_tokens: int = 0
+    # Whether a rejected-API-key warning has already been emitted this
+    # session. The token counter refreshes on every turn, so without this the
+    # same unactionable-until-restart message repeats and buries the log
+    # (issue #1493).
+    token_auth_warned: bool = False
     target_repo: Path | None = None
     # Cumulative token consumption and USD cost across the session (issue #80).
     total_input_tokens: int = 0

--- a/codebase_rag/services/anthropic_token_counter.py
+++ b/codebase_rag/services/anthropic_token_counter.py
@@ -122,6 +122,24 @@ class TokenCountError(Exception):
     pass
 
 
+class TokenCountAuthError(TokenCountError):
+    """The provider rejected the credential (401/403).
+
+    Distinguished from the base error because the two need opposite
+    responses. A rejected key will NEVER succeed, so retrying is pointless
+    and the user has to change something; a 429 or 5xx is transient and the
+    next refresh probably works.
+
+    Collapsing them left an invalid API key reported as an internal
+    token-count failure, with the provider's raw JSON as the only clue
+    (issue #1493).
+
+    Subclasses `TokenCountError` deliberately: an existing
+    `except TokenCountError` caller keeps working rather than having this
+    escape as an unhandled exception in a background task.
+    """
+
+
 async def count_anthropic_context(
     api_key: str,
     model_id: str,
@@ -149,6 +167,14 @@ async def count_anthropic_context(
         resp = await client.post(
             cs.ANTHROPIC_COUNT_TOKENS_URL, json=payload, headers=headers
         )
+        if resp.status_code in cs.HTTP_AUTH_FAILURE_STATUSES:
+            # The actionable part leads. The status is kept for diagnosis,
+            # but a reader should not have to parse a provider JSON blob to
+            # learn their key is wrong.
+            raise TokenCountAuthError(
+                f"the Anthropic API key was rejected ({resp.status_code}); "
+                "check the key configured for this provider"
+            )
         if resp.status_code >= 400:
             raise TokenCountError(f"{resp.status_code}: {resp.text}")
         return int(resp.json().get("input_tokens", 0))

--- a/codebase_rag/tests/test_token_count_auth_error.py
+++ b/codebase_rag/tests/test_token_count_auth_error.py
@@ -1,0 +1,151 @@
+# Authentication failures must be distinguishable from transient ones (#1493).
+#
+# Reported as "Context token count failed: 401: {...invalid x-api-key...}".
+# The count was not broken -- the MESSAGE was. Every HTTP status >= 400 raised
+# the same `TokenCountError`, and the caller logged them all identically at
+# debug level, so an invalid API key looked like an internal hiccup.
+#
+# The two cases need opposite responses from the user:
+#
+#   401/403  the key is wrong; it will NEVER succeed, and no retry helps
+#   429/5xx  transient; the next refresh probably works
+#
+# Collapsing them leaves the user decoding a raw provider JSON blob to work
+# out which one they have.
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
+
+from codebase_rag.services.anthropic_token_counter import (
+    TokenCountAuthError,
+    TokenCountError,
+    count_anthropic_context,
+)
+
+
+def _transport(status: int, body: str) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, text=body)
+
+    return httpx.MockTransport(handler)
+
+
+def _patch_client(
+    monkeypatch: pytest.MonkeyPatch, transport: httpx.MockTransport
+) -> None:
+    """Route `httpx.AsyncClient` through a mock transport.
+
+    Captures the REAL class first. A lambda that calls `httpx.AsyncClient`
+    after patching that same name recurses infinitely -- and the resulting
+    `RecursionError` reads as a code failure rather than a fixture one.
+    """
+    real = httpx.AsyncClient
+
+    def build(**kwargs: object) -> httpx.AsyncClient:
+        kwargs.pop("transport", None)
+        return real(transport=transport, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(httpx, "AsyncClient", build)
+
+
+def _messages() -> list[ModelMessage]:
+    """A message list that actually reaches the HTTP call.
+
+    `count_anthropic_context` returns 0 before making any request when the
+    payload is empty, so an `[]` fixture never reaches the code under test --
+    the unreachable-fixture shape. Every test below asserts on the response
+    to a request, so the request has to happen.
+    """
+    return [ModelRequest(parts=[UserPromptPart(content="hello")])]
+
+
+class TestErrorClassification:
+    """Which exception a status code produces."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_an_auth_status_raises_the_auth_error(
+        self, monkeypatch: pytest.MonkeyPatch, status: int
+    ) -> None:
+        """401 and 403 are configuration errors, not failures to count.
+
+        Both mean the credential is rejected. Neither is retryable, so the
+        caller needs to tell the user rather than log at debug and move on.
+        """
+        transport = _transport(
+            status, '{"type":"error","error":{"message":"invalid x-api-key"}}'
+        )
+        _patch_client(monkeypatch, transport)
+
+        with pytest.raises(TokenCountAuthError):
+            await count_anthropic_context("bad-key", "claude-x", _messages())
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [429, 500, 503])
+    async def test_a_transient_status_raises_the_plain_error(
+        self, monkeypatch: pytest.MonkeyPatch, status: int
+    ) -> None:
+        """Rate limits and server errors stay the ordinary failure.
+
+        The control that keeps the fix from over-reaching: if every status
+        became an auth error, the caller would nag about credentials during a
+        rate limit, which is worse than the original defect.
+        """
+        transport = _transport(status, '{"type":"error","error":{"message":"oops"}}')
+        _patch_client(monkeypatch, transport)
+
+        with pytest.raises(TokenCountError) as caught:
+            await count_anthropic_context("good-key", "claude-x", _messages())
+
+        assert not isinstance(caught.value, TokenCountAuthError), (
+            f"status {status} was classified as an authentication failure; "
+            "it is transient and a retry may succeed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_auth_error_is_a_token_count_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Subclassing keeps existing `except TokenCountError` callers working.
+
+        A separate exception hierarchy would silently escape any caller that
+        already handles the base type -- turning a logged failure into a
+        crash in a background task.
+        """
+        transport = _transport(401, "denied")
+        _patch_client(monkeypatch, transport)
+
+        with pytest.raises(TokenCountError):
+            await count_anthropic_context("bad-key", "claude-x", _messages())
+
+
+class TestMessage:
+    """What the user is actually told."""
+
+    @pytest.mark.asyncio
+    async def test_the_auth_message_names_the_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The message must say the key is invalid, not echo provider JSON.
+
+        The report on #1493 shows the raw blob reaching the user:
+
+            Context token count failed: 401: {"type":"error","error":...}
+
+        A reader has to parse that to learn their key is wrong. The status
+        code is retained for diagnosis, but the actionable part leads.
+        """
+        transport = _transport(
+            401, '{"type":"error","error":{"message":"invalid x-api-key"}}'
+        )
+        _patch_client(monkeypatch, transport)
+
+        with pytest.raises(TokenCountAuthError) as caught:
+            await count_anthropic_context("bad-key", "claude-x", _messages())
+
+        message = str(caught.value)
+        assert "API key" in message, message
+        assert "401" in message, message

--- a/codebase_rag/tests/test_token_count_auth_error.py
+++ b/codebase_rag/tests/test_token_count_auth_error.py
@@ -16,11 +16,9 @@ from __future__ import annotations
 
 import httpx
 import pytest
-
-from codebase_rag import constants as cs
-
 from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
 
+from codebase_rag import constants as cs
 from codebase_rag.services.anthropic_token_counter import (
     TokenCountAuthError,
     TokenCountError,
@@ -177,9 +175,7 @@ class TestCallerBehaviour:
         monkeypatch.setattr(
             main_mod.logger, "warning", lambda msg, *a, **k: warnings.append(str(msg))
         )
-        monkeypatch.setattr(
-            main_mod.logger, "debug", lambda msg, *a, **k: None
-        )
+        monkeypatch.setattr(main_mod.logger, "debug", lambda msg, *a, **k: None)
 
         async def boom(*_args: object, **_kw: object) -> int:
             raise TokenCountAuthError("the Anthropic API key was rejected (401)")
@@ -205,8 +201,7 @@ class TestCallerBehaviour:
         await main_mod._refresh_context_tokens(_messages())
 
         assert len(warnings) == 1, (
-            f"expected exactly one warning per session, got {len(warnings)}: "
-            f"{warnings}"
+            f"expected exactly one warning per session, got {len(warnings)}: {warnings}"
         )
         assert "API key" in warnings[0] or "rejected" in warnings[0], warnings[0]
 
@@ -250,6 +245,4 @@ class TestCallerBehaviour:
 
         await main_mod._refresh_context_tokens(_messages())
 
-        assert warnings == [], (
-            f"a transient failure warned the user: {warnings}"
-        )
+        assert warnings == [], f"a transient failure warned the user: {warnings}"

--- a/codebase_rag/tests/test_token_count_auth_error.py
+++ b/codebase_rag/tests/test_token_count_auth_error.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from codebase_rag import constants as cs
+
 from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
 
 from codebase_rag.services.anthropic_token_counter import (
@@ -149,3 +151,105 @@ class TestMessage:
         message = str(caught.value)
         assert "API key" in message, message
         assert "401" in message, message
+
+
+class TestCallerBehaviour:
+    """What `_refresh_context_tokens` does with each error kind."""
+
+    @pytest.mark.asyncio
+    async def test_an_auth_failure_warns_once_per_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A rejected key must WARN, and only on the first refresh.
+
+        Debug is the wrong level for a permanent failure: it recurs on every
+        turn and silently disables the counter for the whole session, so the
+        user never learns their key is wrong.
+
+        Once per session, because the counter refreshes on every turn and
+        repeating an unactionable-until-restart message would bury the rest
+        of the log. Asserts the SECOND call is silent, which is what
+        distinguishes "warned once" from "warned always".
+        """
+        from codebase_rag import main as main_mod
+
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            main_mod.logger, "warning", lambda msg, *a, **k: warnings.append(str(msg))
+        )
+        monkeypatch.setattr(
+            main_mod.logger, "debug", lambda msg, *a, **k: None
+        )
+
+        async def boom(*_args: object, **_kw: object) -> int:
+            raise TokenCountAuthError("the Anthropic API key was rejected (401)")
+
+        monkeypatch.setattr(
+            "codebase_rag.services.anthropic_token_counter.count_anthropic_context",
+            boom,
+        )
+        main_mod.app_context.session.token_auth_warned = False
+
+        class _Config:
+            provider = cs.Provider.ANTHROPIC
+            api_key = "bad-key"
+            model_id = "claude-x"
+
+        monkeypatch.setattr(
+            type(main_mod.settings),
+            "active_orchestrator_config",
+            property(lambda self: _Config()),
+        )
+
+        await main_mod._refresh_context_tokens(_messages())
+        await main_mod._refresh_context_tokens(_messages())
+
+        assert len(warnings) == 1, (
+            f"expected exactly one warning per session, got {len(warnings)}: "
+            f"{warnings}"
+        )
+        assert "API key" in warnings[0] or "rejected" in warnings[0], warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_a_transient_failure_stays_at_debug(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control: an ordinary failure must NOT warn.
+
+        Without this the fix could warn on every error kind, which is the
+        original defect inverted -- nagging about credentials during a rate
+        limit.
+        """
+        from codebase_rag import main as main_mod
+
+        warnings: list[str] = []
+        monkeypatch.setattr(
+            main_mod.logger, "warning", lambda msg, *a, **k: warnings.append(str(msg))
+        )
+        monkeypatch.setattr(main_mod.logger, "debug", lambda msg, *a, **k: None)
+
+        async def boom(*_args: object, **_kw: object) -> int:
+            raise TokenCountError("503: unavailable")
+
+        monkeypatch.setattr(
+            "codebase_rag.services.anthropic_token_counter.count_anthropic_context",
+            boom,
+        )
+        main_mod.app_context.session.token_auth_warned = False
+
+        class _Config:
+            provider = cs.Provider.ANTHROPIC
+            api_key = "good-key"
+            model_id = "claude-x"
+
+        monkeypatch.setattr(
+            type(main_mod.settings),
+            "active_orchestrator_config",
+            property(lambda self: _Config()),
+        )
+
+        await main_mod._refresh_context_tokens(_messages())
+
+        assert warnings == [], (
+            f"a transient failure warned the user: {warnings}"
+        )

--- a/codebase_rag/tests/test_token_count_auth_error.py
+++ b/codebase_rag/tests/test_token_count_auth_error.py
@@ -80,8 +80,13 @@ class TestErrorClassification:
         )
         _patch_client(monkeypatch, transport)
 
+        # Built OUTSIDE the raises block: a failure inside `_messages()`
+        # would otherwise satisfy `pytest.raises` and the test would pass
+        # for the wrong reason (Sonar S5778).
+        messages = _messages()
+
         with pytest.raises(TokenCountAuthError):
-            await count_anthropic_context("bad-key", "claude-x", _messages())
+            await count_anthropic_context("bad-key", "claude-x", messages)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("status", [429, 500, 503])
@@ -97,8 +102,10 @@ class TestErrorClassification:
         transport = _transport(status, '{"type":"error","error":{"message":"oops"}}')
         _patch_client(monkeypatch, transport)
 
+        messages = _messages()
+
         with pytest.raises(TokenCountError) as caught:
-            await count_anthropic_context("good-key", "claude-x", _messages())
+            await count_anthropic_context("good-key", "claude-x", messages)
 
         assert not isinstance(caught.value, TokenCountAuthError), (
             f"status {status} was classified as an authentication failure; "
@@ -118,8 +125,10 @@ class TestErrorClassification:
         transport = _transport(401, "denied")
         _patch_client(monkeypatch, transport)
 
+        messages = _messages()
+
         with pytest.raises(TokenCountError):
-            await count_anthropic_context("bad-key", "claude-x", _messages())
+            await count_anthropic_context("bad-key", "claude-x", messages)
 
 
 class TestMessage:
@@ -143,8 +152,10 @@ class TestMessage:
         )
         _patch_client(monkeypatch, transport)
 
+        messages = _messages()
+
         with pytest.raises(TokenCountAuthError) as caught:
-            await count_anthropic_context("bad-key", "claude-x", _messages())
+            await count_anthropic_context("bad-key", "claude-x", messages)
 
         message = str(caught.value)
         assert "API key" in message, message


### PR DESCRIPTION
Fixes #1493

## The report

```
Context token count failed: 401:
{"type":"error","error":{"type":"authentication_error",
 "message":"invalid x-api-key"}}
```

**The count was not broken — the message was.** An invalid API key is reported as an internal token-count failure, so the actual problem is not what the user is told.

## Two defects behind one symptom

`anthropic_token_counter.py` raised `TokenCountError(f"{status}: {text}")` for **every** status ≥ 400, and `main.py` caught it with a blanket `except Exception` at **debug** level. That collapses two cases needing opposite responses:

| status | meaning | user action |
|---|---|---|
| 401 / 403 | the credential is rejected | change the key — no retry ever helps |
| 429 / 5xx | transient | none; the next refresh probably works |

And debug is the wrong level for the permanent case: a rejected key recurs on **every** background refresh and silently disables the token counter for the whole session, so the user never learns why the count stopped.

## The fix

`TokenCountAuthError` subclasses `TokenCountError` deliberately — an existing `except TokenCountError` caller keeps working rather than having this escape as an unhandled exception in a background task.

The caller **warns once per session**, not per refresh. The counter runs on every turn, so repeating an unactionable-until-restart message would bury the rest of the log. Transient failures stay at debug.

The message leads with the actionable part and keeps the status for diagnosis, rather than echoing the provider's raw body.

## Verification

Five mutations, each caught by exactly one test:

| mutation | result |
|---|---|
| remove the auth branch | 3 failed |
| treat **all** 4xx as auth errors | 3 failed |
| drop the status from the message | 1 failed |
| warn every time (no once-guard) | 1 failed |
| let an auth failure fall through to debug | 1 failed |

The two **controls** carry the most weight. Treating all 4xx as auth errors fails the transient test, and warning every time fails the once-per-session test — without them this fix would invert the defect and nag about credentials during a rate limit.

Scoped regression: **83 passed, 4 skipped**.

## Two fixture defects found on the way

Both read as code failures, and I record them because each nearly sent me to fix working code:

- **`messages=[]` returns 0 before any HTTP call**, so the fixture never reached the code under test — an unreachable fixture. The failure said `DID NOT RAISE`, which looks like a missing raise rather than a test that never got there.
- **Patching `httpx.AsyncClient` with a lambda that calls `httpx.AsyncClient`** recursed infinitely. The resulting `RecursionError` looks like a product bug; the helper now captures the real class first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of API authentication failures during context token counting.
  * Added a clear warning when credentials are rejected, shown at most once per session.
  * Preserved quieter handling for transient service or rate-limit failures.
  * Error messages now identify authentication failures and include the relevant response status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->