### PR TITLE
test: pin that the C++ frontend hints stay silent when they would be noise

### DIFF
--- a/codebase_rag/tests/test_cpp_frontend_setup.py
+++ b/codebase_rag/tests/test_cpp_frontend_setup.py
@@ -69,3 +69,45 @@ def test_missing_compile_database_logs_generation_hints(
         if "CMAKE_EXPORT_COMPILE_COMMANDS=ON" in message and "bear -- make" in message
     ]
     assert len(matching) == 1, warning_messages
+
+
+def test_a_repo_with_no_c_or_cpp_sources_warns_about_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    warning_messages: list[str],
+) -> None:
+    """The silent half of the same guard, and the consequential one.
+
+    HYBRID is the DEFAULT mode, so a warning that leaked here would fire on
+    every index of every Python or Go repository -- the two hints above and
+    this silence pull against each other, and only the loud half was pinned.
+    """
+    (tmp_path / "main.py").write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setattr(gu.settings, "CPP_FRONTEND", cs.CppFrontend.HYBRID)
+    # Both downstream conditions fail: without the no-C/C++ early exit, either
+    # hint would fire.
+    monkeypatch.setattr(gu, "cpp_frontend_available", lambda: False)
+    monkeypatch.setattr(gu, "find_compile_commands", lambda _path: None)
+    updater = gu.GraphUpdater(MagicMock(), tmp_path, {}, {})
+
+    updater._run_cpp_frontend()
+
+    assert warning_messages == []
+
+
+def test_the_treesitter_mode_warns_about_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    warning_messages: list[str],
+) -> None:
+    # Opting out of the frontend is a choice, not a degradation to report --
+    # even in a repo full of C++ with no libclang and no compile database.
+    repo = _cpp_repo(tmp_path)
+    monkeypatch.setattr(gu.settings, "CPP_FRONTEND", cs.CppFrontend.TREESITTER)
+    monkeypatch.setattr(gu, "cpp_frontend_available", lambda: False)
+    monkeypatch.setattr(gu, "find_compile_commands", lambda _path: None)
+    updater = gu.GraphUpdater(MagicMock(), repo, {}, {})
+
+    updater._run_cpp_frontend()
+
+    assert warning_messages == []


### PR DESCRIPTION
Adds the missing half of an existing guard's coverage. Test-only, no production change.

## What was covered and what was not

#1177 fixed "the default configuration is inert, and nothing tells the user why": `CPP_FRONTEND` defaults to HYBRID while libclang shipped only in the `test` extra, so the macro `Function` nodes and `#include` `IMPORTS` that mode advertises silently never appeared. The fix added a `cpp` extra plus two actionable warnings, and `test_cpp_frontend_setup.py` pins all three — the extra declaration, the libclang install hint, and the compile-database hints.

What nothing pinned is the **silence** half. `_run_cpp_frontend` has two early exits whose whole job is *not* warning:

```python
if settings.CPP_FRONTEND not in (LIBCLANG, HYBRID):
    return
if not self._repo_has_c_or_cpp_files():
    # HYBRID is the default, so a repo with no C/C++ sources must
    # skip silently instead of warning ... on every index of a Python/Go project.
    return
```

That comment states the requirement and nothing enforced it. HYBRID being the **default** is what makes this consequential: a leaked warning fires on every index of every Python or Go repository, and the two requirements pull against each other — making the hints louder risks the noise, making them quieter risks the original defect. Only the loud half was pinned.

## Added

- `test_a_repo_with_no_c_or_cpp_sources_warns_about_nothing` — both downstream conditions forced to fail, so without the early exit either hint would fire.
- `test_the_treesitter_mode_warns_about_nothing` — opting out is a choice, not a degradation to report, even in a C++ repo with no libclang and no compile database.

Both assert `warning_messages == []` rather than the absence of one specific string, so a *new* warning added to this path also has to justify itself.

## Verification

Mutation-tested, each guard against the test that owns it, restores sha-verified:

| mutation | result |
|---|---|
| remove the no-C/C++ early exit | `test_a_repo_with_no_c_or_cpp_sources_warns_about_nothing` fails, 4 pass |
| remove the mode gate | `test_the_treesitter_mode_warns_about_nothing` fails, 4 pass |

Each mutation kills exactly one test, so neither is riding on the other's coverage.

Full unit suite: 8492 passed, 50 skipped. The one `test_cli_smoke::test_help_command_works` failure is a `subprocess.TimeoutExpired` under `-n auto`; that file passes 15/15 in isolation and this branch touches nothing it exercises.

## A note on how this was found

I first wrote a separate test file asserting on the log-constant names and reported to myself that the warnings had no coverage at all. Wrong: `grep` for the constant *names* missed `test_cpp_frontend_setup.py`, which asserts on message *text*. The empty result was a claim about my query rather than about the repository. Re-checked by behaviour, the real gap was narrower and is what this PR fills.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming hybrid indexing produces no warnings for repositories without C/C++ source files.
  * Added coverage confirming Tree-sitter mode produces no warnings when indexing C++ repositories without libclang or a compilation database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->