### PR TITLE
test: fail loudly when a provider's catalogue lookup silently misses

### DIFF
--- a/codebase_rag/tests/test_catalogue_prefix_guard.py
+++ b/codebase_rag/tests/test_catalogue_prefix_guard.py
@@ -1,0 +1,98 @@
+# A mis-keyed provider must not silently disable its model-id validation
+# (issue #1504).
+#
+# `validate_model_id` enforces only where the catalogue is non-empty, which
+# is correct: Ollama, Azure, LiteLLM and MiniMax have open model spaces and
+# gating them would reject working configurations.
+#
+# But an empty set carries two meanings the code cannot tell apart:
+#
+#   - this provider genuinely has no enumerable catalogue  -> do not gate
+#   - this provider is mis-keyed, so the lookup missed      -> DO NOT GATE,
+#     silently, which is the hole
+#
+# Anthropic is absent from PROVIDER_CATALOGUE_PREFIXES and works by falling
+# through to `(provider.lower(),)`. Add an entry for it with a wrong prefix
+# -- a reasonable edit, since OpenAI and Google are both in that map -- and
+# validation disables for Anthropic with no error and no failing test. The
+# `opus-5` typo from #1492 would be accepted again.
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.providers.base import _known_model_ids
+
+# Providers whose catalogue pydantic-ai ships, so `validate_model_id` gates
+# them. Each must keep resolving to a non-empty set: an empty one means the
+# lookup missed and the check has silently stopped running.
+_ENUMERABLE = (
+    cs.Provider.ANTHROPIC,
+    cs.Provider.OPENAI,
+    cs.Provider.GOOGLE,
+)
+
+# Providers with an open model space -- whatever the user has pulled or
+# deployed -- which must NOT be gated.
+_OPEN_SPACE = (
+    cs.Provider.OLLAMA,
+    cs.Provider.AZURE,
+    cs.Provider.LITELLM_PROXY,
+    cs.Provider.MINIMAX,
+)
+
+
+@pytest.mark.parametrize("provider", _ENUMERABLE)
+def test_an_enumerable_provider_still_resolves_to_a_catalogue(
+    provider: str,
+) -> None:
+    """An empty set here means validation is off for this provider.
+
+    This is the failure the function's own docstring describes -- "empty
+    for any provider whose catalogue pydantic-ai does not ship, which is
+    how `validate_model_id` decides to stay silent" -- reached by a
+    mis-key rather than by a genuinely open model space.
+    """
+    assert _known_model_ids(provider), (
+        f"{provider} resolves to an empty catalogue, so model-id validation "
+        "is silently disabled for it. Either the PROVIDER_CATALOGUE_PREFIXES "
+        "entry is wrong, or pydantic-ai stopped shipping its models."
+    )
+
+
+@pytest.mark.parametrize("provider", _OPEN_SPACE)
+def test_an_open_space_provider_is_not_gated(provider: str) -> None:
+    """The control, and the reason the exemption exists at all.
+
+    Without it, a "fix" that gated every provider would satisfy the test
+    above while rejecting every legitimate Ollama, Azure, LiteLLM and
+    MiniMax configuration -- the expensive error direction.
+    """
+    assert not _known_model_ids(provider)
+
+
+def test_a_mis_keyed_prefix_is_what_this_guards_against() -> None:
+    """The mechanism, demonstrated rather than described.
+
+    Documents WHY the parametrised test above matters: a wrong prefix
+    yields an empty set, which the caller reads as "no catalogue" and
+    skips. Asserting it here means the guard's premise is checked rather
+    than assumed, so nobody later reads the test as arbitrary.
+    """
+    assert _known_model_ids("anthropic-typo") == frozenset()
+
+
+def test_the_reported_typo_is_still_rejected() -> None:
+    """End to end: the defect this protects is #1492's `opus-5`.
+
+    A guard on set sizes could pass while validation was broken for some
+    other reason, so this asserts the behaviour the sizes exist to
+    support.
+    """
+    from codebase_rag.config import ModelConfig
+    from codebase_rag.providers.base import validate_model_id
+
+    config = ModelConfig(provider=cs.Provider.ANTHROPIC, model_id="opus-5", api_key="k")
+
+    with pytest.raises(ValueError):
+        validate_model_id(config)


### PR DESCRIPTION
Fixes #1504

## The hole

`validate_model_id` (merged in #1501) gates only providers whose catalogue is non-empty. That exemption is correct and load-bearing: Ollama, Azure, LiteLLM and MiniMax have open model spaces, and gating them would reject working configurations — the expensive error direction.

But an empty set carries two meanings the code cannot tell apart:

| set is empty because | correct response |
|---|---|
| the provider genuinely has no enumerable catalogue | do not gate |
| the lookup **missed** | gate — but it silently does not |

Anthropic is absent from `PROVIDER_CATALOGUE_PREFIXES` and works by falling through to `(provider.lower(),)`. Adding an entry for it with a wrong prefix — a reasonable edit, since OpenAI and Google are both in that map — empties the set and disables validation for Anthropic with no error, no warning, and no failing test. The `opus-5` typo #1492 was filed about would be accepted again.

## Why a test rather than a behaviour change

The exemption cannot be made to detect its own mis-key: any inference it could draw is the same inference that produced the hole. Inverting to default-deny would mean gating providers whose catalogue genuinely cannot be enumerated, which breaks the out-of-the-box Ollama setup.

So the fix converts a silent disable into a failing test.

## This passes today, which is the point

It is a guard, not a bug fix, so green proves nothing on its own. What makes it worth having is that **introducing the defect fails it**:

```
mapping anthropic -> ("anthropic-models",)

FAILED test_an_enumerable_provider_still_resolves_to_a_catalogue[anthropic]
FAILED test_the_reported_typo_is_still_rejected
```

Both, not one. The size check catches the mechanism; the end-to-end test catches the consequence. Without the second, this would degrade into an assertion about set sizes that could hold while validation was broken for some other reason.

## Controls

- **Open-space providers must stay ungated.** Without that list, "fixing" a failure by gating everything passes the size test while breaking every legitimate Ollama, Azure, LiteLLM and MiniMax configuration.
- **The mis-key mechanism is asserted directly** (`_known_model_ids("anthropic-typo") == frozenset()`), so the guard's premise is checked rather than assumed and nobody later reads it as arbitrary.

## Honest limitation

The enumerable list is itself an inventory, and a provider added to the codebase without being added here gets no guard. That is a smaller risk than the one it closes — a failing test on a shrinking set fails loudly, while a silent pass on an empty one fails quietly — but it is the same class, and worth saying rather than implying the pattern is eliminated.

9 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring supported provider catalogues remain available for model validation.
  * Added safeguards distinguishing providers with enumerated model catalogues from open-ended providers.
  * Added regression coverage for invalid model identifiers and misconfigured provider prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->