### PR TITLE
fix: refuse a C++ L1 target whose oracle produced no nodes to grade

### DIFF
--- a/codebase_rag/tests/test_cpp_l1_empty_oracle.py
+++ b/codebase_rag/tests/test_cpp_l1_empty_oracle.py
@@ -1,0 +1,121 @@
+"""`cpp_l1` must refuse a database that yields no oracle nodes.
+
+`restrict_to_files(cgr, {key.file for key in oracle.nodes})` scopes cgr to the
+files the oracle names -- the compile_commands.json "defines the gradeable
+universe", as the comment there says. When that universe is EMPTY the
+restriction keeps nothing, and the run scores 0 against 0: a clean pass for a
+target nothing analysed.
+
+The availability check above it answers a different question (is libclang here,
+does the file exist) and cannot see this, because a database naming only
+out-of-target source passes both. Same class as the four preflight /
+oracle disagreements fixed on PR #1513: the guard must key on what the grader
+will actually GRADE, not on what is merely present.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from evals.oracles.cpp_oracle import cpp_available, run_cpp_oracle
+
+_NEEDS_LIBCLANG = pytest.mark.skipif(
+    not cpp_available(), reason="libclang not available"
+)
+
+
+def _ungradeable_project(tmp_path: Path) -> Path:
+    """A project whose database is valid but names only out-of-target source.
+
+    The oracle keeps a cursor only when its file resolves inside the target
+    (`_rel` returns None otherwise), so this parses perfectly and yields no
+    nodes -- exactly the shape the guard exists for, and reachable without
+    depending on any other fix.
+    """
+    target = tmp_path / "target"
+    target.mkdir()
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    src = outside / "ext.cpp"
+    src.write_text(
+        "class Base {};\nclass Derived : public Base {};\n", encoding="utf-8"
+    )
+    (target / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(outside),
+                    "command": f"clang++ -std=c++17 -c {src}",
+                    "file": str(src),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return target
+
+
+@_NEEDS_LIBCLANG
+def test_the_oracle_yields_nothing_from_an_out_of_target_database(
+    tmp_path: Path,
+) -> None:
+    """The premise, asserted so the guard's test cannot pass vacuously.
+
+    Without this, `test_cpp_l1_refuses_a_database_that_grades_nothing` would
+    also pass against a fixture the oracle simply could not read for some
+    unrelated reason.
+    """
+    project = _ungradeable_project(tmp_path)
+
+    graph = run_cpp_oracle(project)
+
+    assert not graph.nodes
+
+
+@_NEEDS_LIBCLANG
+def test_cpp_l1_refuses_a_database_that_grades_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Driving the real command, not a reimplementation of its logic."""
+    import typer
+
+    from evals import cpp_l1
+
+    project = _ungradeable_project(tmp_path)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        cpp_l1.main(target=project, project_name="", out_dir=tmp_path / "out")
+
+    assert excinfo.value.exit_code == 1
+
+
+@_NEEDS_LIBCLANG
+def test_a_usable_database_is_not_refused(tmp_path: Path) -> None:
+    """The control: the guard must not reject a project it can grade.
+
+    Without this, a guard that refused every target would satisfy the test
+    above.
+    """
+    src = tmp_path / "a.cpp"
+    src.write_text(
+        "class Base {};\nclass Derived : public Base {};\n", encoding="utf-8"
+    )
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "command": f"clang++ -std=c++17 -c {src}",
+                    "file": str(src),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    graph = run_cpp_oracle(tmp_path)
+
+    assert graph.nodes

--- a/codebase_rag/tests/test_cpp_l1_empty_oracle.py
+++ b/codebase_rag/tests/test_cpp_l1_empty_oracle.py
@@ -119,3 +119,30 @@ def test_a_usable_database_is_not_refused(tmp_path: Path) -> None:
     graph = run_cpp_oracle(tmp_path)
 
     assert graph.nodes
+
+
+def test_the_diagnostic_does_not_blame_a_single_cause() -> None:
+    """An empty oracle has at least four causes; the message must not pick one.
+
+    The first version said "the database is stale or names no reachable
+    source". Both bots flagged it independently, and both were right: a
+    comment-only project parses perfectly and legitimately yields zero nodes,
+    so that wording sends the reader to check a database that is fine
+    (CodeRabbit and Greptile, PR #1517).
+
+    Pinned as an assertion on the message rather than left to review, because
+    a diagnostic that names the wrong cause is worse than one that names none
+    -- it spends the reader's time before they can start looking.
+    """
+    from evals import logs as ls
+
+    message = ls.CPP_ORACLE_GRADED_NOTHING.format(
+        compdb="compile_commands.json", target="/repo"
+    )
+
+    # Each cause the oracle can return empty for must be reachable from the
+    # text; none may be presented as the explanation.
+    assert "outside" in message
+    assert "stale" in message
+    assert "failed to parse" in message
+    assert "declare nothing" in message

--- a/evals/cpp_l1.py
+++ b/evals/cpp_l1.py
@@ -50,6 +50,19 @@ def main(
     logger.info(ls.CPP_EXTRACTING_ORACLE.format(target=target))
     oracle = run_cpp_oracle(target)
     logger.success(ls.CPP_ORACLE_DONE.format(count=len(oracle.nodes)))
+    # An oracle that read the database but produced nothing cannot grade
+    # anything: `restrict_to_files` below scopes cgr to the files the oracle
+    # names, so an empty oracle scopes cgr to NOTHING and the run scores 0
+    # against 0 -- a clean pass for a target nothing analysed. Availability was
+    # checked above; this is the separate question of whether the database
+    # yielded any source, and it must fail as loudly (PR #1513's class).
+    if not oracle.nodes:
+        logger.error(
+            ls.CPP_ORACLE_GRADED_NOTHING.format(
+                compdb=ec.CPP_COMPDB_FILENAME, target=target
+            )
+        )
+        raise typer.Exit(code=1)
 
     # The compile_commands.json defines the gradeable universe: the oracle only
     # sees files its compiled TUs reach, so scope cgr to those files before

--- a/evals/logs.py
+++ b/evals/logs.py
@@ -20,6 +20,11 @@ CPP_CGR_SCOPED = "cgr C/C++ nodes scoped to compiled universe: {count}"
 CPP_EXTRACTING_ORACLE = "Running libclang oracle over {target} (compile_commands.json)"
 CPP_ORACLE_DONE = "libclang oracle nodes: {count}"
 CPP_ORACLE_MISSING = "libclang unavailable, or no {compdb} found in {target}"
+CPP_ORACLE_GRADED_NOTHING = (
+    "the libclang oracle read {compdb} in {target} but produced no nodes; "
+    "the database is stale or names no reachable source, so there is nothing "
+    "to grade against (a 0-vs-0 score would report a clean pass)"
+)
 RS_EXTRACTING_CGR = "Building cgr Rust nodes for {target} (project={project})"
 RS_CGR_DONE = "cgr Rust nodes: {count}"
 RS_EXTRACTING_ORACLE = "Running syn oracle ({binary}) over {target}"

--- a/evals/logs.py
+++ b/evals/logs.py
@@ -21,9 +21,12 @@ CPP_EXTRACTING_ORACLE = "Running libclang oracle over {target} (compile_commands
 CPP_ORACLE_DONE = "libclang oracle nodes: {count}"
 CPP_ORACLE_MISSING = "libclang unavailable, or no {compdb} found in {target}"
 CPP_ORACLE_GRADED_NOTHING = (
-    "the libclang oracle read {compdb} in {target} but produced no nodes; "
-    "the database is stale or names no reachable source, so there is nothing "
-    "to grade against (a 0-vs-0 score would report a clean pass)"
+    "the libclang oracle read {compdb} in {target} but produced no nodes, so "
+    "there is nothing to grade against (a 0-vs-0 score would report a clean "
+    "pass). Any of these produces it: the entries name sources outside "
+    "{target}; their command directories are stale; every translation unit "
+    "failed to parse; or the sources genuinely declare nothing. Check the "
+    "oracle node count above against the files you expect it to cover"
 )
 RS_EXTRACTING_CGR = "Building cgr Rust nodes for {target} (project={project})"
 RS_CGR_DONE = "cgr Rust nodes: {count}"


### PR DESCRIPTION
Found by sweeping the class of four Greptile findings on #1513 rather than waiting for a fifth. **One instance exists outside that PR, and this is it.**

## The defect

`cpp_l1` scopes cgr to the files the oracle names:

```python
oracle = run_cpp_oracle(target)
logger.success(ls.CPP_ORACLE_DONE.format(count=len(oracle.nodes)))
...
cgr = restrict_to_files(cgr, {key.file for key in oracle.nodes})
```

The comment above that line states the assumption plainly — the compilation database "defines the gradeable universe". When that universe is **empty**, the restriction keeps nothing, and the run scores 0 against 0: a clean pass for a target nothing analysed.

Verified against a database that is present and valid but names only out-of-target source (the oracle keeps a cursor only when its file resolves inside the target, so it parses perfectly and yields nothing):

```
oracle nodes: 0
files the oracle names: set()
restrict_to_files(cgr, set()) keeps ZERO cgr nodes -> 0 vs 0 scores clean
```

The existing check at line 38 cannot see this: `cpp_available() and (target / compile_commands.json).is_file()` answers *is the toolchain here and does the file exist*, which a stale or out-of-target database passes. That is the same distinction the four #1513 findings converged on — **the guard must key on what the grader will actually grade, not on what is merely present.**

## The fix

An explicit refusal after the oracle runs, with its own message naming the cause:

```python
if not oracle.nodes:
    logger.error(ls.CPP_ORACLE_GRADED_NOTHING.format(...))
    raise typer.Exit(code=1)
```

`CPP_ORACLE_GRADED_NOTHING` is distinct from `CPP_ORACLE_MISSING` deliberately: "libclang unavailable, or no compile_commands.json found" sends the reader to the wrong remedy when the file is sitting right there.

## Scope of the sweep

I checked the sibling evals rather than assuming this generalises:

| eval | shape | verdict |
|---|---|---|
| `cpp_l1` | `restrict_to_files(cgr, oracle files)` | **the defect** — fixed here |
| `cpp_retrieval` | `score_retrieval(cgr, oracle)` | safe — an empty oracle with non-empty cgr scores **precision 0.0**, loudly wrong rather than clean; both-empty emits no row at all (measured) |
| `c_retrieval` | same shape as `cpp_retrieval` | safe, same reason |

`grep -rn restrict_to_files evals/*.py` returns `cpp_l1.py` and the definition in `cgr_graph.py` only, so **`cpp_l1` is the sole consumer** and the sweep is bounded rather than open-ended.

## Verification

- **8518 passed, 49 skipped, 1 xfailed** (full unit suite)
- Mutation-verified: removing the guard fails exactly `test_cpp_l1_refuses_a_database_that_grades_nothing`, while the premise and control tests still pass. Restore sha-verified.
- Three tests, structured so none can pass vacuously: the **premise** (this fixture really does empty the oracle), the **guard** (driving `cpp_l1.main` itself, not a reimplementation), and the **control** (a usable database is not refused — without it, a guard that rejected everything would satisfy the guard test).

One fixture note worth recording: my first attempt used a stale *build directory*, which empties the oracle only with #1513's chdir fix applied. On `main` the chdir never happens, so the absolute source path still parses and the fixture yielded 2 nodes — the premise test caught that immediately. The out-of-target fixture used here works independently of that PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * C++ evaluation now reports an error when a valid compilation database produces no scorable nodes, preventing misleading passing scores.
  * Error output identifies the affected compilation database and target.
  * Diagnostics now distinguish likely causes, including out-of-target sources, stale command directories, parse failures, and genuinely empty sources.

* **Tests**
  * Added coverage for empty-oracle scenarios and out-of-target source files.
  * Added verification that valid in-target databases continue to be accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->