### PR TITLE
test: assert the protobuf parity guard has subjects so it cannot pass vacuously

### DIFF
--- a/codebase_rag/tests/test_protobuf_node_property_parity.py
+++ b/codebase_rag/tests/test_protobuf_node_property_parity.py
@@ -312,3 +312,42 @@ def test_the_unexported_list_names_only_declared_properties() -> None:
         f"{len(unknown)} entr(ies) in _NOT_EXPORTED do not name a declared "
         "property:\n" + "\n".join(unknown)
     )
+
+
+def test_the_guard_is_actually_inspecting_something() -> None:
+    """A control on the INSTRUMENT rather than on the schemas.
+
+    The default-deny check above iterates `NODE_SCHEMAS` and asserts the
+    result is empty. If that collection were ever empty -- renamed, moved,
+    or built lazily -- it would iterate nothing, find nothing, and PASS. A
+    green default-deny guard that inspected zero properties is
+    indistinguishable from one that inspected all of them and approved.
+
+    Measured rather than assumed: emptying `NODE_SCHEMAS` leaves
+    `test_every_declared_property_is_exported_or_declared_unexported`
+    passing. One sibling test does catch it, but the main guard -- the one
+    this file exists for -- does not, so its green tick becomes a claim
+    about whether the check ran rather than about the proto being in sync.
+
+    The opposite emptiness needs no control: a generated module carrying no
+    messages makes every label report "no proto message at all" and fails
+    loudly, which is the safe direction.
+    """
+    assert NODE_SCHEMAS, (
+        "NODE_SCHEMAS is empty; the default-deny guard passes vacuously"
+    )
+
+    labels = {schema.label.value for schema in NODE_SCHEMAS}
+    assert {"Function", "Method"} <= labels, sorted(labels)
+
+    unparsed = sorted(
+        schema.label.value
+        for schema in NODE_SCHEMAS
+        if not _declared_properties(schema.properties)
+    )
+    assert not unparsed, (
+        "these labels parsed to ZERO properties, so nothing about them was "
+        "checked:\n" + "\n".join(unparsed)
+    )
+
+    assert _proto_fields("Function"), "the generated proto module carries no fields"


### PR DESCRIPTION
`test_protobuf_node_property_parity.py` is a **default-deny** guard: every declared node property must have a proto field or an explicit exemption, so forgetting one fails. Every check in it iterates `NODE_SCHEMAS` and asserts the result is empty.

If `NODE_SCHEMAS` were ever empty -- renamed, moved, or built lazily -- those checks would iterate nothing, find nothing, and **pass**. A green default-deny guard that inspected zero properties is indistinguishable from one that inspected all of them and approved.

## Measured, not hypothesised

Emptying the collection and running the file:

```
FAILED test_the_unexported_list_names_only_declared_properties
FAILED test_the_guard_is_actually_inspecting_something          <- this PR
4 passed
```

`test_every_declared_property_is_exported_or_declared_unexported` -- **the check this file exists for** -- is among the four that pass. One sibling test does happen to catch the empty case, but the main guard does not, so its green tick is a claim about whether the check ran rather than about the proto being in sync.

## What the test asserts

That the guard had subjects: `NODE_SCHEMAS` is non-empty, it still carries `Function` and `Method`, every label parses to at least one property, and the generated proto module carries fields.

The opposite emptiness deliberately gets no control. A generated module with no messages makes `_unexported_properties` report every label as "no proto message at all" and fails loudly -- the safe direction. Only the empty **subject list** fails silently, so that is the one worth a guard.

## Verification

Mutation-tested against a committed baseline, restore verified clean by `git status`. The mutant kills exactly the new test plus the one sibling that already caught it; the four remaining tests pass, which is the fact this PR is about.

## Why this shape of bug is worth a test rather than a comment

It is the same failure the file's own header describes -- an inventory that cannot fail for the item nobody listed -- applied one level up, to the inventory's own subject list. A peer session hit the identical shape today writing a duplicate-constant guard: without a control, a moved file yields an empty counter, and an empty counter reads as "no duplicates found".

Absence of findings and absence of measurement are different facts that produce the same green tick.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure schema parity checks inspect populated schemas.
  * Added coverage confirming required node labels and declared properties are present.
  * Added safeguards against parity tests passing vacuously when schema data is missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->