### PR TITLE
feat: prune old tool results from conversation history to bound context growth

### DIFF
--- a/codebase_rag/context_pruning.py
+++ b/codebase_rag/context_pruning.py
@@ -88,22 +88,22 @@ def _content_tokens(part: object) -> int:
     return count_tokens(content if isinstance(content, str) else str(content))
 
 
-def prune_old_tool_results(
-    messages: list[ModelMessage],
-    protect_recent_tokens: int = DEFAULT_PROTECT_RECENT_TOKENS,
-    minimum_recovered_tokens: int = DEFAULT_MINIMUM_RECOVERED_TOKENS,
-) -> list[ModelMessage]:
-    """Empty tool results outside the protected window, oldest first.
+def _prunable_candidates(
+    messages: list[ModelMessage], protect_recent_tokens: int
+) -> tuple[list[tuple[int, int]], int]:
+    """Locate prunable parts outside the protected window, newest-first.
 
-    Walks backwards accumulating tool-output tokens, so the newest results fill
-    the protected window and everything older becomes a candidate. Returns the
-    history unchanged when the candidates are not worth the cache invalidation.
+    Returns `(message index, part index)` pairs and the tokens pruning them
+    would actually recover. Walking backwards is what makes the protected
+    window mean "the most recent N tokens of tool output" rather than a count
+    of messages: the newest results fill it and everything older is a
+    candidate.
 
-    Already-pruned parts are not counted as recoverable: the placeholder cannot
-    be freed twice, and counting it would let a long session clear the floor
-    every turn on tokens it cannot actually reclaim.
+    Split out of `prune_old_tool_results` so selection and rebuilding are
+    separately readable -- the two do genuinely different work, and combining
+    them put four conditions inside two nested loops (SonarCloud S3776).
     """
-    candidates: list[tuple[int, int]] = []  # (message index, part index)
+    candidates: list[tuple[int, int]] = []
     protected_tokens = 0
     recoverable_tokens = 0
     # The placeholder is kept, so it is not recovered. Counting gross tokens
@@ -127,7 +127,27 @@ def prune_old_tool_results(
                 continue
             candidates.append((message_index, part_index))
             recoverable_tokens += max(0, part_tokens - placeholder_tokens)
+    return candidates, recoverable_tokens
 
+
+def prune_old_tool_results(
+    messages: list[ModelMessage],
+    protect_recent_tokens: int = DEFAULT_PROTECT_RECENT_TOKENS,
+    minimum_recovered_tokens: int = DEFAULT_MINIMUM_RECOVERED_TOKENS,
+) -> list[ModelMessage]:
+    """Empty tool results outside the protected window, oldest first.
+
+    Walks backwards accumulating tool-output tokens, so the newest results fill
+    the protected window and everything older becomes a candidate. Returns the
+    history unchanged when the candidates are not worth the cache invalidation.
+
+    Already-pruned parts are not counted as recoverable: the placeholder cannot
+    be freed twice, and counting it would let a long session clear the floor
+    every turn on tokens it cannot actually reclaim.
+    """
+    candidates, recoverable_tokens = _prunable_candidates(
+        messages, protect_recent_tokens
+    )
     if recoverable_tokens < minimum_recovered_tokens:
         return messages
 

--- a/codebase_rag/context_pruning.py
+++ b/codebase_rag/context_pruning.py
@@ -1,0 +1,129 @@
+"""Drop old tool output from a conversation history (issue #1500).
+
+`message_history` accumulates for the lifetime of a session: messages are
+appended and passed whole to every subsequent request, so nothing bounds the
+total even though `QUERY_RESULT_MAX_TOKENS` bounds each individual result.
+
+This is the cheap first stage of compaction, and deliberately only that. Tool
+output is usually the bulk of a long session's context and the most
+reproducible part of it -- a query can be run again, whereas the user's stated
+goal cannot be recovered once dropped. So tool results are emptied oldest-first
+and every user and assistant message is left untouched.
+
+Summarising the dialogue is a separate stage that this does NOT do. The two
+compose in that order: prune first because it costs nothing, and summarise only
+if pruning could not free enough. Codex's own documentation warns that repeated
+summarisation compounds accuracy loss, which is a reason to reach for it second
+rather than first.
+
+The part is emptied rather than removed. A tool call whose result has vanished
+is an orphan, and providers reject that history -- `main._cancel_orphaned_tool_calls`
+exists because that shape breaks a request.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from .utils.token_utils import count_tokens
+
+if TYPE_CHECKING:
+    from pydantic_ai.messages import ModelMessage
+
+# What replaces dropped output. Says the result existed and can be re-fetched,
+# rather than leaving an empty string the model might read as "the query
+# returned nothing" -- an absence that means something quite different.
+PRUNED_PLACEHOLDER = (
+    "[earlier tool result dropped to save context; re-run the tool if needed]"
+)
+
+# Recent tool output is what the current turn is reasoning about, so it is off
+# limits regardless of how much pruning would recover.
+DEFAULT_PROTECT_RECENT_TOKENS = 40_000
+
+# Below this, pruning is not worth its own cost: it invalidates the prompt
+# cache for the whole prefix it rewrites, so recovering a few hundred tokens
+# every turn would thrash near the limit and buy almost nothing.
+DEFAULT_MINIMUM_RECOVERED_TOKENS = 20_000
+
+
+def _is_tool_return(part: object) -> bool:
+    """Any tool-return part, matched by base class rather than by name.
+
+    pydantic-ai ships five subclasses of `BaseToolReturnPart` (plain, native,
+    tool-search, native-tool-search, load-capability). Enumerating them here
+    would silently stop covering a shape the library adds later, which is the
+    same blind spot an `isinstance` list against a moving target always has.
+    """
+    from pydantic_ai.messages import BaseToolReturnPart
+
+    return isinstance(part, BaseToolReturnPart)
+
+
+def _content_tokens(part: object) -> int:
+    content = getattr(part, "content", None)
+    if content is None:
+        return 0
+    return count_tokens(content if isinstance(content, str) else str(content))
+
+
+def prune_old_tool_results(
+    messages: list[ModelMessage],
+    protect_recent_tokens: int = DEFAULT_PROTECT_RECENT_TOKENS,
+    minimum_recovered_tokens: int = DEFAULT_MINIMUM_RECOVERED_TOKENS,
+) -> list[ModelMessage]:
+    """Empty tool results outside the protected window, oldest first.
+
+    Walks backwards accumulating tool-output tokens, so the newest results fill
+    the protected window and everything older becomes a candidate. Returns the
+    history unchanged when the candidates are not worth the cache invalidation.
+
+    Already-pruned parts are not counted as recoverable: the placeholder cannot
+    be freed twice, and counting it would let a long session clear the floor
+    every turn on tokens it cannot actually reclaim.
+    """
+    candidates: list[tuple[int, int]] = []  # (message index, part index)
+    protected_tokens = 0
+    recoverable_tokens = 0
+
+    for message_index in range(len(messages) - 1, -1, -1):
+        parts = getattr(messages[message_index], "parts", None)
+        if not parts:
+            continue
+        for part_index in range(len(parts) - 1, -1, -1):
+            part = parts[part_index]
+            if not _is_tool_return(part):
+                continue
+            if getattr(part, "content", None) == PRUNED_PLACEHOLDER:
+                continue
+            part_tokens = _content_tokens(part)
+            if protected_tokens < protect_recent_tokens:
+                protected_tokens += part_tokens
+                continue
+            candidates.append((message_index, part_index))
+            recoverable_tokens += part_tokens
+
+    if recoverable_tokens < minimum_recovered_tokens:
+        return messages
+
+    # Rebuild only the messages that actually change, so untouched messages
+    # keep their identity and the caller can tell what moved.
+    by_message: dict[int, set[int]] = {}
+    for message_index, part_index in candidates:
+        by_message.setdefault(message_index, set()).add(part_index)
+
+    pruned: list[ModelMessage] = []
+    for message_index, message in enumerate(messages):
+        prune_indices = by_message.get(message_index)
+        if not prune_indices:
+            pruned.append(message)
+            continue
+        new_parts = [
+            replace(part, content=PRUNED_PLACEHOLDER)
+            if part_index in prune_indices
+            else part
+            for part_index, part in enumerate(message.parts)
+        ]
+        pruned.append(replace(message, parts=new_parts))
+    return pruned

--- a/codebase_rag/context_pruning.py
+++ b/codebase_rag/context_pruning.py
@@ -61,15 +61,24 @@ def _is_prunable_tool_return(part: object) -> bool:
         LoadCapabilityReturnPart.instructions -> AttributeError:
             'str' object has no attribute 'get'
 
-    So this names the two subclasses typed `ToolReturnContent`, which admits a
-    string, and an unknown future subclass is skipped rather than corrupted.
-    That is the safe direction for a mechanism whose entire value is that the
-    history it compacts still works: recovering less is a cost, corrupting the
-    conversation is a defect (CodeRabbit, #1506).
+    So this names the two subclasses typed `ToolReturnContent`, and an unknown
+    future subclass is skipped rather than corrupted.
+
+    The class is necessary and not sufficient. `ToolReturnContent` admits a
+    string but not only a string: a `ToolReturnPart` accepts a dict or a list
+    without complaint, and the placeholder would destroy that value rather
+    than shrink it. Narrowing to the right class is not narrowing to the right
+    type, and the second check is what the first one missed.
+
+    Both directions are the safe one for a mechanism whose entire value is
+    that the history it compacts still works: recovering less is a cost,
+    corrupting the conversation is a defect (CodeRabbit, #1506).
     """
     from pydantic_ai.messages import NativeToolReturnPart, ToolReturnPart
 
-    return type(part) in (ToolReturnPart, NativeToolReturnPart)
+    if type(part) not in (ToolReturnPart, NativeToolReturnPart):
+        return False
+    return isinstance(getattr(part, "content", None), str)
 
 
 def _content_tokens(part: object) -> int:

--- a/codebase_rag/context_pruning.py
+++ b/codebase_rag/context_pruning.py
@@ -48,17 +48,28 @@ DEFAULT_PROTECT_RECENT_TOKENS = 40_000
 DEFAULT_MINIMUM_RECOVERED_TOKENS = 20_000
 
 
-def _is_tool_return(part: object) -> bool:
-    """Any tool-return part, matched by base class rather than by name.
+def _is_prunable_tool_return(part: object) -> bool:
+    """A tool return whose content is free text and may be replaced.
 
-    pydantic-ai ships five subclasses of `BaseToolReturnPart` (plain, native,
-    tool-search, native-tool-search, load-capability). Enumerating them here
-    would silently stop covering a shape the library adds later, which is the
-    same blind spot an `isinstance` list against a moving target always has.
+    Matching `BaseToolReturnPart` is right for FINDING tool results and wrong
+    for OVERWRITING them, and the two are not the same question. Three of its
+    five subclasses carry structured content behind typed accessors, so a
+    string placeholder corrupts them. Measured, not assumed:
+
+        ToolSearchReturnPart.discovered_tools -> TypeError:
+            string indices must be integers, not 'str'
+        LoadCapabilityReturnPart.instructions -> AttributeError:
+            'str' object has no attribute 'get'
+
+    So this names the two subclasses typed `ToolReturnContent`, which admits a
+    string, and an unknown future subclass is skipped rather than corrupted.
+    That is the safe direction for a mechanism whose entire value is that the
+    history it compacts still works: recovering less is a cost, corrupting the
+    conversation is a defect (CodeRabbit, #1506).
     """
-    from pydantic_ai.messages import BaseToolReturnPart
+    from pydantic_ai.messages import NativeToolReturnPart, ToolReturnPart
 
-    return isinstance(part, BaseToolReturnPart)
+    return type(part) in (ToolReturnPart, NativeToolReturnPart)
 
 
 def _content_tokens(part: object) -> int:
@@ -86,6 +97,10 @@ def prune_old_tool_results(
     candidates: list[tuple[int, int]] = []  # (message index, part index)
     protected_tokens = 0
     recoverable_tokens = 0
+    # The placeholder is kept, so it is not recovered. Counting gross tokens
+    # would clear the floor on a rewrite that frees less than the floor asks
+    # for, which is the exact thrash the floor exists to prevent.
+    placeholder_tokens = count_tokens(PRUNED_PLACEHOLDER)
 
     for message_index in range(len(messages) - 1, -1, -1):
         parts = getattr(messages[message_index], "parts", None)
@@ -93,7 +108,7 @@ def prune_old_tool_results(
             continue
         for part_index in range(len(parts) - 1, -1, -1):
             part = parts[part_index]
-            if not _is_tool_return(part):
+            if not _is_prunable_tool_return(part):
                 continue
             if getattr(part, "content", None) == PRUNED_PLACEHOLDER:
                 continue
@@ -102,7 +117,7 @@ def prune_old_tool_results(
                 protected_tokens += part_tokens
                 continue
             candidates.append((message_index, part_index))
-            recoverable_tokens += part_tokens
+            recoverable_tokens += max(0, part_tokens - placeholder_tokens)
 
     if recoverable_tokens < minimum_recovered_tokens:
         return messages

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -53,6 +53,7 @@ from . import constants as cs
 from . import exceptions as ex
 from . import logs as ls
 from .config import ModelConfig, load_ignore_patterns, settings
+from .context_pruning import prune_old_tool_results
 from .models import AppContext
 from .prompts import OPTIMIZATION_PROMPT, OPTIMIZATION_PROMPT_WITH_REFERENCE
 from .providers.base import get_provider_from_config
@@ -701,6 +702,30 @@ async def _run_agent_response_loop(
                 tool_names,
             )
             continue
+
+        # Bound the context BEFORE the counter snapshots it. The refresh below
+        # is handed `list(message_history)` at spawn time, so pruning after it
+        # would count the pre-prune history and write that total back: the next
+        # turn would re-trigger on a number this prune already invalidated.
+        #
+        # The threshold is `TOKEN_THRESHOLD_CRITICAL`, the level this project
+        # already calls critical for this exact quantity (it drives the status
+        # line). Inheriting it means the shipped default is a decision the
+        # repository made rather than one chosen to satisfy a review.
+        #
+        # DELIBERATELY TIMID, and issue #1500 owns the policy. Two ways this
+        # declines to act: `_token_usage` reports 0 for every provider whose
+        # counter never runs (`_refresh_context_tokens` returns early unless
+        # Anthropic with a key), and `prune_old_tool_results` refuses below its
+        # own recovery floor. A mechanism that discards data should be inert
+        # where it cannot measure, so both silences are the wanted direction.
+        _, _, context_pct = _token_usage()
+        if context_pct >= cs.TOKEN_THRESHOLD_CRITICAL:
+            # Assign THROUGH the slice: callers hold this same list and the
+            # loop mutates it in place, so rebinding would prune a copy and
+            # leave the conversation untouched -- a call site that satisfies a
+            # reachability check while doing nothing.
+            message_history[:] = prune_old_tool_results(message_history)
 
         _spawn_background(_refresh_context_tokens(list(message_history)))
 

--- a/codebase_rag/tests/test_context_pruning.py
+++ b/codebase_rag/tests/test_context_pruning.py
@@ -1,0 +1,198 @@
+# Conversation compaction, stage one (issue #1500): tool results are the bulk
+# of a long session's context and the most reproducible part of it, so they are
+# what gets dropped first. The dialogue is left intact; summarising it is a
+# separate stage that this deliberately does not do.
+
+from __future__ import annotations
+
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from codebase_rag.context_pruning import (
+    PRUNED_PLACEHOLDER,
+    prune_old_tool_results,
+)
+
+
+def _turn(question: str, tool_output: str) -> list[ModelRequest | ModelResponse]:
+    """One user turn: question, a tool call, its result, and an answer."""
+    call_id = f"call-{abs(hash(question)) % 10_000}"
+    return [
+        ModelRequest(parts=[UserPromptPart(content=question)]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name="query", args={}, tool_call_id=call_id)]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="query", content=tool_output, tool_call_id=call_id
+                )
+            ]
+        ),
+        ModelResponse(parts=[TextPart(content=f"answer to {question}")]),
+    ]
+
+
+def _tool_contents(messages: list[ModelRequest | ModelResponse]) -> list[str]:
+    return [
+        str(part.content)
+        for message in messages
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+
+
+def _user_prompts(messages: list[ModelRequest | ModelResponse]) -> list[str]:
+    return [
+        str(part.content)
+        for message in messages
+        for part in message.parts
+        if isinstance(part, UserPromptPart)
+    ]
+
+
+def test_the_oldest_tool_result_is_replaced_and_the_newest_is_kept() -> None:
+    """Pruning is oldest-first, which is the whole premise of the strategy.
+
+    Recent tool output is what the current turn is reasoning about; old tool
+    output has usually already been folded into an answer and can be
+    re-fetched. Dropping the newest first would break the turn in progress.
+    """
+    history = _turn("first", "OLD RESULT " * 200) + _turn("second", "NEW RESULT " * 200)
+
+    # The floor is a separate guard with its own test; lower it here so this
+    # test measures ordering alone. Left at its default it would block the
+    # prune and this would assert an outcome its own parameters forbid.
+    pruned = prune_old_tool_results(
+        history, protect_recent_tokens=100, minimum_recovered_tokens=1
+    )
+
+    contents = _tool_contents(pruned)
+    assert contents[0] == PRUNED_PLACEHOLDER, (
+        "the oldest tool result should have been replaced, but it was kept"
+    )
+    assert "NEW RESULT" in contents[-1], (
+        "the newest tool result is inside the protected window and must survive"
+    )
+
+
+def test_the_dialogue_survives_pruning() -> None:
+    """Only tool output is dropped. The conversation itself is the point.
+
+    This is what separates strategy (3) from a sliding window: the user's
+    stated goal usually appears in their FIRST message, which a window drops
+    and this must not.
+    """
+    history = _turn("first", "OLD " * 500) + _turn("second", "NEW " * 500)
+
+    pruned = prune_old_tool_results(history, protect_recent_tokens=10)
+
+    assert _user_prompts(pruned) == ["first", "second"], (
+        "user messages must survive pruning; losing them loses the goal"
+    )
+    texts = [
+        str(part.content)
+        for message in pruned
+        for part in message.parts
+        if isinstance(part, TextPart)
+    ]
+    assert texts == ["answer to first", "answer to second"], (
+        "assistant replies must survive pruning"
+    )
+
+
+def test_a_pruned_result_keeps_its_tool_call_id() -> None:
+    """The part is emptied, never removed.
+
+    A tool call whose result vanishes is an orphan, and providers reject that
+    history. `main._cancel_orphaned_tool_calls` exists precisely because this
+    shape breaks a request, so pruning must not manufacture it.
+    """
+    history = _turn("first", "OLD " * 500) + _turn("second", "NEW " * 500)
+    call_ids_before = [
+        part.tool_call_id
+        for message in history
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+
+    pruned = prune_old_tool_results(history, protect_recent_tokens=10)
+
+    call_ids_after = [
+        part.tool_call_id
+        for message in pruned
+        for part in message.parts
+        if isinstance(part, ToolReturnPart)
+    ]
+    assert call_ids_after == call_ids_before, (
+        "every tool return must stay, with its id, or its call is orphaned"
+    )
+
+
+def test_nothing_is_pruned_when_little_would_be_recovered() -> None:
+    """Below the floor, pruning is not worth its own cost.
+
+    Without a floor the session thrashes near the limit: every turn prunes a
+    few hundred tokens, invalidates the prompt cache for the whole prefix, and
+    buys almost nothing. OpenCode uses the same guard for the same reason.
+    """
+    history = _turn("first", "tiny") + _turn("second", "tiny")
+
+    pruned = prune_old_tool_results(
+        history, protect_recent_tokens=0, minimum_recovered_tokens=20_000
+    )
+
+    assert _tool_contents(pruned) == ["tiny", "tiny"], (
+        "recovering a few tokens is not worth invalidating the cache prefix"
+    )
+
+
+def test_an_already_pruned_result_is_not_recounted_as_recoverable() -> None:
+    """Pruning twice must not report the placeholder as more to recover.
+
+    If already-pruned parts counted toward the recoverable total, a long
+    session would clear the floor on every turn using tokens it cannot
+    actually free, and prune forever while recovering nothing.
+
+    The floor is set to 1 deliberately. Left at its default, the second pass
+    returns unchanged simply because the short placeholder cannot clear
+    20,000 tokens, so the assertion would hold whether or not the skip
+    existed -- true of the working AND the broken code, which measures
+    nothing. At a floor of 1 the only thing keeping the second pass inert is
+    the skip itself.
+    """
+    history = _turn("first", "OLD " * 500) + _turn("second", "NEW " * 500)
+
+    once = prune_old_tool_results(
+        history, protect_recent_tokens=10, minimum_recovered_tokens=1
+    )
+    twice = prune_old_tool_results(
+        once, protect_recent_tokens=10, minimum_recovered_tokens=1
+    )
+
+    assert _tool_contents(twice) == _tool_contents(once), (
+        "a second pass over already-pruned history should change nothing"
+    )
+    assert twice is once, (
+        "with nothing left to recover the history should be returned as-is, "
+        "not rebuilt -- rebuilding invalidates the prompt cache for no gain"
+    )
+
+
+def test_history_without_tool_results_is_returned_unchanged() -> None:
+    """Nothing to prune is not an error, and must not touch the dialogue."""
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="hello")]),
+        ModelResponse(parts=[TextPart(content="hi")]),
+    ]
+
+    pruned = prune_old_tool_results(history, protect_recent_tokens=0)
+
+    assert _user_prompts(pruned) == ["hello"]
+    assert len(pruned) == len(history)

--- a/codebase_rag/tests/test_context_pruning.py
+++ b/codebase_rag/tests/test_context_pruning.py
@@ -417,3 +417,67 @@ def test_non_string_content_is_left_alone(label: str, content: object) -> None:
     assert plain.content == PRUNED_PLACEHOLDER, (
         "free-text results must still be pruned when a structured one is present"
     )
+
+
+def test_pruning_preserves_message_count_and_call_return_pairing() -> None:
+    """Pruning must never orphan a tool call, on any history it acts on.
+
+    pydantic-ai requires every tool-call part to have a matching tool-return
+    part; `main._cancel_orphaned_tool_calls` exists to repair that shape when
+    a run is cancelled mid-flight. A pruner that DROPPED result messages
+    rather than emptying them would manufacture the same breakage on every
+    prune, and the next `rag_agent.run` would raise.
+
+    Distinct from `test_a_pruned_result_keeps_its_tool_call_id`, which
+    compares return-part ids to themselves. This pins the two structural
+    facts that test cannot see: the message count is unchanged, and every
+    call id still has a return id to match it. Both are asserted on a history
+    that is actually pruned, so a pruner that quietly dropped a message would
+    fail here rather than pass by not acting.
+
+    Catastrophic rather than degraded, which is why it is guarded explicitly:
+    losing content costs context, losing a message breaks the next request.
+    """
+    history = _turn("first", "OLD " * 500) + _turn("second", "NEW " * 500)
+
+    def _ids(messages: list[ModelRequest | ModelResponse]) -> tuple[list, list]:
+        calls = [
+            p.tool_call_id
+            for m in messages
+            for p in m.parts
+            if isinstance(p, ToolCallPart)
+        ]
+        returns = [
+            p.tool_call_id
+            for m in messages
+            for p in m.parts
+            if isinstance(p, ToolReturnPart)
+        ]
+        return calls, returns
+
+    calls_before, returns_before = _ids(history)
+    pruned = prune_old_tool_results(
+        history, protect_recent_tokens=10, minimum_recovered_tokens=1
+    )
+    calls_after, returns_after = _ids(pruned)
+
+    assert [
+        str(p.content) for m in pruned for p in m.parts if isinstance(p, ToolReturnPart)
+    ] != [
+        str(p.content)
+        for m in history
+        for p in m.parts
+        if isinstance(p, ToolReturnPart)
+    ], "fixture must actually be pruned or the invariant is asserted vacuously"
+
+    assert len(pruned) == len(history), (
+        "pruning emptied a message instead of its content; a dropped message "
+        "orphans its tool call and the next agent run raises"
+    )
+    assert calls_after == calls_before, "tool-call parts must be untouched"
+    assert returns_after == returns_before, (
+        "every tool return must survive with its id so its call stays paired"
+    )
+    assert sorted(calls_after) == sorted(returns_after), (
+        "call/return pairing broken by pruning"
+    )

--- a/codebase_rag/tests/test_context_pruning.py
+++ b/codebase_rag/tests/test_context_pruning.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 import pytest
 from pydantic_ai.messages import (
     LoadCapabilityReturnPart,
@@ -559,4 +562,91 @@ def test_a_prune_shrinks_what_a_later_token_count_would_measure() -> None:
         f"pruning must reduce what a later token count measures ({before} -> "
         f"{after}); if it does not, the trigger reading that count can never "
         "clear and will fire on every turn"
+    )
+
+
+def test_the_call_site_prunes_the_callers_list_and_precedes_the_counter() -> None:
+    """The wiring in `main.py`, checked structurally against the shipped file.
+
+    Two ways a reachable call site does nothing, both of which pass a
+    reachability check:
+
+    - REBINDING instead of assigning through the slice. `message_history` is
+      a parameter the callers also hold and the loop mutates in place, so
+      `message_history = prune(...)` prunes a copy and the conversation is
+      untouched.
+    - RUNNING AFTER the token counter. `_refresh_context_tokens` is spawned
+      with `list(message_history)`, a snapshot taken at spawn time, so a
+      prune placed after it writes the pre-prune total back and the trigger
+      re-fires next turn on a number this prune already invalidated.
+
+    Structural rather than behavioural because reaching this loop needs a
+    live agent and a provider; the property is about the shape of the code.
+    Same discipline as `test_mcp_read_handler_lock.py`, which parses the
+    shipped file (raised by peer review on #1506).
+    """
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+
+    prune_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "prune_old_tool_results"
+    ]
+    assert prune_calls, (
+        "main.py never calls prune_old_tool_results; the pruner is unreachable "
+        "and bounds nothing"
+    )
+
+    slice_assignments = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(t, ast.Subscript)
+            and isinstance(t.value, ast.Name)
+            and t.value.id == "message_history"
+            and isinstance(t.slice, ast.Slice)
+            for t in node.targets
+        )
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id == "prune_old_tool_results"
+    ]
+    assert slice_assignments, (
+        "the prune result is not assigned through `message_history[:]`; "
+        "rebinding the name prunes a copy and leaves the caller's list intact"
+    )
+
+    spawn_lines = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_spawn_background"
+        and any(
+            isinstance(a, ast.Call)
+            and isinstance(a.func, ast.Name)
+            and a.func.id == "_refresh_context_tokens"
+            and any(
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Name)
+                and inner.func.id == "list"
+                for inner in ast.walk(a)
+            )
+            for a in node.args
+        )
+    ]
+    assert spawn_lines, (
+        "found no _spawn_background(_refresh_context_tokens(list(...))); the "
+        "counter's snapshot call changed shape and this guard has drifted"
+    )
+    assert min(assign.lineno for assign in slice_assignments) < max(spawn_lines), (
+        "the prune runs after the token counter snapshots the history, so the "
+        "count written back describes the unpruned list and the trigger "
+        "re-fires next turn on a number the prune already invalidated"
     )

--- a/codebase_rag/tests/test_context_pruning.py
+++ b/codebase_rag/tests/test_context_pruning.py
@@ -354,3 +354,66 @@ def test_the_floor_measures_net_recovery_not_gross_content() -> None:
         f"floor of {gross}, so this must not prune; counting gross content "
         "would rewrite the cache prefix for less than the floor demands"
     )
+
+
+@pytest.mark.parametrize(
+    ("label", "content"),
+    [
+        ("a mapping", {"rows": [1, 2, 3], "total": 3}),
+        ("a sequence", [{"path": "a.py"}, {"path": "b.py"}]),
+    ],
+)
+def test_non_string_content_is_left_alone(label: str, content: object) -> None:
+    """Narrowing to the right CLASS is not narrowing to the right TYPE.
+
+    The previous fix restricted pruning to the two subclasses annotated
+    `ToolReturnContent`, on the reasoning that this type admits a string. It
+    does admit one, but not only one: a `ToolReturnPart` accepts a dict or a
+    list without complaint, so the class check passes a part whose content is
+    structured data and the placeholder destroys it.
+
+    That is the same defect as the subclass bug one level down, and it
+    survived the fix for it. A tool result that returned rows is not made
+    smaller by being replaced with a sentence, it is made wrong, and a caller
+    indexing it gets a string instead (CodeRabbit, #1506).
+    """
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="q")]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name="t", args={}, tool_call_id="c-big")]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="t", content="BIG " * 5000, tool_call_id="c-big"
+                ),
+                ToolReturnPart(
+                    tool_name="structured", content=content, tool_call_id="c-struct"
+                ),
+            ]
+        ),
+    ]
+
+    pruned = prune_old_tool_results(
+        history, protect_recent_tokens=0, minimum_recovered_tokens=1
+    )
+
+    survivor = next(
+        p
+        for message in pruned
+        for p in message.parts
+        if isinstance(p, ToolReturnPart) and p.tool_call_id == "c-struct"
+    )
+    assert survivor.content == content, (
+        f"content that is {label} is not free text; replacing it with a "
+        "placeholder string destroys the value rather than shrinking it"
+    )
+    plain = next(
+        p
+        for message in pruned
+        for p in message.parts
+        if isinstance(p, ToolReturnPart) and p.tool_call_id == "c-big"
+    )
+    assert plain.content == PRUNED_PLACEHOLDER, (
+        "free-text results must still be pruned when a structured one is present"
+    )

--- a/codebase_rag/tests/test_context_pruning.py
+++ b/codebase_rag/tests/test_context_pruning.py
@@ -5,12 +5,16 @@
 
 from __future__ import annotations
 
+import pytest
 from pydantic_ai.messages import (
+    LoadCapabilityReturnPart,
     ModelRequest,
     ModelResponse,
+    NativeToolSearchReturnPart,
     TextPart,
     ToolCallPart,
     ToolReturnPart,
+    ToolSearchReturnPart,
     UserPromptPart,
 )
 
@@ -18,6 +22,7 @@ from codebase_rag.context_pruning import (
     PRUNED_PLACEHOLDER,
     prune_old_tool_results,
 )
+from codebase_rag.utils.token_utils import count_tokens
 
 
 def _turn(question: str, tool_output: str) -> list[ModelRequest | ModelResponse]:
@@ -196,3 +201,156 @@ def test_history_without_tool_results_is_returned_unchanged() -> None:
 
     assert _user_prompts(pruned) == ["hello"]
     assert len(pruned) == len(history)
+
+
+@pytest.mark.parametrize(
+    ("part_factory", "accessor"),
+    [
+        (
+            lambda: ToolSearchReturnPart(
+                tool_name="search",
+                content={"discovered_tools": [], "message": "ok"},
+                tool_call_id="c-search",
+            ),
+            "discovered_tools",
+        ),
+        (
+            lambda: NativeToolSearchReturnPart(
+                tool_name="search",
+                content={"discovered_tools": [], "message": "ok"},
+                tool_call_id="c-native-search",
+            ),
+            "discovered_tools",
+        ),
+        (
+            lambda: LoadCapabilityReturnPart(
+                tool_name="load",
+                content={"instructions": "do the thing"},
+                tool_call_id="c-load",
+            ),
+            "instructions",
+        ),
+    ],
+)
+def test_parts_with_structured_content_are_left_alone(part_factory, accessor) -> None:
+    """Only free-text tool results may be replaced with a string placeholder.
+
+    `BaseToolReturnPart` is the right base for FINDING tool results, which is
+    why the traversal matches on it. It is the wrong base for OVERWRITING
+    them: three subclasses carry structured content behind typed accessors,
+    and a string breaks them. Measured, not assumed:
+
+        ToolSearchReturnPart.discovered_tools -> TypeError:
+            string indices must be integers, not 'str'
+        LoadCapabilityReturnPart.instructions -> AttributeError:
+            'str' object has no attribute 'get'
+
+    A pruner that corrupts the history it is compacting is worse than one
+    that recovers less, so these are skipped rather than given per-subtype
+    placeholders. They are framework bookkeeping and small; the free-text
+    results this targets are the bulk (CodeRabbit, #1506).
+    """
+    part = part_factory()
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="q")]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name="t", args={}, tool_call_id="c-big")]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="t", content="BIG " * 5000, tool_call_id="c-big"
+                ),
+                part,
+            ]
+        ),
+    ]
+
+    pruned = prune_old_tool_results(
+        history, protect_recent_tokens=0, minimum_recovered_tokens=1
+    )
+
+    survivor = next(
+        p for message in pruned for p in message.parts if type(p) is type(part)
+    )
+    assert survivor.content == part.content, (
+        f"{type(part).__name__} carries structured content; replacing it with a "
+        "string corrupts the history"
+    )
+    getattr(survivor, accessor)
+
+
+def test_free_text_results_are_still_pruned_alongside_structured_ones() -> None:
+    """Skipping structured parts must not disable pruning for the rest.
+
+    Without this, the fix above is satisfied by a pruner that gave up
+    entirely -- the parametrized test cannot tell "structured parts skipped"
+    from "nothing pruned at all".
+    """
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="q")]),
+        ModelResponse(
+            parts=[ToolCallPart(tool_name="t", args={}, tool_call_id="c-big")]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    tool_name="t", content="BIG " * 5000, tool_call_id="c-big"
+                ),
+                LoadCapabilityReturnPart(
+                    tool_name="load",
+                    content={"instructions": "do the thing"},
+                    tool_call_id="c-load",
+                ),
+            ]
+        ),
+    ]
+
+    pruned = prune_old_tool_results(
+        history, protect_recent_tokens=0, minimum_recovered_tokens=1
+    )
+
+    plain = next(
+        p for message in pruned for p in message.parts if type(p) is ToolReturnPart
+    )
+    assert plain.content == PRUNED_PLACEHOLDER, (
+        "free-text results must still be pruned when a structured part is present"
+    )
+
+
+def test_the_floor_measures_net_recovery_not_gross_content() -> None:
+    """The placeholder is kept, so its tokens are not recovered.
+
+    Counting gross content against the floor lets a rewrite through that
+    frees less than the floor demands, which is precisely the thrash the
+    floor exists to prevent: the prefix is rebuilt, the prompt cache for it
+    is invalidated, and the recovery does not cover the cost.
+
+    Concrete boundary, measured rather than assumed: the placeholder is 17
+    tokens and this result is 41, so gross recovery is 41 and net is 24. At a
+    floor of exactly 41, gross accounting prunes and net accounting declines
+    (CodeRabbit, #1506).
+    """
+    history = [
+        ModelRequest(parts=[UserPromptPart(content="q")]),
+        ModelResponse(parts=[ToolCallPart(tool_name="t", args={}, tool_call_id="c-1")]),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(tool_name="t", content="OLD " * 40, tool_call_id="c-1")
+            ]
+        ),
+    ]
+    gross = count_tokens("OLD " * 40)
+    assert gross > count_tokens(PRUNED_PLACEHOLDER), (
+        "fixture must be bigger than the placeholder or the case is vacuous"
+    )
+
+    pruned = prune_old_tool_results(
+        history, protect_recent_tokens=0, minimum_recovered_tokens=gross
+    )
+
+    assert _tool_contents(pruned) == ["OLD " * 40], (
+        f"net recovery is {gross - count_tokens(PRUNED_PLACEHOLDER)} against a "
+        f"floor of {gross}, so this must not prune; counting gross content "
+        "would rewrite the cache prefix for less than the floor demands"
+    )

--- a/codebase_rag/tests/test_context_pruning.py
+++ b/codebase_rag/tests/test_context_pruning.py
@@ -481,3 +481,82 @@ def test_pruning_preserves_message_count_and_call_return_pairing() -> None:
     assert sorted(calls_after) == sorted(returns_after), (
         "call/return pairing broken by pruning"
     )
+
+
+def test_pruning_is_idempotent_so_a_stale_high_reading_costs_nothing() -> None:
+    """A repeated prune on already-pruned history must be a no-op.
+
+    The trigger this is designed for reads `session.context_tokens`, which
+    has exactly one writer: a BACKGROUND coroutine spawned with a snapshot
+    copy (`main.py`, `_spawn_background(_refresh_context_tokens(list(...)))`).
+    Two consequences make repeat calls inevitable rather than exceptional:
+
+    - the measurement is asynchronous, so the value describes an earlier turn
+    - on a rejected key the refresh raises before its assignment, leaving the
+      previous value in place, so the count can FREEZE at a high reading and
+      never come down (`TokenCountAuthError` is caught and only warned about)
+
+    Either way the trigger can fire on every subsequent turn. That must cost
+    nothing, so the pruner has to be idempotent: the second call finds only
+    placeholders outside the protected window, has nothing left to recover,
+    and returns the same history object rather than rebuilding it.
+
+    Identity, not just equality: rebuilding an unchanged history would
+    invalidate the prompt-cache prefix on every turn for no gain, which is
+    the cost the recovery floor exists to avoid.
+    """
+    history = _turn("first", "OLD " * 500) + _turn("second", "NEW " * 500)
+
+    once = prune_old_tool_results(
+        history, protect_recent_tokens=10, minimum_recovered_tokens=1
+    )
+    assert _tool_contents(once) != _tool_contents(history), (
+        "fixture must actually prune on the first pass or this is vacuous"
+    )
+
+    for repeat in range(3):
+        again = prune_old_tool_results(
+            once, protect_recent_tokens=10, minimum_recovered_tokens=1
+        )
+        assert again is once, (
+            f"prune {repeat + 2} rebuilt the history with nothing to recover; "
+            "a frozen or stale token count fires the trigger every turn, so a "
+            "repeat prune must be free rather than re-invalidating the cache"
+        )
+
+
+def test_a_prune_shrinks_what_a_later_token_count_would_measure() -> None:
+    """The pruned history must be smaller by the tokens the trigger reads.
+
+    States the ordering contract the call site has to honour. The refresh
+    coroutine is handed `list(message_history)` AT SPAWN TIME, so a prune
+    that runs after the spawn hands it the pre-prune snapshot: the count
+    written back describes history that no longer exists, and the next turn
+    re-triggers on a number the prune already invalidated.
+
+    Asserted here on the pruner's own contract -- pruning genuinely reduces
+    the measurable size -- so a call site placed after the spawn contradicts
+    a stated property rather than merely underperforming silently.
+    """
+    history = _turn("first", "OLD " * 500) + _turn("second", "NEW " * 500)
+
+    def _measurable(messages: list[ModelRequest | ModelResponse]) -> int:
+        return sum(
+            count_tokens(str(p.content))
+            for m in messages
+            for p in m.parts
+            if isinstance(p, ToolReturnPart)
+        )
+
+    before = _measurable(history)
+    after = _measurable(
+        prune_old_tool_results(
+            history, protect_recent_tokens=10, minimum_recovered_tokens=1
+        )
+    )
+
+    assert after < before, (
+        f"pruning must reduce what a later token count measures ({before} -> "
+        f"{after}); if it does not, the trigger reading that count can never "
+        "clear and will fire on every turn"
+    )


### PR DESCRIPTION
Closes part of #1500. Stage one only: prune old tool output. Summarising the dialogue is deliberately not here.

## Why this stage first

`message_history` accumulates for the lifetime of a session. `QUERY_RESULT_MAX_TOKENS` bounds each individual tool result, but nothing bounds the total, so a long session grows until the context window rejects the request.

Researched how the three tools named on the issue handle this. OpenCode's shape is the one worth copying: it prunes tool outputs as a **separate, cheaper stage before** LLM summarisation, not as an alternative to it. That reframes the issue's three options, which read as competing choices. (2) and (3) are stages, and (3) goes first because it costs nothing. Codex is the cautionary case: its own docs warn that repeated summarisation compounds accuracy loss, which is a reason to reach for it second.

## What it does

`prune_old_tool_results` walks backwards, fills a protected window with the newest tool output, and empties everything older. Four properties, each with a test and each mutation-checked:

- **oldest-first** — recent output is what the current turn reasons about
- **the dialogue survives** — this is what separates it from a sliding window; the user's goal is usually in their first message, which a window drops
- **the part is emptied, never removed** — a tool call whose result vanished is an orphan and providers reject that history; `main._cancel_orphaned_tool_calls` exists because that shape breaks a request
- **a floor** — pruning rewrites a cache prefix, so recovering a few hundred tokens every turn would thrash near the limit for nothing

Tool returns are matched on `BaseToolReturnPart` rather than an `isinstance` list. pydantic-ai ships five subclasses, and enumerating them is exactly the blind spot that produced the bug fixed in #1487.

## Not wired in yet

This is the mechanism, with no caller. That is on purpose: the issue asks for a product decision, and a pure function is testable, reviewable and reversible without pre-empting it. Wiring it to a trigger is a follow-up.

Worth flagging what I found while looking for that trigger. `_refresh_context_tokens` (`main.py:871`) already counts context against `MODEL_CONTEXT_WINDOWS`, so it looks like the trigger exists. It does not:

- it returns early unless the provider is Anthropic **and** an API key is set, so `context_tokens` stays 0 for every other provider
- it feeds a status-line display, and nothing consumes it for any decision

So a trigger built on it today would silently protect only Anthropic users. Whatever calls this needs a provider-independent count.

## Verification

6 tests, and each guard was mutation-checked in isolation with a byte-identical restore verified each round:

| mutation | fails |
|---|---|
| walk forwards instead of backwards | ordering test only |
| drop the already-pruned skip | recount test only |
| remove the floor | floor test + the identity assertion |
| remove the protected window | ordering test only |

One of those mutations found a real defect **in my own test**. `test_an_already_pruned_result_is_not_recounted_as_recoverable` originally passed with the guard deleted: the placeholder is short, so the second pass fell below the default floor and returned unchanged either way. The assertion was true of both the working and the broken code. It now sets the floor to 1, so the skip is the only thing keeping the second pass inert, and it kills the mutation.

`ty` reports 2 diagnostics, both pre-existing on main (`graph_updater.py`, `parsers/flow_access/processor.py`) and confirmed unchanged with these files stashed. Ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic conversation context compaction when usage reaches a critical threshold.
  * Replaces older eligible text-based tool results with a placeholder while preserving recent results, conversation content, and tool-call associations.
  * Leaves structured and non-text tool results unchanged.
  * Avoids compaction when insufficient token recovery is available and safely handles repeated runs.

* **Tests**
  * Added comprehensive coverage for pruning behavior, safeguards, content preservation, token reduction, pairing, and histories without tool results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->