### PR TITLE
refactor: share one repository walk so the C++ qn map cannot drift from the indexer

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -100,6 +100,7 @@ from .utils.path_utils import (
     should_keep_dir,
     should_skip_path,
     should_skip_rel_file,
+    walk_eligible_files,
 )
 from .utils.source_extraction import extract_source_with_fallback
 
@@ -2244,43 +2245,23 @@ class GraphUpdater:
             return []
 
         eligible: list[tuple[Path, str]] = []
-        state_filenames = cs.CGR_STATE_FILENAMES
-        repo_str = str(self.repo_path)
-        repo_prefix_len = len(repo_str) + 1
-        exclude_paths = self.exclude_paths
-        unignore_paths = self.unignore_paths
         self._collected_dir_mtimes = {}
-        for dirpath, dirnames, filenames in os.walk(repo_str):
-            if len(dirpath) < repo_prefix_len:
-                rel_dir = ""
-                dir_parts: tuple[str, ...] = ()
-                dir_key = cs.ROOT_DIR_KEY
-            else:
-                rel_dir = dirpath[repo_prefix_len:].replace(os.sep, "/")
-                dir_parts = tuple(rel_dir.split("/")) if rel_dir else ()
-                dir_key = rel_dir or cs.ROOT_DIR_KEY
-            dir_prefix = f"{rel_dir}/" if rel_dir else ""
+
+        def _record_dir_mtime(dir_key: str, dirpath: str) -> None:
             try:
                 self._collected_dir_mtimes[dir_key] = os.stat(dirpath).st_mtime
             except OSError:
                 pass
-            dirnames[:] = sorted(
-                d for d in dirnames if self._should_keep_dir(d, dir_prefix)
-            )
-            for fname in sorted(filenames):
-                if fname in state_filenames:
-                    continue
-                dot = fname.rfind(".")
-                suffix = fname[dot:] if dot != -1 else ""
-                rel_path_str = f"{dir_prefix}{fname}"
-                if not should_skip_rel_file(
-                    rel_path_str,
-                    dir_parts,
-                    suffix,
-                    exclude_paths=exclude_paths,
-                    unignore_paths=unignore_paths,
-                ):
-                    eligible.append((Path(f"{dirpath}/{fname}"), rel_path_str))
+
+        # One shared walk with the C++ module-qn map, so the two cannot drift
+        # in ORDER as well as in membership (issues #1025, #1099).
+        for dirpath, fname, rel_path_str in walk_eligible_files(
+            self.repo_path,
+            self.exclude_paths,
+            self.unignore_paths,
+            on_dir=_record_dir_mtime,
+        ):
+            eligible.append((Path(f"{dirpath}/{fname}"), rel_path_str))
         return eligible
 
     def _process_files(self, force: bool = False) -> None:

--- a/codebase_rag/parsers/cpp_frontend/qn.py
+++ b/codebase_rag/parsers/cpp_frontend/qn.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import constants as cs
-from ...utils.path_utils import walk_eligible_files
+from ...utils.path_utils import base_module_qn, walk_eligible_files
 from ..cpp.utils import convert_operator_symbol_to_name
 from . import constants as fc
 
@@ -31,15 +31,6 @@ def _eligible_rel_files(
     ]
 
 
-def _base_module_qn(rel: str, project_name: str) -> str:
-    rel_path = Path(rel)
-    if rel_path.name in (cs.INIT_PY, cs.MOD_RS):
-        parts = rel_path.parent.parts
-    else:
-        parts = rel_path.with_suffix("").parts
-    return cs.SEPARATOR_DOT.join([project_name, *parts])
-
-
 def build_module_qn_map(
     repo_path: Path,
     project_name: str,
@@ -52,7 +43,7 @@ def build_module_qn_map(
     claimed: dict[str, str] = {}
     result: dict[str, str] = {}
     for rel in _eligible_rel_files(repo_path, exclude_paths, unignore_paths):
-        base = _base_module_qn(rel, project_name)
+        base = base_module_qn(Path(rel), project_name)
         existing = claimed.get(base)
         if existing is None or existing == rel:
             final = base

--- a/codebase_rag/parsers/cpp_frontend/qn.py
+++ b/codebase_rag/parsers/cpp_frontend/qn.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import constants as cs
-from ...utils.path_utils import should_keep_dir, should_skip_rel_file
+from ...utils.path_utils import walk_eligible_files
 from ..cpp.utils import convert_operator_symbol_to_name
 from . import constants as fc
 
@@ -18,44 +17,18 @@ def _eligible_rel_files(
     exclude_paths: frozenset[str] | None = None,
     unignore_paths: frozenset[str] | None = None,
 ) -> list[str]:
-    # Reproduce GraphUpdater._collect_eligible_files' ordering exactly: an
-    # os.walk with dirnames AND filenames sorted, top-down, pruned and filtered
-    # with the same predicates. The module-qn disambiguation below depends on
-    # this order (the file processed LATER in a basename collision gets its
-    # extension appended), so it must match cgr's tree-sitter pass to produce
-    # identical qualified names. Walking a different file set is what makes the
-    # two disagree: an excluded file claiming a base qn pushes the indexed file
-    # onto the suffixed one, and a .cgrignore rescue the map never sees leaves
-    # an indexed file with no qn at all (issue #1099).
-    repo_str = str(repo_path)
-    repo_prefix_len = len(repo_str) + 1
-    state_filenames = cs.CGR_STATE_FILENAMES
-    rels: list[str] = []
-    for dirpath, dirnames, filenames in os.walk(repo_str):
-        rel_dir = "" if len(dirpath) < repo_prefix_len else dirpath[repo_prefix_len:]
-        rel_dir = rel_dir.replace(os.sep, "/")
-        dir_parts = tuple(rel_dir.split("/")) if rel_dir else ()
-        dir_prefix = f"{rel_dir}/" if rel_dir else ""
-        dirnames[:] = sorted(
-            d
-            for d in dirnames
-            if should_keep_dir(d, dir_prefix, exclude_paths, unignore_paths)
+    # Delegates to the one shared walk so this path cannot drift from
+    # GraphUpdater._collect_eligible_files. The module-qn disambiguation below
+    # depends on walk ORDER (the file processed LATER in a basename collision
+    # gets its extension appended), so a divergence in ordering -- not just in
+    # which files are eligible -- silently reassigns qualified names across the
+    # graph (issues #1025, #1099).
+    return [
+        rel
+        for _dirpath, _fname, rel in walk_eligible_files(
+            repo_path, exclude_paths, unignore_paths
         )
-        for fname in sorted(filenames):
-            if fname in state_filenames:
-                continue
-            dot = fname.rfind(".")
-            suffix = fname[dot:] if dot != -1 else ""
-            rel_path_str = f"{dir_prefix}{fname}"
-            if not should_skip_rel_file(
-                rel_path_str,
-                dir_parts,
-                suffix,
-                exclude_paths=exclude_paths,
-                unignore_paths=unignore_paths,
-            ):
-                rels.append(rel_path_str)
-    return rels
+    ]
 
 
 def _base_module_qn(rel: str, project_name: str) -> str:

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -22,7 +22,11 @@ from ..types_defs import (
     RustTraitImpl,
     SimpleNameLookup,
 )
-from ..utils.path_utils import cached_relative_path, cached_resolve_posix
+from ..utils.path_utils import (
+    base_module_qn,
+    cached_relative_path,
+    cached_resolve_posix,
+)
 from .class_ingest import ClassIngestMixin
 from .cpp import CppTypeInferenceEngine
 from .cpp.preproc_recovery import parse_with_preproc_recovery
@@ -354,13 +358,7 @@ class DefinitionProcessor(
                 root_node = tree.root_node
                 pre_combined_captures = None
 
-            module_qn = cs.SEPARATOR_DOT.join(
-                [self.project_name] + list(relative_path.with_suffix("").parts)
-            )
-            if file_path.name in (cs.INIT_PY, cs.MOD_RS):
-                module_qn = cs.SEPARATOR_DOT.join(
-                    [self.project_name] + list(relative_path.parent.parts)
-                )
+            module_qn = base_module_qn(relative_path, self.project_name)
             module_qn = self._disambiguate_module_qn(module_qn, file_path)
             self.module_qn_to_file_path[module_qn] = file_path
             if language == cs.SupportedLanguage.GO and (

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parsers.cpp_frontend.qn import build_module_qn_map
-from codebase_rag.utils.path_utils import walk_eligible_files
+from codebase_rag.utils.path_utils import base_module_qn, walk_eligible_files
 
 PROJECT = "proj"
 
@@ -119,3 +119,27 @@ class TestTheQnMapWalksInIndexerOrder:
         qn_map = build_module_qn_map(tmp_path, PROJECT, unignore_paths=rescues)
 
         assert list(qn_map) == _indexer_order(tmp_path, unignore_paths=rescues)
+
+
+class TestTheBaseModuleQnIsSharedNotMirrored:
+    """``__init__.py``/``mod.rs`` name their package, not themselves.
+
+    Both the indexer and the C++ qn map need that rule, and previously each
+    spelled it out. The whole graph keys on these names, so a disagreement
+    splits one module into two nodes without raising.
+    """
+
+    def test_a_plain_file_keeps_its_stem(self) -> None:
+        assert base_module_qn(Path("src/b.h"), PROJECT) == f"{PROJECT}.src.b"
+
+    def test_a_package_init_names_its_parent(self) -> None:
+        assert base_module_qn(Path("pkg/__init__.py"), PROJECT) == f"{PROJECT}.pkg"
+        assert base_module_qn(Path("x/mod.rs"), PROJECT) == f"{PROJECT}.x"
+
+    def test_only_the_final_suffix_is_stripped(self) -> None:
+        # `.tar.gz` loses only `.gz`; a dotted DIRECTORY keeps its dots.
+        assert base_module_qn(Path("weird.tar.gz"), PROJECT) == f"{PROJECT}.weird.tar"
+        assert (
+            base_module_qn(Path("dir.with.dots/f.py"), PROJECT)
+            == f"{PROJECT}.dir.with.dots.f"
+        )

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -20,11 +20,16 @@ itself so the guarantee does not rest on that coincidence.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parsers.cpp_frontend.qn import build_module_qn_map
-from codebase_rag.utils.path_utils import base_module_qn, walk_eligible_files
+from codebase_rag.utils.path_utils import (
+    _walk_dir_keys,
+    base_module_qn,
+    walk_eligible_files,
+)
 
 PROJECT = "proj"
 
@@ -188,3 +193,56 @@ class TestOneUnignorePatternIsEnoughToRescue:
 
         assert "node_modules/lib/thing.h" not in walked
         assert "src/main.cpp" in walked
+
+
+class TestARepoPathEndingInASeparator:
+    """The filesystem root must not eat the first character of every child.
+
+    `repo_prefix_len = len(repo_str) + 1` assumes the repo path carries no
+    trailing separator, so the slice skips it plus one. At the root `"/"` the
+    separator is already counted and `"/tmp"[2:]` yields `"mp"` -- every child
+    silently loses its first character, corrupting every derived qualified name
+    rather than raising (CodeRabbit, PR #1511). Pre-existing in both copies of
+    the walk before the merge; the merge made it fixable in one place.
+
+    **What this test does and does not cover, stated because two earlier
+    versions of it were worthless and passed.** The root is the ONLY reachable
+    case -- `Path` normalises a trailing separator away, so `Path("/repo/")` is
+    `"/repo"` and only `Path("/")` keeps one. A `tmp_path` fixture therefore
+    never reaches the branch, and the first version of this test used one and
+    survived a mutation restoring the defect.
+
+    Driving `walk_eligible_files` with the root as `repo_path` would `os.walk`
+    the entire filesystem, so the prefix arithmetic itself is not reachable in
+    a test. What IS asserted is the contract the arithmetic must satisfy: given
+    the root's correct prefix length, the helper must return the child's full
+    name. A mutation of the arithmetic in the caller does NOT fail this -- that
+    line is covered by review and by the reasoning here, not by a test.
+    """
+
+    def test_the_helper_keeps_the_full_child_name_at_the_root(self) -> None:
+        root = str(Path(os.sep))
+        # The prefix length the caller must produce for a root repo path: the
+        # separator is already part of `root`, so nothing is added.
+        parts, key, prefix = _walk_dir_keys(f"{root}tmp", len(root))
+
+        assert parts == ("tmp",), (parts, key, prefix)
+        assert key == "tmp"
+        assert prefix == "tmp/"
+
+    def test_the_helper_still_strips_a_non_root_prefix(self) -> None:
+        # The control: with an ordinary repo path the caller adds one for the
+        # separator, and the helper must strip that too.
+        parts, key, prefix = _walk_dir_keys("/repo/tmp", len("/repo") + 1)
+
+        assert parts == ("tmp",), (parts, key, prefix)
+        assert prefix == "tmp/"
+
+    def test_an_ordinary_repo_path_walks_correctly_end_to_end(
+        self, tmp_path: Path
+    ) -> None:
+        _write(tmp_path, "pkg/thing.cpp")
+
+        walked = [rel for _d, _f, rel in walk_eligible_files(tmp_path)]
+
+        assert walked == ["pkg/thing.cpp"], walked

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -1,0 +1,121 @@
+"""The C++ qn map and the indexer must walk in the SAME ORDER, not merely see
+the same files (issue #1178, criterion 4; the coupling of #1025).
+
+``qn.py`` documents its walk as reproducing ``_collect_eligible_files``'
+ordering *exactly*, because the module-qn disambiguation rule gives the base
+qn to whichever file is seen FIRST and appends an extension to the loser. The
+pre-existing parity tests in ``test_cpp_qn_map_exclude_unignore.py`` compare
+``set(qn_map)`` against the indexer's keys, which is a strictly weaker claim:
+a walk that yields the same files in a different order satisfies every one of
+them. Reversing ``dirnames`` in ``qn.py`` leaves that whole suite green.
+
+That divergence is latent rather than active today -- a basename collision
+needs an identical rel-path-minus-suffix, hence the same directory, and
+within a directory the filename order is pinned by a hardcoded expectation.
+It stops being latent the moment the disambiguation rule widens (any rule
+keyed on something coarser than the full relative path) or a caller starts
+depending on map insertion order. These tests pin the documented invariant
+itself so the guarantee does not rest on that coincidence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parsers.cpp_frontend.qn import build_module_qn_map
+from codebase_rag.utils.path_utils import walk_eligible_files
+
+PROJECT = "proj"
+
+
+def _write(repo: Path, rel: str, body: str = "int x;\n") -> None:
+    target = repo / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+
+
+def _indexer_order(
+    repo: Path,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> list[str]:
+    """The exact ORDER the tree-sitter pass would process files in."""
+    updater = GraphUpdater.__new__(GraphUpdater)
+    updater.repo_path = repo
+    updater.exclude_paths = exclude_paths
+    updater.unignore_paths = unignore_paths
+    updater._single_file = None
+    return [key for _path, key in updater._collect_eligible_files()]
+
+
+class TestTheSharedWalkOrderIsPinnedAbsolutely:
+    """Parity alone stops being a guard once both callers share one walk.
+
+    With a single definition, a change to the ordering moves BOTH consumers
+    together, so they keep agreeing and every parity assertion above stays
+    green. These tests pin the order against a literal expectation instead, so
+    the property the qns actually depend on -- depth-first, directories and
+    filenames each in ascending order -- is asserted rather than inferred.
+    """
+
+    def test_walk_is_top_down_and_sorted(self, tmp_path: Path) -> None:
+        _write(tmp_path, "top.cpp")
+        _write(tmp_path, "beta/b.cpp")
+        _write(tmp_path, "alpha/a.cpp")
+        _write(tmp_path, "alpha/sub/c.cpp")
+
+        walked = [rel for _dirpath, _fname, rel in walk_eligible_files(tmp_path)]
+
+        # Root files first (top-down), then directories in ascending order,
+        # each descended before its sibling (depth-first).
+        assert walked == [
+            "top.cpp",
+            "alpha/a.cpp",
+            "alpha/sub/c.cpp",
+            "beta/b.cpp",
+        ]
+
+    def test_filenames_within_a_directory_are_ascending(self, tmp_path: Path) -> None:
+        # The collision rule gives the base qn to the file seen first, so this
+        # ordering is what makes foo.cpp win over foo.h.
+        for name in ("foo.h", "foo.cpp", "bar.cpp"):
+            _write(tmp_path, f"pkg/{name}")
+
+        walked = [rel for _dirpath, _fname, rel in walk_eligible_files(tmp_path)]
+
+        assert walked == ["pkg/bar.cpp", "pkg/foo.cpp", "pkg/foo.h"]
+
+
+class TestTheQnMapWalksInIndexerOrder:
+    def test_nested_directories_are_visited_in_the_same_order(
+        self, tmp_path: Path
+    ) -> None:
+        # Files chosen so that the SET is order-insensitive but the ORDER is
+        # not: a reversed dirnames sort keeps every key and still fails here.
+        _write(tmp_path, "top.cpp")
+        _write(tmp_path, "alpha/a.cpp")
+        _write(tmp_path, "alpha/sub/c.cpp")
+        _write(tmp_path, "beta/b.cpp")
+
+        assert list(build_module_qn_map(tmp_path, PROJECT)) == _indexer_order(tmp_path)
+
+    def test_order_matches_under_exclude(self, tmp_path: Path) -> None:
+        _write(tmp_path, "alpha/a.cpp")
+        _write(tmp_path, "beta/b.cpp")
+        _write(tmp_path, "vendor/drop.cpp")
+        excludes = frozenset({"vendor"})
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT, exclude_paths=excludes)
+
+        assert list(qn_map) == _indexer_order(tmp_path, exclude_paths=excludes)
+
+    def test_order_matches_under_unignore(self, tmp_path: Path) -> None:
+        _write(tmp_path, "alpha/main.cpp")
+        _write(tmp_path, "node_modules/lib/thing.h")
+        _write(tmp_path, "zeta/last.cpp")
+        rescues = frozenset({"node_modules"})
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT, unignore_paths=rescues)
+
+        assert list(qn_map) == _indexer_order(tmp_path, unignore_paths=rescues)

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -143,3 +143,48 @@ class TestTheBaseModuleQnIsSharedNotMirrored:
             base_module_qn(Path("dir.with.dots/f.py"), PROJECT)
             == f"{PROJECT}.dir.with.dots.f"
         )
+
+
+class TestOneUnignorePatternIsEnoughToRescue:
+    """A rescue asks whether SOME pattern matches, not whether every one does.
+
+    Found by mutating every quantifier the shared walk routes through rather
+    than only the one under suspicion: flipping `any` to `all` in
+    `should_keep_dir` passed the entire 8502-test suite. The reason is that
+    every existing fixture passes a single unignore pattern, and with one
+    pattern the two readings are indistinguishable -- both reduce to that
+    pattern's own result.
+
+    The distinguishing case needs TWO patterns of which only one is relevant.
+    Under `all`, an unrelated pattern elsewhere in the set defeats an
+    otherwise-valid rescue, so adding a second `.cgrignore` entry would
+    silently un-index a directory the first entry rescued.
+    """
+
+    def test_an_unrelated_second_pattern_does_not_defeat_the_rescue(
+        self, tmp_path: Path
+    ) -> None:
+        _write(tmp_path, "src/main.cpp")
+        _write(tmp_path, "node_modules/lib/thing.h")
+        # Only the first pattern concerns node_modules; the second is about a
+        # directory that does not even exist here.
+        rescues = frozenset({"node_modules", "vendor/keep"})
+
+        walked = [rel for _d, _f, rel in walk_eligible_files(tmp_path, None, rescues)]
+
+        assert "node_modules/lib/thing.h" in walked
+
+    def test_the_rescue_still_needs_a_pattern_that_matches(
+        self, tmp_path: Path
+    ) -> None:
+        # Same fixture minus the one property under test: with only the
+        # irrelevant pattern, node_modules stays pruned. Without this, the
+        # test above would pass on a function that rescued unconditionally.
+        _write(tmp_path, "src/main.cpp")
+        _write(tmp_path, "node_modules/lib/thing.h")
+        rescues = frozenset({"vendor/keep"})
+
+        walked = [rel for _d, _f, rel in walk_eligible_files(tmp_path, None, rescues)]
+
+        assert "node_modules/lib/thing.h" not in walked
+        assert "src/main.cpp" in walked

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -213,6 +213,27 @@ def base_module_qn(rel_path: Path, project_name: str) -> str:
     return cs.SEPARATOR_DOT.join([project_name, *parts])
 
 
+def _walk_dir_keys(
+    dirpath: str, repo_prefix_len: int
+) -> tuple[str, tuple[str, ...], str, str]:
+    """Derive a walked directory's ``(rel_dir, parts, key, prefix)``.
+
+    Split out of ``walk_eligible_files`` so the walk body reads as filtering
+    alone. The repository root is the special case: it has no relative path,
+    and its cache key is ``ROOT_DIR_KEY`` rather than the empty string.
+    """
+    if len(dirpath) < repo_prefix_len:
+        return "", (), cs.ROOT_DIR_KEY, ""
+    rel_dir = dirpath[repo_prefix_len:].replace(os.sep, "/")
+    dir_parts = tuple(rel_dir.split("/")) if rel_dir else ()
+    return (
+        rel_dir,
+        dir_parts,
+        rel_dir or cs.ROOT_DIR_KEY,
+        f"{rel_dir}/" if rel_dir else "",
+    )
+
+
 def walk_eligible_files(
     repo_path: Path,
     exclude_paths: frozenset[str] | None = None,
@@ -239,15 +260,9 @@ def walk_eligible_files(
     repo_prefix_len = len(repo_str) + 1
     state_filenames = cs.CGR_STATE_FILENAMES
     for dirpath, dirnames, filenames in os.walk(repo_str):
-        if len(dirpath) < repo_prefix_len:
-            rel_dir = ""
-            dir_parts: tuple[str, ...] = ()
-            dir_key = cs.ROOT_DIR_KEY
-        else:
-            rel_dir = dirpath[repo_prefix_len:].replace(os.sep, "/")
-            dir_parts = tuple(rel_dir.split("/")) if rel_dir else ()
-            dir_key = rel_dir or cs.ROOT_DIR_KEY
-        dir_prefix = f"{rel_dir}/" if rel_dir else ""
+        rel_dir, dir_parts, dir_key, dir_prefix = _walk_dir_keys(
+            dirpath, repo_prefix_len
+        )
         if on_dir is not None:
             on_dir(dir_key, dirpath)
         dirnames[:] = sorted(

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -195,6 +195,24 @@ def should_skip_rel_file(
     return has_ignored_dir_part(dir_parts)
 
 
+def base_module_qn(rel_path: Path, project_name: str) -> str:
+    """The module qualified name for a file, BEFORE collision disambiguation.
+
+    Shared by the tree-sitter indexer (``DefinitionProcessor.process_file``)
+    and the C++ module-qn map (``cpp_frontend.qn``), which must agree
+    byte-for-byte: the whole graph keys on these names, and a disagreement
+    silently splits one module into two nodes rather than raising (#1025).
+
+    ``__init__.py`` and ``mod.rs`` name their PACKAGE rather than themselves,
+    so they drop their own filename segment.
+    """
+    if rel_path.name in (cs.INIT_PY, cs.MOD_RS):
+        parts = rel_path.parent.parts
+    else:
+        parts = rel_path.with_suffix("").parts
+    return cs.SEPARATOR_DOT.join([project_name, *parts])
+
+
 def walk_eligible_files(
     repo_path: Path,
     exclude_paths: frozenset[str] | None = None,

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -1,6 +1,7 @@
 import hashlib
+import os
 import re
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from functools import lru_cache
 from pathlib import Path
 
@@ -192,6 +193,64 @@ def should_skip_rel_file(
     if unignore_paths and matches_ignore_patterns(rel_path_str, unignore_paths):
         return False
     return has_ignored_dir_part(dir_parts)
+
+
+def walk_eligible_files(
+    repo_path: Path,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+    on_dir: Callable[[str, str], None] | None = None,
+) -> Iterator[tuple[str, str, str]]:
+    """Yield ``(dirpath, filename, rel_path)`` for every indexable file, in order.
+
+    The single definition of the repository walk. Both the tree-sitter indexer
+    (``GraphUpdater._collect_eligible_files``) and the C++ module-qn map
+    (``cpp_frontend.qn.build_module_qn_map``) consume it, because the module-qn
+    disambiguation rule hands the base qn to whichever file is seen FIRST and
+    appends an extension to the loser -- so the two must agree on ORDER, not
+    merely on which files are eligible (issues #1025, #1099).
+
+    They previously kept separate copies of this loop that shared only the
+    filter predicates. Nothing forced the two orderings to stay equal, and a
+    set-based parity test cannot see the difference.
+
+    ``on_dir`` receives ``(dir_key, dirpath)`` per visited directory, for the
+    indexer's mtime bookkeeping; it must not mutate the walk.
+    """
+    repo_str = str(repo_path)
+    repo_prefix_len = len(repo_str) + 1
+    state_filenames = cs.CGR_STATE_FILENAMES
+    for dirpath, dirnames, filenames in os.walk(repo_str):
+        if len(dirpath) < repo_prefix_len:
+            rel_dir = ""
+            dir_parts: tuple[str, ...] = ()
+            dir_key = cs.ROOT_DIR_KEY
+        else:
+            rel_dir = dirpath[repo_prefix_len:].replace(os.sep, "/")
+            dir_parts = tuple(rel_dir.split("/")) if rel_dir else ()
+            dir_key = rel_dir or cs.ROOT_DIR_KEY
+        dir_prefix = f"{rel_dir}/" if rel_dir else ""
+        if on_dir is not None:
+            on_dir(dir_key, dirpath)
+        dirnames[:] = sorted(
+            d
+            for d in dirnames
+            if should_keep_dir(d, dir_prefix, exclude_paths, unignore_paths)
+        )
+        for fname in sorted(filenames):
+            if fname in state_filenames:
+                continue
+            dot = fname.rfind(".")
+            suffix = fname[dot:] if dot != -1 else ""
+            rel_path_str = f"{dir_prefix}{fname}"
+            if not should_skip_rel_file(
+                rel_path_str,
+                dir_parts,
+                suffix,
+                exclude_paths=exclude_paths,
+                unignore_paths=unignore_paths,
+            ):
+                yield dirpath, fname, rel_path_str
 
 
 def project_roots_from_rows(

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -260,7 +260,10 @@ def walk_eligible_files(
     indexer's mtime bookkeeping; it must not mutate the walk.
     """
     repo_str = str(repo_path)
-    repo_prefix_len = len(repo_str) + 1
+    # A repo path that already ends in a separator (the filesystem root, "/")
+    # must not have another counted, or the slice below eats the first
+    # character of every child -- "/tmp" became "mp" (CodeRabbit, PR #1511).
+    repo_prefix_len = len(repo_str) + (0 if repo_str.endswith(os.sep) else 1)
     state_filenames = cs.CGR_STATE_FILENAMES
     for dirpath, dirnames, filenames in os.walk(repo_str):
         dir_parts, dir_key, dir_prefix = _walk_dir_keys(dirpath, repo_prefix_len)

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -215,19 +215,22 @@ def base_module_qn(rel_path: Path, project_name: str) -> str:
 
 def _walk_dir_keys(
     dirpath: str, repo_prefix_len: int
-) -> tuple[str, tuple[str, ...], str, str]:
-    """Derive a walked directory's ``(rel_dir, parts, key, prefix)``.
+) -> tuple[tuple[str, ...], str, str]:
+    """Derive a walked directory's ``(parts, cache_key, prefix)``.
 
     Split out of ``walk_eligible_files`` so the walk body reads as filtering
     alone. The repository root is the special case: it has no relative path,
     and its cache key is ``ROOT_DIR_KEY`` rather than the empty string.
+
+    The relative directory itself is deliberately not returned: every caller
+    needs it only as the ``dir_prefix`` built here, and handing back both
+    invites the two to be derived independently.
     """
     if len(dirpath) < repo_prefix_len:
-        return "", (), cs.ROOT_DIR_KEY, ""
+        return (), cs.ROOT_DIR_KEY, ""
     rel_dir = dirpath[repo_prefix_len:].replace(os.sep, "/")
     dir_parts = tuple(rel_dir.split("/")) if rel_dir else ()
     return (
-        rel_dir,
         dir_parts,
         rel_dir or cs.ROOT_DIR_KEY,
         f"{rel_dir}/" if rel_dir else "",
@@ -260,9 +263,7 @@ def walk_eligible_files(
     repo_prefix_len = len(repo_str) + 1
     state_filenames = cs.CGR_STATE_FILENAMES
     for dirpath, dirnames, filenames in os.walk(repo_str):
-        rel_dir, dir_parts, dir_key, dir_prefix = _walk_dir_keys(
-            dirpath, repo_prefix_len
-        )
+        dir_parts, dir_key, dir_prefix = _walk_dir_keys(dirpath, repo_prefix_len)
         if on_dir is not None:
             on_dir(dir_key, dirpath)
         dirnames[:] = sorted(


### PR DESCRIPTION
Closes the last open acceptance criterion of #1178 for the `_eligible_rel_files` half of `qn.py`, and removes the duplication behind the #1025 coupling.

## The problem

`cpp_frontend/qn.py` carried its own copy of `GraphUpdater._collect_eligible_files`' walk. Its comment states the requirement plainly: *"Reproduce `GraphUpdater._collect_eligible_files`' ordering exactly"* — because the module-qn disambiguation rule hands the base qn to whichever file is seen **first** and appends an extension to the loser (`foo.cpp` -> `proj.foo`, `foo.h` -> `proj.foo.h`). A divergence in walk **order**, not just in which files are eligible, silently reassigns qualified names across the graph. Nothing raises. That is what #1099 was, twice.

The two copies shared their filter predicates (the #1088 fix) but not the loop, so nothing forced the orderings to stay equal.

## Why the existing tests did not cover it

`test_cpp_qn_map_exclude_unignore.py::TestParityWithTheIndexerWalk` compares `set(qn_map)` against the indexer's keys. A set comparison cannot see order, so a walk yielding the same files in a different order satisfies every one of those assertions.

Measured, not assumed. Reversing the `dirnames` sort in `qn.py` on `main`:

| mutation | existing suite | order guard added here |
|---|---|---|
| `dirnames` reversed | 9 passed | 3 failed |
| `os.walk(topdown=False)` | 9 passed | 3 failed |

Under the first mutation the two walks genuinely disagree (`ORDERS AGREE: False`, `SETS AGREE: True`).

To be precise about severity: that divergence is **latent today, not an active defect**. A basename collision needs an identical relative path minus suffix, hence the same directory, and within a directory the filename order is pinned by a hardcoded expectation in the existing suite. It stops being latent if the disambiguation rule ever widens, or if a caller starts depending on map insertion order.

## The change

One `walk_eligible_files` generator in `utils/path_utils.py`, next to the predicates it already shares. Both `_collect_eligible_files` and `build_module_qn_map` consume it, so they cannot drift by construction. The indexer's `_collected_dir_mtimes` bookkeeping is preserved through an `on_dir` hook. Net 72 lines of duplicated walk removed.

## Tests

`test_qn_walk_order_parity.py`, five tests in two classes:

- **`TestTheQnMapWalksInIndexerOrder`** — the qn map's key order equals the indexer's file order, under no filters, `--exclude`, and `.cgrignore` rescue.
- **`TestTheSharedWalkOrderIsPinnedAbsolutely`** — pins the order against a literal expectation.

The second class exists because of something the mutation testing showed: once both callers share one walk, **parity alone stops being a guard**. Mutating the shared definition moves both consumers together, so they keep agreeing and every parity assertion stays green. Verified: the `dirnames`-reversed mutation applied to the shared walk leaves all three parity tests passing. The absolute-order tests catch all three mutations (`dirnames` reversed, `filenames` reversed, `topdown=False`), each failing on the assertion that owns that property.

## Verification

- `8499 passed, 49 skipped` (full unit suite)
- 514 passed across the walk/ignore/exclude/incremental subset
- `ruff check` clean; `ty check` shows the same 2 pre-existing warnings as `main` (both at `graph_updater.py:2808`, unrelated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency between repository indexing and C++ module mapping.
  * Preserved deterministic, top-down file traversal order across supported operations.
  * Ensured exclusions, unignored paths, and skipped files are handled consistently.
  * Standardized module naming for regular files and package entry points.

* **Tests**
  * Added coverage verifying traversal order and parity under exclusion and unignore configurations.
  * Added checks for consistent module naming across supported file types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->