### PR TITLE
ci: cap the Greptile gate poll at 20 minutes so it stops gating other jobs' logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,18 @@ jobs:
                 # Resolve to the full SHA so the comparison below is exact
                 # equality, never a prefix guess; an unresolvable reference
                 # just skips this candidate.
-                reviewed=$(timeout 60 gh api "repos/$REPO/commits/$reviewed" \
+                #
+                # The bound is the REMAINING budget, not a fixed 60s. A
+                # per-call bound does not bound the loop: one stalled call per
+                # abbreviated candidate accumulates, and with enough candidates
+                # the total runs past the deadline and into the job timeout,
+                # which kills the job without the remedy below. Bounding each
+                # call by what is left makes the aggregate unable to exceed the
+                # deadline however many candidates there are.
+                remaining=$(( deadline - $(date +%s) ))
+                [ "$remaining" -lt 1 ] && break
+                [ "$remaining" -gt 60 ] && remaining=60
+                reviewed=$(timeout "$remaining" gh api "repos/$REPO/commits/$reviewed" \
                   --jq .sha 2>/dev/null || true)
               fi
               [ "$reviewed" = "$HEAD_SHA" ] || continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,18 @@ jobs:
           # Failing closed is safe here. Nothing merges without a 5/5 review of
           # head; a fast fail only moves the wait out of a job that is blocking
           # everyone else's logs.
+          # `timeout` bounds the API calls below. If it were ever missing, each
+          # call would fail, `|| true` would swallow it, and the gate would
+          # report "no review yet" forever -- a false statement that blocks
+          # every merge. Fail loudly here instead: a missing tool is a broken
+          # gate, not an unreviewed pull request.
+          command -v timeout >/dev/null || {
+            echo "❌ 'timeout' (GNU coreutils) is not available on this runner."
+            echo "The gate bounds its API calls with it; without it a stalled"
+            echo "request cannot be distinguished from a missing review."
+            exit 1
+          }
+
           deadline=$(( $(date +%s) + 1200 ))
           while :; do
             # --jq would run per page; slurp the pages so every scored comment
@@ -502,11 +514,22 @@ jobs:
             # the globally latest comment instead would let a late update to
             # an old-commit review mask a valid 5/5 review of head. Bodies are
             # multiline, so ship them through base64.
-            candidates=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            # `timeout` bounds the request itself. The deadline below is only
+            # consulted AFTER this call returns, so an unbounded `gh api` that
+            # stalls runs past the deadline and into the job timeout, which
+            # kills the job WITHOUT printing the remedy underneath -- the whole
+            # point of failing fast. Capping the poll at 20 minutes made that
+            # more reachable, not less: the job timeout is now 25 minutes.
+            # A stalled or failed request is treated as a poll that found no
+            # review, so the loop proceeds to the deadline check and either
+            # retries or fails with guidance. `|| true` keeps a non-zero exit
+            # (124 on timeout) from aborting the loop.
+            candidates=$(timeout 120 gh api "repos/$REPO/issues/$PR/comments" --paginate 2>/dev/null \
               | jq -rs 'add
                         | [.[] | select(.user.login == "greptile-apps[bot]")
                                | select(.body | contains("Confidence Score:"))]
-                        | sort_by(.updated_at) | reverse | .[].body | @base64')
+                        | sort_by(.updated_at) | reverse | .[].body | @base64' \
+              2>/dev/null || true)
             score=""
             for encoded in $candidates; do
               body=$(printf '%s' "$encoded" | base64 -d)
@@ -519,7 +542,7 @@ jobs:
                 # Resolve to the full SHA so the comparison below is exact
                 # equality, never a prefix guess; an unresolvable reference
                 # just skips this candidate.
-                reviewed=$(gh api "repos/$REPO/commits/$reviewed" \
+                reviewed=$(timeout 60 gh api "repos/$REPO/commits/$reviewed" \
                   --jq .sha 2>/dev/null || true)
               fi
               [ "$reviewed" = "$HEAD_SHA" ] || continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,8 @@ jobs:
     name: Greptile 5/5 Gate
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    timeout-minutes: 65
+    # Comfortably over the poll deadline below; the deadline is the real bound.
+    timeout-minutes: 25
     permissions:
       # contents: read backs the commits API call that resolves an
       # abbreviated reviewed-commit reference to a full SHA.
@@ -473,9 +474,27 @@ jobs:
           # a missing review, or any lower score fails this job, which fails
           # "All Checks Pass", which the branch ruleset requires. Greptile
           # posts its review minutes after a push, so poll until its summary
-          # comment covers this exact commit. The deadline leaves headroom
-          # over Greptile's slowest observed review (37 minutes on PR #1404).
-          deadline=$(( $(date +%s) + 3600 ))
+          # comment covers this exact commit.
+          #
+          # The deadline is 20 minutes rather than 60, because a job that polls
+          # holds the WHOLE RUN open, and GitHub refuses the logs of every job
+          # in a run until the run completes (issue #1507). A gate waiting on an
+          # external service was therefore withholding the failure logs of the
+          # unit-test matrix beside it -- on #1480, nine failing jobs were
+          # undiagnosable for over an hour while this job polled.
+          #
+          # 20 minutes costs no legitimate pass. Measured over 48 gate runs:
+          # every success that did not need human intervention finished within
+          # 11 minutes, and 8 of 9 failures within 18. The three successes past
+          # 20 minutes (28, 46 and 54) each had a review REQUESTED mid-poll, so
+          # none of them would have passed unaided anyway -- and the remedy for
+          # those is the same after a fast fail as during a long poll: request
+          # the review, then re-run this job.
+          #
+          # Failing closed is safe here. Nothing merges without a 5/5 review of
+          # head; a fast fail only moves the wait out of a job that is blocking
+          # everyone else's logs.
+          deadline=$(( $(date +%s) + 1200 ))
           while :; do
             # --jq would run per page; slurp the pages so every scored comment
             # is considered across all of them. Walk candidates NEWEST FIRST
@@ -520,8 +539,13 @@ jobs:
             fi
             echo "No Greptile review of $HEAD_SHA yet, waiting ..."
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "❌ No Greptile review of $HEAD_SHA appeared within 60 minutes."
-              echo "Re-trigger the Greptile review, then re-run this job."
+              echo "❌ No Greptile review of $HEAD_SHA appeared within 20 minutes."
+              echo "Greptile does not review a new head automatically here: post"
+              echo "'@greptile-apps review' on the pull request, wait for its"
+              echo "summary comment to name $HEAD_SHA, then re-run this job with"
+              echo "  gh run rerun \$GITHUB_RUN_ID --failed"
+              echo "This job fails fast so the other jobs' logs are readable now;"
+              echo "see issue #1507."
               exit 1
             fi
             sleep 60

--- a/codebase_rag/tests/test_greptile_gate_deadline.py
+++ b/codebase_rag/tests/test_greptile_gate_deadline.py
@@ -63,6 +63,10 @@ def _run_gate(
     # would fail the harness before the behavioural assertions ever ran --
     # reporting a guard that works when it was never exercised.
     script = script.replace("timeout 120 gh api", "timeout 2 gh api")
+    # Same for the per-candidate resolution cap. Not asserted unique for the
+    # same reason as above: a mutation removing it must reach the behavioural
+    # assertions rather than dying in the harness.
+    script = script.replace('[ "$remaining" -gt 60 ]', '[ "$remaining" -gt 2 ]')
     assert script.count("\n  sleep 60\n") == 1, "gate poll interval moved"
     script = script.replace("\n  sleep 60\n", "\n  sleep 1\n")
 
@@ -186,3 +190,57 @@ def test_a_five_of_five_review_of_head_still_passes() -> None:
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     assert "5/5" in result.stdout
+
+
+def test_many_stalled_candidates_cannot_outlast_the_deadline() -> None:
+    """Per-call bounds do not bound the loop.
+
+    Each ABBREVIATED candidate costs one commit-resolution request. Bounding
+    each request individually leaves the total unbounded: enough stalled
+    candidates accumulate past the deadline and into the job timeout, which
+    kills the job without the remedy -- the same defect as the unbounded call,
+    one level down. Found by Greptile on #1510 after the per-call fix.
+
+    The fix bounds each call by the REMAINING budget, so the aggregate cannot
+    exceed the deadline however many candidates there are. This drives many
+    candidates, each of which stalls, and requires the deadline message anyway.
+    """
+    import tempfile
+
+    # Every candidate is abbreviated, so every one triggers a resolution call.
+    payload = json.dumps(
+        [
+            {
+                "user": {"login": "greptile-apps[bot]"},
+                "body": f"Confidence Score: 5/5\nLast reviewed commit: {i:07x}",
+                "updated_at": f"2026-01-01T00:00:{i:02d}Z",
+            }
+            for i in range(20)
+        ]
+    )
+    # The comments call answers; the per-candidate resolution call hangs. The
+    # gate distinguishes them by URL, so the stub does too.
+    stub = (
+        "#!/bin/sh\n"
+        'case "$*" in\n'
+        "  *commits*) exec sleep 600 ;;\n"
+        "esac\n"
+        "cat <<'JSON'\n" + payload + "\nJSON\n"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        result = _run_gate(
+            Path(tmp),
+            gh_behaviour=stub,
+            deadline_seconds=3,
+            wall_clock=90,
+        )
+
+    assert result.returncode == 1, (
+        "20 stalled resolutions must not outlast the deadline; the gate has to "
+        f"fail with guidance rather than hang\nstdout:\n{result.stdout}"
+    )
+    assert "@greptile-apps review" in result.stdout, (
+        "the deadline branch never ran, so accumulated per-candidate stalls "
+        f"still bypass the remedy\nstdout:\n{result.stdout}"
+    )

--- a/codebase_rag/tests/test_greptile_gate_deadline.py
+++ b/codebase_rag/tests/test_greptile_gate_deadline.py
@@ -1,0 +1,188 @@
+"""The Greptile gate must reach its deadline branch even when the API stalls.
+
+The gate polls GitHub for a review of the head commit and fails after a
+deadline, printing the remedy: request a review, then re-run the job. That
+message is the whole point of failing fast (issue #1507) -- a contributor who
+gets a bare job timeout instead has to rediscover the handle and the rerun
+command themselves.
+
+The deadline is only consulted AFTER the API call returns. An unbounded `gh
+api` can therefore block past the deadline and into GitHub's job timeout, which
+kills the job without running the failure branch at all. Capping the poll at 20
+minutes made this MORE reachable rather than less: the job timeout is now 25
+minutes, so an API stall of a few minutes is enough.
+
+Found by Greptile on #1510 with an executed reproducer.
+
+The tests EXECUTE the gate's own shell, extracted from the workflow, against a
+stubbed API. A structural check for the word `timeout` would pass on a
+`timeout` that bounds the wrong command or whose non-zero exit aborts the loop
+under `set -e`, and neither would emit the message this guards.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+JOB_ID = "greptile-gate"
+
+
+def _gate_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"][JOB_ID]["steps"]
+    return "\n".join(step.get("run", "") for step in steps)
+
+
+def _run_gate(
+    tmp_path: Path, *, gh_behaviour: str, deadline_seconds: int, wall_clock: float
+) -> subprocess.CompletedProcess[str]:
+    """Execute the gate script with `gh` and `date` stubbed.
+
+    `deadline_seconds` shrinks the gate's own budget so the test does not wait
+    20 real minutes; `wall_clock` bounds the whole run so a hang is a FAILURE
+    with output rather than a suite that never finishes.
+    """
+    script = _gate_script()
+    # The gate computes its deadline from a literal; rewrite that one number so
+    # the loop's structure -- the thing under test -- is untouched.
+    assert script.count("+ 1200 ))") == 1, "gate deadline literal moved"
+    script = script.replace("+ 1200 ))", f"+ {deadline_seconds} ))")
+    # The gate bounds its API call at 120s and sleeps 60s between polls. Both
+    # are correct in CI and far too slow for a test, so shrink them here. The
+    # STRUCTURE under test -- bound the call, then check the deadline -- is
+    # untouched; only the durations change.
+    # Deliberately NOT asserted unique: a mutation that removes the bound is
+    # exactly what these tests must detect, and asserting the bound exists here
+    # would fail the harness before the behavioural assertions ever ran --
+    # reporting a guard that works when it was never exercised.
+    script = script.replace("timeout 120 gh api", "timeout 2 gh api")
+    assert script.count("\n  sleep 60\n") == 1, "gate poll interval moved"
+    script = script.replace("\n  sleep 60\n", "\n  sleep 1\n")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(gh_behaviour, encoding="utf-8")
+    gh.chmod(0o755)
+
+    # macOS has no GNU `timeout`, and the workflow runs on ubuntu-latest where
+    # it is present. Supplying a stub keeps this test measuring the GATE -- does
+    # it bound the call and reach its deadline -- rather than the host's
+    # coreutils. The stub is a real bound, not a no-op: it must kill an
+    # overrunning child and exit 124, or the stall test would pass vacuously.
+    timeout_stub = bin_dir / "timeout"
+    timeout_stub.write_text(
+        "#!/bin/sh\n"
+        "limit=$1\n"
+        "shift\n"
+        '"$@" &\n'
+        "child=$!\n"
+        '( sleep "$limit"; kill -9 $child 2>/dev/null ) & killer=$!\n'
+        "wait $child 2>/dev/null; status=$?\n"
+        "kill $killer 2>/dev/null\n"
+        "[ $status -ge 128 ] && exit 124\n"
+        "exit $status\n",
+        encoding="utf-8",
+    )
+    timeout_stub.chmod(0o755)
+
+    env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin:/usr/local/bin",
+        "HEAD_SHA": "0" * 40,
+        "REPO": "owner/repo",
+        "PR": "1",
+        "GITHUB_RUN_ID": "12345",
+    }
+    return subprocess.run(
+        ["bash", "-c", script],
+        # The gate's exit code is the thing under test, so a non-zero exit must
+        # come back as data rather than raise.
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=wall_clock,
+    )
+
+
+def test_a_stalled_api_call_still_reaches_the_deadline_message() -> None:
+    """The defect: an unbounded `gh api` blocks past the deadline.
+
+    The stub hangs the way a stalled request does. If the API call is bounded,
+    the loop treats the stall as a poll that found nothing, notices the
+    deadline has passed, and prints the remedy. If it is not bounded, the
+    script never reaches that branch and this fails on the wall clock.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        result = _run_gate(
+            Path(tmp),
+            # Hangs for far longer than the gate's budget, as a stalled
+            # connection does. `exec sleep` so `timeout` signals the sleep
+            # itself rather than a shell that ignores the signal.
+            gh_behaviour="#!/bin/sh\nexec sleep 600\n",
+            deadline_seconds=1,
+            wall_clock=60,
+        )
+
+    assert result.returncode == 1, (
+        "the gate must FAIL on a stalled API, not hang until the job timeout; "
+        f"got {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "@greptile-apps review" in result.stdout, (
+        "the deadline branch never ran, so the contributor gets a bare job "
+        f"timeout with no remedy\nstdout:\n{result.stdout}"
+    )
+    assert "gh run rerun" in result.stdout, (
+        "the remedy must name the rerun command; a fast fail that does not say "
+        f"how to recover is not an improvement\nstdout:\n{result.stdout}"
+    )
+
+
+def test_a_five_of_five_review_of_head_still_passes() -> None:
+    """The bound must not break the success path.
+
+    A timeout wrapper whose non-zero exit propagates, or one that truncates the
+    response, would fail a pull request that Greptile has actually approved.
+    This is the acceptance half: without it, the guard above is satisfied by a
+    gate that fails everything.
+    """
+    import tempfile
+
+    head = "0" * 40
+    payload = json.dumps(
+        [
+            {
+                "user": {"login": "greptile-apps[bot]"},
+                # A real body is multiline; the gate base64s it for that reason,
+                # so a single-line fixture would not exercise the same path.
+                "body": f"Confidence Score: 5/5\nLast reviewed commit: {head}",
+                "updated_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+    )
+    # The gate calls `gh api .../comments` for candidates. The commit-resolution
+    # call is not reached, because this fixture names a full-length SHA.
+    stub = "#!/bin/sh\ncat <<'JSON'\n" + payload + "\nJSON\n"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        result = _run_gate(
+            Path(tmp),
+            gh_behaviour=stub,
+            deadline_seconds=1200,
+            wall_clock=60,
+        )
+
+    assert result.returncode == 0, (
+        "a 5/5 review of the exact head must pass the gate\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "5/5" in result.stdout

--- a/codebase_rag/tests/test_greptile_gate_deadline.py
+++ b/codebase_rag/tests/test_greptile_gate_deadline.py
@@ -31,6 +31,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from codebase_rag.constants import core as cs
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
@@ -124,6 +126,9 @@ def _run_gate(
         check=False,
         capture_output=True,
         text=True,
+        # Explicit rather than the locale's encoding, which varies by runner
+        # (issue #1454). The gate emits UTF-8: its messages carry ✅ and ❌.
+        encoding=cs.ENCODING_UTF8,
         env=env,
         timeout=wall_clock,
     )

--- a/codebase_rag/tests/test_greptile_gate_deadline.py
+++ b/codebase_rag/tests/test_greptile_gate_deadline.py
@@ -23,15 +23,28 @@ under `set -e`, and neither would emit the message this guards.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 
 JOB_ID = "greptile-gate"
+
+# The gate is a POSIX shell script and these tests EXECUTE it, with `bash`, a
+# stubbed `gh` and a stubbed `timeout` on PATH. Windows runners have no such
+# shell, so the tests cannot run there -- and the gate never runs there either:
+# `greptile-gate` is `runs-on: ubuntu-latest`. Skipping loses no coverage of
+# any platform the job actually uses.
+_NEEDS_POSIX_SHELL = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="the gate is a bash script executed here; needs a POSIX shell",
+)
 
 
 def _gate_script() -> str:
@@ -116,6 +129,7 @@ def _run_gate(
     )
 
 
+@_NEEDS_POSIX_SHELL
 def test_a_stalled_api_call_still_reaches_the_deadline_message() -> None:
     """The defect: an unbounded `gh api` blocks past the deadline.
 
@@ -151,6 +165,7 @@ def test_a_stalled_api_call_still_reaches_the_deadline_message() -> None:
     )
 
 
+@_NEEDS_POSIX_SHELL
 def test_a_five_of_five_review_of_head_still_passes() -> None:
     """The bound must not break the success path.
 
@@ -192,6 +207,7 @@ def test_a_five_of_five_review_of_head_still_passes() -> None:
     assert "5/5" in result.stdout
 
 
+@_NEEDS_POSIX_SHELL
 def test_many_stalled_candidates_cannot_outlast_the_deadline() -> None:
     """Per-call bounds do not bound the loop.
 


### PR DESCRIPTION
Closes #1507.

## The problem

GitHub refuses the logs of **every** job in a run until the **whole run** completes. `Greptile 5/5 Gate` polled for up to 60 minutes waiting for a review of the head commit, so a job waiting on an external service was withholding the failure logs of the unit-test matrix beside it.

Measured on #1480: 26 of 28 checks finished, including nine failures across all seven unit-test platforms, and none of their logs were retrievable for over an hour.

Reproduced fresh while writing this, on an unrelated run:

```
run 33225205863 — 9 of 16 jobs completed
gh run view --job 99027370629 --log
  -> run 33225205863 is still in progress; logs will be available when it is complete
```

A finished job's log, refused because a sibling was still polling.

## The change

Poll deadline 3600s -> 1200s, and `timeout-minutes` 65 -> 25. The failure message now names the remedy, including the correct bot handle and the rerun command.

## Why 20 minutes costs no legitimate pass

Measured over **48 gate runs**:

| outcome | durations (minutes) |
|---|---|
| success | 0 0 0 0 0 0 2 3 3 4 4 9 9 11 · 28 46 54 |
| failure | 0 0 7 9 10 12 12 18 · 60 |

Every success that did not need human intervention finished within **11 minutes**; 8 of 9 failures within 18.

The three successes past 20 minutes each had a review **requested mid-poll**, so none would have passed unaided:

| head | gate window | review requested |
|---|---|---|
| `2a98692b` (#1502) | 00:26–00:54 | 00:46, mid-poll |
| `df56b363` (#1480) | 19:16–20:02 | mid-poll |
| `0f4d03ff` (#1480) | 00:05–00:59 | mid-poll |

The remedy after a fast fail is the same one those three used during a long poll: request the review, then re-run the job. The only difference is that everyone else's logs are readable while you do it.

**This fails closed.** Nothing merges without a 5/5 review of head. The change moves the waiting out of a job that blocks other jobs' diagnosis.

## Withdrawn: the issue's suggestion 2

#1507 also proposed failing immediately when no `Greptile Review` check run exists on the head, citing `df56b363` as having none. That evidence was wrong and I have [corrected it on the issue](https://github.com/vitali87/code-graph-rag/issues/1507#issuecomment-5459376472). Both reviewed heads now carry a completed `Greptile Review`, each started ~41 minutes post-commit and only after a manual request; `ba9f4e30` has none at all because none was ever requested. Absence is the normal state of every head until someone asks, so a gate failing on it would fail every PR at the moment CI starts.

## The Sonar gate is deliberately untouched

`Sonar Zero Issues Gate` has the same polling shape, but different measured behaviour: successes run 14–19 minutes, clustered at the top of that range. A 20-minute cap would sit on top of its normal completion time and fail legitimate passes. Its 40-minute deadline is proportionate to a service that does respond unaided, which Greptile does not.

## Verification

- YAML parses; all 12 jobs intact
- Gate script passes `bash -n`
- Failure branch executed directly: `$HEAD_SHA` expands, `$GITHUB_RUN_ID` stays literal for copy-paste

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced the automated review wait period from 60 minutes to 20 minutes.
  * Added safeguards to prevent stalled review requests and network calls from exceeding the time limit.
  * Updated timeout guidance with clearer instructions for requesting a review and rerunning failed checks.

* **Tests**
  * Expanded coverage for delayed, unresponsive, and numerous review candidates.
  * Confirmed that completed reviews continue to pass the automated gate as expected.
  * Improved compatibility by skipping shell-based checks when required tools are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->