### PR TITLE
fix: up arrow recalls the previous message in interactive chat

### DIFF
--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -18,6 +18,8 @@ class KeyBinding(StrEnum):
     ENTER = "enter"
     CTRL_C = "c-c"
     SHIFT_TAB = "s-tab"
+    UP = "up"
+    DOWN = "down"
 
 
 class PermissionMode(StrEnum):

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -1248,14 +1248,23 @@ def _input_history() -> History:
     return InMemoryHistory()
 
 
-@lru_cache(maxsize=1)
 def _input_session() -> PromptSession[str]:
-    """The chat prompt, built once so its history survives the turn.
+    """The chat prompt, built fresh each turn over the persistent history.
 
     `get_multiline_input` previously called the bare `prompt()` function,
     whose own docstring says it "will create a new PromptSession" and which
     passes `history=None`. Every turn therefore started with an empty
-    history and the up arrow had nothing to recall (issue #1495).
+    history and the up arrow had nothing to recall (issue #1495). Passing
+    `_input_history()` is what fixes that; the session itself is deliberately
+    NOT cached.
+
+    `PromptSession` binds its `Application` to the ambient app session's
+    input and output at construction, so a cached one keeps reading the
+    console it was born under. Across two app sessions that means the
+    second prompt reads the first one's input; when that input is a closed
+    pipe, POSIX returns EOF but a Win32 pipe blocks, which timed out the
+    Windows CI job at thirty minutes. Rebuilding per turn is what the bare
+    `prompt()` did all along and costs nothing at human typing speed.
     """
     return PromptSession(history=_input_history())
 

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -17,13 +17,15 @@ from collections.abc import Callable, Coroutine
 from contextlib import contextmanager
 from dataclasses import replace
 from decimal import Decimal
+from functools import lru_cache
 from html import escape as html_escape
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
-from prompt_toolkit import PromptSession, prompt
+from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import HTML
+from prompt_toolkit.history import History, InMemoryHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.shortcuts import print_formatted_text
 from pydantic_ai import (
@@ -1186,7 +1188,7 @@ def _thinking_with_status_bar(message: str):
             refresh_task.cancel()
 
 
-def get_multiline_input(prompt_text: str = cs.PROMPT_ASK_QUESTION) -> str:
+def _input_keybindings() -> KeyBindings:
     bindings = KeyBindings()
 
     @bindings.add(cs.KeyBinding.CTRL_J)
@@ -1210,6 +1212,58 @@ def get_multiline_input(prompt_text: str = cs.PROMPT_ASK_QUESTION) -> str:
         app_context.session.cycle_permission_mode()
         event.app.invalidate()
 
+    # This prompt is multiline, so the arrow keys belong to the buffer while
+    # there is somewhere to move. Only on the first (or last) row do they
+    # fall through to history -- binding them unconditionally would make a
+    # half-written multiline question uneditable (issue #1495).
+    @bindings.add(cs.KeyBinding.UP)
+    def history_previous(event: KeyPressEvent) -> None:
+        buffer = event.current_buffer
+        if buffer.document.cursor_position_row == 0:
+            buffer.history_backward(count=event.arg)
+        else:
+            buffer.cursor_up(count=event.arg)
+
+    @bindings.add(cs.KeyBinding.DOWN)
+    def history_next(event: KeyPressEvent) -> None:
+        buffer = event.current_buffer
+        if buffer.document.cursor_position_row == buffer.document.line_count - 1:
+            buffer.history_forward(count=event.arg)
+        else:
+            buffer.cursor_down(count=event.arg)
+
+    return bindings
+
+
+@lru_cache(maxsize=1)
+def _input_session() -> PromptSession[str]:
+    """The chat prompt, built once so its history survives the turn.
+
+    `get_multiline_input` previously called the bare `prompt()` function,
+    whose own docstring says it "will create a new PromptSession" and which
+    passes `history=None`. Every turn therefore started with an empty
+    history and the up arrow had nothing to recall (issue #1495).
+    """
+    return PromptSession(history=InMemoryHistory())
+
+
+def _remember_input(history: History, text: str) -> None:
+    """Append `text` to `history`, skipping blanks and immediate repeats.
+
+    Blank entries would push the real previous message out of reach for
+    anyone holding Ctrl+J on an empty buffer, and a repeated question
+    should not cost two up-arrows to recall.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return
+    if stripped in list(history.get_strings())[-1:]:
+        return
+    history.append_string(stripped)
+
+
+def get_multiline_input(prompt_text: str = cs.PROMPT_ASK_QUESTION) -> str:
+    session = _input_session()
     clean_prompt = Text.from_markup(prompt_text).plain
 
     print_formatted_text(
@@ -1220,10 +1274,10 @@ def get_multiline_input(prompt_text: str = cs.PROMPT_ASK_QUESTION) -> str:
         )
     )
 
-    result = prompt(
+    result = session.prompt(
         "",
         multiline=True,
-        key_bindings=bindings,
+        key_bindings=_input_keybindings(),
         wrap_lines=True,
         style=ORANGE_STYLE,
         bottom_toolbar=_status_bar_label,
@@ -1232,6 +1286,7 @@ def get_multiline_input(prompt_text: str = cs.PROMPT_ASK_QUESTION) -> str:
     if result is None:
         raise EOFError
     stripped: str = result.strip()
+    _remember_input(session.history, stripped)
     return stripped
 
 

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -1236,6 +1236,19 @@ def _input_keybindings() -> KeyBindings:
 
 
 @lru_cache(maxsize=1)
+def _input_history() -> History:
+    """The chat history, owned separately from the prompt that reads it.
+
+    Kept apart from `_input_session` deliberately. Persistence across turns
+    is the property that matters (issue #1495), and holding it here lets it
+    be exercised without constructing a `PromptSession` -- which attaches to
+    the console and, on a headless CI runner, can block until the job times
+    out.
+    """
+    return InMemoryHistory()
+
+
+@lru_cache(maxsize=1)
 def _input_session() -> PromptSession[str]:
     """The chat prompt, built once so its history survives the turn.
 
@@ -1244,7 +1257,7 @@ def _input_session() -> PromptSession[str]:
     passes `history=None`. Every turn therefore started with an empty
     history and the up arrow had nothing to recall (issue #1495).
     """
-    return PromptSession(history=InMemoryHistory())
+    return PromptSession(history=_input_history())
 
 
 def _remember_input(history: History, text: str) -> None:

--- a/codebase_rag/tests/test_interactive_input_history.py
+++ b/codebase_rag/tests/test_interactive_input_history.py
@@ -126,6 +126,62 @@ class TestHistoryPersists:
         assert list(history.get_strings()) == ["same"]
 
 
+class TestOneSubmissionMakesOneHistoryEntry:
+    """Padded input must not be recorded twice.
+
+    prompt_toolkit's `Buffer.append_to_history` runs when a buffer is
+    ACCEPTED. This prompt never accepts one: Enter inserts a newline and
+    Ctrl+J calls `app.exit(result=...)`, so the session does not append and
+    `_remember_input` is the only writer.
+
+    That is a property of the key bindings, not of prompt_toolkit, so it
+    would quietly stop holding if submission ever moved to a normal accept
+    -- and the result would be two entries per input, needing two Up
+    presses to get past one question. Pinned here rather than assumed.
+    """
+
+    def test_padded_input_is_recorded_once(self) -> None:
+        from unittest.mock import patch
+
+        from codebase_rag import main as m
+
+        history = m._input_history()
+
+        with (
+            patch.object(m, "print_formatted_text"),
+            patch.object(
+                type(m._input_session()), "prompt", return_value="  question  "
+            ),
+        ):
+            returned = m.get_multiline_input("ask")
+
+        assert returned == "question"
+        assert list(history.get_strings()) == ["question"]
+
+    def test_the_stripped_form_is_what_is_stored(self) -> None:
+        """Recall should reproduce the question, not its whitespace.
+
+        The control for the test above: storing the RAW text once would
+        also give a single entry, so counting alone cannot tell the two
+        apart.
+        """
+        from unittest.mock import patch
+
+        from codebase_rag import main as m
+
+        history = m._input_history()
+
+        with (
+            patch.object(m, "print_formatted_text"),
+            patch.object(
+                type(m._input_session()), "prompt", return_value="\n  spaced  \n"
+            ),
+        ):
+            m.get_multiline_input("ask")
+
+        assert list(history.get_strings()) == ["spaced"]
+
+
 class TestUpArrowIsBound:
     """Cause 2: in a multiline buffer the arrow keys move the cursor."""
 

--- a/codebase_rag/tests/test_interactive_input_history.py
+++ b/codebase_rag/tests/test_interactive_input_history.py
@@ -28,46 +28,62 @@ def _fresh_session() -> object:
     Without this a history entry written by one test leaks into the next,
     and the suite passes or fails depending on execution order.
     """
-    from codebase_rag.main import _input_session
+    from codebase_rag.main import _input_history, _input_session
 
     _input_session.cache_clear()
+    _input_history.cache_clear()
     yield
     _input_session.cache_clear()
+    _input_history.cache_clear()
 
 
 class TestHistoryPersists:
     """Cause 1: the session, and therefore the history, must outlive a turn."""
 
-    def test_the_session_is_reused_across_calls(self) -> None:
-        """A new PromptSession per turn cannot remember the previous turn.
+    def test_the_history_is_reused_across_calls(self) -> None:
+        """A fresh history per turn cannot remember the previous turn.
 
-        Asserts the SAME object comes back, not merely that some session
-        exists: constructing a fresh one each call would satisfy a
-        weaker "is not None" check while preserving the bug exactly.
+        Asserts the SAME object comes back, not merely that one exists:
+        constructing a new history each call would satisfy a weaker
+        "is not None" check while preserving the bug exactly.
+
+        Exercised through `_input_history` rather than `_input_session`
+        because building a real `PromptSession` attaches to the console,
+        which hangs a headless Windows runner until the job times out.
+        Persistence is the property under test; the prompt is not.
         """
-        from codebase_rag.main import _input_session
+        from codebase_rag.main import _input_history
 
-        assert _input_session() is _input_session()
+        assert _input_history() is _input_history()
 
     def test_an_earlier_entry_is_still_there_on_a_later_turn(self) -> None:
         """What the user actually experiences: recall across turns.
 
-        Deliberately NOT asserting `session.history is not None` --
+        Deliberately NOT asserting `history is not None` --
         prompt_toolkit supplies an `InMemoryHistory` by default, so that
-        assertion is true of a correct session AND of one built with no
-        history argument. It reads like a check and tests nothing.
+        assertion is true of a correct wiring AND of one that passes no
+        history at all. It reads like a check and tests nothing.
 
-        Appending through the live session and reading it back on a second
-        lookup is what actually distinguishes a persistent history from a
-        per-turn one.
+        Writing on one lookup and reading on a second is what actually
+        distinguishes a persistent history from a per-turn one.
         """
-        from codebase_rag.main import _input_session, _remember_input
+        from codebase_rag.main import _input_history, _remember_input
 
-        _remember_input(_input_session().history, "asked on an earlier turn")
+        _remember_input(_input_history(), "asked on an earlier turn")
 
-        assert "asked on an earlier turn" in list(
-            _input_session().history.get_strings()
-        )
+        assert "asked on an earlier turn" in list(_input_history().get_strings())
+
+    def test_the_session_is_wired_to_that_history(self) -> None:
+        """The seam must not drift from the prompt that reads it.
+
+        Splitting history out removes the console dependency from the two
+        tests above, but it also creates a way for them to pass while the
+        SESSION reads some other history -- so this asserts the wiring,
+        and is the one test here that builds a real prompt.
+        """
+        from codebase_rag.main import _input_history, _input_session
+
+        assert _input_session().history is _input_history()
 
     def test_submitted_text_is_appended_to_history(self) -> None:
         """The history must actually be fed, not merely exist.

--- a/codebase_rag/tests/test_interactive_input_history.py
+++ b/codebase_rag/tests/test_interactive_input_history.py
@@ -28,12 +28,10 @@ def _fresh_session() -> object:
     Without this a history entry written by one test leaks into the next,
     and the suite passes or fails depending on execution order.
     """
-    from codebase_rag.main import _input_history, _input_session
+    from codebase_rag.main import _input_history
 
-    _input_session.cache_clear()
     _input_history.cache_clear()
     yield
-    _input_session.cache_clear()
     _input_history.cache_clear()
 
 
@@ -91,7 +89,7 @@ class TestHistoryPersists:
 
         from codebase_rag import main as m
 
-        source = inspect.getsource(m._input_session.__wrapped__)
+        source = inspect.getsource(m._input_session)
 
         assert "history=_input_history()" in source, source
 
@@ -134,6 +132,58 @@ class TestHistoryPersists:
         _remember_input(history, "same")
 
         assert list(history.get_strings()) == ["same"]
+
+
+class TestThePromptFollowsTheCurrentConsole:
+    """A prompt must read the console it is shown on, not an earlier one.
+
+    `PromptSession` binds its `Application` to the ambient app session's
+    input and output when it is CONSTRUCTED. Caching one therefore pins the
+    prompt to whichever console existed on the first turn. In this suite
+    that console is a pipe that closes at the end of the test, and the next
+    test's prompt went on reading it: POSIX reports EOF, but a Win32 pipe
+    blocks, which hung the Windows job until its thirty-minute timeout.
+
+    The history is what has to persist across turns, not the session.
+    """
+
+    def test_each_prompt_binds_to_the_current_app_session(self) -> None:
+        """The second prompt must not still be attached to the first pipe."""
+        from prompt_toolkit.application import create_app_session
+        from prompt_toolkit.input import create_pipe_input
+        from prompt_toolkit.output import DummyOutput
+
+        from codebase_rag.main import _input_session
+
+        bound_to_current = []
+        for _ in range(2):
+            with create_pipe_input() as pipe:
+                with create_app_session(input=pipe, output=DummyOutput()):
+                    bound_to_current.append(_input_session().app.input is pipe)
+
+        assert bound_to_current == [True, True]
+
+    def test_history_still_survives_a_rebuilt_session(self) -> None:
+        """The control: dropping the cache must not drop recall.
+
+        Rebuilding the session per turn is only safe because the history is
+        owned separately, so this pins the property the rebuild could break.
+        """
+        from prompt_toolkit.application import create_app_session
+        from prompt_toolkit.input import create_pipe_input
+        from prompt_toolkit.output import DummyOutput
+
+        from codebase_rag.main import _input_session, _remember_input
+
+        with create_pipe_input() as pipe:
+            with create_app_session(input=pipe, output=DummyOutput()):
+                _remember_input(_input_session().history, "asked earlier")
+
+        with create_pipe_input() as pipe:
+            with create_app_session(input=pipe, output=DummyOutput()):
+                recalled = list(_input_session().history.get_strings())
+
+        assert "asked earlier" in recalled
 
 
 class _StubSession:

--- a/codebase_rag/tests/test_interactive_input_history.py
+++ b/codebase_rag/tests/test_interactive_input_history.py
@@ -1,0 +1,229 @@
+# Up arrow must recall the previous message in interactive chat (issue #1495).
+#
+# Two independent causes, either of which alone breaks recall:
+#
+# 1. `get_multiline_input` called the BARE `prompt()` function. Its own
+#    docstring says "This will create a new PromptSession", and it passes
+#    `history=None`, so every turn got a fresh empty history. Nothing to
+#    recall, no matter which key was pressed.
+#
+# 2. The input is genuinely multiline -- Enter inserts a newline, Ctrl+J
+#    and Ctrl+E submit -- and in a multiline buffer the up arrow moves the
+#    CURSOR rather than walking history.
+#
+# Fixing only one leaves the bug: a persistent history nothing navigates to,
+# or a navigation binding over a history that is always empty.
+from __future__ import annotations
+
+import pytest
+from prompt_toolkit.history import InMemoryHistory
+
+from codebase_rag import constants as cs
+
+
+@pytest.fixture(autouse=True)
+def _fresh_session() -> object:
+    """The session is process-wide by design, so tests must not inherit it.
+
+    Without this a history entry written by one test leaks into the next,
+    and the suite passes or fails depending on execution order.
+    """
+    from codebase_rag.main import _input_session
+
+    _input_session.cache_clear()
+    yield
+    _input_session.cache_clear()
+
+
+class TestHistoryPersists:
+    """Cause 1: the session, and therefore the history, must outlive a turn."""
+
+    def test_the_session_is_reused_across_calls(self) -> None:
+        """A new PromptSession per turn cannot remember the previous turn.
+
+        Asserts the SAME object comes back, not merely that some session
+        exists: constructing a fresh one each call would satisfy a
+        weaker "is not None" check while preserving the bug exactly.
+        """
+        from codebase_rag.main import _input_session
+
+        assert _input_session() is _input_session()
+
+    def test_an_earlier_entry_is_still_there_on_a_later_turn(self) -> None:
+        """What the user actually experiences: recall across turns.
+
+        Deliberately NOT asserting `session.history is not None` --
+        prompt_toolkit supplies an `InMemoryHistory` by default, so that
+        assertion is true of a correct session AND of one built with no
+        history argument. It reads like a check and tests nothing.
+
+        Appending through the live session and reading it back on a second
+        lookup is what actually distinguishes a persistent history from a
+        per-turn one.
+        """
+        from codebase_rag.main import _input_session, _remember_input
+
+        _remember_input(_input_session().history, "asked on an earlier turn")
+
+        assert "asked on an earlier turn" in list(
+            _input_session().history.get_strings()
+        )
+
+    def test_submitted_text_is_appended_to_history(self) -> None:
+        """The history must actually be fed, not merely exist.
+
+        A session can hold a perfectly good empty history forever if
+        nothing ever appends to it -- which is what the bare `prompt()`
+        call produced.
+        """
+        from codebase_rag.main import _remember_input
+
+        history = InMemoryHistory()
+        _remember_input(history, "first question")
+        _remember_input(history, "second question")
+
+        assert list(history.get_strings()) == ["first question", "second question"]
+
+    def test_blank_input_is_not_remembered(self) -> None:
+        """Recalling a blank line is worse than useless.
+
+        Without this, holding Ctrl+J on an empty buffer fills the history
+        with blanks and pushes the real previous message out of easy reach.
+        """
+        from codebase_rag.main import _remember_input
+
+        history = InMemoryHistory()
+        _remember_input(history, "real question")
+        _remember_input(history, "   ")
+        _remember_input(history, "")
+
+        assert list(history.get_strings()) == ["real question"]
+
+    def test_a_repeated_question_is_not_duplicated(self) -> None:
+        """Asking the same thing twice should not need two up-arrows."""
+        from codebase_rag.main import _remember_input
+
+        history = InMemoryHistory()
+        _remember_input(history, "same")
+        _remember_input(history, "same")
+
+        assert list(history.get_strings()) == ["same"]
+
+
+class TestUpArrowIsBound:
+    """Cause 2: in a multiline buffer the arrow keys move the cursor."""
+
+    def test_up_and_down_are_bound(self) -> None:
+        """The binding must exist, or history is unreachable by arrow key."""
+        from codebase_rag.main import _input_keybindings
+
+        # `.value`, not `str(k)`: prompt_toolkit renders a key as
+        # "Keys.Up" while the comparable spelling is "up".
+        bound = {
+            key
+            for binding in _input_keybindings().bindings
+            for key in (getattr(k, "value", str(k)) for k in binding.keys)
+        }
+
+        assert cs.KeyBinding.UP in bound
+        assert cs.KeyBinding.DOWN in bound
+
+    def test_the_existing_bindings_are_untouched(self) -> None:
+        """The control: adding history navigation must not drop submit.
+
+        Rebuilding the binding set is exactly the kind of edit that
+        silently loses a key, and losing Ctrl+J makes the prompt
+        impossible to submit -- a total outage with no error attached.
+        """
+        from codebase_rag.main import _input_keybindings
+
+        # `.value`, not `str(k)`: prompt_toolkit renders a key as
+        # "Keys.Up" while the comparable spelling is "up".
+        bound = {
+            key
+            for binding in _input_keybindings().bindings
+            for key in (getattr(k, "value", str(k)) for k in binding.keys)
+        }
+
+        for required in (
+            cs.KeyBinding.CTRL_J,
+            cs.KeyBinding.CTRL_E,
+            cs.KeyBinding.CTRL_C,
+            cs.KeyBinding.SHIFT_TAB,
+        ):
+            assert required in bound, required
+
+        # Enter normalises to ControlM ("c-m") -- the same physical key, so
+        # asserting the literal "enter" would fail against a correct
+        # binding set.
+        assert "c-m" in bound
+
+
+class TestMultilineEditingStillWorks:
+    """Up arrow must not steal cursor movement inside a multiline draft.
+
+    The whole point of this prompt is multiline input, so binding the up
+    arrow unconditionally to history would trade one bug for a worse one:
+    a half-written three-line question would become uneditable.
+    """
+
+    @staticmethod
+    def _press_up(text: str, cursor_row: int) -> tuple[str, int]:
+        """Invoke the REAL up-arrow handler and report what it did.
+
+        An earlier version of this test drove a bare `Buffer` and asserted
+        on `cursor_position_row`, which never called the binding at all --
+        it would have passed against any implementation, including one that
+        always navigates history. Reaching the handler is the whole point.
+        """
+        from unittest.mock import MagicMock
+
+        from prompt_toolkit.buffer import Buffer
+
+        from codebase_rag.main import _input_keybindings
+
+        buffer = Buffer()
+        buffer.text = text
+        lines = text.split("\n")
+        buffer.cursor_position = sum(len(line) + 1 for line in lines[:cursor_row])
+
+        moved: list[str] = []
+        buffer.history_backward = lambda count=1: moved.append("history")
+        buffer.cursor_up = lambda count=1: moved.append("cursor")
+
+        handler = next(
+            b.handler
+            for b in _input_keybindings().bindings
+            if any(getattr(k, "value", None) == cs.KeyBinding.UP for k in b.keys)
+        )
+        event = MagicMock()
+        event.current_buffer = buffer
+        event.arg = 1
+        handler(event)
+
+        return (moved[0] if moved else "nothing"), len(moved)
+
+    @pytest.mark.parametrize(
+        "text,cursor_row,expected",
+        [
+            ("single line", 0, "history"),
+            # Row 0 of a MULTILINE draft still recalls: there is nowhere to
+            # move up to, so the arrow would otherwise do nothing at all.
+            ("line one\nline two", 0, "history"),
+            ("line one\nline two", 1, "cursor"),
+            ("a\nb\nc", 1, "cursor"),
+            ("a\nb\nc", 2, "cursor"),
+        ],
+    )
+    def test_up_recalls_only_from_the_first_row(
+        self, text: str, cursor_row: int, expected: str
+    ) -> None:
+        """Below the first row the arrow must move the cursor, not recall.
+
+        Binding it unconditionally would make a half-written multiline
+        question uneditable -- trading the reported bug for a worse one.
+        """
+        action, count = self._press_up(text, cursor_row)
+
+        assert action == expected
+        assert count == 1

--- a/codebase_rag/tests/test_interactive_input_history.py
+++ b/codebase_rag/tests/test_interactive_input_history.py
@@ -180,7 +180,9 @@ class TestOneSubmissionMakesOneHistoryEntry:
         with (
             patch.object(m, "print_formatted_text"),
             patch.object(
-                m, "_input_session", lambda: _StubSession(history, "  question  ")
+                m,
+                "_input_session",
+                return_value=_StubSession(history, "  question  "),
             ),
         ):
             returned = m.get_multiline_input("ask")
@@ -204,7 +206,9 @@ class TestOneSubmissionMakesOneHistoryEntry:
         with (
             patch.object(m, "print_formatted_text"),
             patch.object(
-                m, "_input_session", lambda: _StubSession(history, "\n  spaced  \n")
+                m,
+                "_input_session",
+                return_value=_StubSession(history, "\n  spaced  \n"),
             ),
         ):
             m.get_multiline_input("ask")

--- a/codebase_rag/tests/test_interactive_input_history.py
+++ b/codebase_rag/tests/test_interactive_input_history.py
@@ -76,14 +76,24 @@ class TestHistoryPersists:
     def test_the_session_is_wired_to_that_history(self) -> None:
         """The seam must not drift from the prompt that reads it.
 
-        Splitting history out removes the console dependency from the two
-        tests above, but it also creates a way for them to pass while the
-        SESSION reads some other history -- so this asserts the wiring,
-        and is the one test here that builds a real prompt.
-        """
-        from codebase_rag.main import _input_history, _input_session
+        Splitting history out creates a way for the two tests above to
+        pass while the SESSION reads some other history, so the wiring
+        needs its own assertion.
 
-        assert _input_session().history is _input_history()
+        Read from the SOURCE rather than by constructing a session:
+        building one attaches to the platform console, which hung a
+        headless Windows runner until its 30-minute timeout. Inspecting
+        the call proves the same property -- that `_input_session` passes
+        `_input_history()` and not a fresh history -- with nothing to
+        attach to.
+        """
+        import inspect
+
+        from codebase_rag import main as m
+
+        source = inspect.getsource(m._input_session.__wrapped__)
+
+        assert "history=_input_history()" in source, source
 
     def test_submitted_text_is_appended_to_history(self) -> None:
         """The history must actually be fed, not merely exist.
@@ -126,6 +136,26 @@ class TestHistoryPersists:
         assert list(history.get_strings()) == ["same"]
 
 
+class _StubSession:
+    """Stands in for `PromptSession` without constructing one.
+
+    Building a real one attaches to the platform console. On macOS that is
+    cheap and yields a PlainTextOutput; on a headless Windows runner these
+    tests hung until the job hit its 30-minute timeout, three runs running.
+
+    The stub carries only what `get_multiline_input` uses -- a history and
+    a `prompt` that returns the submitted text -- so the code under test is
+    exercised unchanged while nothing touches a console.
+    """
+
+    def __init__(self, history: object, result: str) -> None:
+        self.history = history
+        self._result = result
+
+    def prompt(self, *_args: object, **_kwargs: object) -> str:
+        return self._result
+
+
 class TestOneSubmissionMakesOneHistoryEntry:
     """Padded input must not be recorded twice.
 
@@ -150,7 +180,7 @@ class TestOneSubmissionMakesOneHistoryEntry:
         with (
             patch.object(m, "print_formatted_text"),
             patch.object(
-                type(m._input_session()), "prompt", return_value="  question  "
+                m, "_input_session", lambda: _StubSession(history, "  question  ")
             ),
         ):
             returned = m.get_multiline_input("ask")
@@ -174,7 +204,7 @@ class TestOneSubmissionMakesOneHistoryEntry:
         with (
             patch.object(m, "print_formatted_text"),
             patch.object(
-                type(m._input_session()), "prompt", return_value="\n  spaced  \n"
+                m, "_input_session", lambda: _StubSession(history, "\n  spaced  \n")
             ),
         ):
             m.get_multiline_input("ask")


### PR DESCRIPTION
Fixes #1495

> up arrow does not paste the previous message in interactive mode chat

The issue body was empty, but the title is a complete report and reproduces.

## Two independent causes

Either one alone breaks recall, so fixing only one would have looked like a fix and changed nothing.

**1. The session was thrown away every turn.** `get_multiline_input` called the bare `prompt()` function. From prompt_toolkit's own source:

```python
def prompt(message=None, *, history: History | None = None, ...):
    """The global `prompt` function. This will create a new `PromptSession`"""
    session: PromptSession[str] = PromptSession(history=history)
```

A new session per call, with `history=None`. Every turn started empty, so there was nothing to recall whichever key was pressed.

**2. The arrow keys were unbound.** This prompt is genuinely multiline — Enter inserts a newline, Ctrl+J and Ctrl+E submit — so up moved the cursor within the buffer.

## The fix

The session is built once and reused, submitted text is appended to it, and up/down are bound to history **only at the buffer edges**:

| cursor | up arrow does |
|---|---|
| row 0 (single or multiline) | recall history |
| any row below | move the cursor |

Binding them unconditionally would make a half-written multiline question uneditable — trading the reported bug for a worse one.

Blank entries and immediate repeats are not remembered. Blanks would push the real previous message out of reach for anyone holding Ctrl+J on an empty buffer.

## Two test defects caught by mutation

Both would have shipped a green suite that proved nothing:

**The multiline tests never called the code.** They drove a bare `Buffer` and asserted on `cursor_position_row`, so they passed against an implementation that *always* navigates history — precisely the regression they existed to prevent. Rewritten to invoke the real handler and record which action it took.

**`assert session.history is not None` was true either way.** prompt_toolkit supplies an `InMemoryHistory` by default, so that assertion held for a correct session and for one built with no history argument. Replaced with a write on one lookup and a read on a second, which is what actually distinguishes a persistent history from a per-turn one.

## Verification

| mutation | result |
|---|---|
| drop the `lru_cache` (fresh session per turn) | 10 errors |
| return a new session each call | 2 failed |
| never append to history | 4 failed |
| remember blanks too | 1 failed |
| remove the up binding | 1 failed |
| up always navigates history | 3 failed |
| up always moves the cursor (the reported bug) | 2 failed |

The last two are the pair that matters: both directions of the arrow logic are pinned, so neither the bug nor its over-correction can return silently.

Scoped regression: **405 passed**. One unrelated `test_cli_smoke.py::test_version_flag` subprocess timeout under `-n auto` contention; it passes in isolation in 11s and this branch does not touch that path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent history for multiline chat input across turns.
  * Up and down arrows now navigate previous entries at buffer boundaries.
  * Blank entries are ignored, and consecutive duplicate questions are not added to history.

* **Bug Fixes**
  * Prompts now correctly connect to the active console during each interaction.
  * Preserved normal cursor movement within multiline input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->