### PR TITLE
fix: reject unknown model ids at startup instead of at first query

### DIFF
--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -18,6 +18,9 @@ ARG_DRY_RUN = "dry_run"
 
 SEPARATOR_DOT = "."
 SEPARATOR_SLASH = "/"
+# Splits "provider:model" both in user-supplied settings and in the model
+# names pydantic-ai enumerates.
+MODEL_STRING_SEPARATOR = ":"
 # Disambiguates definitions that share one qualified name (if/else import
 # fallbacks, typing.overload, try/except fallbacks): "<qn>@<start_line>".
 DUP_QN_MARKER = "@"

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -46,6 +46,16 @@ OLLAMA_HEALTH_PATH = "/api/tags"
 GOOGLE_CLOUD_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 V1_PATH = "/v1"
 
+# The endpoint each provider serves its own published catalogue from. A
+# config pointing somewhere else (vLLM, an OpenAI-compatible proxy) serves
+# whatever that host chooses, so model-id validation does not apply to it.
+# Providers absent here have no single canonical endpoint and are never
+# gated on model id.
+PROVIDER_DEFAULT_ENDPOINTS: dict[str, str] = {
+    Provider.OPENAI: OPENAI_DEFAULT_ENDPOINT,
+    Provider.MINIMAX: MINIMAX_DEFAULT_ENDPOINT,
+}
+
 HTTP_OK = 200
 
 UNIXCODER_MODEL = "microsoft/unixcoder-base"

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -56,6 +56,18 @@ PROVIDER_DEFAULT_ENDPOINTS: dict[str, str] = {
     Provider.MINIMAX: MINIMAX_DEFAULT_ENDPOINT,
 }
 
+# Catalogue prefixes to consult per provider, where pydantic-ai splits one
+# vendor across several. `openai-chat` carries five ids absent from
+# `openai` (the search-preview variants and gpt-3.5-turbo-16k), so
+# consulting only `openai:` would reject real models.
+PROVIDER_CATALOGUE_PREFIXES: dict[str, tuple[str, ...]] = {
+    Provider.OPENAI: ("openai", "openai-chat"),
+    Provider.GOOGLE: ("google", "google-cloud"),
+}
+
+# How many model ids to list when nothing resembles what the user typed.
+MODEL_ID_SUGGESTION_LIMIT = 20
+
 HTTP_OK = 200
 
 UNIXCODER_MODEL = "microsoft/unixcoder-base"

--- a/codebase_rag/exceptions.py
+++ b/codebase_rag/exceptions.py
@@ -63,6 +63,12 @@ MODEL_FORMAT_INVALID = (
 )
 BATCH_SIZE_POSITIVE = "batch_size must be a positive integer"
 CONFIG = "{role} configuration error: {error}"
+MODEL_ID_UNKNOWN = (
+    "Unknown {provider} model {model_id!r}. Did you mean {suggestions}?"
+)
+MODEL_ID_UNKNOWN_NO_MATCH = (
+    "Unknown {provider} model {model_id!r}. Known {provider} models: {known}"
+)
 
 # Graph loading errors
 GRAPH_FILE_NOT_FOUND = "Graph file not found: {path}"

--- a/codebase_rag/exceptions.py
+++ b/codebase_rag/exceptions.py
@@ -63,9 +63,7 @@ MODEL_FORMAT_INVALID = (
 )
 BATCH_SIZE_POSITIVE = "batch_size must be a positive integer"
 CONFIG = "{role} configuration error: {error}"
-MODEL_ID_UNKNOWN = (
-    "Unknown {provider} model {model_id!r}. Did you mean {suggestions}?"
-)
+MODEL_ID_UNKNOWN = "Unknown {provider} model {model_id!r}. Did you mean {suggestions}?"
 MODEL_ID_UNKNOWN_NO_MATCH = (
     "Unknown {provider} model {model_id!r}. Known {provider} models: {known}"
 )

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -1651,11 +1651,15 @@ def prompt_for_unignored_directories(
 
 def _validate_provider_config(role: cs.ModelRole, config: ModelConfig) -> None:
     """Fail fast at startup when a model role is misconfigured."""
-    from .providers.base import get_provider_from_config
+    from .providers.base import get_provider_from_config, validate_model_id
 
     try:
         provider = get_provider_from_config(config)
         provider.validate_config()
+        # Credentials only get you as far as a 404: `validate_config` takes
+        # no model id, so a typo used to surface as a raw provider error at
+        # the first query instead of here (issue #1492).
+        validate_model_id(config)
     except Exception as e:
         raise ValueError(ex.CONFIG.format(role=role.value.title(), error=e)) from e
 

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -340,6 +340,23 @@ def get_provider_from_config(config: ModelConfig) -> ModelProvider:
     )
 
 
+def _serves_own_catalogue(config: ModelConfig) -> bool:
+    """Whether `config` talks to the provider's own endpoint.
+
+    A custom endpoint reopens the model space: `provider=openai` pointed at
+    vLLM or an OpenAI-compatible proxy (which the docs recommend) serves
+    whatever that server hosts, not what OpenAI publishes. Validating those
+    ids against the vendor catalogue would reject a working setup.
+    """
+    endpoint = config.endpoint
+    if not endpoint:
+        return True
+    default = cs.PROVIDER_DEFAULT_ENDPOINTS.get(config.provider)
+    return default is None or endpoint.rstrip(cs.SEPARATOR_SLASH) == default.rstrip(
+        cs.SEPARATOR_SLASH
+    )
+
+
 def _known_model_ids(provider: str) -> frozenset[str]:
     """Model ids pydantic-ai enumerates for `provider`, without its prefix.
 
@@ -369,6 +386,9 @@ def validate_model_id(config: ModelConfig) -> None:
     checked, and a provider added later is not gated until pydantic-ai
     knows its models.
     """
+    if not _serves_own_catalogue(config):
+        return
+
     known = _known_model_ids(config.provider)
     if not known or config.model_id in known:
         return

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import difflib
 import os
 from abc import ABC, abstractmethod
 from urllib.parse import urljoin, urlsplit
@@ -336,6 +337,57 @@ def get_provider_from_config(config: ModelConfig) -> ModelProvider:
         provider_type=config.provider_type,
         thinking_budget=config.thinking_budget,
         service_account_file=config.service_account_file,
+    )
+
+
+def _known_model_ids(provider: str) -> frozenset[str]:
+    """Model ids pydantic-ai enumerates for `provider`, without its prefix.
+
+    Empty for any provider whose catalogue pydantic-ai does not ship, which
+    is how `validate_model_id` decides to stay silent.
+    """
+    from pydantic_ai.models import known_model_names
+
+    prefix = f"{provider}{cs.MODEL_STRING_SEPARATOR}"
+    return frozenset(
+        name[len(prefix) :] for name in known_model_names() if name.startswith(prefix)
+    )
+
+
+def validate_model_id(config: ModelConfig) -> None:
+    """Reject a model id the provider does not serve (issue #1492).
+
+    Only providers with an enumerable catalogue are checked. Ollama --
+    this project's default -- exposes whatever the user has pulled locally,
+    and Azure deployment names, LiteLLM routes and MiniMax ids are equally
+    user-defined; pydantic-ai ships zero entries for any of them. Gating
+    those would reject working configurations, which is a far more
+    expensive error than missing a typo.
+
+    The enforced set is therefore derived from the catalogue itself rather
+    than from a hand-maintained list: a provider nobody enumerates is not
+    checked, and a provider added later is not gated until pydantic-ai
+    knows its models.
+    """
+    known = _known_model_ids(config.provider)
+    if not known or config.model_id in known:
+        return
+
+    suggestions = difflib.get_close_matches(config.model_id, sorted(known), n=3)
+    if suggestions:
+        raise ValueError(
+            ex.MODEL_ID_UNKNOWN.format(
+                provider=config.provider,
+                model_id=config.model_id,
+                suggestions=", ".join(repr(s) for s in suggestions),
+            )
+        )
+    raise ValueError(
+        ex.MODEL_ID_UNKNOWN_NO_MATCH.format(
+            provider=config.provider,
+            model_id=config.model_id,
+            known=", ".join(sorted(known)),
+        )
     )
 
 

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -402,6 +402,19 @@ def validate_model_id(config: ModelConfig) -> None:
     if not _serves_own_catalogue(config):
         return
 
+    # Vertex Model Garden serves third-party models as
+    # "{publisher}/{model_id}" (meta/llama-3.3-70b-instruct-maas and the
+    # like). They are valid selections that will never appear in the Google
+    # catalogue, so a Vertex config has an open model space. Scoped to
+    # Vertex deliberately: GLA serves Google's own published models, and
+    # exempting the provider wholesale would disable the common case to
+    # serve the rare one.
+    if (
+        config.provider.lower() == cs.Provider.GOOGLE
+        and config.provider_type == cs.GoogleProviderType.VERTEX
+    ):
+        return
+
     known = _known_model_ids(config.provider)
     if not known or config.model_id in known:
         return

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -351,7 +351,7 @@ def _serves_own_catalogue(config: ModelConfig) -> bool:
     endpoint = config.endpoint
     if not endpoint:
         return True
-    default = cs.PROVIDER_DEFAULT_ENDPOINTS.get(config.provider)
+    default = cs.PROVIDER_DEFAULT_ENDPOINTS.get(config.provider.lower())
     return default is None or endpoint.rstrip(cs.SEPARATOR_SLASH) == default.rstrip(
         cs.SEPARATOR_SLASH
     )
@@ -365,10 +365,23 @@ def _known_model_ids(provider: str) -> frozenset[str]:
     """
     from pydantic_ai.models import known_model_names
 
-    prefix = f"{provider}{cs.MODEL_STRING_SEPARATOR}"
-    return frozenset(
-        name[len(prefix) :] for name in known_model_names() if name.startswith(prefix)
+    # Lowercased because a `ModelConfig` built directly (rather than through
+    # the env path, which lowercases at config.py) can carry "Anthropic",
+    # and an unmatched prefix yields an empty set -- which this function's
+    # caller reads as "no catalogue" and skips validation entirely. Case
+    # would silently disable the check rather than merely mis-key it.
+    catalogue = cs.PROVIDER_CATALOGUE_PREFIXES.get(
+        provider.lower(), (provider.lower(),)
     )
+    ids: set[str] = set()
+    for entry in catalogue:
+        prefix = f"{entry}{cs.MODEL_STRING_SEPARATOR}"
+        ids.update(
+            name[len(prefix) :]
+            for name in known_model_names()
+            if name.startswith(prefix)
+        )
+    return frozenset(ids)
 
 
 def validate_model_id(config: ModelConfig) -> None:
@@ -402,11 +415,18 @@ def validate_model_id(config: ModelConfig) -> None:
                 suggestions=", ".join(repr(s) for s in suggestions),
             )
         )
+    # Truncated: openai alone lists 78 ids, which renders as several
+    # thousand characters and buries the error it is attached to.
+    listed = sorted(known)
+    shown = listed[: cs.MODEL_ID_SUGGESTION_LIMIT]
+    known_text = ", ".join(shown)
+    if len(listed) > len(shown):
+        known_text += f", ... ({len(listed) - len(shown)} more)"
     raise ValueError(
         ex.MODEL_ID_UNKNOWN_NO_MATCH.format(
             provider=config.provider,
             model_id=config.model_id,
-            known=", ".join(sorted(known)),
+            known=known_text,
         )
     )
 

--- a/codebase_rag/tests/test_model_id_validation.py
+++ b/codebase_rag/tests/test_model_id_validation.py
@@ -180,6 +180,64 @@ class TestCustomEndpoints:
             validate_model_id(config)
 
 
+class TestProviderNameCase:
+    """A capitalised provider name must not switch validation off.
+
+    `_known_model_ids` keys on the provider string, and an unmatched
+    prefix yields an empty set -- which the caller reads as "this provider
+    has no catalogue" and skips the check. So case does not mis-key the
+    lookup, it silently disables the fix. The env path lowercases, but a
+    `ModelConfig` built directly does not.
+    """
+
+    @pytest.mark.parametrize("provider", ["anthropic", "Anthropic", "ANTHROPIC"])
+    def test_the_typo_is_rejected_whatever_the_provider_case(
+        self, provider: str
+    ) -> None:
+        from codebase_rag.providers.base import validate_model_id
+
+        with pytest.raises(ValueError):
+            validate_model_id(_config(provider, "opus-5"))
+
+    @pytest.mark.parametrize("provider", ["anthropic", "Anthropic", "ANTHROPIC"])
+    def test_a_real_id_still_passes_whatever_the_provider_case(
+        self, provider: str
+    ) -> None:
+        """The control: folding case must not reject valid configurations."""
+        from codebase_rag.providers.base import validate_model_id
+
+        validate_model_id(_config(provider, "claude-opus-5"))
+
+
+class TestSplitCatalogues:
+    """One vendor can span several pydantic-ai prefixes.
+
+    `openai-chat` carries five ids that `openai` does not, so consulting a
+    single prefix rejects real models. Enumerated rather than assumed --
+    the set difference was measured, not guessed.
+    """
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "gpt-4o-search-preview",
+            "gpt-4o-mini-search-preview",
+            "gpt-3.5-turbo-16k",
+        ],
+    )
+    def test_an_openai_chat_only_id_is_accepted(self, model_id: str) -> None:
+        from codebase_rag.providers.base import validate_model_id
+
+        validate_model_id(_config(cs.Provider.OPENAI, model_id))
+
+    def test_the_split_catalogue_still_rejects_a_typo(self) -> None:
+        """The control: widening the accepted set must not accept everything."""
+        from codebase_rag.providers.base import validate_model_id
+
+        with pytest.raises(ValueError):
+            validate_model_id(_config(cs.Provider.OPENAI, "gpt4o"))
+
+
 class TestStartupWiring:
     """The check must actually run at startup, not merely exist."""
 

--- a/codebase_rag/tests/test_model_id_validation.py
+++ b/codebase_rag/tests/test_model_id_validation.py
@@ -137,6 +137,49 @@ class TestOpenModelSpaces:
         validate_model_id(_config(provider, model_id))
 
 
+class TestCustomEndpoints:
+    """A non-default endpoint reopens the model space.
+
+    The catalogue describes what the PROVIDER'S OWN endpoint serves. Point
+    `provider=openai` at vLLM or an OpenAI-compatible proxy -- which the
+    docs actively recommend -- and the served model names are whatever that
+    server hosts. Validating those against OpenAI's catalogue rejects a
+    working configuration, which is the expensive direction again.
+    """
+
+    def test_a_custom_openai_endpoint_is_not_gated(self) -> None:
+        """The concrete case: a self-hosted model behind the OpenAI protocol."""
+        from codebase_rag.providers.base import validate_model_id
+
+        config = ModelConfig(
+            provider=cs.Provider.OPENAI,
+            model_id="Qwen2.5-Coder-32B-Instruct",
+            api_key="k",
+            endpoint="http://localhost:8000/v1",
+        )
+
+        validate_model_id(config)
+
+    def test_the_default_endpoint_is_still_gated(self) -> None:
+        """The control, and the one that keeps the fix meaningful.
+
+        Without it, `endpoint`-suppression could be written to disable the
+        check for everyone -- the typo from the issue would sail through
+        again and every other test here would still pass.
+        """
+        from codebase_rag.providers.base import validate_model_id
+
+        config = ModelConfig(
+            provider=cs.Provider.OPENAI,
+            model_id="Qwen2.5-Coder-32B-Instruct",
+            api_key="k",
+            endpoint=cs.OPENAI_DEFAULT_ENDPOINT,
+        )
+
+        with pytest.raises(ValueError):
+            validate_model_id(config)
+
+
 class TestStartupWiring:
     """The check must actually run at startup, not merely exist."""
 

--- a/codebase_rag/tests/test_model_id_validation.py
+++ b/codebase_rag/tests/test_model_id_validation.py
@@ -48,8 +48,10 @@ class TestTheReportedTypo:
         """
         from codebase_rag.providers.base import validate_model_id
 
+        config = _config(cs.Provider.ANTHROPIC, "opus-5")
+
         with pytest.raises(ValueError) as excinfo:
-            validate_model_id(_config(cs.Provider.ANTHROPIC, "opus-5"))
+            validate_model_id(config)
 
         assert "opus-5" in str(excinfo.value)
 
@@ -67,8 +69,10 @@ class TestTheReportedTypo:
         """
         from codebase_rag.providers.base import validate_model_id
 
+        config = _config(cs.Provider.ANTHROPIC, "opus-5")
+
         with pytest.raises(ValueError) as excinfo:
-            validate_model_id(_config(cs.Provider.ANTHROPIC, "opus-5"))
+            validate_model_id(config)
 
         message = str(excinfo.value)
 
@@ -196,8 +200,10 @@ class TestProviderNameCase:
     ) -> None:
         from codebase_rag.providers.base import validate_model_id
 
+        config = _config(provider, "opus-5")
+
         with pytest.raises(ValueError):
-            validate_model_id(_config(provider, "opus-5"))
+            validate_model_id(config)
 
     @pytest.mark.parametrize("provider", ["anthropic", "Anthropic", "ANTHROPIC"])
     def test_a_real_id_still_passes_whatever_the_provider_case(
@@ -234,8 +240,10 @@ class TestSplitCatalogues:
         """The control: widening the accepted set must not accept everything."""
         from codebase_rag.providers.base import validate_model_id
 
+        config = _config(cs.Provider.OPENAI, "gpt4o")
+
         with pytest.raises(ValueError):
-            validate_model_id(_config(cs.Provider.OPENAI, "gpt4o"))
+            validate_model_id(config)
 
 
 class TestVertexModelGarden:
@@ -302,11 +310,10 @@ class TestStartupWiring:
         """
         from codebase_rag.main import _validate_provider_config
 
+        config = _config(cs.Provider.ANTHROPIC, "opus-5")
+
         with pytest.raises(ValueError) as excinfo:
-            _validate_provider_config(
-                cs.ModelRole.ORCHESTRATOR,
-                _config(cs.Provider.ANTHROPIC, "opus-5"),
-            )
+            _validate_provider_config(cs.ModelRole.ORCHESTRATOR, config)
 
         assert "opus-5" in str(excinfo.value)
 

--- a/codebase_rag/tests/test_model_id_validation.py
+++ b/codebase_rag/tests/test_model_id_validation.py
@@ -1,0 +1,171 @@
+# A mistyped model id must fail at startup, not at the first query (issue #1492).
+#
+# Reported as:
+#
+#     pydantic_ai.exceptions.ModelHTTPError: status_code: 404,
+#     model_name: opus-5, body: {'type': 'error', 'error':
+#     {'type': 'not_found_error', 'message': 'model: opus-5'}}
+#
+# `opus-5` is not a model id -- the real one is `claude-opus-5`. Startup
+# already runs `_validate_provider_config` for both roles, but that checks
+# CREDENTIALS only: `validate_config()` takes no model id, so it structurally
+# cannot catch this. The user gets a raw provider traceback after ingestion
+# has already run.
+#
+# The hard constraint is the other direction. Ollama is this project's
+# DEFAULT provider and pydantic-ai enumerates zero Ollama models, because
+# the model space is whatever the user has pulled locally. The same is true
+# of LiteLLM and any custom endpoint. A strict allow-list would reject every
+# legitimate local setup -- turning a rare typo into a universal outage.
+#
+# So the check is provider-scoped: enforced where the catalogue is
+# authoritative, silent where the model space is open by design.
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.config import ModelConfig
+
+
+def _config(provider: str, model_id: str) -> ModelConfig:
+    return ModelConfig(
+        provider=provider,
+        model_id=model_id,
+        api_key="k",
+        project_id="p",
+    )
+
+
+class TestTheReportedTypo:
+    """The exact string from the issue."""
+
+    def test_the_reported_model_id_is_rejected(self) -> None:
+        """`opus-5` must not reach the provider.
+
+        This is the whole issue: it is a plausible-looking id that no
+        provider serves, and today it costs a full startup plus a 404.
+        """
+        from codebase_rag.providers.base import validate_model_id
+
+        with pytest.raises(ValueError) as excinfo:
+            validate_model_id(_config(cs.Provider.ANTHROPIC, "opus-5"))
+
+        assert "opus-5" in str(excinfo.value)
+
+    def test_the_error_names_the_real_model_id(self) -> None:
+        """A rejection that does not say what to type instead is half a fix.
+
+        `opus-5` -> `claude-opus-5` is a near-miss, so the message must
+        carry the correction.
+
+        Asserting the SUGGESTION form, not just that `claude-opus-5` occurs
+        somewhere: the fallback branch lists the whole catalogue, which
+        contains that id too. A mutation dropping suggestions entirely once
+        passed this test for exactly that reason -- the assertion was true
+        of the working and the degraded message alike.
+        """
+        from codebase_rag.providers.base import validate_model_id
+
+        with pytest.raises(ValueError) as excinfo:
+            validate_model_id(_config(cs.Provider.ANTHROPIC, "opus-5"))
+
+        message = str(excinfo.value)
+
+        assert "Did you mean" in message
+        assert "claude-opus-5" in message
+        # The near-miss branch offers at most three; the fallback dumps all
+        # 17. Counting them is what distinguishes the two messages.
+        assert message.count("claude-") <= 3
+
+
+class TestValidIdsSurvive:
+    """The control: rejecting real models would be a worse bug."""
+
+    @pytest.mark.parametrize(
+        "provider,model_id",
+        [
+            (cs.Provider.ANTHROPIC, "claude-opus-5"),
+            (cs.Provider.ANTHROPIC, "claude-haiku-4-5"),
+            (cs.Provider.OPENAI, "gpt-4o"),
+        ],
+    )
+    def test_a_real_model_id_passes(self, provider: str, model_id: str) -> None:
+        """Each must pass on its own, so one bad entry cannot hide behind another."""
+        from codebase_rag.providers.base import validate_model_id
+
+        validate_model_id(_config(provider, model_id))
+
+
+class TestOpenModelSpaces:
+    """Providers whose catalogue cannot be enumerated must not be gated.
+
+    This is the constraint that shapes the design, and it is measured
+    rather than assumed: pydantic-ai ships zero Ollama entries.
+    """
+
+    def test_pydantic_ai_really_enumerates_no_ollama_models(self) -> None:
+        """The premise, asserted directly.
+
+        If a future pydantic-ai DID enumerate Ollama models, the exemption
+        below would silently become over-permissive and this test is what
+        would say so. Without it the exemption looks like an arbitrary
+        choice rather than a forced one.
+        """
+        from pydantic_ai.models import known_model_names
+
+        ollama = [n for n in known_model_names() if n.startswith("ollama")]
+
+        assert ollama == []
+
+    @pytest.mark.parametrize(
+        "provider,model_id",
+        [
+            (cs.Provider.OLLAMA, "llama3"),
+            (cs.Provider.OLLAMA, "qwen2.5-coder:7b"),
+            (cs.Provider.OLLAMA, "some-locally-pulled-model"),
+        ],
+    )
+    def test_a_local_model_is_not_rejected(self, provider: str, model_id: str) -> None:
+        """Ollama is the DEFAULT provider.
+
+        Gating it would break the out-of-the-box configuration for every
+        local user -- the expensive error direction by a wide margin.
+        """
+        from codebase_rag.providers.base import validate_model_id
+
+        validate_model_id(_config(provider, model_id))
+
+
+class TestStartupWiring:
+    """The check must actually run at startup, not merely exist."""
+
+    def test_startup_validation_rejects_the_bad_id(self) -> None:
+        """A validator nothing calls fixes nothing.
+
+        `_validate_provider_config` is the startup seam that already runs
+        for both roles. This asserts the model id is checked THERE, which
+        is the difference between a helpful message and the reported 404.
+        """
+        from codebase_rag.main import _validate_provider_config
+
+        with pytest.raises(ValueError) as excinfo:
+            _validate_provider_config(
+                cs.ModelRole.ORCHESTRATOR,
+                _config(cs.Provider.ANTHROPIC, "opus-5"),
+            )
+
+        assert "opus-5" in str(excinfo.value)
+
+    def test_startup_validation_accepts_a_good_id(self) -> None:
+        """The control for the wiring test.
+
+        Without it, a `_validate_provider_config` that raised on EVERY
+        config would pass the test above while breaking all startups.
+        """
+        from codebase_rag.main import _validate_provider_config
+
+        _validate_provider_config(
+            cs.ModelRole.ORCHESTRATOR,
+            _config(cs.Provider.ANTHROPIC, "claude-opus-5"),
+        )

--- a/codebase_rag/tests/test_model_id_validation.py
+++ b/codebase_rag/tests/test_model_id_validation.py
@@ -238,6 +238,58 @@ class TestSplitCatalogues:
             validate_model_id(_config(cs.Provider.OPENAI, "gpt4o"))
 
 
+class TestVertexModelGarden:
+    """Vertex serves models pydantic-ai's Google catalogue does not list.
+
+    Model Garden exposes third-party models as `{publisher}/{model_id}` --
+    `meta/llama-3.3-70b-instruct-maas` and the like. They are valid Vertex
+    selections and will never appear under `google:`, so validating a
+    Vertex config against that catalogue rejects a working setup. Same
+    open-model-space argument as a custom endpoint, reached through a
+    different door.
+    """
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "meta/llama-3.3-70b-instruct-maas",
+            "publishers/anthropic/models/claude-sonnet-4-5",
+        ],
+    )
+    def test_a_model_garden_id_is_not_gated(self, model_id: str) -> None:
+        from codebase_rag.providers.base import validate_model_id
+
+        config = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id=model_id,
+            api_key="k",
+            project_id="p",
+            provider_type=cs.GoogleProviderType.VERTEX,
+        )
+
+        validate_model_id(config)
+
+    def test_the_gla_path_is_still_gated(self) -> None:
+        """The control, and the reason this is scoped to Vertex.
+
+        GLA serves Google's own published models, so its catalogue IS
+        authoritative. Exempting Google wholesale would switch validation
+        off for the common case in order to serve the rare one.
+        """
+        from codebase_rag.providers.base import validate_model_id
+
+        config = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id="gemini-not-a-real-model",
+            api_key="k",
+            project_id="p",
+            provider_type=cs.GoogleProviderType.GLA,
+        )
+
+        with pytest.raises(ValueError):
+            validate_model_id(config)
+
+
 class TestStartupWiring:
     """The check must actually run at startup, not merely exist."""
 


### PR DESCRIPTION
Fixes #1492

## The report

```
pydantic_ai.exceptions.ModelHTTPError: status_code: 404, model_name: opus-5,
{'type': 'not_found_error', 'message': 'model: opus-5'}
```

`opus-5` is not a model id. The real one is `claude-opus-5`.

## Why startup did not catch it

`_validate_provider_config` already ran for both roles at startup, so the seam existed. But it calls `provider.validate_config()`, which **takes no model id** — it checks credentials. It could not have caught this. The user paid for a full startup and got a raw provider traceback at the first query.

Now:

```
Orchestrator configuration error: Unknown anthropic model 'opus-5'.
Did you mean 'claude-opus-5'?
```

## The constraint that shaped the design

The obvious implementation — reject anything not in pydantic-ai's catalogue — breaks the project's default configuration.

| provider | catalogued ids |
|---|---|
| anthropic | 17 |
| openai | 73 |
| google | 20 |
| **ollama** | **0** |
| **azure** | **0** |
| **litellm_proxy** | **0** |
| **minimax** | **0** |

Ollama is the default provider, and its model space is whatever the user has pulled locally. Azure deployment names, LiteLLM routes and MiniMax ids are equally user-defined. A strict allow-list turns a rare typo into a **universal outage**.

So a provider with no catalogue is not gated, and the enforced set is derived from the catalogue itself rather than hand-maintained — a provider added later is not gated until pydantic-ai knows its models.

I verified every model id in this repo's own documentation still passes. The MiniMax examples survive **only** through that exemption.

## A false rejection found before review

`provider=openai` pointed at vLLM or an OpenAI-compatible proxy is a documented setup, and the catalogue only describes what OpenAI's *own* endpoint serves:

```
provider=openai, model_id=Qwen2.5-Coder-32B-Instruct,
endpoint=http://localhost:8000/v1   ->  REJECTED
```

Validation is now suppressed when the endpoint differs from the provider's default, normalised for a trailing slash so a stray `/` cannot silently disable the check.

## Two more from an adversarial review

**Case failed open**, which is the worse direction. An unmatched prefix yields an empty set, which the caller reads as "no catalogue" and skips entirely — so `provider="Anthropic"` did not mis-key the lookup, it switched the whole check off. `"Anthropic"` + `"opus-5"` passed.

**One vendor can span several prefixes.** `openai-chat` carries five ids absent from `openai` (the search-preview variants and `gpt-3.5-turbo-16k`), so consulting a single prefix rejected real models. Measured, not assumed.

## Verification

Seven mutations, each caught:

| mutation | result |
|---|---|
| remove the startup call | 1 failed |
| gate every provider | 3 failed |
| accept everything | 3 failed |
| drop the `.lower()` | 2 failed |
| consult only the first prefix | 3 failed |
| suppress for all endpoints | 8 failed |
| drop the suggestion | 1 failed |

The last one **initially survived**. `test_the_error_names_the_real_model_id` asserted `"claude-opus-5" in message`, and the fallback branch lists the entire catalogue — which contains that id — so the assertion was true of the working and the degraded message alike. It now asserts the suggestion form and counts candidates.

Scoped regression: **280 passed**. Cost is 0.03 ms per call, twice per startup.

## Also

The no-close-match message listed all 78 openai ids at 6,368 characters, burying the error it was attached to. Truncated to 20, now 429.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-specific model ID validation during application startup.
  * Invalid model names now provide close-match suggestions or available model listings.
  * Supports provider-prefixed configurations and case-insensitive provider names.
  * Custom endpoints, Ollama, and Vertex Model Garden IDs remain supported without catalogue checks.

* **Bug Fixes**
  * Prevents mistyped model IDs from failing during the first query.

* **Tests**
  * Added coverage for valid, invalid, custom-endpoint, and provider-specific configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->