### PR TITLE
feat: store call-site and import-site locations on graph edges

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -524,7 +524,8 @@ CYPHER_INBOUND_EDGES = (
     "AND (caller.path IS NULL OR NOT caller.path IN $paths) "
     "RETURN head(labels(caller)) AS caller_label, "
     "caller.qualified_name AS caller_qn, type(r) AS rel, "
-    "head(labels(target)) AS target_label, target.qualified_name AS target_qn"
+    "head(labels(target)) AS target_label, target.qualified_name AS target_qn, "
+    "properties(r) AS props"
 )
 # Files whose code DEPENDS on a re-indexed file (issue #1229 phase 4): a
 # change there can rebind their calls (a new override shadowing an inherited

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -35,6 +35,29 @@ KEY_START_COL = "start_col"
 KEY_NAME_START_LINE = "name_start_line"
 KEY_NAME_START_COL = "name_start_col"
 KEY_END_LINE = "end_line"
+# Edge-site location properties (issue #1522). Every CALLS / REFERENCES /
+# INSTANTIATES edge records the span of the expression that produced it, and
+# every IMPORTS edge the span of its import statement, so a consumer can jump
+# to, verify, or rewrite the exact site. Lines are 1-based and columns 0-based,
+# matching the node `start_line` / `start_col` convention. Sites are stored as
+# ONE EDGE PER SITE: the site props join the MERGE key (see
+# MERGE_KEY_PROPS_BY_REL), so a caller invoking one callee twice carries two
+# parallel edges. Edges emitted without a site (libclang macro uses, Roslyn
+# facts, dynamic-trace write-back, inferred C# namespace imports) carry none of
+# these keys and keep collapsing on their endpoints.
+KEY_LINE = "line"
+KEY_COL = "col"
+KEY_END_COL = "end_col"
+KEY_ARG_COUNT = "arg_count"
+KEY_KWARG_NAMES = "kwarg_names"
+# IMPORTS only: the name the statement binds in the importing scope (the
+# `as` name when renamed, else the imported/module name) and, for
+# symbol-level imports (`from x import y`, `import { y }`, `use a::b::y`),
+# the symbol's own name. A whole-module import has no `imported_name`.
+KEY_ALIAS = "alias"
+KEY_IMPORTED_NAME = "imported_name"
+# `imported_name` of a wildcard import (`from x import *`, `export * from`).
+IMPORTED_NAME_WILDCARD = "*"
 KEY_PATH = "path"
 KEY_ABSOLUTE_PATH = "absolute_path"
 # Whether flow analysis covered a Module: its language is in the source/sink
@@ -593,6 +616,14 @@ REL_TYPE_CALLS = "CALLS"
 # still dedups on endpoints.
 MERGE_KEY_PROPS_BY_REL: dict[str, tuple[str, ...]] = {
     RelationshipType.FLOWS_TO.value: ("via", "kind"),
+    # One edge per call/reference/instantiation site (issue #1522); a row
+    # without a site still merges on its endpoints alone.
+    RelationshipType.CALLS.value: (KEY_LINE, KEY_COL),
+    RelationshipType.REFERENCES.value: (KEY_LINE, KEY_COL),
+    RelationshipType.INSTANTIATES.value: (KEY_LINE, KEY_COL),
+    # One edge per bound name: `from x import a, b` shares a statement span
+    # but binds two names, each its own edge.
+    RelationshipType.IMPORTS.value: (KEY_LINE, KEY_COL, KEY_ALIAS),
 }
 
 NODE_UNIQUE_CONSTRAINTS: dict[str, str] = {

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -89,6 +89,7 @@ from .types_defs import (
     NodeType,
     PendingExpansionCall,
     PendingMacroCall,
+    PropertyDict,
     ResultRow,
     SimpleNameLookup,
 )
@@ -1810,10 +1811,17 @@ class GraphUpdater:
             target_key = cs.NODE_UNIQUE_CONSTRAINTS.get(target_label)
             if caller_key is None or target_key is None:
                 continue
+            # The edge's own properties (its site, issue #1522) come back with
+            # it: per-site edges are keyed by them, so a bare re-emission
+            # would land beside the original instead of restoring it.
+            props = row.get(cs.KEY_PROPS)
             self._sink.ensure_relationship_batch(
                 (caller_label, caller_key, caller_qn),
                 rel,
                 (target_label, target_key, target_qn),
+                properties=cast(PropertyDict, props)
+                if isinstance(props, dict) and props
+                else None,
             )
             restored += 1
         if restored:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
 from collections.abc import Callable, Mapping
+from functools import wraps
 from pathlib import Path
 from typing import NamedTuple
 
@@ -22,6 +23,7 @@ from ..types_defs import (
     FunctionSpanKey,
     LanguageQueries,
     NodeType,
+    PropertyDict,
 )
 from ..utils.path_utils import cached_relative_path
 from .call_resolver import PY_EXTERNAL_TARGET, CallResolver
@@ -52,6 +54,7 @@ from .utils import (
     is_method_node,
     js_ts_parameter_names,
     module_qn_for_entity,
+    node_site_properties,
     python_parameter_names,
     safe_decode_text,
     sorted_captures,
@@ -617,6 +620,68 @@ def _add_py_keyword_argument(child: Node, keyword: dict[str, Node]) -> None:
         keyword[name] = value_node
 
 
+def _split_call_arguments(args_node: Node) -> tuple[list[Node], dict[str, Node]]:
+    positional: list[Node] = []
+    keyword: dict[str, Node] = {}
+    for child in args_node.named_children:
+        # C# wraps every argument expression in an `argument` node (which
+        # may carry a ref/out modifier or a name: colon); Dart wraps
+        # positional values the same way. Unwrap to the expression itself,
+        # its LAST named child, so downstream reference-type checks see
+        # the identifier, not the wrapper.
+        if (
+            child.type in (cs.TS_CSHARP_ARGUMENT, cs.TS_DART_ARGUMENT)
+            and child.named_children
+        ):
+            child = child.named_children[-1]
+        if child.type == cs.TS_DART_NAMED_ARGUMENT:
+            _add_dart_named_argument(child, keyword)
+        elif child.type == cs.TS_PY_KEYWORD_ARGUMENT:
+            _add_py_keyword_argument(child, keyword)
+        else:
+            positional.append(child)
+    return positional, keyword
+
+
+def call_site_properties(node: Node) -> PropertyDict:
+    """Edge-site properties for the expression that produced an edge (#1522).
+
+    Every site carries its span; a node with an argument list (a call, a
+    constructor invocation) also carries `arg_count` and the keyword names
+    it passes, so a consumer can check arity at the site without re-parsing.
+    A reference site (a bare function value, an attribute read) has no
+    argument list and carries the span alone.
+    """
+    props = node_site_properties(node)
+    args_node = _find_call_arguments_node(node)
+    if args_node is not None:
+        positional, keyword = _split_call_arguments(args_node)
+        props[cs.KEY_ARG_COUNT] = len(positional) + len(keyword)
+        props[cs.KEY_KWARG_NAMES] = list(keyword)
+    return props
+
+
+def _site_scoped[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
+    """Restore the processor's current edge-site node when the pass returns.
+
+    A pass sets `_site_node` as it visits nodes so every edge it emits picks
+    up that site; restoring the previous value on exit keeps a nested pass
+    from leaking its last node into the edges its caller emits afterwards.
+    """
+
+    @wraps(fn)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        self = args[0]
+        assert isinstance(self, CallProcessor)
+        prev = self._site_node
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            self._site_node = prev
+
+    return wrapper
+
+
 class _JsFileBindingCollector:
     """Whole-file binding index for the #988 receiver resolution.
 
@@ -927,6 +992,8 @@ class _JsFileBindingCollector:
 class CallProcessor:
     __slots__ = (
         "ingestor",
+        "_site_node",
+        "_site_cache",
         "repo_path",
         "project_name",
         "module_qn_to_file_path",
@@ -977,6 +1044,12 @@ class CallProcessor:
         declared_module_qns: set[str] | None = None,
     ) -> None:
         self.ingestor = ingestor
+        # The tree-sitter node whose span every edge emitted right now records
+        # as its site (issue #1522); each pass sets it per visited node and
+        # `_site_scoped` restores it on exit. The cache keeps the variant
+        # fan-out of one site from re-deriving the same property dict.
+        self._site_node: Node | None = None
+        self._site_cache: tuple[int, PropertyDict] | None = None
         self.repo_path = repo_path
         self.project_name = project_name
         # Dispatchers that name their callee in a string argument, declared in
@@ -1061,6 +1134,30 @@ class CallProcessor:
             selection=selection,
             function_locations=self.function_locations,
         )
+
+    def _emit_rel(
+        self,
+        from_spec: tuple[str, str, str],
+        rel_type: str,
+        to_spec: tuple[str, str, str],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        # Every CALLS/REFERENCES/INSTANTIATES edge this processor emits goes
+        # through here so the current site (line/col/arg shape of the
+        # producing expression) rides along as edge properties (#1522).
+        site = self._site_node
+        if site is not None:
+            cached = self._site_cache
+            if cached is None or cached[0] != site.id:
+                cached = (site.id, call_site_properties(site))
+                self._site_cache = cached
+            properties = {**cached[1], **properties} if properties else dict(cached[1])
+        if properties:
+            self.ingestor.ensure_relationship_batch(
+                from_spec, rel_type, to_spec, properties=properties
+            )
+        else:
+            self.ingestor.ensure_relationship_batch(from_spec, rel_type, to_spec)
 
     def _get_node_name(self, node: Node, field: str = cs.FIELD_NAME) -> str | None:
         name_node = node.child_by_field_name(field)
@@ -1170,6 +1267,7 @@ class CallProcessor:
             ancestor = ancestor.parent
         return True
 
+    @_site_scoped
     def _ingest_decorator_calls(
         self,
         nodes: list[Node],
@@ -1181,7 +1279,7 @@ class CallProcessor:
         # methods, AND classes: the decoration executes at module-load time,
         # so the module is the caller. Only first-party callables get an edge.
         resolver = self._resolver
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         qn_key = cs.KEY_QUALIFIED_NAME
         module_spec = (cs.NodeLabel.MODULE, qn_key, module_qn)
         callable_labels = (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD)
@@ -1195,6 +1293,7 @@ class CallProcessor:
             for child in parent.children:
                 if child.type != cs.TS_PY_DECORATOR:
                     continue
+                self._site_node = child
                 name = self._bare_decorator_name(child)
                 if not name:
                     continue
@@ -2861,6 +2960,7 @@ class CallProcessor:
             return True
         return False
 
+    @_site_scoped
     def _ingest_function_calls(
         self,
         caller_node: Node,
@@ -3136,7 +3236,7 @@ class CallProcessor:
         resolve_cpp_op = resolver.resolve_cpp_operator_call if is_cpp else None
         get_target = self._get_call_target_name
         class_label = cs.NodeLabel.CLASS
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         calls_rel = cs.RelationshipType.CALLS
         qn_key = cs.KEY_QUALIFIED_NAME
         _id = id
@@ -3170,6 +3270,7 @@ class CallProcessor:
         cpp_local_aliases: dict[str, list[tuple[str, int, int]]] | None = None
 
         for call_node in call_nodes:
+            self._site_node = call_node
             node_id = _id(call_node)
             if call_name_cache is not None and node_id in call_name_cache:
                 call_name = call_name_cache[node_id]
@@ -3955,6 +4056,7 @@ class CallProcessor:
                             (cs.NodeLabel.FUNCTION, qn_key, variant),
                         )
 
+    @_site_scoped
     def _ingest_operator_dispatch_calls(
         self,
         caller_node: Node,
@@ -3965,7 +4067,7 @@ class CallProcessor:
         boundary = (cs.TS_PY_FUNCTION_DEFINITION, cs.TS_PY_CLASS_DEFINITION)
         stack: list[Node] = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             if node.type in boundary:
                 continue
             match node.type:
@@ -4051,6 +4153,7 @@ class CallProcessor:
                     )
             stack.extend(node.children)
 
+    @_site_scoped
     def _emit_truthiness(
         self,
         operand: Node | None,
@@ -4061,6 +4164,8 @@ class CallProcessor:
         # Truthiness of an object calls __bool__ if defined, else __len__. Only a
         # bare name/attribute operand names an object (a comparison/call is already
         # a bool and is handled elsewhere); try __bool__ first, then __len__.
+        if operand is not None:
+            self._site_node = operand
         if operand is None or operand.type not in (
             cs.TS_PY_IDENTIFIER,
             cs.TS_PY_ATTRIBUTE,
@@ -4072,6 +4177,7 @@ class CallProcessor:
             ):
                 return
 
+    @_site_scoped
     def _emit_operator_dunder(
         self,
         operand: Node | None,
@@ -4086,6 +4192,7 @@ class CallProcessor:
         # Returns whether an edge was emitted.
         if operand is None or not (operand_text := safe_decode_text(operand)):
             return False
+        self._site_node = operand
         if any(ch in operand_text for ch in cs.PY_OPERAND_REJECT_CHARS):
             return False
         targets = self._resolver.operator_dunder_targets(
@@ -4095,7 +4202,7 @@ class CallProcessor:
             return False
         for callee_type, callee_qn in targets:
             for target_qn in self._resolver.function_registry.variants(callee_qn):
-                self.ingestor.ensure_relationship_batch(
+                self._emit_rel(
                     caller_spec,
                     cs.RelationshipType.CALLS,
                     (callee_type, cs.KEY_QUALIFIED_NAME, target_qn),
@@ -4114,6 +4221,7 @@ class CallProcessor:
             and safe_decode_text(operator) in cs.JS_SHORT_CIRCUIT_OPERATORS
         )
 
+    @_site_scoped
     def _ingest_assignment_function_references(
         self,
         caller_node: Node,
@@ -4132,10 +4240,10 @@ class CallProcessor:
         # name/attribute RHS counts (calls resolve as calls); the walk stops at
         # nested scope boundaries, which own their own pass.
         resolve_func = self._resolver.resolve_function_call
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         stack: list[Node] = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             # Continue THROUGH an unowned anonymous arrow (zustand's curried
             # middleware body `(config) => (set, get, api) => { api.setState =
             # ... }`): it gets no caller pass, so its assignments would else be
@@ -4305,6 +4413,7 @@ class CallProcessor:
                             )
             stack.extend(node.children)
 
+    @_site_scoped
     def _emit_assigned_name_ref(
         self,
         assign_node: Node,
@@ -4316,6 +4425,7 @@ class CallProcessor:
         # setState, `listener` -> listener) to a def-pass registration in the
         # enclosing scope. Registry-guarded: emits only when such a node exists,
         # so a plain data assignment adds nothing.
+        self._site_node = assign_node
         if assign_node.type != cs.TS_ASSIGNMENT_EXPRESSION:
             return
         left = assign_node.child_by_field_name(cs.FIELD_LEFT)
@@ -4345,6 +4455,7 @@ class CallProcessor:
                 (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
             )
 
+    @_site_scoped
     def _ingest_jsx_component_references(
         self,
         caller_node: Node,
@@ -4368,11 +4479,11 @@ class CallProcessor:
         # and drops the edge when __init__ is absent, as it always is for a
         # JS/TS class.
         resolve_func = self._resolver.resolve_function_call
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         registry = self._resolver.function_registry
         stack: list[Node] = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             # Stop at a nested scope that gets its OWN caller pass (a named
             # function/arrow, a class), but continue THROUGH an anonymous arrow
             # (a `.map()`/`cell`/forwardRef callback): those are skipped as
@@ -4437,6 +4548,7 @@ class CallProcessor:
             return _conditional_result_operands(node, is_dart=False)
         return [node]
 
+    @_site_scoped
     def _ingest_returned_function_references(
         self,
         caller_node: Node,
@@ -4455,7 +4567,7 @@ class CallProcessor:
         # callback is anonymous, so its `return` bubbles here) but stops at named
         # nested functions, which own their returns.
         resolve_func = self._resolver.resolve_function_call
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         # An expression-bodied arrow (`const persistImpl = (config) =>
         # (set, get, api) => {...}`, zustand's curried middleware shape) has NO
         # return_statement; its body IS the implicit return. Reference the inner
@@ -4473,7 +4585,7 @@ class CallProcessor:
         )
         stack: list[Node] = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             if node.type in boundary_types:
                 if not self._is_unowned_js_scope(node):
                     continue
@@ -4592,6 +4704,7 @@ class CallProcessor:
             current = current.child_by_field_name(cs.FIELD_OBJECT)
         return None
 
+    @_site_scoped
     def _ingest_collection_function_references(
         self,
         caller_node: Node,
@@ -4614,14 +4727,15 @@ class CallProcessor:
         # getter descriptor) must be scanned here too or the callbacks inside are
         # orphaned and report as dead.
         resolve_func = self._resolver.resolve_function_call
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         stack: list[Node] = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             if node.type in boundary_types and not self._is_unowned_js_scope(node):
                 continue
             if node.type in _DICT_LIKE_COLLECTION_TYPES:
                 for pair in node.named_children:
+                    self._site_node = pair
                     # An object-literal SHORTHAND METHOD (`return { then(x)
                     # {...}, catch(x) {...} }`, persist's thenable) is a stored
                     # callable like a pair value, but it is a method_definition
@@ -4729,7 +4843,7 @@ class CallProcessor:
         if class_qn is None:
             return
         registry = self._resolver.function_registry
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         for class_variant in registry.variants(class_qn):
             variant_type = registry.get(class_variant)
             if variant_type is not None and variant_type != NodeType.CLASS:
@@ -4859,7 +4973,7 @@ class CallProcessor:
         registry = self._resolver.function_registry
         for target_type, target_qn in sorted(targets):
             for variant in registry.variants(target_qn):
-                self.ingestor.ensure_relationship_batch(
+                self._emit_rel(
                     caller_spec,
                     cs.RelationshipType.CALLS,
                     (target_type, cs.KEY_QUALIFIED_NAME, variant),
@@ -4942,7 +5056,7 @@ class CallProcessor:
             variant_type = registry.get(class_variant)
             if variant_type is not None and variant_type != NodeType.CLASS:
                 continue
-            self.ingestor.ensure_relationship_batch(
+            self._emit_rel(
                 caller_spec,
                 cs.RelationshipType.INSTANTIATES,
                 (cs.NodeLabel.CLASS, cs.KEY_QUALIFIED_NAME, class_variant),
@@ -4972,7 +5086,7 @@ class CallProcessor:
         ) | self._resolver.cpp_destructor_targets(class_qn)
         for target_type, target_qn in sorted(targets):
             for variant in registry.variants(target_qn):
-                self.ingestor.ensure_relationship_batch(
+                self._emit_rel(
                     caller_spec,
                     cs.RelationshipType.CALLS,
                     (target_type, cs.KEY_QUALIFIED_NAME, variant),
@@ -5004,6 +5118,7 @@ class CallProcessor:
         name = head.text.decode(cs.ENCODING_UTF8).split(cs.CHAR_ANGLE_OPEN, 1)[0]
         return name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT) or None
 
+    @_site_scoped
     def _ingest_go_composite_function_references(
         self,
         caller_node: Node,
@@ -5021,14 +5136,15 @@ class CallProcessor:
         # {keyed_element(value=literal_element) | literal_element}, and the element
         # wraps the bare identifier one level down, so unwrap before resolving.
         resolve_func = self._resolver.resolve_function_call
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         stack: list[Node] = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             if node.type in boundary_types:
                 continue
             if node.type == cs.TS_GO_LITERAL_VALUE:
                 for element in node.named_children:
+                    self._site_node = element
                     value = (
                         element.child_by_field_name(cs.FIELD_VALUE)
                         if element.type == cs.TS_GO_KEYED_ELEMENT
@@ -5050,6 +5166,7 @@ class CallProcessor:
                     )
             stack.extend(node.children)
 
+    @_site_scoped
     def _emit_value_function_ref(
         self,
         node: Node,
@@ -5064,6 +5181,7 @@ class CallProcessor:
         # transparent for reference resolution, and `fn.bind(ctx)` /
         # `fn.call(...)` / `fn.apply(...)` in value position (onError:
         # handleError.bind(toast)) hands off `fn`; peel both to a fixpoint.
+        self._site_node = node
         node = self._peel_bound_callable(node)
         # An inline arrow/function-expression element (`handlers = [() => {}]`,
         # zod's `onattach = [(inst) => {...}]`) is registered anonymously in the
@@ -5152,6 +5270,7 @@ class CallProcessor:
             return None
         return fn.child_by_field_name(cs.FIELD_OBJECT)
 
+    @_site_scoped
     def _emit_inline_value_function_ref(
         self,
         pair: Node,
@@ -5166,6 +5285,7 @@ class CallProcessor:
         # has no property name, so it registers as scope.anonymous_<row>_<col> from
         # the value's position. Reference every candidate actually registered
         # (variants cover same-name duplicates in one scope).
+        self._site_node = value
         registry = self._resolver.function_registry
         scope_qn = caller_spec[2]
         candidates = {
@@ -5227,6 +5347,7 @@ class CallProcessor:
         keys.reverse()
         return cs.SEPARATOR_DOT.join(keys)
 
+    @_site_scoped
     def _emit_shorthand_method_ref(
         self,
         method_node: Node,
@@ -5238,6 +5359,7 @@ class CallProcessor:
         # (persist's thenable `catch` -> `...middleware.persist.catch`), while
         # this scan runs per enclosing caller; try both scopes, plus the
         # position form used when the name is taken.
+        self._site_node = method_node
         name_node = method_node.child_by_field_name(cs.FIELD_NAME)
         registry = self._resolver.function_registry
         scope_qn = caller_spec[2]
@@ -5258,6 +5380,7 @@ class CallProcessor:
                     (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
                 )
 
+    @_site_scoped
     def _ingest_default_param_references(
         self,
         caller_node: Node,
@@ -5271,8 +5394,9 @@ class CallProcessor:
         if params is None:
             return
         resolve_func = self._resolver.resolve_function_call
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         for param in params.named_children:
+            self._site_node = param
             # TS carries a param default in required_parameter's `value` field;
             # plain JS wraps the param in an assignment_pattern whose default
             # sits under `right`. Scan both forms.
@@ -5321,6 +5445,7 @@ class CallProcessor:
                     module_qn=module_qn,
                 )
 
+    @_site_scoped
     def _emit_inline_arg_function_ref(
         self,
         arg_node: Node,
@@ -5342,6 +5467,7 @@ class CallProcessor:
         # module-flat name candidate and reference the WRONG top-level node. The
         # candidate fallback is kept for an incremental run where an unchanged
         # file's span was not re-recorded this pass.
+        self._site_node = arg_node
         if (
             module_qn is not None
             and (loc := self._recorded_caller(arg_node, module_qn)) is not None
@@ -5602,30 +5728,12 @@ class CallProcessor:
     def _parse_call_arguments(
         self, call_node: Node
     ) -> tuple[list[Node], dict[str, Node]]:
-        positional: list[Node] = []
-        keyword: dict[str, Node] = {}
         args_node = _find_call_arguments_node(call_node)
         if args_node is None:
-            return positional, keyword
-        for child in args_node.named_children:
-            # C# wraps every argument expression in an `argument` node (which
-            # may carry a ref/out modifier or a name: colon); Dart wraps
-            # positional values the same way. Unwrap to the expression itself,
-            # its LAST named child, so downstream reference-type checks see
-            # the identifier, not the wrapper.
-            if (
-                child.type in (cs.TS_CSHARP_ARGUMENT, cs.TS_DART_ARGUMENT)
-                and child.named_children
-            ):
-                child = child.named_children[-1]
-            if child.type == cs.TS_DART_NAMED_ARGUMENT:
-                _add_dart_named_argument(child, keyword)
-            elif child.type == cs.TS_PY_KEYWORD_ARGUMENT:
-                _add_py_keyword_argument(child, keyword)
-            else:
-                positional.append(child)
-        return positional, keyword
+            return [], {}
+        return _split_call_arguments(args_node)
 
+    @_site_scoped
     def _emit_callback_edge(
         self,
         source_spec: tuple[str, str, str],
@@ -5644,6 +5752,7 @@ class CallProcessor:
         # argument position (addEventListener("click", handler.bind(this)),
         # django admin's inlines.js) hands off `fn` while the call itself
         # resolves to the Function.prototype builtin; peel both to a fixpoint.
+        self._site_node = arg_node
         arg_node = self._peel_bound_callable(arg_node)
         # An arrow/function-expression passed DIRECTLY as a call argument
         # (useCallback(() => {}), setTimeout(() => {}), arr.map(x => ...)) is
@@ -5861,7 +5970,7 @@ class CallProcessor:
             else:
                 edges[slot].add((arg.source_caller, arg.source_param))
 
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         # A nested closure a function returns is reachable whenever that function
         # is reached (created and handed back as the return value). Nested
         # functions are no longer roots, so this producer edge keeps a genuinely
@@ -6158,6 +6267,7 @@ class CallProcessor:
                 return self._resolve_str_const(right, module_qn)
         return None
 
+    @_site_scoped
     def _ingest_property_accesses(
         self,
         caller_node: Node,
@@ -6177,7 +6287,7 @@ class CallProcessor:
         resolver = self._resolver
         resolve_func = resolver.resolve_function_call
         registry = resolver.function_registry
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         calls_rel = cs.RelationshipType.CALLS
         qn_key = cs.KEY_QUALIFIED_NAME
         method_label = cs.NodeLabel.METHOD
@@ -6190,7 +6300,7 @@ class CallProcessor:
 
         stack = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             node_type = node.type
             if node_type in function_types or node_type in class_types:
                 continue
@@ -6227,6 +6337,7 @@ class CallProcessor:
                                 )
             stack.extend(node.children)
 
+    @_site_scoped
     def _ingest_dart_getter_reads(
         self,
         caller_node: Node,
@@ -6270,7 +6381,7 @@ class CallProcessor:
 
         stack = list(walk_root.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             if node.type in class_types:
                 # Class subtrees (field initializers) are scanned once at
                 # FILE level by _ingest_dart_class_initializer_reads.
@@ -6290,6 +6401,7 @@ class CallProcessor:
                 )
             stack.extend(node.children)
 
+    @_site_scoped
     def _ingest_dart_class_initializer_reads(
         self,
         class_node: Node,
@@ -6338,7 +6450,7 @@ class CallProcessor:
 
         stack = list(class_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             if node.type in class_types:
                 self._ingest_dart_class_initializer_reads(
                     node,
@@ -6434,7 +6546,7 @@ class CallProcessor:
         if not registry.is_property(res_qn) or res_qn == caller_qn:
             return
         seen.add(read_name)
-        self.ingestor.ensure_relationship_batch(
+        self._emit_rel(
             caller_spec,
             cs.RelationshipType.REFERENCES,
             (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, res_qn),
@@ -6535,6 +6647,7 @@ class CallProcessor:
             stack.extend(node.children)
         return spans
 
+    @_site_scoped
     def _ingest_csharp_property_reads(
         self,
         caller_node: Node,
@@ -6550,7 +6663,7 @@ class CallProcessor:
         # its enclosing type read in receiver position. Registry-guarded via
         # resolve_property_read, which accepts only marked properties.
         engine = self._resolver.type_inference.csharp_type_inference
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         refs_rel = cs.RelationshipType.REFERENCES
         qn_key = cs.KEY_QUALIFIED_NAME
         method_label = cs.NodeLabel.METHOD
@@ -6579,7 +6692,7 @@ class CallProcessor:
 
         stack = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             node_type = node.type
             if node_type in function_types or node_type in class_types:
                 continue
@@ -6766,6 +6879,7 @@ class CallProcessor:
             return self._resolver._resolve_class_name(recv_name, module_qn)
         return None
 
+    @_site_scoped
     def _ingest_js_ts_getter_reads(
         self,
         caller_node: Node,
@@ -6787,7 +6901,7 @@ class CallProcessor:
         # emitted only when it is a registered property, so a same-named data
         # field, a same-named regular method, or a same-named getter on an
         # unrelated class never fabricates an edge.
-        ensure_rel = self.ingestor.ensure_relationship_batch
+        ensure_rel = self._emit_rel
         registry = self._resolver.function_registry
         refs_rel = cs.RelationshipType.REFERENCES
         qn_key = cs.KEY_QUALIFIED_NAME
@@ -6796,7 +6910,7 @@ class CallProcessor:
         seen: set[str] = set()
         stack = list(caller_node.children)
         while stack:
-            node = stack.pop()
+            node = self._site_node = stack.pop()
             node_type = node.type
             # A nested class or NON-arrow function owns its own reads (and
             # rebinds `this`), so it is processed as its own caller; do not

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1049,7 +1049,9 @@ class CallProcessor:
         # `_site_scoped` restores it on exit. The cache keeps the variant
         # fan-out of one site from re-deriving the same property dict.
         self._site_node: Node | None = None
-        self._site_cache: tuple[int, PropertyDict] | None = None
+        # Keyed by the node OBJECT, not Node.id: tree-sitter recycles ids
+        # across trees, and holding the node keeps its id from being reused.
+        self._site_cache: tuple[Node, PropertyDict] | None = None
         self.repo_path = repo_path
         self.project_name = project_name
         # Dispatchers that name their callee in a string argument, declared in
@@ -1148,8 +1150,8 @@ class CallProcessor:
         site = self._site_node
         if site is not None:
             cached = self._site_cache
-            if cached is None or cached[0] != site.id:
-                cached = (site.id, call_site_properties(site))
+            if cached is None or cached[0] is not site:
+                cached = (site, call_site_properties(site))
                 self._site_cache = cached
             properties = {**cached[1], **properties} if properties else dict(cached[1])
         if properties:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -4811,6 +4811,7 @@ class CallProcessor:
                         )
             stack.extend(node.children)
 
+    @_site_scoped
     def _ingest_cpp_braced_return_instantiations(
         self,
         caller_node: Node,
@@ -4846,6 +4847,8 @@ class CallProcessor:
             return
         registry = self._resolver.function_registry
         ensure_rel = self._emit_rel
+        # The return statement is the construction site (issue #1522).
+        self._site_node = node
         for class_variant in registry.variants(class_qn):
             variant_type = registry.get(class_variant)
             if variant_type is not None and variant_type != NodeType.CLASS:
@@ -4857,6 +4860,7 @@ class CallProcessor:
             )
         self._emit_cpp_ctor_calls(caller_spec, class_qn)
 
+    @_site_scoped
     def _ingest_cpp_member_init_ctor_calls(
         self,
         caller_node: Node,
@@ -4887,6 +4891,7 @@ class CallProcessor:
                     else None
                 )
                 if class_qn is not None:
+                    self._site_node = initializer
                     self._emit_cpp_ctor_calls(caller_spec, class_qn)
 
     def _ingest_cpp_implicit_base_lifecycle_calls(
@@ -5000,6 +5005,7 @@ class CallProcessor:
                     named.add(resolved)
         return named
 
+    @_site_scoped
     def _ingest_cpp_declaration_ctor_calls(
         self,
         caller_node: Node,
@@ -5037,6 +5043,7 @@ class CallProcessor:
                 else None
             )
             if class_qn is not None:
+                self._site_node = node
                 self._emit_cpp_construction_edges(caller_spec, class_qn)
 
     @staticmethod

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -876,13 +876,7 @@ class ImportProcessor:
         lang_config = queries[language]["config"]
 
         self.import_mapping[module_qn] = {}
-        for scope_qn, name in self._import_site_owners.pop(module_qn, ()):
-            scope_sites = self._import_sites.get(scope_qn)
-            if scope_sites is not None:
-                scope_sites.pop(name, None)
-                if not scope_sites:
-                    del self._import_sites[scope_qn]
-        self._import_sites[module_qn] = {}
+        self._retract_import_sites(module_qn)
         # A watch-mode re-parse must not carry references the edited file no
         # longer makes (issue #1347).
         self._inferred_module_imports.pop(module_qn, None)
@@ -971,6 +965,18 @@ class ImportProcessor:
 
         except Exception as e:
             logger.warning(ls.IMP_PARSE_FAILED, module=module_qn, error=e)
+
+    def _retract_import_sites(self, module_qn: str) -> None:
+        # A re-parse must not keep the sub-scope site entries the previous
+        # parse of this file wrote under other scope keys (issue #1522).
+        for scope_qn, name in self._import_site_owners.pop(module_qn, ()):
+            scope_sites = self._import_sites.get(scope_qn)
+            if scope_sites is None:
+                continue
+            scope_sites.pop(name, None)
+            if not scope_sites:
+                del self._import_sites[scope_qn]
+        self._import_sites[module_qn] = {}
 
     def _record_import_site(
         self,

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -985,7 +985,15 @@ class ImportProcessor:
             scope_sites.pop(name, None)
             if not scope_sites:
                 del self._import_sites[scope_qn]
-        self._import_sites[module_qn] = {}
+        # The file's own scope key may also hold entries an inline module of
+        # ANOTHER file wrote (a file-backed `a/b/mod.rs` and an inline `mod b`
+        # in `a.rs` share `p.src.a.b`): keep those, drop only this file's.
+        own = self._import_sites.get(module_qn, {})
+        for name in list(own):
+            if self._import_site_writers.get((module_qn, name), module_qn) == module_qn:
+                del own[name]
+                self._import_site_writers.pop((module_qn, name), None)
+        self._import_sites[module_qn] = own
 
     def _record_import_site(
         self,

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -495,6 +495,7 @@ class ImportProcessor:
         "_deferred_import_edges",
         "_import_sites",
         "_import_site_owners",
+        "_import_site_writers",
         "_inferred_module_imports",
         "_csharp_module_namespaces",
         "_csharp_module_identifiers",
@@ -563,6 +564,10 @@ class ImportProcessor:
         # Sub-scope site entries a file wrote under OTHER scope keys (Rust
         # fn/inline-mod uses), so its re-parse can retract them (#1522).
         self._import_site_owners: dict[str, set[tuple[str, str]]] = {}
+        # (scope, name) -> the file module that wrote the CURRENT entry, so a
+        # re-parse retracts only entries it still owns: a fn-local inline mod
+        # in src/a.rs and src/a/b/mod.rs can share a scope key and a name.
+        self._import_site_writers: dict[tuple[str, str], str] = {}
         self._inferred_module_imports: dict[str, set[str]] = {}
         self._csharp_module_namespaces: dict[str, dict[str, set[str]]] = {}
         self._csharp_module_identifiers: dict[str, frozenset[str]] = {}
@@ -970,6 +975,10 @@ class ImportProcessor:
         # A re-parse must not keep the sub-scope site entries the previous
         # parse of this file wrote under other scope keys (issue #1522).
         for scope_qn, name in self._import_site_owners.pop(module_qn, ()):
+            if self._import_site_writers.get((scope_qn, name)) != module_qn:
+                # Another file wrote the live entry since; it is theirs.
+                continue
+            self._import_site_writers.pop((scope_qn, name), None)
             scope_sites = self._import_sites.get(scope_qn)
             if scope_sites is None:
                 continue
@@ -1000,6 +1009,10 @@ class ImportProcessor:
             self._import_site_owners.setdefault(owner_qn, set()).add(
                 (scope_qn, local_name)
             )
+        # A file-level record is written by the scope's own file.
+        self._import_site_writers[(scope_qn, local_name)] = (
+            owner_qn if owner_qn is not None else scope_qn
+        )
         site = node_site_properties(node)
         if not local_name.startswith((cs.IMPORTED_NAME_WILDCARD, cs.SEPARATOR_DOT)):
             site[cs.KEY_ALIAS] = local_name

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -989,10 +989,14 @@ class ImportProcessor:
         # ANOTHER file wrote (a file-backed `a/b/mod.rs` and an inline `mod b`
         # in `a.rs` share `p.src.a.b`): keep those, drop only this file's.
         own = self._import_sites.get(module_qn, {})
-        for name in list(own):
-            if self._import_site_writers.get((module_qn, name), module_qn) == module_qn:
-                del own[name]
-                self._import_site_writers.pop((module_qn, name), None)
+        mine = [
+            name
+            for name in own
+            if self._import_site_writers.get((module_qn, name), module_qn) == module_qn
+        ]
+        for name in mine:
+            del own[name]
+            self._import_site_writers.pop((module_qn, name), None)
         self._import_sites[module_qn] = own
 
     def _record_import_site(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -21,6 +21,7 @@ from ..types_defs import (
     FunctionRegistryTrieProtocol,
     FunctionSpanKey,
     LanguageQueries,
+    PropertyDict,
 )
 from ..utils.path_utils import should_keep_dir, should_skip_rel_file
 from .cpp_frontend.qn import build_module_qn_map
@@ -44,6 +45,7 @@ from .stdlib_extractor import (
 )
 from .utils import (
     get_query_cursor,
+    node_site_properties,
     safe_decode_text,
     safe_decode_with_fallback,
     sorted_captures,
@@ -491,6 +493,7 @@ class ImportProcessor:
         "_cpp_module_qn_map",
         "_cpp_qn_to_rel",
         "_deferred_import_edges",
+        "_import_sites",
         "_inferred_module_imports",
         "_csharp_module_namespaces",
         "_csharp_module_identifiers",
@@ -553,6 +556,9 @@ class ImportProcessor:
         # IMPORTS edges held back until every file is parsed, so internal
         # targets verify against the full module registry (issue #652).
         self._deferred_import_edges: list[DeferredImportEdge] = []
+        # Per scope qn: the site props of each bound import name (#1522),
+        # attached to the IMPORTS edge when the deferred edge flushes.
+        self._import_sites: dict[str, dict[str, PropertyDict]] = {}
         self._inferred_module_imports: dict[str, set[str]] = {}
         self._csharp_module_namespaces: dict[str, dict[str, set[str]]] = {}
         self._csharp_module_identifiers: dict[str, frozenset[str]] = {}
@@ -866,6 +872,7 @@ class ImportProcessor:
         lang_config = queries[language]["config"]
 
         self.import_mapping[module_qn] = {}
+        self._import_sites[module_qn] = {}
         # A watch-mode re-parse must not carry references the edited file no
         # longer makes (issue #1347).
         self._inferred_module_imports.pop(module_qn, None)
@@ -934,7 +941,8 @@ class ImportProcessor:
                 # Hold the edges back: an internal target is only real if some file
                 # yields that module qn, known only after every file is parsed
                 # (flush_deferred_import_edges).
-                for full_name in self.import_mapping[module_qn].values():
+                sites = self._import_sites.get(module_qn, {})
+                for local_name, full_name in self.import_mapping[module_qn].items():
                     if (module_qn, full_name) in self._cpp_declaration_mappings:
                         continue
                     if full_name == cs.RUST_UNRESOLVABLE_QN:
@@ -947,14 +955,42 @@ class ImportProcessor:
                             module_qn=module_qn,
                             full_name=full_name,
                             language=language,
+                            site=sites.get(local_name),
                         )
                     )
 
         except Exception as e:
             logger.warning(ls.IMP_PARSE_FAILED, module=module_qn, error=e)
 
+    def _record_import_site(
+        self,
+        scope_qn: str,
+        local_name: str,
+        node: Node | None,
+        imported_name: str | None = None,
+    ) -> PropertyDict | None:
+        """Remember where an import binding was written (issue #1522).
+
+        `node` is the import statement (for a grouped Go block, the spec line)
+        whose span the IMPORTS edge will carry. Sentinel keys (`*pkg`
+        wildcards, Go `.pkg` dot-imports) bind no name and record no alias.
+        """
+        if node is None:
+            return None
+        site = node_site_properties(node)
+        if not local_name.startswith((cs.IMPORTED_NAME_WILDCARD, cs.SEPARATOR_DOT)):
+            site[cs.KEY_ALIAS] = local_name
+        if imported_name:
+            site[cs.KEY_IMPORTED_NAME] = imported_name
+        self._import_sites.setdefault(scope_qn, {})[local_name] = site
+        return site
+
     def defer_import_edge(
-        self, module_qn: str, full_name: str, language: cs.SupportedLanguage
+        self,
+        module_qn: str,
+        full_name: str,
+        language: cs.SupportedLanguage,
+        site: PropertyDict | None = None,
     ) -> None:
         # Entry point for import shapes discovered outside parse_imports (the
         # CommonJS destructuring fallback); every IMPORTS edge goes through the same
@@ -966,7 +1002,7 @@ class ImportProcessor:
             return
         self._deferred_import_edges.append(
             DeferredImportEdge(
-                module_qn=module_qn, full_name=full_name, language=language
+                module_qn=module_qn, full_name=full_name, language=language, site=site
             )
         )
 
@@ -1174,13 +1210,25 @@ class ImportProcessor:
         for target_module_qn in sorted(targets):
             if target_module_qn not in known_module_qns:
                 continue
-            self.ingestor.ensure_relationship_batch(
-                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
-                cs.RelationshipType.IMPORTS,
-                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, target_module_qn),
-            )
+            self._emit_import_edge(entry, cs.NodeLabel.MODULE, target_module_qn)
             emitted += 1
         return emitted
+
+    def _emit_import_edge(
+        self, entry: DeferredImportEdge, target_label: str, target_qn: str
+    ) -> None:
+        if self.ingestor is None:
+            return
+        from_spec = (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn)
+        to_spec = (target_label, cs.KEY_QUALIFIED_NAME, target_qn)
+        if entry.site:
+            self.ingestor.ensure_relationship_batch(
+                from_spec, cs.RelationshipType.IMPORTS, to_spec, properties=entry.site
+            )
+        else:
+            self.ingestor.ensure_relationship_batch(
+                from_spec, cs.RelationshipType.IMPORTS, to_spec
+            )
 
     def record_resolved_cross_module_use(
         self, importing_module_qn: str, target_module_qn: str
@@ -1244,11 +1292,7 @@ class ImportProcessor:
                     entry.full_name, known_module_paths, module_aliases, entry.language
                 )
             ):
-                self.ingestor.ensure_relationship_batch(
-                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
-                    cs.RelationshipType.IMPORTS,
-                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, full_target),
-                )
+                self._emit_import_edge(entry, cs.NodeLabel.MODULE, full_target)
                 emitted += 1
                 continue
             if entry.language == cs.SupportedLanguage.RUST and (
@@ -1285,11 +1329,7 @@ class ImportProcessor:
                         to_module=entry.full_name,
                     )
                     continue
-                self.ingestor.ensure_relationship_batch(
-                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
-                    cs.RelationshipType.IMPORTS,
-                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, target),
-                )
+                self._emit_import_edge(entry, cs.NodeLabel.MODULE, target)
                 emitted += 1
                 continue
             if entry.language == cs.SupportedLanguage.CSHARP and (
@@ -1328,11 +1368,7 @@ class ImportProcessor:
                     )
                     continue
                 module_path = verified
-            self.ingestor.ensure_relationship_batch(
-                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
-                cs.RelationshipType.IMPORTS,
-                (target_label, cs.KEY_QUALIFIED_NAME, module_path),
-            )
+            self._emit_import_edge(entry, target_label, module_path)
             emitted += 1
             logger.debug(
                 ls.IMP_CREATED_RELATIONSHIP,
@@ -1450,6 +1486,7 @@ class ImportProcessor:
         local_name = module_name.split(cs.SEPARATOR_DOT)[0]
         full_name = self._resolve_import_full_name(module_name, local_name)
         self.import_mapping[module_qn][local_name] = full_name
+        self._record_import_site(module_qn, local_name, child.parent)
         logger.debug(ls.IMP_IMPORT, local=local_name, full=full_name)
 
     def _handle_aliased_import(self, child: Node, module_qn: str) -> None:
@@ -1466,6 +1503,7 @@ class ImportProcessor:
         top_level = module_name.split(cs.SEPARATOR_DOT)[0]
         full_name = self._resolve_import_full_name(module_name, top_level)
         self.import_mapping[module_qn][alias] = full_name
+        self._record_import_site(module_qn, alias, child.parent)
         logger.debug(ls.IMP_ALIASED_IMPORT, alias=alias, full=full_name)
 
     def _resolve_import_full_name(self, module_name: str, top_level: str) -> str:
@@ -2849,7 +2887,7 @@ class ImportProcessor:
             return
 
         self._register_python_from_imports(
-            module_qn, module_name, imported_items, is_wildcard
+            module_qn, module_name, imported_items, is_wildcard, import_node
         )
 
     def _extract_python_from_module_name(
@@ -2909,16 +2947,21 @@ class ImportProcessor:
         base_module: str,
         imported_items: list[tuple[str, str]],
         is_wildcard: bool,
+        import_node: Node | None = None,
     ) -> None:
         if is_wildcard:
             wildcard_key = f"*{base_module}"
             self.import_mapping[module_qn][wildcard_key] = base_module
+            self._record_import_site(
+                module_qn, wildcard_key, import_node, cs.IMPORTED_NAME_WILDCARD
+            )
             logger.debug(ls.IMP_WILDCARD_IMPORT, module=base_module)
             return
 
         for local_name, original_name in imported_items:
             full_name = f"{base_module}{cs.SEPARATOR_DOT}{original_name}"
             self.import_mapping[module_qn][local_name] = full_name
+            self._record_import_site(module_qn, local_name, import_node, original_name)
             logger.debug(ls.IMP_FROM_IMPORT, local=local_name, full=full_name)
 
     def _is_package_qn(self, module_qn: str) -> bool:
@@ -3096,11 +3139,17 @@ class ImportProcessor:
                     local_name
                 )
 
+        # The clause's parent is the import statement whose span the edge
+        # records; the clause alone would drop the `from '...'` half.
+        statement = clause_node.parent or clause_node
         for child in clause_node.children:
             if child.type == cs.TS_IDENTIFIER:
                 imported_name = safe_decode_with_fallback(child)
                 self.import_mapping[current_module][imported_name] = (
                     f"{source_module}{cs.IMPORT_DEFAULT_SUFFIX}"
+                )
+                self._record_import_site(
+                    current_module, imported_name, statement, cs.TS_EXPORT_DEFAULT
                 )
                 _note_bare(imported_name)
                 logger.debug(
@@ -3122,6 +3171,9 @@ class ImportProcessor:
                             self.import_mapping[current_module][local_name] = (
                                 f"{source_module}{cs.SEPARATOR_DOT}{imported_name}"
                             )
+                            self._record_import_site(
+                                current_module, local_name, statement, imported_name
+                            )
                             _note_bare(local_name)
                             logger.debug(
                                 ls.IMP_JS_NAMED,
@@ -3136,6 +3188,9 @@ class ImportProcessor:
                         namespace_name = safe_decode_with_fallback(grandchild)
                         self.import_mapping[current_module][namespace_name] = (
                             source_module
+                        )
+                        self._record_import_site(
+                            current_module, namespace_name, statement
                         )
                         logger.debug(
                             ls.IMP_JS_NAMESPACE,
@@ -3177,6 +3232,7 @@ class ImportProcessor:
                 # `const fs = require('fs')`: bind the whole module.
                 var_name = safe_decode_with_fallback(name_node)
                 self.import_mapping[current_module][var_name] = resolved_module
+                self._record_import_site(current_module, var_name, decl_node)
                 logger.debug(ls.IMP_JS_REQUIRE, var=var_name, module=resolved_module)
             elif name_node.type == cs.TS_OBJECT_PATTERN:
                 # `const { writeFileSync } = require('fs')` / `{ x: y }`: bind each
@@ -3184,6 +3240,7 @@ class ImportProcessor:
                 for local, imported in _js_destructured_names(name_node):
                     full = f"{resolved_module}{cs.SEPARATOR_DOT}{imported}"
                     self.import_mapping[current_module][local] = full
+                    self._record_import_site(current_module, local, decl_node, imported)
                     logger.debug(ls.IMP_JS_REQUIRE, var=local, module=full)
 
     def _parse_js_reexport(self, export_node: Node, current_module: str) -> None:
@@ -3203,6 +3260,9 @@ class ImportProcessor:
             if child.type == cs.TS_ASTERISK:
                 wildcard_key = f"*{source_module}"
                 self.import_mapping[current_module][wildcard_key] = source_module
+                self._record_import_site(
+                    current_module, wildcard_key, export_node, cs.IMPORTED_NAME_WILDCARD
+                )
                 logger.debug(ls.IMP_JS_NAMESPACE_REEXPORT, module=source_module)
             elif child.type == cs.TS_EXPORT_CLAUSE:
                 for grandchild in child.children:
@@ -3218,6 +3278,12 @@ class ImportProcessor:
                             )
                             self.import_mapping[current_module][exported_name] = (
                                 f"{source_module}{cs.SEPARATOR_DOT}{original_name}"
+                            )
+                            self._record_import_site(
+                                current_module,
+                                exported_name,
+                                export_node,
+                                original_name,
                             )
                             logger.debug(
                                 ls.IMP_JS_REEXPORT,
@@ -3249,9 +3315,18 @@ class ImportProcessor:
                 if is_wildcard:
                     logger.debug(ls.IMP_JAVA_WILDCARD, path=resolved_path)
                     self.import_mapping[module_qn][f"*{resolved_path}"] = resolved_path
+                    self._record_import_site(
+                        module_qn,
+                        f"*{resolved_path}",
+                        import_node,
+                        cs.IMPORTED_NAME_WILDCARD,
+                    )
                 elif parts := resolved_path.split(cs.SEPARATOR_DOT):
                     imported_name = parts[-1]
                     self.import_mapping[module_qn][imported_name] = resolved_path
+                    self._record_import_site(
+                        module_qn, imported_name, import_node, imported_name
+                    )
                     if is_static:
                         logger.debug(
                             ls.IMP_JAVA_STATIC,
@@ -3494,10 +3569,18 @@ class ImportProcessor:
                     # send that name's bare calls to the trie (issue #1054).
                     continue
             resolved_imports[imported_name] = resolved
+            site = self._record_import_site(
+                effective_qn,
+                imported_name,
+                use_node,
+                full_path.split(cs.SEPARATOR_DOUBLE_COLON)[-1],
+            )
             if sub_scope:
                 # The generic deferral loop only reads the file-level map;
                 # sub-scope imports still owe the file its IMPORTS edge.
-                self.defer_import_edge(module_qn, resolved, cs.SupportedLanguage.RUST)
+                self.defer_import_edge(
+                    module_qn, resolved, cs.SupportedLanguage.RUST, site=site
+                )
             logger.debug(ls.IMP_RUST, name=imported_name, path=resolved)
         if scope_node is not None:
             if scope_node.type == cs.TS_RS_FUNCTION_ITEM:
@@ -3865,11 +3948,12 @@ class ImportProcessor:
                 # `import . "fmt"` binds the package's exported names, not the
                 # package identifier; a `.`-prefixed sentinel key (no identifier
                 # can contain a dot) lets bare-callee lookups re-qualify.
-                self.import_mapping[module_qn][f"{cs.SEPARATOR_DOT}{package_name}"] = (
-                    import_path
-                )
+                dot_key = f"{cs.SEPARATOR_DOT}{package_name}"
+                self.import_mapping[module_qn][dot_key] = import_path
+                self._record_import_site(module_qn, dot_key, spec_node)
             else:
                 self.import_mapping[module_qn][package_name] = import_path
+                self._record_import_site(module_qn, package_name, spec_node)
             logger.debug(ls.IMP_GO, package=package_name, path=import_path)
 
     def _parse_cpp_imports(self, captures: dict, module_qn: str) -> None:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -3207,7 +3207,10 @@ class ImportProcessor:
                             source_module
                         )
                         self._record_import_site(
-                            current_module, namespace_name, statement
+                            current_module,
+                            namespace_name,
+                            statement,
+                            cs.IMPORTED_NAME_WILDCARD,
                         )
                         logger.debug(
                             ls.IMP_JS_NAMESPACE,

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -494,6 +494,7 @@ class ImportProcessor:
         "_cpp_qn_to_rel",
         "_deferred_import_edges",
         "_import_sites",
+        "_import_site_owners",
         "_inferred_module_imports",
         "_csharp_module_namespaces",
         "_csharp_module_identifiers",
@@ -559,6 +560,9 @@ class ImportProcessor:
         # Per scope qn: the site props of each bound import name (#1522),
         # attached to the IMPORTS edge when the deferred edge flushes.
         self._import_sites: dict[str, dict[str, PropertyDict]] = {}
+        # Sub-scope site entries a file wrote under OTHER scope keys (Rust
+        # fn/inline-mod uses), so its re-parse can retract them (#1522).
+        self._import_site_owners: dict[str, set[tuple[str, str]]] = {}
         self._inferred_module_imports: dict[str, set[str]] = {}
         self._csharp_module_namespaces: dict[str, dict[str, set[str]]] = {}
         self._csharp_module_identifiers: dict[str, frozenset[str]] = {}
@@ -872,6 +876,12 @@ class ImportProcessor:
         lang_config = queries[language]["config"]
 
         self.import_mapping[module_qn] = {}
+        for scope_qn, name in self._import_site_owners.pop(module_qn, ()):
+            scope_sites = self._import_sites.get(scope_qn)
+            if scope_sites is not None:
+                scope_sites.pop(name, None)
+                if not scope_sites:
+                    del self._import_sites[scope_qn]
         self._import_sites[module_qn] = {}
         # A watch-mode re-parse must not carry references the edited file no
         # longer makes (issue #1347).
@@ -968,15 +978,22 @@ class ImportProcessor:
         local_name: str,
         node: Node | None,
         imported_name: str | None = None,
+        owner_qn: str | None = None,
     ) -> PropertyDict | None:
         """Remember where an import binding was written (issue #1522).
 
         `node` is the import statement (for a grouped Go block, the spec line)
         whose span the IMPORTS edge will carry. Sentinel keys (`*pkg`
         wildcards, Go `.pkg` dot-imports) bind no name and record no alias.
+        `owner_qn` names the FILE module when `scope_qn` is one of its
+        sub-scopes, so the file's re-parse retracts the entry.
         """
         if node is None:
             return None
+        if owner_qn is not None and owner_qn != scope_qn:
+            self._import_site_owners.setdefault(owner_qn, set()).add(
+                (scope_qn, local_name)
+            )
         site = node_site_properties(node)
         if not local_name.startswith((cs.IMPORTED_NAME_WILDCARD, cs.SEPARATOR_DOT)):
             site[cs.KEY_ALIAS] = local_name
@@ -3363,6 +3380,12 @@ class ImportProcessor:
             else:
                 local_name = imported_path.split(cs.SEPARATOR_DOT)[-1]
             self.import_mapping[module_qn][local_name] = imported_path
+            self._record_import_site(
+                module_qn,
+                local_name,
+                import_node,
+                imported_path.split(cs.SEPARATOR_DOT)[-1],
+            )
             logger.debug(ls.IMP_CSHARP, name=local_name, path=imported_path)
 
     def reset_java_path_caches(self) -> None:
@@ -3574,6 +3597,7 @@ class ImportProcessor:
                 imported_name,
                 use_node,
                 full_path.split(cs.SEPARATOR_DOUBLE_COLON)[-1],
+                owner_qn=module_qn,
             )
             if sub_scope:
                 # The generic deferral loop only reads the file-level map;
@@ -3810,13 +3834,15 @@ class ImportProcessor:
         group: list[Node] = []
         for child in import_node.children:
             if child.type == cs.CHAR_COMMA:
-                self._parse_scala_import_group(group, module_qn)
+                self._parse_scala_import_group(group, module_qn, import_node)
                 group = []
             elif child.type != cs.TS_SCALA_IMPORT_KEYWORD:
                 group.append(child)
-        self._parse_scala_import_group(group, module_qn)
+        self._parse_scala_import_group(group, module_qn, import_node)
 
-    def _parse_scala_import_group(self, children: list[Node], module_qn: str) -> None:
+    def _parse_scala_import_group(
+        self, children: list[Node], module_qn: str, import_node: Node
+    ) -> None:
         prefix_parts: list[str] = []
         selectors: Node | None = None
         wildcard: Node | None = None
@@ -3838,7 +3864,7 @@ class ImportProcessor:
 
         if renamed is not None:
             self._bind_scala_rename(
-                renamed, cs.SEPARATOR_DOT.join(prefix_parts), module_qn
+                renamed, cs.SEPARATOR_DOT.join(prefix_parts), module_qn, import_node
             )
             return
 
@@ -3850,19 +3876,25 @@ class ImportProcessor:
             # here; the package itself is what comes into scope.
             package = cs.SEPARATOR_DOT.join(prefix_parts)
             self.import_mapping[module_qn][f"*{package}"] = package
+            self._record_import_site(module_qn, f"*{package}", import_node)
             return
 
         if selectors is not None:
             package = cs.SEPARATOR_DOT.join(prefix_parts)
-            self._parse_scala_selectors(selectors, package, module_qn)
+            self._parse_scala_selectors(selectors, package, module_qn, import_node)
             return
 
         # Plain `import a.b.C`: the last part is the imported name, and
         # everything is also the full path.
         full_path = cs.SEPARATOR_DOT.join(prefix_parts)
         self.import_mapping[module_qn][prefix_parts[-1]] = full_path
+        self._record_import_site(
+            module_qn, prefix_parts[-1], import_node, prefix_parts[-1]
+        )
 
-    def _bind_scala_rename(self, node: Node, package: str, module_qn: str) -> None:
+    def _bind_scala_rename(
+        self, node: Node, package: str, module_qn: str, import_node: Node
+    ) -> None:
         """Bind `original as/=> alias` to the ALIAS only.
 
         Binding the original as well would make it resolvable under a name
@@ -3884,9 +3916,10 @@ class ImportProcessor:
         original, alias = names
         full = f"{package}{cs.SEPARATOR_DOT}{original}" if package else original
         self.import_mapping[module_qn][alias] = full
+        self._record_import_site(module_qn, alias, import_node, original)
 
     def _parse_scala_selectors(
-        self, selectors: Node, package: str, module_qn: str
+        self, selectors: Node, package: str, module_qn: str, import_node: Node
     ) -> None:
         for child in selectors.children:
             if child.type in (
@@ -3895,15 +3928,17 @@ class ImportProcessor:
             ):
                 # `{Map => MMap}` (Scala 2) and `{Map as MMap}` (Scala 3) are
                 # different node types spelling the same thing.
-                self._bind_scala_rename(child, package, module_qn)
+                self._bind_scala_rename(child, package, module_qn, import_node)
             elif child.type == cs.TS_SCALA_NAMESPACE_WILDCARD:
                 # `import a.{b, _}` -- a wildcard alongside explicit names.
                 self.import_mapping[module_qn][f"*{package}"] = package
+                self._record_import_site(module_qn, f"*{package}", import_node)
             elif child.type == cs.TS_IDENTIFIER:
                 if name := safe_decode_with_fallback(child):
                     self.import_mapping[module_qn][name] = (
                         f"{package}{cs.SEPARATOR_DOT}{name}"
                     )
+                    self._record_import_site(module_qn, name, import_node, name)
 
     def _parse_go_imports(self, captures: dict, module_qn: str) -> None:
         for import_node in captures.get(cs.CAPTURE_IMPORT, []):
@@ -4054,6 +4089,7 @@ class ImportProcessor:
                 full_name = f"{cs.IMPORT_STD_PREFIX}{include_path}"
 
             self.import_mapping[module_qn][local_name] = full_name
+            self._record_import_site(module_qn, local_name, include_node, include_path)
             logger.debug(
                 ls.IMP_CPP_INCLUDE,
                 local=local_name,
@@ -4091,6 +4127,9 @@ class ImportProcessor:
                 full_name = f"{cs.IMPORT_STD_PREFIX}{module_name}"
 
                 self.import_mapping[module_qn][local_name] = full_name
+                self._record_import_site(
+                    module_qn, local_name, import_node, module_name
+                )
                 logger.debug(ls.IMP_CPP_MODULE, local=local_name, full=full_name)
 
     def _parse_cpp_module_declaration(self, decl_node: Node, module_qn: str) -> None:
@@ -4229,6 +4268,12 @@ class ImportProcessor:
                 parts = imported_path.split(cs.SEPARATOR_DOT)
                 local_name = parts[-1] if parts else imported_path
             self.import_mapping[module_qn][local_name] = imported_path
+            self._record_import_site(
+                module_qn,
+                local_name,
+                use_node,
+                imported_path.split(cs.SEPARATOR_DOT)[-1],
+            )
             if decl_is_function or any(
                 c.type == cs.TS_PHP_FUNCTION for c in child.children
             ):
@@ -4249,6 +4294,7 @@ class ImportProcessor:
                 parts = path_str.split(cs.SEPARATOR_DOT)
                 local_name = parts[-1] if parts else path_str
                 self.import_mapping[module_qn][local_name] = path_str
+                self._record_import_site(module_qn, local_name, node, path_str)
                 return
 
     def _parse_generic_imports(
@@ -4272,7 +4318,9 @@ class ImportProcessor:
             if not uri:
                 continue
             if full_name := dart_resolve_import(uri, module_qn, self.project_name):
-                self.import_mapping[module_qn][dart_local_name(uri)] = full_name
+                local_name = dart_local_name(uri)
+                self.import_mapping[module_qn][local_name] = full_name
+                self._record_import_site(module_qn, local_name, import_node, uri)
 
     def _parse_lua_imports(self, captures: dict, module_qn: str) -> None:
         for call_node in captures.get(cs.CAPTURE_IMPORT, []):
@@ -4284,6 +4332,9 @@ class ImportProcessor:
                     )
                     resolved = self._resolve_lua_module_path(module_path, module_qn)
                     self.import_mapping[module_qn][local_name] = resolved
+                    self._record_import_site(
+                        module_qn, local_name, call_node, module_path
+                    )
             elif self._lua_is_pcall_require(call_node):
                 if module_path := self._lua_extract_pcall_require_arg(call_node):
                     local_name = (
@@ -4292,10 +4343,16 @@ class ImportProcessor:
                     )
                     resolved = self._resolve_lua_module_path(module_path, module_qn)
                     self.import_mapping[module_qn][local_name] = resolved
+                    self._record_import_site(
+                        module_qn, local_name, call_node, module_path
+                    )
 
             elif self._lua_is_stdlib_call(call_node):
                 if stdlib_module := self._lua_extract_stdlib_module(call_node):
                     self.import_mapping[module_qn][stdlib_module] = stdlib_module
+                    self._record_import_site(
+                        module_qn, stdlib_module, call_node, stdlib_module
+                    )
 
     def _lua_is_require_call(self, call_node: Node) -> bool:
         first_child = call_node.children[0] if call_node.children else None

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -245,6 +245,21 @@ def _cached_decode_bytes(text_bytes: bytes) -> str:
     return text_bytes.decode(cs.ENCODING_UTF8)
 
 
+def node_site_properties(node: Node) -> PropertyDict:
+    """Edge-site span of a tree-sitter node (issue #1522).
+
+    1-based lines, 0-based columns, end exclusive, matching the node
+    `start_line`/`start_col` convention so a site can be sliced straight
+    out of the file.
+    """
+    return {
+        cs.KEY_LINE: node.start_point[0] + 1,
+        cs.KEY_COL: node.start_point[1],
+        cs.KEY_END_LINE: node.end_point[0] + 1,
+        cs.KEY_END_COL: node.end_point[1],
+    }
+
+
 def safe_decode_text(node: ASTNode | TreeSitterNodeProtocol | None) -> str | None:
     if node is None or (text_bytes := node.text) is None:
         return None

--- a/codebase_rag/schema_builder.py
+++ b/codebase_rag/schema_builder.py
@@ -1,7 +1,9 @@
 from .types_defs import (
     NODE_SCHEMAS,
+    RELATIONSHIP_PROPERTY_SCHEMAS,
     RELATIONSHIP_SCHEMAS,
     NodeSchema,
+    RelationshipPropertySchema,
     RelationshipSchema,
 )
 
@@ -32,10 +34,29 @@ def build_relationships_section() -> str:
     return "\n".join(lines)
 
 
+def _format_relationship_property_schema(schema: RelationshipPropertySchema) -> str:
+    types = "|".join(str(t) for t in schema.rel_types)
+    return f"- {types}: {schema.properties}"
+
+
+def build_relationship_properties_section() -> str:
+    lines = [
+        "Relationship properties (one CALLS/REFERENCES/INSTANTIATES edge per "
+        "call site, one IMPORTS edge per bound name; use DISTINCT for endpoints):"
+    ]
+    lines.extend(
+        _format_relationship_property_schema(schema)
+        for schema in RELATIONSHIP_PROPERTY_SCHEMAS
+    )
+    return "\n".join(lines)
+
+
 def build_graph_schema_text() -> str:
     return f"""{build_node_labels_section()}
 
-{build_relationships_section()}"""
+{build_relationships_section()}
+
+{build_relationship_properties_section()}"""
 
 
 GRAPH_SCHEMA_DEFINITION = build_graph_schema_text()

--- a/codebase_rag/services/graph_diff.py
+++ b/codebase_rag/services/graph_diff.py
@@ -130,6 +130,24 @@ def _node_map(indexes: list[pb.GraphCodeIndex]) -> dict[NodeKey, JsonDict]:
     return nodes
 
 
+# Edge-site properties (issue #1522) locate an edge in the file; they are not
+# part of the structure a diff reports, or every line shift would surface as
+# a changed relationship. Per-site parallel edges collapse onto their
+# endpoint triple here for the same reason.
+_SITE_PROPS = frozenset(
+    {
+        cs.KEY_LINE,
+        cs.KEY_COL,
+        cs.KEY_END_LINE,
+        cs.KEY_END_COL,
+        cs.KEY_ARG_COUNT,
+        cs.KEY_KWARG_NAMES,
+        cs.KEY_ALIAS,
+        cs.KEY_IMPORTED_NAME,
+    }
+)
+
+
 def _rel_map(indexes: list[pb.GraphCodeIndex]) -> dict[tuple[str, str, str], JsonDict]:
     rels: dict[tuple[str, str, str], JsonDict] = {}
     for index in indexes:
@@ -139,7 +157,8 @@ def _rel_map(indexes: list[pb.GraphCodeIndex]) -> dict[tuple[str, str, str], Jso
                 pb.Relationship.RelationshipType.Name(rel.type),
                 rel.target_id,
             )
-            rels[key] = dict(rel.properties)
+            props = {k: v for k, v in rel.properties.items() if k not in _SITE_PROPS}
+            rels.setdefault(key, {}).update(props)
     return rels
 
 

--- a/codebase_rag/services/protobuf_service.py
+++ b/codebase_rag/services/protobuf_service.py
@@ -42,6 +42,10 @@ PATH_BASED_LABELS = frozenset({cs.NodeLabel.FOLDER, cs.NodeLabel.FILE})
 NAME_BASED_LABELS = frozenset({cs.NodeLabel.EXTERNAL_PACKAGE, cs.NodeLabel.PROJECT})
 
 
+# Endpoints plus the site-keyed props (issue #1522) that make parallel edges
+# between one node pair distinct records, mirroring MERGE_KEY_PROPS_BY_REL.
+_RelKey = tuple[str, int, str, tuple[tuple[str, PropertyValue], ...]]
+
 _REL_TYPE_CACHE: dict = {}
 _MSG_CLASS_CACHE: dict[str, type | None] = {}
 
@@ -63,7 +67,7 @@ class ProtobufFileIngestor:
     ):
         self.output_dir = Path(output_path)
         self._nodes: dict[str, pb.Node] = {}
-        self._relationships: dict[tuple[str, int, str], pb.Relationship] = {}
+        self._relationships: dict[_RelKey, pb.Relationship] = {}
         self.split_index = split_index
         # File/Folder identities are ABSOLUTE paths in the live graph (the
         # realtime watcher deletes by absolute path, issue #1141), which would
@@ -180,7 +184,15 @@ class ProtobufFileIngestor:
         )
         to_val = self._canonical_ref(str(to_val_raw)) if to_val_raw is not None else ""
 
-        unique_key = (from_val, rel_type_enum, to_val)
+        # Site-keyed edges (one CALLS per call site, one IMPORTS per bound
+        # name; issue #1522) are distinct records, mirroring the graph sink's
+        # MERGE key; a row without a site still collapses on its endpoints.
+        site_key = tuple(
+            (key, properties[key])
+            for key in cs.MERGE_KEY_PROPS_BY_REL.get(rel_type, ())
+            if properties and key in properties
+        )
+        unique_key = (from_val, rel_type_enum, to_val, site_key)
         if unique_key in self._relationships:
             if properties:
                 self._relationships[unique_key].properties.update(properties)

--- a/codebase_rag/tests/test_edge_site_properties.py
+++ b/codebase_rag/tests/test_edge_site_properties.py
@@ -407,3 +407,235 @@ def test_reference_site_without_arguments_carries_span_only(
     # `return` statement or dict literal.
     assert _site(props) == _span(src, "helper", occurrence=1)
     assert cs.KEY_ARG_COUNT not in props
+
+
+# --- Review findings on PR #1537 ------------------------------------------------
+
+
+def _import_props(mock: MagicMock, module_suffix: str) -> dict[str, PropertyDict]:
+    """alias -> site props for every sited IMPORTS edge out of one module."""
+    return {
+        str(props[cs.KEY_ALIAS]): props
+        for _dst, props in _imports_from(mock, module_suffix)
+        if cs.KEY_ALIAS in props
+    }
+
+
+CSHARP_SRC = "using System.Text;\nusing IO = System.IO;\n\nclass A { }\n"
+CPP_SRC = '#include <vector>\n#include "util.h"\n\nint main() { return 0; }\n'
+PHP_SRC = "<?php\nuse App\\Models\\User as U;\nuse App\\Helpers\\Fmt;\n\nclass A {}\n"
+DART_SRC = (
+    "import 'package:flutter/material.dart';\nimport 'util.dart';\n\nclass A {}\n"
+)
+LUA_SRC = "local Person = require('person')\nlocal json = require('json')\n"
+SCALA_SRC = (
+    "package com.example\n"
+    "import scala.collection.mutable.{Map => MMap}\n"
+    "import scala.util.Try\n"
+    "import scala.io._\n\n"
+    "object Solo { def run(): Int = 1 }\n"
+)
+
+
+@pytest.mark.parametrize(
+    ("grammar", "filename", "src", "extra_files", "expected"),
+    [
+        (
+            "c_sharp",
+            "A.cs",
+            CSHARP_SRC,
+            {},
+            {
+                "Text": ("using System.Text;", "Text"),
+                "IO": ("using IO = System.IO;", "IO"),
+            },
+        ),
+        (
+            "cpp",
+            "main.cpp",
+            CPP_SRC,
+            {"util.h": "int util();\n"},
+            {
+                # tree-sitter's preproc_include spans through its newline.
+                "vector": ("#include <vector>\n", "vector"),
+                "util": ('#include "util.h"\n', "util.h"),
+            },
+        ),
+        (
+            "php",
+            "a.php",
+            PHP_SRC,
+            {},
+            {
+                "U": ("use App\\Models\\User as U;", "User"),
+                "Fmt": ("use App\\Helpers\\Fmt;", "Fmt"),
+            },
+        ),
+        (
+            "dart",
+            "a.dart",
+            DART_SRC,
+            {"util.dart": "int util() => 1;\n"},
+            {
+                "material": (
+                    "import 'package:flutter/material.dart';",
+                    "package:flutter/material.dart",
+                ),
+                "util": ("import 'util.dart';", "util.dart"),
+            },
+        ),
+        (
+            "lua",
+            "main.lua",
+            LUA_SRC,
+            {"person.lua": "local Person = {}\nreturn Person\n"},
+            {
+                "Person": ("require('person')", "person"),
+                "json": ("require('json')", "json"),
+            },
+        ),
+        (
+            "scala",
+            "a.scala",
+            SCALA_SRC,
+            {},
+            {
+                "MMap": ("import scala.collection.mutable.{Map => MMap}", "Map"),
+                "Try": ("import scala.util.Try", "Try"),
+            },
+        ),
+    ],
+)
+def test_every_import_handler_records_the_site(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+    grammar: str,
+    filename: str,
+    src: str,
+    extra_files: dict[str, str],
+    expected: dict[str, tuple[str, str]],
+) -> None:
+    """C#, C++, PHP, Dart, Lua and Scala imports carry a span, alias and name.
+
+    The first cut of #1522 wired only the five languages the acceptance list
+    named; the rest still emitted property-less IMPORTS edges, so two
+    bindings of one provider collapsed onto a single edge (Greptile P1).
+    """
+    for name, body in extra_files.items():
+        (temp_repo / name).write_text(body, encoding="utf-8")
+    (temp_repo / filename).write_text(src, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=grammar)
+
+    sited = _import_props(mock_ingestor, Path(filename).stem)
+    for alias, (needle, imported_name) in expected.items():
+        assert alias in sited, (alias, sorted(sited))
+        assert _site(sited[alias]) == _span(src, needle), alias
+        assert sited[alias][cs.KEY_IMPORTED_NAME] == imported_name, alias
+
+
+def test_scala_wildcard_import_records_span_without_alias(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "a.scala").write_text(SCALA_SRC, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="scala")
+    wildcard = [
+        props
+        for dst, props in _imports_from(mock_ingestor, ".a")
+        if dst.endswith("scala.io")
+    ]
+    (props,) = wildcard
+    assert _site(props) == _span(SCALA_SRC, "import scala.io._")
+    assert cs.KEY_ALIAS not in props
+
+
+def test_rust_reparse_retracts_sub_scope_import_sites(temp_repo: Path) -> None:
+    """A re-parsed Rust file drops the sub-scope site entries it wrote before.
+
+    Sub-scope uses record their site under the fn / inline-mod scope qn, not
+    the file's, so the per-module reset alone left the removed binding's span
+    standing beside its replacement (Greptile P1 on #1537).
+    """
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.RUST not in parsers:
+        pytest.skip("rust parser not available")
+    processor = ImportProcessor(repo_path=temp_repo, project_name="p")
+    module_qn = "p.src.worker"
+
+    def parse(source: str) -> None:
+        tree = parsers[cs.SupportedLanguage.RUST].parse(source.encode())
+        processor.parse_imports(
+            tree.root_node, module_qn, cs.SupportedLanguage.RUST, queries
+        )
+
+    parse("mod nested {\n    use std::fmt::Display as Inline;\n}\n")
+    scope = f"{module_qn}.nested"
+    assert set(processor._import_sites[scope]) == {"Inline"}
+
+    parse("mod nested {\n    use std::fmt::Debug as Replacement;\n}\n")
+    assert set(processor._import_sites[scope]) == {"Replacement"}
+
+    parse("fn main() {}\n")
+    assert scope not in processor._import_sites
+
+
+def test_call_site_cache_is_not_keyed_by_recycled_node_ids() -> None:
+    """A fresh tree whose node id happens to match must not reuse a cached site.
+
+    tree-sitter recycles node ids across trees, so a cache keyed by bare
+    `Node.id` could hand a later call the span and argument shape of an
+    earlier, unrelated one (Greptile P1 on #1537). Keying by the node object
+    (and holding it) makes a hit impossible for any node but that one.
+    """
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.call_processor import CallProcessor
+
+    parsers, _queries = load_parsers()
+    if cs.SupportedLanguage.PYTHON not in parsers:
+        pytest.skip("python parser not available")
+    parser = parsers[cs.SupportedLanguage.PYTHON]
+
+    def first_call(source: str) -> Any:
+        tree = parser.parse(source.encode())
+        stack = [tree.root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == "call":
+                return node
+            stack.extend(node.children)
+        raise AssertionError("no call node")
+
+    ingestor = MagicMock()
+    cp = CallProcessor.__new__(CallProcessor)
+    cp.ingestor = ingestor
+    cp._site_node = None
+    cp._site_cache = None
+
+    src_a = "f(1)\n"
+    src_b = "g(1, 2, k=3)\n"
+    call_a = first_call(src_a)
+    call_b = first_call(src_b)
+    cp._site_node = call_a
+    cp._emit_rel(
+        ("Function", "qualified_name", "x"),
+        "CALLS",
+        ("Function", "qualified_name", "f"),
+    )
+    cp._site_node = call_b
+    cp._emit_rel(
+        ("Function", "qualified_name", "x"),
+        "CALLS",
+        ("Function", "qualified_name", "g"),
+    )
+
+    (first, second) = ingestor.ensure_relationship_batch.call_args_list
+    assert first.kwargs["properties"][cs.KEY_ARG_COUNT] == 1
+    assert second.kwargs["properties"][cs.KEY_ARG_COUNT] == 3
+    assert second.kwargs["properties"][cs.KEY_KWARG_NAMES] == ["k"]
+    assert _site(second.kwargs["properties"]) == _span(src_b, "g(1, 2, k=3)")
+    # An id collision cannot be forced from a test, so the behavioural check
+    # above passes on the old code too; the key must be the node itself.
+    assert cp._site_cache is not None
+    assert cp._site_cache[0] is call_b

--- a/codebase_rag/tests/test_edge_site_properties.py
+++ b/codebase_rag/tests/test_edge_site_properties.py
@@ -6,6 +6,7 @@
 # imported symbol, so a consumer can jump to, check, or rewrite the exact site.
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -190,7 +191,7 @@ def test_typescript_call_and_import_sites(
     assert _site(imports["h"]) == _span(TS_B, 'import { helper as h } from "./a";')
     assert imports["h"][cs.KEY_IMPORTED_NAME] == "helper"
     assert _site(imports["ns"]) == _span(TS_B, 'import * as ns from "./a";')
-    assert cs.KEY_IMPORTED_NAME not in imports["ns"]
+    assert imports["ns"][cs.KEY_IMPORTED_NAME] == cs.IMPORTED_NAME_WILDCARD
 
 
 # --- Go ------------------------------------------------------------------------
@@ -639,3 +640,55 @@ def test_call_site_cache_is_not_keyed_by_recycled_node_ids() -> None:
     # above passes on the old code too; the key must be the node itself.
     assert cp._site_cache is not None
     assert cp._site_cache[0] is call_b
+
+
+CPP_CONSTRUCTIONS = (
+    "class Point {\n"
+    " public:\n"
+    "  Point(int x, int y) : x_(x), y_(y) {}\n"
+    "  int x_;\n"
+    "  int y_;\n"
+    "};\n"
+    "\n"
+    "class Line : public Point {\n"
+    " public:\n"
+    "  Line() : Point(0, 0) {}\n"
+    "};\n"
+    "\n"
+    "Point make() { return {1, 2}; }\n"
+    "\n"
+    "int main() {\n"
+    "  Point origin(3, 4);\n"
+    "  return origin.x_;\n"
+    "}\n"
+)
+
+
+def test_cpp_construction_paths_carry_their_site(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """Declaration, member-initializer and braced-return constructions have
+    no call node; their edges still carry the statement that constructs.
+
+    The per-call loop pinned the site for explicit `Point(3, 4)` calls only;
+    these three C++ paths emitted edges with no site at all (CodeRabbit on
+    #1537).
+    """
+    (temp_repo / "main.cpp").write_text(CPP_CONSTRUCTIONS, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
+
+    def sites(caller_suffix: str) -> set[tuple[Any, ...]]:
+        found = set()
+        for rel in (cs.RelationshipType.CALLS, cs.RelationshipType.INSTANTIATES):
+            for src, dst, props in _edges(mock_ingestor, rel):
+                if (
+                    re.search(rf"{re.escape(caller_suffix)}(\(|$)", src)
+                    and "Point" in dst
+                ):
+                    assert props is not None, (src, dst)
+                    found.add(_site(props))
+        return found
+
+    assert sites(".main") == {_span(CPP_CONSTRUCTIONS, "Point origin(3, 4);")}
+    assert sites(".Line.Line") == {_span(CPP_CONSTRUCTIONS, "Point(0, 0)")}
+    assert sites(".make") == {_span(CPP_CONSTRUCTIONS, "return {1, 2};")}

--- a/codebase_rag/tests/test_edge_site_properties.py
+++ b/codebase_rag/tests/test_edge_site_properties.py
@@ -692,3 +692,36 @@ def test_cpp_construction_paths_carry_their_site(
     assert sites(".main") == {_span(CPP_CONSTRUCTIONS, "Point origin(3, 4);")}
     assert sites(".Line.Line") == {_span(CPP_CONSTRUCTIONS, "Point(0, 0)")}
     assert sites(".make") == {_span(CPP_CONSTRUCTIONS, "return {1, 2};")}
+
+
+def test_rust_reparse_keeps_a_sibling_writers_sub_scope_site(temp_repo: Path) -> None:
+    """Two files can write the same sub-scope key and name (an inline mod in
+    src/a.rs and src/a/b/mod.rs both resolve to `p.src.a.b`); re-parsing one
+    must not drop the entry the OTHER wrote last (Greptile P1 on #1537)."""
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.RUST not in parsers:
+        pytest.skip("rust parser not available")
+    processor = ImportProcessor(repo_path=temp_repo, project_name="p")
+
+    def parse(module_qn: str, source: str) -> None:
+        tree = parsers[cs.SupportedLanguage.RUST].parse(source.encode())
+        processor.parse_imports(
+            tree.root_node, module_qn, cs.SupportedLanguage.RUST, queries
+        )
+
+    scope = "p.src.a.b"
+    # src/a.rs declares an inline `mod b` with a use; its scope key is p.src.a.b.
+    parse("p.src.a", "mod b {\n    use std::fmt::Display as Shared;\n}\n")
+    assert "Shared" in processor._import_sites[scope]
+    # src/a/b/mod.rs is the child file whose OWN scope is p.src.a.b (a file
+    # module writes its file-level sites directly under its qn).
+    parse(scope, "use std::fmt::Debug as Shared;\n")
+    child_site = processor._import_sites[scope]["Shared"]
+    assert child_site[cs.KEY_IMPORTED_NAME] == "Debug"
+
+    # Re-parsing src/a.rs without the use must leave the child's entry alone.
+    parse("p.src.a", "fn main() {}\n")
+    assert processor._import_sites[scope]["Shared"] is child_site

--- a/codebase_rag/tests/test_edge_site_properties.py
+++ b/codebase_rag/tests/test_edge_site_properties.py
@@ -725,3 +725,34 @@ def test_rust_reparse_keeps_a_sibling_writers_sub_scope_site(temp_repo: Path) ->
     # Re-parsing src/a.rs without the use must leave the child's entry alone.
     parse("p.src.a", "fn main() {}\n")
     assert processor._import_sites[scope]["Shared"] is child_site
+
+
+def test_rust_file_module_reparse_keeps_the_inline_siblings_entries(
+    temp_repo: Path,
+) -> None:
+    """The mirror case: re-parsing the FILE-backed module whose key an inline
+    mod of another file also writes must keep that inline mod's entries,
+    including names the file never bound (CodeRabbit on #1537)."""
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.RUST not in parsers:
+        pytest.skip("rust parser not available")
+    processor = ImportProcessor(repo_path=temp_repo, project_name="p")
+
+    def parse(module_qn: str, source: str) -> None:
+        tree = parsers[cs.SupportedLanguage.RUST].parse(source.encode())
+        processor.parse_imports(
+            tree.root_node, module_qn, cs.SupportedLanguage.RUST, queries
+        )
+
+    scope = "p.src.a.b"
+    parse(scope, "use std::fmt::Debug as Own;\n")
+    parse("p.src.a", "mod b {\n    use std::fmt::Display as Inline;\n}\n")
+    inline_site = processor._import_sites[scope]["Inline"]
+
+    parse(scope, "use std::fmt::Write as Own2;\n")
+    assert processor._import_sites[scope]["Inline"] is inline_site
+    assert "Own" not in processor._import_sites[scope]
+    assert "Own2" in processor._import_sites[scope]

--- a/codebase_rag/tests/test_edge_site_properties.py
+++ b/codebase_rag/tests/test_edge_site_properties.py
@@ -1,0 +1,409 @@
+# Edge-site locations on CALLS / REFERENCES / INSTANTIATES / IMPORTS (issue #1522).
+#
+# The graph knew THAT `f` calls `g`, not WHERE. Every call edge now carries the
+# span of the call expression plus its argument shape, one edge per site, and
+# every IMPORTS edge the span of its statement plus the bound alias and the
+# imported symbol, so a consumer can jump to, check, or rewrite the exact site.
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import codec.schema_pb2 as pb
+from codebase_rag import constants as cs
+from codebase_rag.cypher_queries import build_merge_relationship_query
+from codebase_rag.services.graph_diff import _rel_map
+from codebase_rag.services.protobuf_service import ProtobufFileIngestor
+from codebase_rag.tests.conftest import create_and_run_updater
+from codebase_rag.types_defs import PropertyDict
+
+
+def _span(text: str, needle: str, occurrence: int = 0) -> tuple[int, int, int, int]:
+    """(line, col, end_line, end_col) of the n-th `needle` in `text`."""
+    idx = -1
+    for _ in range(occurrence + 1):
+        idx = text.index(needle, idx + 1)
+    line = text.count("\n", 0, idx) + 1
+    col = idx - (text.rfind("\n", 0, idx) + 1)
+    end = idx + len(needle)
+    end_line = text.count("\n", 0, end) + 1
+    end_col = end - (text.rfind("\n", 0, end) + 1)
+    return line, col, end_line, end_col
+
+
+def _edges(
+    mock: MagicMock, rel_type: str
+) -> list[tuple[str, str, PropertyDict | None]]:
+    out = []
+    for c in mock.ensure_relationship_batch.call_args_list:
+        if c.args[1] != rel_type:
+            continue
+        props = c.kwargs.get("properties")
+        if props is None and len(c.args) > 3:
+            props = c.args[3]
+        out.append((str(c.args[0][2]), str(c.args[2][2]), props))
+    return out
+
+
+def _site(props: PropertyDict | None) -> tuple[Any, ...]:
+    assert props is not None
+    return (
+        props[cs.KEY_LINE],
+        props[cs.KEY_COL],
+        props[cs.KEY_END_LINE],
+        props[cs.KEY_END_COL],
+    )
+
+
+def _calls_between(
+    mock: MagicMock, caller_suffix: str, callee_suffix: str
+) -> list[PropertyDict]:
+    out = []
+    for src, dst, props in _edges(mock, cs.RelationshipType.CALLS):
+        if src.endswith(caller_suffix) and dst.endswith(callee_suffix):
+            assert props is not None, (src, dst)
+            out.append(props)
+    return out
+
+
+def _imports_from(
+    mock: MagicMock, module_suffix: str
+) -> list[tuple[str, PropertyDict]]:
+    return [
+        (dst, props)
+        for src, dst, props in _edges(mock, cs.RelationshipType.IMPORTS)
+        if src.endswith(module_suffix) and props is not None
+    ]
+
+
+# --- Python --------------------------------------------------------------------
+
+PY_UTIL = "def f():\n    return 1\n"
+PY_MAIN = (
+    "import os\n"
+    "from json import loads as jl\n"
+    "from .util import f\n"
+    "\n"
+    "\n"
+    "def helper(a, b=1):\n"
+    "    return a\n"
+    "\n"
+    "\n"
+    "def caller():\n"
+    "    helper(1)\n"
+    "    return helper(2, b=3) + f()\n"
+)
+
+
+def _write_python_repo(root: Path) -> None:
+    pkg = root / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "util.py").write_text(PY_UTIL, encoding="utf-8")
+    (pkg / "main.py").write_text(PY_MAIN, encoding="utf-8")
+
+
+def test_python_call_edges_carry_one_site_per_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_python_repo(temp_repo)
+    create_and_run_updater(temp_repo, mock_ingestor)
+
+    sites = sorted(
+        (_site(p), p[cs.KEY_ARG_COUNT], p[cs.KEY_KWARG_NAMES])
+        for p in _calls_between(mock_ingestor, "pkg.main.caller", "pkg.main.helper")
+    )
+    assert sites == [
+        (_span(PY_MAIN, "helper(1)"), 1, []),
+        (_span(PY_MAIN, "helper(2, b=3)"), 2, ["b"]),
+    ]
+    (f_props,) = _calls_between(mock_ingestor, "pkg.main.caller", "pkg.util.f")
+    assert _site(f_props) == _span(PY_MAIN, "f()")
+    assert f_props[cs.KEY_ARG_COUNT] == 0
+
+
+def test_python_import_edges_carry_statement_alias_and_symbol(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_python_repo(temp_repo)
+    create_and_run_updater(temp_repo, mock_ingestor)
+
+    by_alias = {
+        props[cs.KEY_ALIAS]: (dst, props)
+        for dst, props in _imports_from(mock_ingestor, "pkg.main")
+    }
+    assert set(by_alias) == {"os", "jl", "f"}
+
+    dst, props = by_alias["os"]
+    assert _site(props) == _span(PY_MAIN, "import os")
+    assert cs.KEY_IMPORTED_NAME not in props
+
+    dst, props = by_alias["jl"]
+    assert _site(props) == _span(PY_MAIN, "from json import loads as jl")
+    assert props[cs.KEY_IMPORTED_NAME] == "loads"
+
+    dst, props = by_alias["f"]
+    assert dst.endswith("pkg.util")
+    assert _site(props) == _span(PY_MAIN, "from .util import f")
+    assert props[cs.KEY_IMPORTED_NAME] == "f"
+
+
+# --- TypeScript ----------------------------------------------------------------
+
+TS_A = "export function helper(x: number): number {\n  return x;\n}\n"
+TS_B = (
+    'import { helper as h } from "./a";\n'
+    'import * as ns from "./a";\n'
+    "\n"
+    "export function caller(): number {\n"
+    "  return h(1) + h(2, 3) + ns.helper(4);\n"
+    "}\n"
+)
+
+
+def test_typescript_call_and_import_sites(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    src = temp_repo / "src"
+    src.mkdir()
+    (src / "a.ts").write_text(TS_A, encoding="utf-8")
+    (src / "b.ts").write_text(TS_B, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor)
+
+    sites = sorted(
+        (_site(p), p[cs.KEY_ARG_COUNT])
+        for p in _calls_between(mock_ingestor, "src.b.caller", "src.a.helper")
+    )
+    assert sites == [
+        (_span(TS_B, "h(1)"), 1),
+        (_span(TS_B, "h(2, 3)"), 2),
+        (_span(TS_B, "ns.helper(4)"), 1),
+    ]
+
+    imports = {
+        props[cs.KEY_ALIAS]: props
+        for _dst, props in _imports_from(mock_ingestor, "src.b")
+    }
+    assert _site(imports["h"]) == _span(TS_B, 'import { helper as h } from "./a";')
+    assert imports["h"][cs.KEY_IMPORTED_NAME] == "helper"
+    assert _site(imports["ns"]) == _span(TS_B, 'import * as ns from "./a";')
+    assert cs.KEY_IMPORTED_NAME not in imports["ns"]
+
+
+# --- Go ------------------------------------------------------------------------
+
+GO_M = (
+    "package p\n"
+    "\n"
+    'import (\n\t"fmt"\n\tstr "strings"\n)\n'
+    "\n"
+    "func free(a int) int { return a }\n"
+    "\n"
+    "func caller() int {\n"
+    '\tfmt.Println(str.ToUpper("x"))\n'
+    "\treturn free(1) + free(2)\n"
+    "}\n"
+)
+
+
+def test_go_call_and_import_sites(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    pkg = temp_repo / "p"
+    pkg.mkdir()
+    (pkg / "m.go").write_text(GO_M, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor)
+
+    sites = sorted(
+        _site(p) for p in _calls_between(mock_ingestor, "p.m.caller", "p.m.free")
+    )
+    assert sites == [_span(GO_M, "free(1)"), _span(GO_M, "free(2)")]
+
+    imports = {
+        props[cs.KEY_ALIAS]: props
+        for _dst, props in _imports_from(mock_ingestor, "p.m")
+    }
+    # A grouped import block records each spec line as its own site.
+    assert _site(imports["fmt"]) == _span(GO_M, '"fmt"')
+    assert _site(imports["str"]) == _span(GO_M, 'str "strings"')
+
+
+# --- Java ----------------------------------------------------------------------
+
+JAVA_A = (
+    "package com.x;\n"
+    "\n"
+    "import java.util.List;\n"
+    "\n"
+    "public class A {\n"
+    "    static int helper(int a) { return a; }\n"
+    "    static int caller() { return helper(1) + helper(2); }\n"
+    "}\n"
+)
+
+
+def test_java_call_and_import_sites(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    pkg = temp_repo / "src" / "main" / "java" / "com" / "x"
+    pkg.mkdir(parents=True)
+    (pkg / "A.java").write_text(JAVA_A, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor)
+
+    sites = sorted(
+        _site(p) for p in _calls_between(mock_ingestor, ".A.caller()", ".A.helper(int)")
+    )
+    assert sites == [_span(JAVA_A, "helper(1)"), _span(JAVA_A, "helper(2)")]
+
+    ((_dst, props),) = _imports_from(mock_ingestor, "com.x.A")
+    assert _site(props) == _span(JAVA_A, "import java.util.List;")
+    assert props[cs.KEY_ALIAS] == "List"
+    assert props[cs.KEY_IMPORTED_NAME] == "List"
+
+
+# --- Rust ----------------------------------------------------------------------
+
+RUST_MAIN = (
+    "use std::collections::HashMap as Map;\n"
+    "\n"
+    "fn helper(a: i32) -> i32 {\n"
+    "    a\n"
+    "}\n"
+    "\n"
+    "fn main() {\n"
+    "    let _m: Map<i32, i32> = Map::new();\n"
+    "    helper(1);\n"
+    "    helper(2);\n"
+    "}\n"
+)
+
+
+def test_rust_call_and_import_sites(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    src = temp_repo / "src"
+    src.mkdir()
+    (temp_repo / "Cargo.toml").write_text(
+        '[package]\nname = "app"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (src / "main.rs").write_text(RUST_MAIN, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor)
+
+    sites = sorted(
+        _site(p) for p in _calls_between(mock_ingestor, "main.main", "main.helper")
+    )
+    assert sites == [_span(RUST_MAIN, "helper(1)"), _span(RUST_MAIN, "helper(2)")]
+
+    imports = [props for _dst, props in _imports_from(mock_ingestor, "src.main")]
+    (props,) = imports
+    assert _site(props) == _span(RUST_MAIN, "use std::collections::HashMap as Map;")
+    assert props[cs.KEY_ALIAS] == "Map"
+    assert props[cs.KEY_IMPORTED_NAME] == "HashMap"
+
+
+# --- Sink semantics ------------------------------------------------------------
+
+
+def test_site_props_join_the_merge_key() -> None:
+    # Two calls from one caller to one callee must stay two edges at write
+    # time; the merge pattern keys on the site the same way FLOWS_TO keys on
+    # `via`/`kind` (issue #722).
+    for rel in (
+        cs.RelationshipType.CALLS,
+        cs.RelationshipType.REFERENCES,
+        cs.RelationshipType.INSTANTIATES,
+    ):
+        assert cs.MERGE_KEY_PROPS_BY_REL[rel.value] == (cs.KEY_LINE, cs.KEY_COL)
+    assert cs.MERGE_KEY_PROPS_BY_REL[cs.RelationshipType.IMPORTS.value] == (
+        cs.KEY_LINE,
+        cs.KEY_COL,
+        cs.KEY_ALIAS,
+    )
+    query = build_merge_relationship_query(
+        "Function",
+        "qualified_name",
+        "CALLS",
+        "Function",
+        "qualified_name",
+        has_props=True,
+        merge_key_props=cs.MERGE_KEY_PROPS_BY_REL["CALLS"],
+    )
+    assert (
+        "MERGE (a)-[r:CALLS {line: row.props.line, col: row.props.col}]->(b)" in query
+    )
+
+
+def _call_row(
+    line: int, col: int
+) -> tuple[tuple[str, str, str], str, tuple[str, str, str], PropertyDict]:
+    return (
+        ("Function", "qualified_name", "p.m.caller"),
+        "CALLS",
+        ("Function", "qualified_name", "p.m.helper"),
+        {
+            cs.KEY_LINE: line,
+            cs.KEY_COL: col,
+            cs.KEY_END_LINE: line,
+            cs.KEY_END_COL: col + 9,
+            cs.KEY_ARG_COUNT: 1,
+            cs.KEY_KWARG_NAMES: [],
+        },
+    )
+
+
+def test_protobuf_export_keeps_one_relationship_per_site(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    out.mkdir()
+    ingestor = ProtobufFileIngestor(str(out), split_index=False)
+    for spec in ("p.m.caller", "p.m.helper"):
+        ingestor.ensure_node_batch(
+            "Function", {"qualified_name": spec, "name": spec.rsplit(".", 1)[-1]}
+        )
+    ingestor.ensure_relationship_batch(*_call_row(11, 4))
+    ingestor.ensure_relationship_batch(*_call_row(12, 11))
+    # A site-less row (a libclang macro use, a trace write-back) still
+    # collapses on its endpoints rather than minting a third edge per flush.
+    ingestor.ensure_relationship_batch(*_call_row(11, 4)[:3])
+    ingestor.ensure_relationship_batch(*_call_row(11, 4)[:3])
+    ingestor.flush_all()
+
+    index = pb.GraphCodeIndex()
+    index.ParseFromString((out / "index.bin").read_bytes())
+    calls = [r for r in index.relationships if r.type == pb.Relationship.CALLS]
+    assert len(calls) == 3
+    sited = sorted(
+        (int(p["line"]), int(p["col"]), int(p["arg_count"]))
+        for p in (dict(r.properties) for r in calls)
+        if "line" in p
+    )
+    assert sited == [(11, 4, 1), (12, 11, 1)]
+    (bare,) = [r for r in calls if "line" not in r.properties]
+    assert bare.source_id == "p.m.caller"
+
+    # graph diff stays structural: per-site edges fold onto their triple and
+    # the site props drop out, so a line shift is not a relationship change.
+    rels = _rel_map([index])
+    assert rels == {("p.m.caller", "CALLS", "p.m.helper"): {}}
+
+
+@pytest.mark.parametrize(
+    "rel_type",
+    [cs.RelationshipType.CALLS, cs.RelationshipType.REFERENCES],
+)
+def test_reference_site_without_arguments_carries_span_only(
+    temp_repo: Path, mock_ingestor: MagicMock, rel_type: str
+) -> None:
+    # `{"k": helper}` references helper by value: the site is the bare name,
+    # with no argument list and therefore no arg_count.
+    src = 'def helper():\n    return 1\n\n\ndef build():\n    return {"k": helper}\n'
+    (temp_repo / "m.py").write_text(src, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor)
+    matches = [
+        props
+        for s, d, props in _edges(mock_ingestor, rel_type)
+        if s.endswith("m.build") and d.endswith("m.helper") and props is not None
+    ]
+    if not matches:
+        pytest.skip(f"dict-value reference is not emitted as {rel_type}")
+    (props,) = matches
+    # The site is the referencing expression itself, not the enclosing
+    # `return` statement or dict literal.
+    assert _site(props) == _span(src, "helper", occurrence=1)
+    assert cs.KEY_ARG_COUNT not in props

--- a/codebase_rag/tests/test_edge_site_properties.py
+++ b/codebase_rag/tests/test_edge_site_properties.py
@@ -541,7 +541,7 @@ def test_scala_wildcard_import_records_span_without_alias(
     wildcard = [
         props
         for dst, props in _imports_from(mock_ingestor, ".a")
-        if dst.endswith("scala.io")
+        if dst.rpartition(".")[2] == "io" and "scala" in dst.split(".")
     ]
     (props,) = wildcard
     assert _site(props) == _span(SCALA_SRC, "import scala.io._")

--- a/codebase_rag/tests/test_edge_site_properties.py
+++ b/codebase_rag/tests/test_edge_site_properties.py
@@ -756,3 +756,46 @@ def test_rust_file_module_reparse_keeps_the_inline_siblings_entries(
     assert processor._import_sites[scope]["Inline"] is inline_site
     assert "Own" not in processor._import_sites[scope]
     assert "Own2" in processor._import_sites[scope]
+
+
+def test_incremental_update_restores_inbound_edges_with_their_sites(
+    temp_repo: Path,
+) -> None:
+    """An untouched caller's edge into a re-indexed file keeps its site.
+
+    Per-site edges are keyed by their site, so restoring the captured edge
+    bare would land a second, site-less edge beside the original.
+    """
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    sink = MagicMock()
+    site = {cs.KEY_LINE: 5, cs.KEY_COL: 4, cs.KEY_END_LINE: 5, cs.KEY_END_COL: 9}
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(sink, temp_repo, parsers, queries)
+    updater.function_registry["proj.pkg.util.helper"] = cs.NodeLabel.FUNCTION.value
+    updater._restore_inbound_edges(
+        [
+            {
+                cs.KEY_CALLER_LABEL: cs.NodeLabel.FUNCTION.value,
+                cs.KEY_CALLER_QN: "proj.main.main",
+                cs.KEY_REL: cs.RelationshipType.CALLS.value,
+                cs.KEY_TARGET_LABEL: cs.NodeLabel.FUNCTION.value,
+                cs.KEY_TARGET_QN: "proj.pkg.util.helper",
+                cs.KEY_PROPS: dict(site),
+            },
+            {
+                cs.KEY_CALLER_LABEL: cs.NodeLabel.MODULE.value,
+                cs.KEY_CALLER_QN: "proj.main",
+                cs.KEY_REL: cs.RelationshipType.IMPORTS.value,
+                cs.KEY_TARGET_LABEL: cs.NodeLabel.MODULE.value,
+                cs.KEY_TARGET_QN: "proj.pkg.util",
+                cs.KEY_PROPS: {},
+            },
+        ]
+    )
+    calls = sink.ensure_relationship_batch.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs[cs.KEY_PROPERTIES] == site
+    assert calls[1].kwargs[cs.KEY_PROPERTIES] is None
+    assert "properties(r) AS props" in cs.CYPHER_INBOUND_EDGES

--- a/codebase_rag/tests/test_graph_updater_integration.py
+++ b/codebase_rag/tests/test_graph_updater_integration.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -38,19 +38,24 @@ def test_function_call_relationships_are_created(
     local_func_qn = f"{project_name}.main.local_func"
 
     expected_calls = [
-        call(
+        (
             ("Function", "qualified_name", main_func_qn),
             "CALLS",
             ("Function", "qualified_name", util_func_qn),
         ),
-        call(
+        (
             ("Function", "qualified_name", main_func_qn),
             "CALLS",
             ("Function", "qualified_name", local_func_qn),
         ),
     ]
 
-    actual_calls = get_relationships(mock_ingestor, "CALLS")
+    # Endpoints only: every CALLS edge also carries its call-site properties
+    # (line/col/arg shape, issue #1522), which this test does not pin.
+    actual_calls = [
+        (c.args[0], c.args[1], c.args[2])
+        for c in get_relationships(mock_ingestor, "CALLS")
+    ]
 
     assert len(actual_calls) >= len(expected_calls)
     assert expected_calls[0] in actual_calls

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -819,6 +819,9 @@ class DeferredImportEdge(NamedTuple):
     module_qn: str
     full_name: str
     language: SupportedLanguage
+    # Import-site edge properties (statement span, alias, imported name;
+    # issue #1522), or None for an import shape that records no site.
+    site: PropertyDict | None = None
 
 
 class RelationshipSchema(NamedTuple):
@@ -903,6 +906,35 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     NodeSchema(NodeLabel.SECURITY_ISSUE, _FINDING_NODE_PROPS),
 )
 
+
+class RelationshipPropertySchema(NamedTuple):
+    rel_types: tuple[RelationshipType, ...]
+    properties: str
+
+
+# Edge properties, documented for the query-generation prompt (issue #1522):
+# every CALLS/REFERENCES/INSTANTIATES edge locates its producing expression
+# and every IMPORTS edge its statement; FLOWS_TO carries its conduit shape.
+RELATIONSHIP_PROPERTY_SCHEMAS: tuple[RelationshipPropertySchema, ...] = (
+    RelationshipPropertySchema(
+        (
+            RelationshipType.CALLS,
+            RelationshipType.REFERENCES,
+            RelationshipType.INSTANTIATES,
+        ),
+        "{line: int?, col: int?, end_line: int?, end_col: int?, "
+        "arg_count: int?, kwarg_names: list[string]?}",
+    ),
+    RelationshipPropertySchema(
+        (RelationshipType.IMPORTS,),
+        "{line: int?, col: int?, end_line: int?, end_col: int?, "
+        "alias: string?, imported_name: string?}",
+    ),
+    RelationshipPropertySchema(
+        (RelationshipType.FLOWS_TO,),
+        "{kind: string, via: string?}",
+    ),
+)
 
 RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
     RelationshipSchema(

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -72,7 +72,22 @@ The knowledge graph uses a unified schema across all supported languages.
 
 `REFERENCES` records a non-call mention of a callable or class (a function passed as a value, a callback stored in a dict). `INSTANTIATES` records a class being constructed. Both belong to the default `calls` capture group. The findings relationships (`IMPLEMENTS_PATTERN`, `HAS_SMELL`, `HAS_VULNERABILITY`) are opt-in with the `findings` capture group.
 
-`CALLS` edges are created by static analysis and carry no properties by default. [Dynamic call tracing](../guide/dynamic-tracing.md) decorates them with runtime provenance (`dynamic`, `dynamic_call_count`, `dynamic_workloads`, `dynamic_workload_count`, `dynamic_receiver_types`) and creates runtime-only edges flagged `static_missed: true` when no matching static edge existed in the graph at ingest time. Dynamic dispatch, reflection, and registries are the common causes.
+### Edge-site properties
+
+`CALLS`, `REFERENCES` and `INSTANTIATES` edges record *where* they were produced, not only that they exist, and `IMPORTS` edges record the statement that produced them (issue #1522):
+
+| Edge types | Property | Meaning |
+|---|---|---|
+| CALLS, REFERENCES, INSTANTIATES, IMPORTS | `line: int`, `col: int`, `end_line: int`, `end_col: int` | Span of the producing expression (the call, the referencing name, the constructor invocation) or of the import statement. Lines are 1-based, columns 0-based and the end is exclusive, matching node `start_line` / `start_col`. |
+| CALLS, REFERENCES, INSTANTIATES | `arg_count: int?`, `kwarg_names: list[string]?` | Present when the site has an argument list: the number of arguments passed (positional plus keyword) and the keyword names in source order. A reference site (a bare function value) carries neither. |
+| IMPORTS | `alias: string?` | The name the statement binds in the importing scope: the `as` name when renamed, otherwise the imported symbol or module name. Wildcard imports and Go dot-imports bind no name and carry no alias. |
+| IMPORTS | `imported_name: string?` | For symbol-level imports (`from x import y`, `import { y as z }`, `use a::b::y`, Java `import a.b.C`, `const { y } = require(...)`) the symbol's own name; `*` for wildcards; absent for whole-module imports. |
+
+Sites are stored as **one edge per site**: a function that calls `g` twice has two `CALLS` edges to `g`, one per call expression, and `from x import a, b` yields two `IMPORTS` edges to `x` (same statement span, different `alias`). The site properties join the write-time `MERGE` key (`line`, `col`; plus `alias` for `IMPORTS`), the same mechanism that keeps parallel `FLOWS_TO` edges apart, so re-indexing is idempotent. A query that wants callers rather than call sites should `DISTINCT` on the endpoint; a query that wants the sites reads `r.line`.
+
+Edges emitted without a syntactic site carry none of these properties and keep collapsing on their endpoints: libclang macro uses and `#include` edges, Roslyn-only facts, inferred C# namespace imports, interprocedural callable-parameter flow edges, and edges written back by dynamic tracing. For a Go grouped `import ( ... )` block the site is the individual spec line, which is the unit an import rewrite edits. `cgr diff` treats these properties as location, not structure: a line shift never reports as a changed relationship.
+
+`CALLS` edges are otherwise created by static analysis with no further properties. [Dynamic call tracing](../guide/dynamic-tracing.md) decorates them with runtime provenance (`dynamic`, `dynamic_call_count`, `dynamic_workloads`, `dynamic_workload_count`, `dynamic_receiver_types`) and creates runtime-only edges flagged `static_missed: true` when no matching static edge existed in the graph at ingest time. Dynamic dispatch, reflection, and registries are the common causes.
 
 ## I/O and Data-Flow Edges
 

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -153,7 +153,8 @@ class _StatefulIngestor:
                     set(raw_paths) if isinstance(raw_paths, list) else set()
                 )
                 inbound: list[ResultRow] = []
-                for from_label, from_val, rel_type, to_label, to_val in self.edges:
+                for edge in self.edges:
+                    from_label, from_val, rel_type, to_label, to_val = edge
                     if rel_type not in _INBOUND_DEPENDENT_RELS:
                         continue
                     target = self.nodes.get((to_label, to_val))
@@ -170,6 +171,7 @@ class _StatefulIngestor:
                             cs.KEY_REL: rel_type,
                             cs.KEY_TARGET_LABEL: to_label,
                             cs.KEY_TARGET_QN: _text(to_val),
+                            cs.KEY_PROPS: dict(self.edge_props.get(edge, {})),
                         }
                     )
                 return inbound


### PR DESCRIPTION
## Summary
Implements #1522 (Epic #1521, T1). Closes #1522.

- `CALLS` / `REFERENCES` / `INSTANTIATES` edges now carry `line, col, end_line, end_col`, plus `arg_count` and `kwarg_names` when the site has an argument list.
- `IMPORTS` edges carry `line, col, end_line, end_col, alias, imported_name` (`*` for wildcards).
- **One edge per site**: the site coordinates join the MERGE key (`MERGE_KEY_PROPS_BY_REL`), so a function calling `g` twice yields two `CALLS` edges. Rows without site props still merge on endpoints only, so the change is additive.
- Sites come from the tree-sitter node already in hand (no extra parse pass): `CallProcessor._emit_rel` stamps the current site node; `ImportProcessor` records sites per `(scope, local_name)` and flushes them via `DeferredImportEdge.site`.
- Protobuf export dedups on site keys so per-site edges round-trip; `graph_diff` strips site props so `cgr diff` stays structural.
- LLM schema prompt lists relationship property schemas; `docs/architecture/graph-schema.md` documents the schema and the per-site decision.

## Test plan
- [x] `uv run ruff check` / `uv run ruff format` / `uv run ty check` clean
- [x] New `codebase_rag/tests/test_edge_site_properties.py` (Python, TypeScript, Go, Java, Rust call and import sites; REFERENCES span; merge-key wiring; protobuf round-trip and diff folding)
- [x] Full non-integration suite: 8732 passed, 38 skipped, 1 xfailed
- [ ] Memgraph integration tests (CI; no Docker locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph relationships now include source-code locations for calls, references, instantiations, and imports.
  * Call relationships include argument counts and keyword names.
  * Import relationships include aliases and imported symbols, including wildcard imports.
  * Multiple relationship sites remain distinct, improving code navigation, querying, and analysis.
  * Re-indexing and incremental updates preserve relationship-site metadata reliably.
* **Documentation**
  * Updated graph schema documentation to describe relationship-site properties and storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->