### PR TITLE
test: pin that a C++ template specialization is unreachable from calls

### DIFF
--- a/codebase_rag/tests/test_cpp_template_specialization_qn.py
+++ b/codebase_rag/tests/test_cpp_template_specialization_qn.py
@@ -1,0 +1,89 @@
+"""An explicit C++ template specialization is unreachable from calls (#1188).
+
+Measured on `main` rather than argued. Given a primary template and an explicit
+specialization, the graph contains BOTH classes and both methods, and the
+specialization gets its own `INHERITS` edge -- but every call resolves to the
+primary:
+
+    CLASSES : Proc, Proc<int>
+    INHERITS: Proc -> Base, Proc<int> -> Base
+    CALLS   : use -> Proc.f            <- on a `Proc<int>` receiver
+
+So `Proc<int>.f` is reachable structurally and never by a call. The cause is on
+the CALL side, not in the node name: `CppTypeInference` maps a receiver to its
+"bare C++ type name", stripping template arguments, because `_resolve_class_name`
+takes bare names -- a contract documented in three places with 15 call sites
+through it. `Proc<int>` and `Proc` therefore reduce to the same key.
+
+A note for anyone tempted by the node name, since I tried it and was wrong.
+`extract_cpp_class_name` returns `Proc<int>` verbatim because tree-sitter names
+a specialization with a `template_type` node rather than a `type_identifier`,
+and `_scope_segment_name` states that template arguments are text "no registry
+class QN holds". Unwrapping it does NOT fix the orphan: the specialization then
+collides with the primary's bare name and is disambiguated to `Proc@3`, which is
+the same orphan with a less informative name, and it breaks
+`test_cpp_inheritance_edge_cases`, which asserts the bracketed form. The
+bracketed qn is at least self-describing.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+_SOURCE = (
+    "template<typename T>\n"
+    "struct Box { void put(T v) {} };\n"
+    "template<>\n"
+    "struct Box<char> { void put(char v) {} };\n"
+    "void use() {\n"
+    "    Box<double> bd; bd.put(1.0);\n"
+    "    Box<char>   bc; bc.put('x');\n"
+    "}\n"
+)
+
+
+def _write(project: Path) -> None:
+    (project / "box.cpp").write_text(_SOURCE, encoding="utf-8")
+
+
+def _put_targets(mock_ingestor: MagicMock) -> set[str]:
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    return {target for _caller, target in calls if target.endswith(".put")}
+
+
+def test_a_call_on_a_specialized_receiver_is_attributed_to_the_primary(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """Pins TODAY's behaviour so the limitation is visible rather than folklore.
+
+    Deliberately asserts what the graph does, not what it should do. The
+    companion xfail below asserts the intended behaviour, so the pair fails
+    from one side or the other the moment dispatch changes.
+    """
+    _write(temp_repo)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
+
+    assert _put_targets(mock_ingestor) == {f"{temp_repo.name}.box.Box.put"}
+
+
+@pytest.mark.xfail(
+    reason="specialization dispatch needs the receiver type to keep its "
+    "template arguments; the C++ type map is bare-name by contract and 15 "
+    "call sites resolve through _resolve_class_name (issue #1188)",
+    strict=True,
+)
+def test_a_call_on_a_specialized_receiver_should_reach_the_specialization(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Two receivers of DIFFERENT types each call `put`; one definition cannot
+    # be the right answer for both. strict=True so this fails loudly the day
+    # dispatch works, rather than rotting into a silent pass.
+    _write(temp_repo)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
+
+    assert len(_put_targets(mock_ingestor)) == 2

--- a/codebase_rag/tests/test_cpp_template_specialization_qn.py
+++ b/codebase_rag/tests/test_cpp_template_specialization_qn.py
@@ -49,11 +49,22 @@ def _write(project: Path) -> None:
     (project / "box.cpp").write_text(_SOURCE, encoding="utf-8")
 
 
+def _put_calls(mock_ingestor: MagicMock) -> list[tuple[str, str]]:
+    """Every CALLS edge whose target is a `put`, as a LIST.
+
+    A list rather than a set: the two receivers call the same target under
+    today's behaviour, so a set collapses them to one element and cannot tell
+    "both calls resolved to the primary" from "only one call exists".
+    """
+    return [
+        (c.args[0][2], c.args[2][2])
+        for c in get_relationships(mock_ingestor, "CALLS")
+        if c.args[2][2].endswith(".put")
+    ]
+
+
 def _put_targets(mock_ingestor: MagicMock) -> set[str]:
-    calls = {
-        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
-    }
-    return {target for _caller, target in calls if target.endswith(".put")}
+    return {target for _caller, target in _put_calls(mock_ingestor)}
 
 
 def test_a_call_on_a_specialized_receiver_is_attributed_to_the_primary(
@@ -68,7 +79,16 @@ def test_a_call_on_a_specialized_receiver_is_attributed_to_the_primary(
     _write(temp_repo)
     run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
 
-    assert _put_targets(mock_ingestor) == {f"{temp_repo.name}.box.Box.put"}
+    calls = _put_calls(mock_ingestor)
+
+    # BOTH receivers must have produced a call edge. Asserting only on the set
+    # of TARGETS is satisfied by a fixture with no `Box<char>` receiver at all,
+    # so deleting that line would leave this test green while it stopped
+    # characterising anything (Greptile, PR #1514).
+    assert len(calls) == 2, calls
+    assert {target for _caller, target in calls} == {f"{temp_repo.name}.box.Box.put"}, (
+        calls
+    )
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Characterisation only — **no production change**. Pins a C++ limitation found while investigating #1188, plus the reason a tempting fix is wrong.

## The finding

Given a primary template and an explicit specialization, the graph contains both classes and both methods, and the specialization gets its own `INHERITS` edge — but every call resolves to the primary:

```
CLASSES : Proc, Proc<int>
INHERITS: Proc -> Base, Proc<int> -> Base
CALLS   : use -> Proc.f            <- on a Proc<int> receiver
```

So `Proc<int>.f` is reachable structurally and never by a call, and a call on a specialized receiver is silently attributed to the primary template's method.

The cause is on the **call** side. `CppTypeInference` maps a receiver to its "bare C++ type name", stripping template arguments, because `_resolve_class_name` takes bare names — a contract documented in three places with 15 call sites through it. `Proc<int>` and `Proc` reduce to the same key.

## Why I am not fixing it here, and why the obvious fix is wrong

`extract_cpp_class_name` returns `Proc<int>` verbatim: tree-sitter names a specialization with a `template_type` node rather than a `type_identifier`, so the extractor's scan misses it and the `name`-field fallback returns the raw text. Meanwhile `_scope_segment_name` states the invariant that template arguments are text "no registry class QN holds".

That looks like the bug. I implemented the unwrap, and **three tests I had written first went red then green** — and it was still wrong:

```
before: CLASSES: Box, Box<char>     CALLS: use -> Box.put
after : CLASSES: Box, Box@3         CALLS: use -> Box.put     <- unchanged
```

The specialization then collides with the primary's bare name and takes the `@line` disambiguation suffix. Same orphan, less informative name. It also breaks `test_cpp_inheritance_edge_cases`, which asserts the bracketed form on an `INHERITS` source. Reverted.

My assertions were "no angle brackets in a class qn" and "none in a method qn" — both true of the broken graph *and* of the working one. Red/green proves a test is coupled to your change; it does not prove the test measures the defect, and when test and fix come from one mental model in one sitting they inherit its misconception together. Probing the actual graph after green is what caught it.

## What this PR adds

Two tests, pinning the limitation from both sides so it cannot drift silently:

- `test_a_call_on_a_specialized_receiver_is_attributed_to_the_primary` — asserts **today's** behaviour, so the limitation is visible rather than folklore.
- `test_a_call_on_a_specialized_receiver_should_reach_the_specialization` — `xfail(strict=True)`, asserts the **intended** behaviour. Strict so it fails loudly the day dispatch starts working instead of rotting into a silent pass.

The module docstring records the failed approach and its measurements, so the next person does not re-derive it or re-attempt the unwrap.

## Also on #1188

Three of that issue's four bullets do not describe current `main`: overload selection and external-callee suppression are already implemented via `cursor.referenced`, and the template bullet prescribes `cursor.specialized_template`, which does not exist on this libclang's `Cursor` at all (verified by `dir()`). Details are on the issue; it needs a scope decision rather than an implementation.

## Verification

Full unit suite green with this branch (the one `test_cli_smoke::test_version_flag` failure is a `subprocess.TimeoutExpired` under `-n auto` that passes in isolation and touches nothing here). `ruff` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for C++ template specialization dispatch.
  - Verified current call attribution for primary and specialized template receivers.
  - Added an expected-failure test documenting the intended resolution of calls to specialized implementations.
  - Improved regression coverage for distinguishing primary-template and specialization targets.
  - Added checks confirming that calls from both receiver types are detected and attributed consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->