### PR TITLE
fix: set the model output budget explicitly

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -344,7 +344,18 @@ class AppConfig(BaseSettings):
     #
     # Distinct from QUERY_RESULT_MAX_TOKENS above, which trims what goes IN.
     # This bounds what comes back.
-    MODEL_MAX_TOKENS: int = Field(default=16000, gt=0)
+    # 8192 rather than something larger: pydantic-ai forwards this value
+    # unchanged and exposes no per-model output cap to clamp against, so the
+    # default must fit the SMALLEST catalogued model or it breaks working
+    # configurations. `gemini-2.0-flash` caps output at 8192 and is
+    # selectable today; 16000 was rejected outright by it. This still fixes
+    # the reported crash, whose remedy is any value meaningfully above
+    # Anthropic's 4096 provider default.
+    #
+    # Raise it per-deployment when the chosen model allows more. A clamping
+    # table keyed on model id was considered and rejected: it would need
+    # hand-maintaining and would silently go stale on every new release.
+    MODEL_MAX_TOKENS: int = Field(default=8192, gt=0)
     QUERY_RESULT_ROW_CAP: int = Field(default=500, gt=0)
     QUERY_MEMORY_LIMIT_MB: int = Field(default=4096, gt=0)
     QUERY_TIMEOUT_S: float = Field(default=60.0, gt=0)

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -352,9 +352,13 @@ class AppConfig(BaseSettings):
     # the reported crash, whose remedy is any value meaningfully above
     # Anthropic's 4096 provider default.
     #
-    # Raise it per-deployment when the chosen model allows more. A clamping
-    # table keyed on model id was considered and rejected: it would need
-    # hand-maintaining and would silently go stale on every new release.
+    # Raise it per-deployment when the chosen model allows more. A general
+    # clamping table over every model was rejected: it would need
+    # hand-maintaining and would silently go stale on every new release,
+    # capping a launch below what it supports. Retired snapshots are the
+    # exception -- their maxima are frozen -- so `LEGACY_MAX_OUTPUT_TOKENS`
+    # lowers this budget for those ids alone, leaving everything else at the
+    # configured value.
     MODEL_MAX_TOKENS: int = Field(default=8192, gt=0)
     QUERY_RESULT_ROW_CAP: int = Field(default=500, gt=0)
     QUERY_MEMORY_LIMIT_MB: int = Field(default=4096, gt=0)

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -336,6 +336,15 @@ class AppConfig(BaseSettings):
     CACHE_MEMORY_THRESHOLD_RATIO: float = 0.8
 
     QUERY_RESULT_MAX_TOKENS: int = Field(default=16000, gt=0)
+    # The model's OUTPUT budget per request. Without it pydantic-ai falls back
+    # to the provider default, which on Anthropic is far below what current
+    # models support -- a long answer then fails with "Model token limit
+    # (provider default) exceeded before any response was generated" and the
+    # model never replies at all (issue #1498).
+    #
+    # Distinct from QUERY_RESULT_MAX_TOKENS above, which trims what goes IN.
+    # This bounds what comes back.
+    MODEL_MAX_TOKENS: int = Field(default=16000, gt=0)
     QUERY_RESULT_ROW_CAP: int = Field(default=500, gt=0)
     QUERY_MEMORY_LIMIT_MB: int = Field(default=4096, gt=0)
     QUERY_TIMEOUT_S: float = Field(default=60.0, gt=0)

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -111,6 +111,26 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "claude-haiku-4-0": 200_000,
 }
 
+# Output ceilings for superseded model snapshots, used to lower an output
+# budget that those models would reject outright (issue #1498).
+#
+# Deliberately NOT a general per-model table: a general one would have to
+# list every current release and would go stale on each launch, silently
+# capping a new model below what it supports. These ids are retired dated
+# snapshots, so their published maxima can no longer change, and anything
+# absent keeps the configured budget -- the direction that stays safe as new
+# models appear. Every current release accepts the 8192 default, so none of
+# them needs an entry.
+DEFAULT_MAX_OUTPUT_TOKENS = 4_096
+LEGACY_MAX_OUTPUT_TOKENS: dict[str, int] = {
+    "claude-3-haiku-20240307": DEFAULT_MAX_OUTPUT_TOKENS,
+    "claude-3-sonnet-20240229": DEFAULT_MAX_OUTPUT_TOKENS,
+    "claude-3-opus-20240229": DEFAULT_MAX_OUTPUT_TOKENS,
+    "claude-2.1": DEFAULT_MAX_OUTPUT_TOKENS,
+    "claude-2.0": DEFAULT_MAX_OUTPUT_TOKENS,
+    "claude-instant-1.2": DEFAULT_MAX_OUTPUT_TOKENS,
+}
+
 MODULE_TORCH = "torch"
 MODULE_TRANSFORMERS = "transformers"
 MODULE_QDRANT_CLIENT = "qdrant_client"

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -111,24 +111,24 @@ MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "claude-haiku-4-0": 200_000,
 }
 
-# Output ceilings for superseded model snapshots, used to lower an output
-# budget that those models would reject outright (issue #1498).
+# Output ceilings for model snapshots that reject the configured budget
+# outright (issue #1498).
 #
 # Deliberately NOT a general per-model table: a general one would have to
 # list every current release and would go stale on each launch, silently
-# capping a new model below what it supports. These ids are retired dated
-# snapshots, so their published maxima can no longer change, and anything
-# absent keeps the configured budget -- the direction that stays safe as new
-# models appear. Every current release accepts the 8192 default, so none of
-# them needs an entry.
+# capping a new model below what it supports. An id absent from here keeps
+# the configured budget, which is the direction that stays safe as new
+# models appear, and every current release accepts the 8192 default.
+#
+# An entry is added only where the rejection has been DEMONSTRATED against
+# that id, never from recollection of a published limit. Anthropic's catalog
+# stops publishing max-output once a model retires, so for exactly the old
+# snapshots this table describes there is no longer an authoritative source
+# to check a remembered number against -- and a wrong entry here truncates
+# answers silently, which is the failure this issue exists to remove.
 DEFAULT_MAX_OUTPUT_TOKENS = 4_096
 LEGACY_MAX_OUTPUT_TOKENS: dict[str, int] = {
     "claude-3-haiku-20240307": DEFAULT_MAX_OUTPUT_TOKENS,
-    "claude-3-sonnet-20240229": DEFAULT_MAX_OUTPUT_TOKENS,
-    "claude-3-opus-20240229": DEFAULT_MAX_OUTPUT_TOKENS,
-    "claude-2.1": DEFAULT_MAX_OUTPUT_TOKENS,
-    "claude-2.0": DEFAULT_MAX_OUTPUT_TOKENS,
-    "claude-instant-1.2": DEFAULT_MAX_OUTPUT_TOKENS,
 }
 
 MODULE_TORCH = "torch"

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -51,6 +51,25 @@ def _resolve_api_key(api_key: str | None, env_var: str) -> str | None:
     return os.environ.get(env_var)
 
 
+def _output_budget(model_id: str) -> int:
+    """`MODEL_MAX_TOKENS`, lowered for models that would reject it outright.
+
+    pydantic-ai forwards `max_tokens` unchanged and offers no per-model
+    output cap, so a budget above the selected model's maximum is not
+    trimmed: the request is refused and the model never answers. The 8192
+    default fits every current release, but the retired snapshots in
+    `LEGACY_MAX_OUTPUT_TOKENS` cap output at 4096 and fail on it.
+
+    Only ever lowers, and only for ids listed there, so an unrecognised or
+    newer model keeps the configured budget unchanged.
+    """
+    bare = model_id.split(":", 1)[-1]
+    ceiling = cs.LEGACY_MAX_OUTPUT_TOKENS.get(bare)
+    if ceiling is None:
+        return settings.MODEL_MAX_TOKENS
+    return min(settings.MODEL_MAX_TOKENS, ceiling)
+
+
 class GoogleProvider(ModelProvider):
     __slots__ = (
         "api_key",
@@ -118,7 +137,7 @@ class GoogleProvider(ModelProvider):
         # thinking budget was configured, so the DEFAULT path carried no
         # settings at all and the output budget never applied -- the same
         # defect as the Anthropic one, on the more common branch (issue #1498).
-        model_settings = GoogleModelSettings(max_tokens=settings.MODEL_MAX_TOKENS)
+        model_settings = GoogleModelSettings(max_tokens=_output_budget(model_id))
         if self.thinking_budget is not None:
             model_settings["google_thinking_config"] = {
                 "thinking_budget": int(self.thinking_budget)
@@ -218,7 +237,7 @@ class AnthropicProvider(ModelProvider):
             anthropic_cache_messages=True,
             # Explicit, because the provider default is small enough that a
             # long answer fails before the model emits anything (issue #1498).
-            max_tokens=settings.MODEL_MAX_TOKENS,
+            max_tokens=_output_budget(model_id),
         )
         return AnthropicModel(model_id, provider=provider, settings=model_settings)
 

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -114,11 +114,15 @@ class GoogleProvider(ModelProvider):
             assert self.api_key is not None
             provider = PydanticGoogleProvider(api_key=self.api_key)
 
-        if self.thinking_budget is None:
-            return GoogleModel(model_id, provider=provider)
-        model_settings = GoogleModelSettings(
-            google_thinking_config={"thinking_budget": int(self.thinking_budget)}
-        )
+        # Built unconditionally. An earlier version returned early when no
+        # thinking budget was configured, so the DEFAULT path carried no
+        # settings at all and the output budget never applied -- the same
+        # defect as the Anthropic one, on the more common branch (issue #1498).
+        model_settings = GoogleModelSettings(max_tokens=settings.MODEL_MAX_TOKENS)
+        if self.thinking_budget is not None:
+            model_settings["google_thinking_config"] = {
+                "thinking_budget": int(self.thinking_budget)
+            }
         return GoogleModel(model_id, provider=provider, settings=model_settings)
 
 
@@ -212,6 +216,9 @@ class AnthropicProvider(ModelProvider):
             anthropic_cache_instructions=True,
             anthropic_cache_tool_definitions=True,
             anthropic_cache_messages=True,
+            # Explicit, because the provider default is small enough that a
+            # long answer fails before the model emits anything (issue #1498).
+            max_tokens=settings.MODEL_MAX_TOKENS,
         )
         return AnthropicModel(model_id, provider=provider, settings=model_settings)
 

--- a/codebase_rag/tests/test_model_max_tokens.py
+++ b/codebase_rag/tests/test_model_max_tokens.py
@@ -156,3 +156,72 @@ class TestProviders:
         assert model.settings is not None
         assert model.settings.get("max_tokens") == AppConfig().MODEL_MAX_TOKENS
         assert model.settings.get("google_thinking_config") == {"thinking_budget": 512}
+
+
+class TestRetiredModelsGetALoweredBudget:
+    """A budget a model cannot accept fails the request outright.
+
+    pydantic-ai forwards `max_tokens` unchanged and offers no per-model cap,
+    so the 8192 default reaches models whose maximum is 4096 and the Messages
+    API rejects the call before the model answers -- the same class of
+    "no reply at all" failure this issue is about, reintroduced from the
+    other side.
+
+    Only retired snapshots are lowered. Their published maxima are frozen,
+    so unlike a general table this cannot go stale into capping a new release
+    below what it supports.
+    """
+
+    def test_a_retired_snapshot_is_capped_at_its_own_maximum(self) -> None:
+        """The reported case: 8192 sent to a 4096-token model is refused."""
+        from codebase_rag import constants as cs
+        from codebase_rag.providers.base import AnthropicProvider
+
+        model = AnthropicProvider(api_key="k").create_model("claude-3-haiku-20240307")
+
+        assert model.settings is not None
+        assert model.settings.get("max_tokens") == cs.DEFAULT_MAX_OUTPUT_TOKENS
+
+    def test_a_current_model_keeps_the_configured_budget(self) -> None:
+        """The control: the cap must not quietly apply to everything.
+
+        Lowering every model to the legacy maximum would "fix" the rejection
+        by reintroducing the truncation this issue exists to remove.
+        """
+        from codebase_rag.providers.base import AnthropicProvider
+
+        model = AnthropicProvider(api_key="k").create_model("claude-sonnet-5")
+
+        assert model.settings is not None
+        assert model.settings.get("max_tokens") == AppConfig().MODEL_MAX_TOKENS
+
+    def test_a_provider_prefixed_id_is_still_recognised(self) -> None:
+        """Model ids may carry a `provider:model` prefix.
+
+        Matching the raw string would miss the prefixed spelling and send the
+        rejected budget anyway.
+        """
+        from codebase_rag import constants as cs
+        from codebase_rag.providers.base import AnthropicProvider
+
+        model = AnthropicProvider(api_key="k").create_model(
+            "anthropic:claude-3-haiku-20240307"
+        )
+
+        assert model.settings is not None
+        assert model.settings.get("max_tokens") == cs.DEFAULT_MAX_OUTPUT_TOKENS
+
+    def test_a_budget_below_the_cap_is_not_raised_to_it(self) -> None:
+        """The clamp lowers only.
+
+        A deployment that deliberately sets a small budget must keep it; the
+        cap is a ceiling, not a target.
+        """
+        from codebase_rag.providers.base import _output_budget
+
+        with pytest.MonkeyPatch.context() as mp:
+            from codebase_rag.config import settings
+
+            mp.setattr(settings, "MODEL_MAX_TOKENS", 1024, raising=False)
+
+            assert _output_budget("claude-3-haiku-20240307") == 1024

--- a/codebase_rag/tests/test_model_max_tokens.py
+++ b/codebase_rag/tests/test_model_max_tokens.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from codebase_rag.config import AppConfig
 
@@ -41,17 +42,22 @@ class TestSetting:
         """
         assert AppConfig().MODEL_MAX_TOKENS > 4096
 
-    def test_a_non_positive_value_is_rejected(self) -> None:
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_a_non_positive_value_is_rejected(self, value: int) -> None:
         """Zero or negative is not a smaller budget, it is a broken request.
 
         Validated at construction rather than discovered as a provider error
         at the first query, which is where an unvalidated value would surface.
-        """
-        with pytest.raises(Exception):
-            AppConfig(MODEL_MAX_TOKENS=0)
 
-        with pytest.raises(Exception):
-            AppConfig(MODEL_MAX_TOKENS=-1)
+        `ValidationError` specifically, and the field must be named in it: a
+        bare `Exception` would pass on a typo raising `AttributeError`, or on
+        an unrelated field's constraint firing -- neither of which is this
+        field being validated.
+        """
+        with pytest.raises(ValidationError) as excinfo:
+            AppConfig(MODEL_MAX_TOKENS=value)
+
+        assert "MODEL_MAX_TOKENS" in str(excinfo.value)
 
 
 class TestProviders:

--- a/codebase_rag/tests/test_model_max_tokens.py
+++ b/codebase_rag/tests/test_model_max_tokens.py
@@ -1,0 +1,127 @@
+# The model's output budget must be set explicitly (issue #1498).
+#
+# Reported as:
+#
+#     UnexpectedModelBehavior: Model token limit (provider default) exceeded
+#     before any response was generated.
+#
+# "provider default" is the tell, and "before any response was generated" is
+# the other one: this is the OUTPUT budget, not the prompt. `create_model`
+# set three Anthropic cache flags and never `max_tokens`, so pydantic-ai fell
+# back to a default far below what the model supports.
+#
+# Distinct from the unbounded `message_history` gap, which produces a
+# CONTEXT-WINDOW error rather than an output-token one. That is filed
+# separately; conflating them would fix neither properly.
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.config import AppConfig
+
+
+class TestSetting:
+    """The configured value itself."""
+
+    def test_a_default_is_declared(self) -> None:
+        """There must be a value, not a silent fallback to the provider's.
+
+        The whole defect is that no value was set anywhere, so asserting the
+        attribute exists is the minimum this issue asks for.
+        """
+        assert AppConfig().MODEL_MAX_TOKENS > 0
+
+    def test_the_default_exceeds_the_anthropic_fallback(self) -> None:
+        """A default at or below 4096 would not fix the reported crash.
+
+        Anthropic's implicit default is small relative to what current models
+        support. Setting the field but leaving it at that value would look
+        like a fix and change nothing -- the assertion names the number so a
+        future edit downward has to argue with this test.
+        """
+        assert AppConfig().MODEL_MAX_TOKENS > 4096
+
+    def test_a_non_positive_value_is_rejected(self) -> None:
+        """Zero or negative is not a smaller budget, it is a broken request.
+
+        Validated at construction rather than discovered as a provider error
+        at the first query, which is where an unvalidated value would surface.
+        """
+        with pytest.raises(Exception):
+            AppConfig(MODEL_MAX_TOKENS=0)
+
+        with pytest.raises(Exception):
+            AppConfig(MODEL_MAX_TOKENS=-1)
+
+
+class TestProviders:
+    """Every provider that builds model settings must carry the budget."""
+
+    def test_anthropic_settings_carry_max_tokens(self) -> None:
+        """The provider from the report.
+
+        Asserts the VALUE reaches the settings object, not merely that the
+        key is present: a settings object built with `max_tokens=None` has
+        the key and changes nothing.
+        """
+        from codebase_rag.providers.base import AnthropicProvider
+
+        model = AnthropicProvider(api_key="k").create_model("claude-x")
+
+        assert model.settings is not None
+        assert model.settings.get("max_tokens") == AppConfig().MODEL_MAX_TOKENS
+
+    def test_google_settings_carry_max_tokens(self) -> None:
+        """The other provider that builds settings.
+
+        Fixing only the provider named in the report would leave the same
+        crash reachable through Google -- the defect is the missing setting,
+        not the vendor.
+        """
+        from codebase_rag.providers.base import GoogleProvider
+
+        model = GoogleProvider(api_key="k").create_model("gemini-x")
+
+        assert model.settings is not None
+        assert model.settings.get("max_tokens") == AppConfig().MODEL_MAX_TOKENS
+
+    def test_the_anthropic_cache_flags_are_preserved(self) -> None:
+        """The control: adding the budget must not drop what was there.
+
+        `create_model` sets three cache flags. A rewrite that replaced the
+        settings object rather than extending it would silently disable
+        prompt caching -- a performance regression with no error attached,
+        which is exactly the kind that ships unnoticed.
+        """
+        from codebase_rag.providers.base import AnthropicProvider
+
+        model = AnthropicProvider(api_key="k").create_model("claude-x")
+
+        assert model.settings is not None
+        for flag in (
+            "anthropic_cache_instructions",
+            "anthropic_cache_tool_definitions",
+            "anthropic_cache_messages",
+        ):
+            assert model.settings.get(flag) is True, flag
+
+    def test_the_google_thinking_budget_survives(self) -> None:
+        """The control for restructuring Google's settings construction.
+
+        That path returned early when no thinking budget was configured, so
+        the DEFAULT case carried no settings and the output budget never
+        applied. Building unconditionally fixes that -- but must not lose the
+        thinking config when one IS set, which is a silent behaviour change
+        with no error attached.
+        """
+        from codebase_rag.providers.base import GoogleProvider
+
+        model = GoogleProvider(api_key="k", thinking_budget=512).create_model(
+            "gemini-x"
+        )
+
+        assert model.settings is not None
+        assert model.settings.get("max_tokens") == AppConfig().MODEL_MAX_TOKENS
+        assert model.settings.get("google_thinking_config") == {
+            "thinking_budget": 512
+        }

--- a/codebase_rag/tests/test_model_max_tokens.py
+++ b/codebase_rag/tests/test_model_max_tokens.py
@@ -21,6 +21,19 @@ from pydantic import ValidationError
 from codebase_rag.config import AppConfig
 
 
+def _declared_default() -> int:
+    """The value declared on the field, not the one the environment resolves.
+
+    `AppConfig` is a `BaseSettings` reading `.env`, so `AppConfig().X` is the
+    EFFECTIVE configuration: a `MODEL_MAX_TOKENS` in the environment makes
+    these bounds tests fail against perfectly correct code, and pass against
+    incorrect code. What they mean to pin is the shipped default.
+    """
+    default = AppConfig.model_fields["MODEL_MAX_TOKENS"].default
+    assert isinstance(default, int)
+    return default
+
+
 class TestSetting:
     """The configured value itself."""
 
@@ -30,7 +43,7 @@ class TestSetting:
         The whole defect is that no value was set anywhere, so asserting the
         attribute exists is the minimum this issue asks for.
         """
-        assert AppConfig().MODEL_MAX_TOKENS > 0
+        assert _declared_default() > 0
 
     def test_the_default_exceeds_the_anthropic_fallback(self) -> None:
         """A default at or below 4096 would not fix the reported crash.
@@ -40,7 +53,7 @@ class TestSetting:
         like a fix and change nothing -- the assertion names the number so a
         future edit downward has to argue with this test.
         """
-        assert AppConfig().MODEL_MAX_TOKENS > 4096
+        assert _declared_default() > 4096
 
     def test_the_default_fits_the_smallest_catalogued_model(self) -> None:
         """The other bound, and the one a bigger-is-better edit would break.
@@ -54,7 +67,7 @@ class TestSetting:
         Paired with the test above, these two pin the default into the only
         band that serves both: above Anthropic's 4096, at or below 8192.
         """
-        assert AppConfig().MODEL_MAX_TOKENS <= 8192
+        assert _declared_default() <= 8192
 
     @pytest.mark.parametrize("value", [0, -1])
     def test_a_non_positive_value_is_rejected(self, value: int) -> None:

--- a/codebase_rag/tests/test_model_max_tokens.py
+++ b/codebase_rag/tests/test_model_max_tokens.py
@@ -42,6 +42,20 @@ class TestSetting:
         """
         assert AppConfig().MODEL_MAX_TOKENS > 4096
 
+    def test_the_default_fits_the_smallest_catalogued_model(self) -> None:
+        """The other bound, and the one a bigger-is-better edit would break.
+
+        pydantic-ai forwards `max_tokens` unchanged and offers no per-model
+        output cap to clamp against, so a default above the smallest
+        selectable model's limit turns a fix into a new failure for that
+        model. `gemini-2.0-flash` is in the catalogue today and caps output
+        at 8192; an earlier 16000 default was rejected by it outright.
+
+        Paired with the test above, these two pin the default into the only
+        band that serves both: above Anthropic's 4096, at or below 8192.
+        """
+        assert AppConfig().MODEL_MAX_TOKENS <= 8192
+
     @pytest.mark.parametrize("value", [0, -1])
     def test_a_non_positive_value_is_rejected(self, value: int) -> None:
         """Zero or negative is not a smaller budget, it is a broken request.

--- a/codebase_rag/tests/test_model_max_tokens.py
+++ b/codebase_rag/tests/test_model_max_tokens.py
@@ -122,6 +122,4 @@ class TestProviders:
 
         assert model.settings is not None
         assert model.settings.get("max_tokens") == AppConfig().MODEL_MAX_TOKENS
-        assert model.settings.get("google_thinking_config") == {
-            "thinking_budget": 512
-        }
+        assert model.settings.get("google_thinking_config") == {"thinking_budget": 512}

--- a/codebase_rag/tests/test_provider_classes.py
+++ b/codebase_rag/tests/test_provider_classes.py
@@ -8,6 +8,7 @@ from pydantic_ai.models.anthropic import AnthropicModel
 from pydantic_ai.models.google import GoogleModel
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
 
+from codebase_rag.config import settings
 from codebase_rag.constants import (
     ENV_MINIMAX_API_KEY,
     MODEL_CONTEXT_WINDOWS,
@@ -459,7 +460,16 @@ class TestModelCreation:
 
         mock_google_model.assert_called_once()
         call_kwargs = mock_google_model.call_args[1]
-        assert "settings" not in call_kwargs
+        # Settings are now built UNCONDITIONALLY. This previously asserted
+        # their absence, which pinned the defect in #1498: the default path
+        # carried no settings, so the model's output budget was never set and
+        # a long answer failed with "Model token limit (provider default)
+        # exceeded before any response was generated".
+        assert "settings" in call_kwargs
+        assert call_kwargs["settings"]["max_tokens"] == settings.MODEL_MAX_TOKENS
+        # And no thinking config, since none was requested -- the budget must
+        # not smuggle in an unrelated setting.
+        assert "google_thinking_config" not in call_kwargs["settings"]
 
     @patch("codebase_rag.providers.base.PydanticGoogleProvider")
     @patch("codebase_rag.providers.base.GoogleModel")
@@ -483,8 +493,14 @@ class TestModelCreation:
 
         provider.create_model("gemini-2.0-flash-thinking-exp")
 
+        # Constructed with the output budget, then the thinking config is
+        # assigned. Previously the thinking config was the only argument,
+        # which is what left the default path with no settings at all (#1498).
         mock_model_settings.assert_called_once_with(
-            google_thinking_config={"thinking_budget": 5000}
+            max_tokens=settings.MODEL_MAX_TOKENS
+        )
+        mock_settings.__setitem__.assert_called_once_with(
+            "google_thinking_config", {"thinking_budget": 5000}
         )
 
         mock_google_model.assert_called_once()
@@ -513,8 +529,13 @@ class TestModelCreation:
             location="us-central1",
             credentials=None,
         )
+        # Vertex carries the output budget too. The settings argument is new:
+        # previously this path built none, so the budget was never applied and
+        # the crash in #1498 was reachable here as well.
         mock_google_model.assert_called_once_with(
-            "gemini-2.5-pro", provider=mock_cloud_provider.return_value
+            "gemini-2.5-pro",
+            provider=mock_cloud_provider.return_value,
+            settings={"max_tokens": settings.MODEL_MAX_TOKENS},
         )
 
     @patch("codebase_rag.providers.base.PydanticOpenAIProvider")


### PR DESCRIPTION
Fixes #1498

## The report

```
UnexpectedModelBehavior: Model token limit (provider default) exceeded
before any response was generated.
```

## Root cause

`max_tokens` appeared **nowhere** outside query-result truncation, so pydantic-ai fell back to the provider default — small enough on Anthropic that a long answer failed before the model emitted anything.

Two phrases in the error pin it down. *"provider default"* says nothing was configured; *"before any response was generated"* says this is the **output** budget, not the prompt. Input is already bounded by `QUERY_RESULT_MAX_TOKENS` and Anthropic prompt caching, so neither was the problem.

## A second instance the tests found

`GoogleProvider.create_model` returned early when no thinking budget was configured, so the **default path built no settings object at all** and no budget could apply. My first fix set `max_tokens` on a branch most users never reach.

The test caught it only because it exercised the default configuration rather than the configured one. Settings are now built unconditionally, with the thinking config assigned when present.

## Three existing tests were pinning the defect

They broke, and they were asserting the bug as intended behaviour:

```python
assert "settings" not in call_kwargs
```

That is precisely the state that produces the crash, so those tests would fail whenever the bug was fixed. Updated to the new contract — and each now checks more than before:

- the default path carries `max_tokens` **and** no thinking config, so the budget cannot smuggle in an unrelated setting
- the thinking-budget path carries both
- Vertex carries the budget, which it previously did not

Calling this out explicitly because *"I changed the tests to pass"* and *"the tests encoded the defect"* look identical in a diff, and only one is legitimate.

## Verification

| mutation | result |
|---|---|
| drop Anthropic `max_tokens` | 1 failed |
| drop Google `max_tokens` | 2 failed |
| restore Google's early return | 1 failed |
| default down to 4096 | 1 failed |
| drop `gt=0` validation | 1 failed |

Two of the seven tests are **controls for silent regressions** the restructuring could have caused: Anthropic's three cache flags must survive, and Google's thinking config must survive when configured. Both would degrade behaviour with no error attached.

Scoped regression: **255 passed, 10 skipped**.

## Deliberately not included

The unbounded `message_history` is a real gap — there is no compaction, windowing or summarisation — but it produces a **context-window** error rather than an output-token one, and choosing the strategy is a maintainer decision. Filed separately rather than folded in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum output-token limit for model requests, defaulting to 8,192 tokens.
  * Applied the limit consistently to supported Anthropic and Google models.
  * Preserved Google thinking-budget settings alongside the output limit.
  * Automatically applies lower output limits to retired model versions.

* **Bug Fixes**
  * Added validation to reject zero or negative output-token limits.
  * Improved compatibility with models that enforce lower output caps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->