### PR TITLE
docs: state and pin the imports eval's internal-dep granularity

### DIFF
--- a/codebase_rag/tests/test_import_resolution_eval.py
+++ b/codebase_rag/tests/test_import_resolution_eval.py
@@ -1,3 +1,4 @@
+import ast
 from pathlib import Path
 
 from evals import constants as ec
@@ -55,12 +56,28 @@ def test_every_internal_import_from_one_file_collapses_to_one_dep(
     file. Pinned rather than left emergent because the reduction reads as
     informative from the external side, where top-level names distinguish
     `numpy` from `os`, and a reader can carry that over.
+
+    The fixture precondition is asserted, not assumed. Checking only that
+    one internal dep comes out would pass just as well on a fixture with a
+    single first-party import, which exercises no collapse at all: the
+    claim is about MANY reducing to one, so the many has to be established.
+    It is counted from the source rather than from `deps`, so the assertion
+    does not depend on the reduction it is measuring.
     """
     src = tmp_path / "proj"
     _make_repo(src)
-    deps = oracle_import_deps(src, "proj")
+    module = ast.parse((src / "m.py").read_text(encoding="utf-8"))
+    first_party = {
+        node.module or ""
+        for node in ast.walk(module)
+        if isinstance(node, ast.ImportFrom)
+        and (node.level > 0 or (node.module or "").startswith("proj"))
+    }
 
+    deps = oracle_import_deps(src, "proj")
     internal = {d for d in deps if not d[2]}
+
+    assert len(first_party) > 1, first_party
     assert internal == {("m.py", "proj", False)}
     assert len({d for d in deps if d[2]}) == 3
 

--- a/codebase_rag/tests/test_import_resolution_eval.py
+++ b/codebase_rag/tests/test_import_resolution_eval.py
@@ -38,6 +38,33 @@ def test_oracle_classifies_internal_and_external(tmp_path: Path) -> None:
     assert ("m.py", "proj", True) not in deps
 
 
+def test_every_internal_import_from_one_file_collapses_to_one_dep(
+    tmp_path: Path,
+) -> None:
+    """The granularity this eval grades internal imports at, pinned.
+
+    An internal import's top-level package IS the project name, by the same
+    expression that decides externality (`top != project`). So every
+    first-party import from one file reduces to a single dep and the
+    `imports/internal` row measures which files import something internal,
+    not which module they import. `m.py` imports two distinct first-party
+    modules and contributes one internal dep.
+
+    Deliberate: the eval isolates internal/external misclassification
+    (issue #498), and the structural L1 grades internal targets by resolved
+    file. Pinned rather than left emergent because the reduction reads as
+    informative from the external side, where top-level names distinguish
+    `numpy` from `os`, and a reader can carry that over.
+    """
+    src = tmp_path / "proj"
+    _make_repo(src)
+    deps = oracle_import_deps(src, "proj")
+
+    internal = {d for d in deps if not d[2]}
+    assert internal == {("m.py", "proj", False)}
+    assert len({d for d in deps if d[2]}) == 3
+
+
 def test_oracle_excludes_future_pseudo_import(tmp_path: Path) -> None:
     # `from __future__ import ...` is a compiler directive, not a dependency;
     # cgr rightly ignores it, so the oracle must too or it reports false misses.

--- a/evals/README.md
+++ b/evals/README.md
@@ -279,12 +279,17 @@ the misclassification signal this eval exists to isolate. It is stated because a
 `1.0` on that row is narrower than the label suggests, and pinned by
 `test_every_internal_import_from_one_file_collapses_to_one_dep`.
 
-The reduction is also **Python-shaped**, which matters before this eval is
-generalised (issue #1190). Python's flat package namespace is what makes a
-top-level name identify a third-party package; Java's does not, where
-`com.fasterxml.jackson` and `com.google.common` both reduce to `com`. Extending
-this eval to another language therefore needs a different external-side unit.
-The external row, not the internal one, is what breaks first.
+The external key is the **first import-path component**, which matters before this
+eval is generalised (issue #1190). That component usually coincides with the
+distribution in this repository's dependencies, which is what makes the external
+row informative here. It is not guaranteed to: under a shared namespace package
+`import google.protobuf` and `import google.cloud.storage` both reduce to
+`google`, so two distributions become one dep, and `azure.*` behaves the same
+way. Java package paths break the same way as a rule rather than as an
+exception, with `com.fasterxml.jackson` and `com.google.common` both reducing to
+`com`. The difference is degree, not kind, so extending this eval to another
+language needs a different external-side unit. The external row, not the
+internal one, is what breaks first.
 
 ## Inheritance — resolved INHERITS and OVERRIDES
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -266,6 +266,26 @@ the tests pin). Writes `evals/results/imports_scores.csv` and
 `evals/results/imports_diff.json`; the oracle and the misclassification signal
 are pinned by `codebase_rag/tests/test_import_resolution_eval.py`.
 
+**What the two rows measure, at different granularities.** The reduction reads as
+informative from the external side, where top-level names separate `numpy` from
+`os`, and it does not carry over: an internal import's top level *is* the project
+package, by the same expression that decides externality. So every first-party
+import from one file collapses to a single dep, and `imports/internal` measures
+which files import something internal rather than which module they import. A
+graph resolving `proj.alpha` to the wrong first-party module scores identically.
+That is deliberate, since resolved internal targets are graded by file in the
+structural L1 above and keying them here would fold resolution accuracy back into
+the misclassification signal this eval exists to isolate. It is stated because a
+`1.0` on that row is narrower than the label suggests, and pinned by
+`test_every_internal_import_from_one_file_collapses_to_one_dep`.
+
+The reduction is also **Python-shaped**, which matters before this eval is
+generalised (issue #1190). Python's flat package namespace is what makes a
+top-level name identify a third-party package; Java's does not, where
+`com.fasterxml.jackson` and `com.google.common` both reduce to `com`. Extending
+this eval to another language therefore needs a different external-side unit.
+The external row, not the internal one, is what breaks first.
+
 ## Inheritance — resolved INHERITS and OVERRIDES
 
 The structural L1 grades `INHERITS` by the base's simple *name*. This eval grades


### PR DESCRIPTION
Closes the "honest reporting" item of #1190 for the imports eval: *"the evals README / results tables should state per-metric language scope so a 1.0 is never read wider than it was measured."*

No behaviour change. One characterisation test and one README paragraph.

## What is unstated today

`evals/import_resolution.py` reduces both sides to `(importing_file, top_level_package, is_external)`, and the README explains that reduction with external examples: `import numpy.linalg` and `from numpy import x` both reduce to `numpy`. From that side the reduction is informative, because a top-level name identifies a third-party package.

It does not carry over to the internal side, and the README does not say so. An internal import's top level **is** the project package, by the same expression that decides externality (`top != project`). Measured on the existing fixture:

```
import os
import myproj.alpha
import myproj.beta.deep
from myproj.gamma import thing
from . import sibling
import requests
import numpy
```

```
('myproj/pkg/mod.py', 'myproj', False)
('myproj/pkg/mod.py', 'numpy',  True)
('myproj/pkg/mod.py', 'os',     True)
('myproj/pkg/mod.py', 'requests', True)
```

Four distinct first-party imports, one internal dep. So `imports/internal` measures which files import something internal, not which module they import, and a graph resolving `proj.alpha` to the wrong first-party module scores identically.

## This is deliberate, and the PR says so rather than changing it

The module docstring states the design: the eval isolates internal/external misclassification (#498), and the structural L1 grades internal targets by resolved file. Keying internal deps by target path here would fold resolution accuracy back into the signal this eval exists to isolate.

I went the wrong way on this first and want the record to be plain: I read the code, measured the collapse, and proposed changing it. The rationale was four lines above the code I read. The correct outcome is that the row stays exactly as it is and its granularity gets written down, which is what this does.

## Why a test and not only prose

The existing coverage cannot see this property. `test_oracle_classifies_internal_and_external` asserts `("m.py", "proj", False) in deps` — a membership check that holds whether one internal dep is produced or four.

Verified by mutation rather than asserted. Widening `_import_deps_for_module` to key internal imports on the full dotted base (`".".join(base_parts)`):

| test | under mutation |
|---|---|
| `test_every_internal_import_from_one_file_collapses_to_one_dep` (new) | **FAILS** |
| `test_oracle_classifies_internal_and_external` (existing) | passes |

The new test discriminates where the membership assertion cannot. Restored afterwards and confirmed by sha compare against the committed baseline (`54bb6c26…`), not by trusting `git checkout`.

The fixture already contained two distinct first-party imports (`from proj.helper import thing` and `from . import sibling`), so the property was present and unasserted; no fixture change was needed.

## The second paragraph, and its scope

The README now also records that the reduction is Python-shaped, because that bears directly on #1190's plan to extend this eval to other languages. Python's flat package namespace is what makes a top-level name identify a package. Java's does not: `com.fasterxml.jackson` and `com.google.common` both reduce to `com`, so it is the **external** row that breaks first, not the internal one.

I am deliberately **not** proposing the replacement unit here. That is a design decision on #1190 that should be made deliberately rather than by me while I am the only one looking at it; this PR only records the constraint so whoever takes that work finds it rather than trips over it.

## Checks

`test_import_resolution_eval.py` and `test_eval_imports_internal_modules.py`: 6 passed. No production code touched, so no eval numbers move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how external dependencies are grouped by their top-level import path.
  * Documented namespace-package naming collisions and related considerations for Python and Java evaluations.
  * Explained limitations when comparing dependency metrics across programming languages.

* **Tests**
  * Added coverage verifying that multiple first-party imports from one file consolidate into a single internal dependency.
  * Added assertions validating the expected external dependency count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->