### PR TITLE
feat: transactional multi-file edits with staged verification and undo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ evals/oracles/scala_oracle/.bsp/
 .cgr-hash-cache.json
 .cgr-dir-mtimes.json
 .cgr-parser-fingerprint
+.cgr-delombok-state.json
+.cgr-edit-history.json
 
 # Runtime call traces (pytest --cgr-trace default output)
 cgr-trace.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ evals/oracles/scala_oracle/.bsp/
 .cgr-parser-fingerprint
 .cgr-delombok-state.json
 .cgr-edit-history.json
+.cgr-edit-lock
 
 # Runtime call traces (pytest --cgr-trace default output)
 cgr-trace.jsonl

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -27,6 +27,7 @@ from . import cypher_queries as cq
 from . import logs as ls
 from .capture import CaptureSelection, resolve_capture, split_spec
 from .config import load_ignore_patterns, settings
+from .editing.cli import cli as edits_cli
 from .editor_links import (
     EditorTemplateError,
     diff_command,
@@ -1074,6 +1075,18 @@ def workspace_command(ctx: typer.Context) -> None:
 )
 def trace_command(ctx: typer.Context) -> None:
     _run_delegated_group(trace_cli, ctx)
+
+
+@app.command(
+    name=ch.CLICommandName.EDITS,
+    help=ch.CMD_EDITS,
+    short_help=ch.CMD_EDITS,
+    add_help_option=False,
+    context_settings=_DELEGATED_GROUP_CONTEXT,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
+def edits_command(ctx: typer.Context) -> None:
+    _run_delegated_group(edits_cli, ctx)
 
 
 @app.command(

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -17,6 +17,7 @@ class CLICommandName(StrEnum):
     DAEMON = "daemon"
     WORKSPACE = "workspace"
     TRACE = "trace"
+    EDITS = "edits"
     STOP = "stop"
     STATUS = "status"
     HELP = "help"
@@ -72,6 +73,26 @@ CMD_WORKSPACE_REMOVE_REPO = "Remove a repository from a workspace by path"
 
 CMD_TRACE = "Ingest runtime call traces as dynamic CALLS edges"
 CMD_TRACE_GROUP = CMD_TRACE
+CMD_EDITS = (
+    "Show or undo recorded edit transactions (multi-file edits applied through cgr)."
+)
+CMD_EDITS_GROUP = CMD_EDITS
+CMD_EDITS_SHOW = (
+    "List the last N recorded edit transactions, newest first, with their diffs."
+)
+CMD_EDITS_UNDO = "Reverse the last N recorded edit transactions, newest first; stops at the first file that changed since."
+EPILOG_EDITS = "Run 'cgr help edits COMMAND' for command-specific help."
+EXAMPLES_EDITS_SHOW = (
+    "Examples:\n  cgr edits show\n  cgr edits show -n 5 --repo-path ~/proj"
+)
+EXAMPLES_EDITS_UNDO = (
+    "Examples:\n  cgr edits undo\n  cgr edits undo -n 2 --repo-path ~/proj"
+)
+HELP_EDITS_COUNT = "How many transactions to show or undo."
+HELP_EDITS_REPO_PATH = (
+    "Repository root holding .cgr-edit-history.json (default: current directory)."
+)
+HELP_EDITS_DIFF = "Print each transaction's unified diff."
 CMD_TRACE_INGEST = "Resolve a trace file against a project and write dynamic edges"
 CMD_TRACE_CONVERT = "Convert a V8 .cpuprofile (node --cpu-prof) to a trace file"
 
@@ -385,6 +406,7 @@ CLI_COMMANDS: dict[CLICommandName, str] = {
     CLICommandName.LANGUAGE: CMD_LANGUAGE,
     CLICommandName.DAEMON: CMD_DAEMON,
     CLICommandName.TRACE: CMD_TRACE,
+    CLICommandName.EDITS: CMD_EDITS,
     CLICommandName.WORKSPACE: CMD_WORKSPACE,
     CLICommandName.STOP: CMD_STOP,
     CLICommandName.STATUS: CMD_STATUS,

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -496,6 +496,7 @@ PATCH_FORMAT_DRIFT = "{path} applied, but {tool} would reformat it"
 PATCH_OK = "{path}: {count} edit(s) applied"
 # Edit transactions (issue #1528).
 EDIT_NOT_A_FILE = "Staged path is not a regular file: {path}"
+EDIT_RESERVED_PATH = "Path is cgr state, not part of the tree: {path}"
 EDIT_TRANSACTION_FINISHED = "This transaction has already been committed or rolled back"
 EDIT_CONFLICT = "File changed since it was staged; transaction refused: {path}"
 EDIT_NOTHING_STAGED = "Nothing staged; the working tree is untouched"

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -494,6 +494,22 @@ PATCH_NOT_AN_IDENTIFIER = "{path}:{line}:{col} is not a whole identifier"
 PATCH_PARSE_FAILED = "{path} no longer parses after the patch"
 PATCH_FORMAT_DRIFT = "{path} applied, but {tool} would reformat it"
 PATCH_OK = "{path}: {count} edit(s) applied"
+# Edit transactions (issue #1528).
+EDIT_NOT_A_FILE = "Staged path is not a regular file: {path}"
+EDIT_TRANSACTION_FINISHED = "This transaction has already been committed or rolled back"
+EDIT_CONFLICT = "File changed since it was staged; transaction refused: {path}"
+EDIT_NOTHING_STAGED = "Nothing staged; the working tree is untouched"
+EDIT_VERIFICATION_FAILED = (
+    "Verification failed; the working tree is untouched: {reason}"
+)
+EDIT_VERIFIER_RAISED = "verifier raised {error!r}"
+EDIT_VERIFIER_FALSE = "verifier returned False"
+EDIT_APPLIED = "Applied {count} file(s)"
+EDIT_UNDO_NONE = "No recorded edit transactions to undo"
+EDIT_UNDO_DONE = "Undid transaction {tx} ({count} file(s))"
+EDIT_UNDO_STOPPED = "Stopped at transaction {tx}: {reason}"
+EDIT_SHOW_NONE = "No recorded edit transactions"
+EDIT_SHOW_HEADER = "{tx}  {at}  {count} file(s)  verification={ok}"
 MSG_SURGICAL_FAILED = (
     "Failed to apply surgical replacement in {path}. "
     "Target code not found or patches failed."

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -129,14 +129,30 @@ HASH_CACHE_FILENAME = ".cgr-hash-cache.json"
 DIR_MTIMES_FILENAME = ".cgr-dir-mtimes.json"
 PARSER_FINGERPRINT_FILENAME = ".cgr-parser-fingerprint"
 DELOMBOK_STATE_FILENAME = ".cgr-delombok-state.json"
+# Recorded edit transactions for `cgr edits show|undo` (issue #1528).
+EDIT_HISTORY_FILENAME = ".cgr-edit-history.json"
 CGR_STATE_FILENAMES: frozenset[str] = frozenset(
     {
         HASH_CACHE_FILENAME,
         DIR_MTIMES_FILENAME,
         PARSER_FINGERPRINT_FILENAME,
         DELOMBOK_STATE_FILENAME,
+        EDIT_HISTORY_FILENAME,
     }
 )
+# Edit transactions (issue #1528).
+EDIT_HISTORY_LIMIT = 50
+EDIT_TRANSACTION_ID_LENGTH = 12
+EDIT_STAGING_PREFIX = "cgr-edit-"
+DIFF_DEV_NULL = "/dev/null"
+EDIT_KEY_ID = "id"
+EDIT_KEY_AT = "at"
+EDIT_KEY_FILES = "files"
+EDIT_KEY_BEFORE = "before"
+EDIT_KEY_AFTER = "after"
+EDIT_KEY_VERIFICATION = "verification"
+EDIT_KEY_OK = "ok"
+EDIT_KEY_MESSAGE = "message"
 
 # Inputs to the parser fingerprint: everything that changes how source files
 # become graph nodes and edges, plus the installed grammar wheels. Paths are

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -133,6 +133,8 @@ DELOMBOK_STATE_FILENAME = ".cgr-delombok-state.json"
 EDIT_HISTORY_FILENAME = ".cgr-edit-history.json"
 EDIT_LOCK_FILENAME = ".cgr-edit-lock"
 PLATFORM_WINDOWS = "win32"
+# Permission bits copied onto a replacement file (rwx for u/g/o, setuid etc.).
+EDIT_MODE_MASK = 0o7777
 CGR_STATE_FILENAMES: frozenset[str] = frozenset(
     {
         HASH_CACHE_FILENAME,

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -135,6 +135,9 @@ EDIT_LOCK_FILENAME = ".cgr-edit-lock"
 PLATFORM_WINDOWS = "win32"
 # Permission bits copied onto a replacement file (rwx for u/g/o, setuid etc.).
 EDIT_MODE_MASK = 0o7777
+# Mode of the exclusively created temp sibling before the target's mode is
+# copied onto it: owner-only, so nothing reads staged bytes mid-write.
+EDIT_TEMP_FILE_MODE = 0o600
 CGR_STATE_FILENAMES: frozenset[str] = frozenset(
     {
         HASH_CACHE_FILENAME,

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -131,6 +131,8 @@ PARSER_FINGERPRINT_FILENAME = ".cgr-parser-fingerprint"
 DELOMBOK_STATE_FILENAME = ".cgr-delombok-state.json"
 # Recorded edit transactions for `cgr edits show|undo` (issue #1528).
 EDIT_HISTORY_FILENAME = ".cgr-edit-history.json"
+EDIT_LOCK_FILENAME = ".cgr-edit-lock"
+PLATFORM_WINDOWS = "win32"
 CGR_STATE_FILENAMES: frozenset[str] = frozenset(
     {
         HASH_CACHE_FILENAME,
@@ -138,6 +140,7 @@ CGR_STATE_FILENAMES: frozenset[str] = frozenset(
         PARSER_FINGERPRINT_FILENAME,
         DELOMBOK_STATE_FILENAME,
         EDIT_HISTORY_FILENAME,
+        EDIT_LOCK_FILENAME,
     }
 )
 # Edit transactions (issue #1528).

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -158,6 +158,7 @@ EDIT_KEY_AFTER = "after"
 EDIT_KEY_VERIFICATION = "verification"
 EDIT_KEY_OK = "ok"
 EDIT_KEY_MESSAGE = "message"
+EDIT_KEY_MODE = "mode"
 
 # Inputs to the parser fingerprint: everything that changes how source files
 # become graph nodes and edges, plus the installed grammar wheels. Paths are

--- a/codebase_rag/editing/__init__.py
+++ b/codebase_rag/editing/__init__.py
@@ -1,4 +1,5 @@
-"""Graph-aware editing primitives: span-preserving patchers (issue #1529)."""
+"""Graph-aware editing primitives: span-preserving patchers (issue #1529) and
+transactions (issue #1528)."""
 
 from .patcher import (
     Patcher,
@@ -10,14 +11,34 @@ from .patcher import (
     formatter_check,
     line_col_to_byte,
 )
+from .transaction import (
+    EditTransaction,
+    StagedFile,
+    StagedTree,
+    TransactionConflict,
+    TransactionError,
+    TransactionOutcome,
+    VerificationResult,
+    transaction,
+    undo_last,
+)
 
 __all__ = [
+    "EditTransaction",
     "PatchResult",
     "Patcher",
     "PatcherError",
     "SpanEdit",
+    "StagedFile",
+    "StagedTree",
+    "TransactionConflict",
+    "TransactionError",
+    "TransactionOutcome",
+    "VerificationResult",
     "apply_span_edits",
     "byte_to_line_col",
     "formatter_check",
     "line_col_to_byte",
+    "transaction",
+    "undo_last",
 ]

--- a/codebase_rag/editing/cli.py
+++ b/codebase_rag/editing/cli.py
@@ -1,0 +1,108 @@
+"""The `cgr edits` command group: show or undo recorded edit transactions."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import click
+
+from .. import cli_help as ch
+from .. import constants as cs
+from .transaction import TransactionConflict, entry_diff, load_history, undo_last
+
+
+@click.group(
+    help=ch.CMD_EDITS_GROUP,
+    short_help=ch.CMD_EDITS_GROUP,
+    epilog=ch.EPILOG_EDITS,
+    no_args_is_help=True,
+)
+def cli() -> None:
+    """Group callback: subcommands carry the behaviour."""
+
+
+def _repo_option[F: Callable[..., None]](fn: F) -> F:
+    return click.option(
+        "--repo-path",
+        type=click.Path(exists=True, file_okay=False, path_type=Path),
+        default=Path(cs.MCP_DEFAULT_DIRECTORY),
+        show_default=True,
+        help=ch.HELP_EDITS_REPO_PATH,
+    )(fn)
+
+
+@cli.command(
+    "show",
+    help=ch.CMD_EDITS_SHOW,
+    short_help=ch.CMD_EDITS_SHOW,
+    epilog=ch.EXAMPLES_EDITS_SHOW,
+)
+@click.option(
+    "-n", "--count", type=int, default=5, show_default=True, help=ch.HELP_EDITS_COUNT
+)
+@click.option(
+    "--diff", "show_diff", is_flag=True, default=False, help=ch.HELP_EDITS_DIFF
+)
+@_repo_option
+def show_cmd(count: int, show_diff: bool, repo_path: Path) -> None:
+    entries = load_history(repo_path.resolve())
+    if not entries:
+        click.echo(cs.EDIT_SHOW_NONE)
+        return
+    for entry in reversed(entries[-count:]):
+        files = entry.get(cs.EDIT_KEY_FILES, [])
+        verification = entry.get(cs.EDIT_KEY_VERIFICATION, {})
+        click.echo(
+            cs.EDIT_SHOW_HEADER.format(
+                tx=entry.get(cs.EDIT_KEY_ID, ""),
+                at=entry.get(cs.EDIT_KEY_AT, ""),
+                count=len(files),
+                ok=verification.get(cs.EDIT_KEY_OK, True),
+            )
+        )
+        for staged in files:
+            click.echo(f"  {staged.get(cs.KEY_PATH, '')}")
+        if show_diff:
+            click.echo(entry_diff(entry))
+
+
+@cli.command(
+    "undo",
+    help=ch.CMD_EDITS_UNDO,
+    short_help=ch.CMD_EDITS_UNDO,
+    epilog=ch.EXAMPLES_EDITS_UNDO,
+)
+@click.option(
+    "-n", "--count", type=int, default=1, show_default=True, help=ch.HELP_EDITS_COUNT
+)
+@_repo_option
+def undo_cmd(count: int, repo_path: Path) -> None:
+    try:
+        outcomes = undo_last(repo_path.resolve(), count)
+    except TransactionConflict as error:
+        click.secho(str(error), fg="red", err=True)
+        sys.exit(1)
+    if not outcomes:
+        click.echo(cs.EDIT_UNDO_NONE)
+        return
+    failed = False
+    for outcome in outcomes:
+        if outcome.applied:
+            click.echo(
+                cs.EDIT_UNDO_DONE.format(
+                    tx=outcome.transaction_id, count=len(outcome.files)
+                )
+            )
+        else:
+            failed = True
+            click.secho(
+                cs.EDIT_UNDO_STOPPED.format(
+                    tx=outcome.transaction_id, reason=outcome.message
+                ),
+                fg="red",
+                err=True,
+            )
+    if failed:
+        sys.exit(1)

--- a/codebase_rag/editing/cli.py
+++ b/codebase_rag/editing/cli.py
@@ -40,7 +40,12 @@ def _repo_option[F: Callable[..., None]](fn: F) -> F:
     epilog=ch.EXAMPLES_EDITS_SHOW,
 )
 @click.option(
-    "-n", "--count", type=int, default=5, show_default=True, help=ch.HELP_EDITS_COUNT
+    "-n",
+    "--count",
+    type=click.IntRange(min=1),
+    default=5,
+    show_default=True,
+    help=ch.HELP_EDITS_COUNT,
 )
 @click.option(
     "--diff", "show_diff", is_flag=True, default=False, help=ch.HELP_EDITS_DIFF
@@ -75,7 +80,12 @@ def show_cmd(count: int, show_diff: bool, repo_path: Path) -> None:
     epilog=ch.EXAMPLES_EDITS_UNDO,
 )
 @click.option(
-    "-n", "--count", type=int, default=1, show_default=True, help=ch.HELP_EDITS_COUNT
+    "-n",
+    "--count",
+    type=click.IntRange(min=1),
+    default=1,
+    show_default=True,
+    help=ch.HELP_EDITS_COUNT,
 )
 @_repo_option
 def undo_cmd(count: int, repo_path: Path) -> None:

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -590,6 +590,10 @@ def undo_last(repo_root: Path, count: int = 1) -> list[TransactionOutcome]:
             reverse = EditTransaction(root, record=False)
             for staged in entry_files(entry):
                 key = reverse._relative(staged.path)
+                if key in cs.CGR_STATE_FILENAMES:
+                    # The history is data on disk: an entry naming the lock
+                    # or the history itself must not replace their inodes.
+                    raise TransactionError(cs.EDIT_RESERVED_PATH.format(path=key))
                 reverse._overlay[key] = StagedFile(
                     key, staged.after, staged.before, staged.mode
                 )

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -461,10 +461,11 @@ def _contained(root: Path, rel_path: str) -> Path:
     # Every path written comes from a repo-relative key; resolving it and
     # checking containment again here means no caller (an undo replaying a
     # history file, a restore) can reach outside the root.
-    candidate = (root / rel_path).resolve()
-    if not candidate.is_relative_to(root.resolve()):
+    real_root = os.path.realpath(root)
+    candidate = os.path.realpath(os.path.join(real_root, rel_path))
+    if os.path.commonpath([real_root, candidate]) != real_root:
         raise TransactionError(ls.FILE_OUTSIDE_ROOT.format(action=cs.FileAction.EDIT))
-    return candidate
+    return Path(candidate)
 
 
 def _write_file(path: Path, content: bytes | None, mode: int | None = None) -> None:

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -49,11 +49,16 @@ Verifier = Callable[["StagedTree"], "VerificationResult | bool | None"]
 
 
 class StagedFile(NamedTuple):
-    """One file's before/after bytes; `None` means absent (create / delete)."""
+    """One file's before/after bytes; `None` means absent (create / delete).
+
+    `mode` is the permission bits the file had when it was staged (`None`
+    when absent), so a restore of a deleted executable is executable again.
+    """
 
     path: str
     before: bytes | None
     after: bytes | None
+    mode: int | None = None
 
 
 class TransactionOutcome(NamedTuple):
@@ -195,30 +200,46 @@ class StagedTree:
             skipped: set[str] = set()
             for name in names:
                 candidate = here / name
-                if name in cs.CGR_STATE_FILENAMES:
-                    skipped.add(name)
-                elif candidate.is_symlink() and not _inside(candidate, resolved_root):
-                    # A link out of the repo would let a verifier write
-                    # through the copy into the live tree or beyond it.
-                    skipped.add(name)
-                elif candidate.is_dir() and should_skip_path(
-                    candidate, repo_root, exclude, unignore, is_file=False
+                # State files never travel; a link out of the repo would let
+                # a verifier write through the copy into the live tree or
+                # beyond it; ignored directories are not part of the tree.
+                if (
+                    name in cs.CGR_STATE_FILENAMES
+                    or (
+                        candidate.is_symlink() and not _inside(candidate, resolved_root)
+                    )
+                    or (
+                        candidate.is_dir()
+                        and should_skip_path(
+                            candidate, repo_root, exclude, unignore, is_file=False
+                        )
+                    )
                 ):
                     skipped.add(name)
             return skipped
 
-        # symlinks=False: in-repo links are copied as the files they point
-        # at, so nothing under `root` reaches outside the staging copy.
-        shutil.copytree(
-            repo_root, target, ignore=ignore, symlinks=False, dirs_exist_ok=True
-        )
-        for rel_path, staged in self._overlay.items():
-            path = target / rel_path
-            if staged.after is None:
-                path.unlink(missing_ok=True)
-            else:
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_bytes(staged.after)
+        try:
+            # symlinks=False: in-repo links are copied as the files they
+            # point at, so nothing under `root` reaches outside the staging
+            # copy; a dangling in-repo link is skipped rather than fatal.
+            shutil.copytree(
+                repo_root,
+                target,
+                ignore=ignore,
+                symlinks=False,
+                ignore_dangling_symlinks=True,
+                dirs_exist_ok=True,
+            )
+            for rel_path, staged in self._overlay.items():
+                path = target / rel_path
+                if staged.after is None:
+                    path.unlink(missing_ok=True)
+                else:
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(staged.after)
+        except Exception:
+            shutil.rmtree(target, ignore_errors=True)
+            raise
         return target
 
     def cleanup(self) -> None:
@@ -277,12 +298,20 @@ class EditTransaction:
         """Set a file's full content; `None` deletes it. Later stages win."""
         self._check_open()
         key = self._relative(rel_path)
+        if key in cs.CGR_STATE_FILENAMES:
+            # The lock file and the history are the transaction's own
+            # machinery; replacing the lock's inode would let another
+            # process lock the new one without waiting.
+            raise TransactionError(cs.EDIT_RESERVED_PATH.format(path=key))
         after = (
             content.encode(cs.ENCODING_UTF8) if isinstance(content, str) else content
         )
         existing = self._overlay.get(key)
-        before = existing.before if existing is not None else self._current(key)
-        staged = StagedFile(key, before, after)
+        if existing is not None:
+            before, mode = existing.before, existing.mode
+        else:
+            before, mode = self._current(key), _mode_of(self.repo_root / key)
+        staged = StagedFile(key, before, after, mode)
         if before == after:
             # Staging what is already there is not an edit; forgetting a
             # no-op also lets a later real stage of the same path start
@@ -384,7 +413,9 @@ class EditTransaction:
         done: list[StagedFile] = []
         try:
             for staged in self.staged:
-                _write_file(self.repo_root / staged.path, staged.after)
+                _write_file(
+                    _contained(self.repo_root, staged.path), staged.after, staged.mode
+                )
                 done.append(staged)
             if self._record:
                 record_transaction(
@@ -400,7 +431,7 @@ def _restore(repo_root: Path, applied: list[StagedFile]) -> None:
     # the first write; a disk that fails here is logged, not masked.
     for staged in reversed(applied):
         try:
-            _write_file(repo_root / staged.path, staged.before)
+            _write_file(_contained(repo_root, staged.path), staged.before, staged.mode)
         except OSError as error:  # pragma: no cover - disk failure
             logger.error(ls.EDIT_TX_RESTORE_FAILED, path=staged.path, error=error)
 
@@ -419,7 +450,24 @@ def _run_verifier(verify: Verifier | None, tree: StagedTree) -> VerificationResu
     return result
 
 
-def _write_file(path: Path, content: bytes | None) -> None:
+def _mode_of(path: Path) -> int | None:
+    try:
+        return path.stat().st_mode & cs.EDIT_MODE_MASK
+    except OSError:
+        return None
+
+
+def _contained(root: Path, rel_path: str) -> Path:
+    # Every path written comes from a repo-relative key; resolving it and
+    # checking containment again here means no caller (an undo replaying a
+    # history file, a restore) can reach outside the root.
+    candidate = (root / rel_path).resolve()
+    if not candidate.is_relative_to(root.resolve()):
+        raise TransactionError(ls.FILE_OUTSIDE_ROOT.format(action=cs.FileAction.EDIT))
+    return candidate
+
+
+def _write_file(path: Path, content: bytes | None, mode: int | None = None) -> None:
     if content is None:
         path.unlink(missing_ok=True)
         return
@@ -428,9 +476,10 @@ def _write_file(path: Path, content: bytes | None) -> None:
     try:
         temp_path.write_bytes(content)
         # The replacement keeps the target's mode (an executable stays
-        # executable); a new file takes the temp file's default.
-        if path.exists():
-            os.chmod(temp_path, path.stat().st_mode & cs.EDIT_MODE_MASK)
+        # executable); a re-created file takes the mode it was staged with.
+        current = _mode_of(path) if mode is None else mode
+        if current is not None:
+            os.chmod(temp_path, current)
         os.replace(temp_path, path)
     except Exception:
         temp_path.unlink(missing_ok=True)
@@ -488,6 +537,7 @@ def record_transaction(
                     cs.KEY_PATH: s.path,
                     cs.EDIT_KEY_BEFORE: _b64(s.before),
                     cs.EDIT_KEY_AFTER: _b64(s.after),
+                    cs.EDIT_KEY_MODE: s.mode,
                 }
                 for s in staged
             ],
@@ -506,6 +556,7 @@ def entry_files(entry: dict) -> list[StagedFile]:
             f[cs.KEY_PATH],
             _unb64(f.get(cs.EDIT_KEY_BEFORE)),
             _unb64(f.get(cs.EDIT_KEY_AFTER)),
+            mode if isinstance(mode := f.get(cs.EDIT_KEY_MODE), int) else None,
         )
         for f in entry.get(cs.EDIT_KEY_FILES, [])
     ]
@@ -527,16 +578,21 @@ def undo_last(repo_root: Path, count: int = 1) -> list[TransactionOutcome]:
     root = repo_root.resolve()
     outcomes: list[TransactionOutcome] = []
     for _ in range(count):
-        entries = load_history(root)
-        if not entries:
-            break
-        entry = entries[-1]
-        reverse = EditTransaction(root, record=False)
-        for staged in entry_files(entry):
-            key = reverse._relative(staged.path)
-            reverse._overlay[key] = StagedFile(key, staged.after, staged.before)
-        reversed_files = reverse.staged
+        # The history read, the reversal and the truncation share one lock
+        # window: a commit landing in between would otherwise be dropped
+        # from the history by a truncation of a stale snapshot.
         with _repo_lock(root):
+            entries = load_history(root)
+            if not entries:
+                break
+            entry = entries[-1]
+            reverse = EditTransaction(root, record=False)
+            for staged in entry_files(entry):
+                key = reverse._relative(staged.path)
+                reverse._overlay[key] = StagedFile(
+                    key, staged.after, staged.before, staged.mode
+                )
+            reversed_files = reverse.staged
             outcome = reverse.commit(_lock=False)
             if outcome.applied:
                 try:

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -427,6 +427,10 @@ def _write_file(path: Path, content: bytes | None) -> None:
     temp_path = path.with_name(f"{path.name}{cs.TMP_EXTENSION}")
     try:
         temp_path.write_bytes(content)
+        # The replacement keeps the target's mode (an executable stays
+        # executable); a new file takes the temp file's default.
+        if path.exists():
+            os.chmod(temp_path, path.stat().st_mode & cs.EDIT_MODE_MASK)
         os.replace(temp_path, path)
     except Exception:
         temp_path.unlink(missing_ok=True)

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -463,7 +463,9 @@ def _contained(root: Path, rel_path: str) -> Path:
     # history file, a restore) can reach outside the root.
     real_root = os.path.realpath(root)
     candidate = os.path.realpath(os.path.join(real_root, rel_path))
-    if not candidate.startswith(real_root + os.sep):
+    # A filesystem root already ends with the separator.
+    root_prefix = real_root if real_root.endswith(os.sep) else real_root + os.sep
+    if not candidate.startswith(root_prefix):
         raise TransactionError(ls.FILE_OUTSIDE_ROOT.format(action=cs.FileAction.EDIT))
     return Path(candidate)
 
@@ -475,7 +477,8 @@ def _write_file(path: Path, content: bytes | None, mode: int | None = None) -> N
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = path.with_name(f"{path.name}{cs.TMP_EXTENSION}")
     try:
-        temp_path.write_bytes(content)
+        with open(temp_path, "wb") as handle:
+            handle.write(content)
         # The replacement keeps the target's mode (an executable stays
         # executable); a re-created file takes the mode it was staged with.
         current = _mode_of(path) if mode is None else mode

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -476,8 +476,16 @@ def _write_file(path: Path, content: bytes | None, mode: int | None = None) -> N
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = path.with_name(f"{path.name}{cs.TMP_EXTENSION}")
+    # A leftover at the temp path (a stale sibling, or a planted symlink) is
+    # removed by name, never followed, and the sibling is then created
+    # exclusively: an `open("wb")` would write through a symlink to wherever
+    # it points, and the replace below would then install the link itself.
+    temp_path.unlink(missing_ok=True)
     try:
-        with open(temp_path, "wb") as handle:
+        fd = os.open(
+            temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, cs.EDIT_TEMP_FILE_MODE
+        )
+        with os.fdopen(fd, "wb") as handle:
             handle.write(content)
         # The replacement keeps the target's mode (an executable stays
         # executable); a re-created file takes the mode it was staged with.

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -463,7 +463,7 @@ def _contained(root: Path, rel_path: str) -> Path:
     # history file, a restore) can reach outside the root.
     real_root = os.path.realpath(root)
     candidate = os.path.realpath(os.path.join(real_root, rel_path))
-    if os.path.commonpath([real_root, candidate]) != real_root:
+    if not candidate.startswith(real_root + os.sep):
         raise TransactionError(ls.FILE_OUTSIDE_ROOT.format(action=cs.FileAction.EDIT))
     return Path(candidate)
 
@@ -583,36 +583,42 @@ def undo_last(repo_root: Path, count: int = 1) -> list[TransactionOutcome]:
         # window: a commit landing in between would otherwise be dropped
         # from the history by a truncation of a stale snapshot.
         with _repo_lock(root):
-            entries = load_history(root)
-            if not entries:
-                break
-            entry = entries[-1]
-            reverse = EditTransaction(root, record=False)
-            for staged in entry_files(entry):
-                key = reverse._relative(staged.path)
-                if key in cs.CGR_STATE_FILENAMES:
-                    # The history is data on disk: an entry naming the lock
-                    # or the history itself must not replace their inodes.
-                    raise TransactionError(cs.EDIT_RESERVED_PATH.format(path=key))
-                reverse._overlay[key] = StagedFile(
-                    key, staged.after, staged.before, staged.mode
-                )
-            reversed_files = reverse.staged
-            outcome = reverse.commit(_lock=False)
-            if outcome.applied:
-                try:
-                    _save_history(root, entries[:-1])
-                except Exception:
-                    # The reversal landed but its record did not go: put the
-                    # files back as the entry says, so history and tree agree.
-                    _restore(root, list(reversed_files))
-                    raise
-        outcomes.append(
-            outcome._replace(transaction_id=str(entry.get(cs.EDIT_KEY_ID, "")))
-        )
+            outcome = _undo_newest(root)
+        if outcome is None:
+            break
+        outcomes.append(outcome)
         if not outcome.applied and outcome.message != cs.EDIT_NOTHING_STAGED:
             break
     return outcomes
+
+
+def _undo_newest(root: Path) -> TransactionOutcome | None:
+    """Reverse the newest history entry under the caller's lock; None if empty."""
+    entries = load_history(root)
+    if not entries:
+        return None
+    entry = entries[-1]
+    reverse = EditTransaction(root, record=False)
+    for staged in entry_files(entry):
+        key = reverse._relative(staged.path)
+        if key in cs.CGR_STATE_FILENAMES:
+            # The history is data on disk: an entry naming the lock or the
+            # history itself must not replace their inodes.
+            raise TransactionError(cs.EDIT_RESERVED_PATH.format(path=key))
+        reverse._overlay[key] = StagedFile(
+            key, staged.after, staged.before, staged.mode
+        )
+    reversed_files = reverse.staged
+    outcome = reverse.commit(_lock=False)
+    if outcome.applied:
+        try:
+            _save_history(root, entries[:-1])
+        except Exception:
+            # The reversal landed but its record did not go: put the files
+            # back as the entry says, so history and tree agree.
+            _restore(root, list(reversed_files))
+            raise
+    return outcome._replace(transaction_id=str(entry.get(cs.EDIT_KEY_ID, "")))
 
 
 @contextmanager

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -1,0 +1,491 @@
+"""Transactional multi-file edits (issue #1528).
+
+An edit-algebra operation that touches twelve files must land completely or
+not at all. `EditTransaction` collects the new content of every file it will
+touch in an in-memory overlay keyed by repo-relative posix path (the delombok
+overlay idiom), lets a verifier inspect the staged tree, and only then writes
+to the real tree: each file through a temp sibling and `os.replace`, with the
+originals held so a failure part-way restores what was already written.
+
+Every committed transaction is appended to `.cgr-edit-history.json` at the
+repo root (the patch set plus the verification outcome), so `cgr edits show`
+can list the last N and `cgr edits undo` can reverse them, each undo being a
+transaction itself that refuses if the tree has moved on since.
+"""
+
+from __future__ import annotations
+
+import base64
+import difflib
+import json
+import os
+import shutil
+import tempfile
+import threading
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import NamedTuple
+
+from loguru import logger
+
+from .. import constants as cs
+from .. import logs as ls
+from ..config import load_ignore_patterns
+from ..utils.path_utils import should_skip_path
+
+
+class VerificationResult(NamedTuple):
+    """What a verifier concluded about the staged tree."""
+
+    ok: bool
+    message: str = ""
+
+
+Verifier = Callable[["StagedTree"], "VerificationResult | bool | None"]
+
+
+class StagedFile(NamedTuple):
+    """One file's before/after bytes; `None` means absent (create / delete)."""
+
+    path: str
+    before: bytes | None
+    after: bytes | None
+
+
+class TransactionOutcome(NamedTuple):
+    """The result of `EditTransaction.commit` (or of an undo)."""
+
+    transaction_id: str
+    applied: bool
+    files: tuple[str, ...]
+    diff: str
+    verification: VerificationResult
+    message: str
+
+
+class TransactionConflict(ValueError):
+    """The working tree no longer matches what the transaction was staged on."""
+
+
+class TransactionError(ValueError):
+    """The transaction could not be prepared (bad path, unreadable file)."""
+
+
+# One lock per repo root: two transactions committing into the same tree must
+# serialise their read-verify-write windows, the same invariant FileEditor keeps
+# for single-file writes.
+_REPO_LOCKS: dict[str, threading.Lock] = {}
+_REPO_LOCKS_GUARD = threading.Lock()
+
+
+def _repo_lock(root: Path) -> threading.Lock:
+    key = str(root)
+    with _REPO_LOCKS_GUARD:
+        return _REPO_LOCKS.setdefault(key, threading.Lock())
+
+
+def _decode(data: bytes | None) -> list[str]:
+    if data is None:
+        return []
+    return data.decode(cs.ENCODING_UTF8, errors="replace").splitlines(keepends=True)
+
+
+def unified_diff(staged: StagedFile) -> str:
+    """A unified diff for one staged file, `/dev/null` for create and delete."""
+    from_name = cs.DIFF_DEV_NULL if staged.before is None else f"a/{staged.path}"
+    to_name = cs.DIFF_DEV_NULL if staged.after is None else f"b/{staged.path}"
+    lines = difflib.unified_diff(
+        _decode(staged.before),
+        _decode(staged.after),
+        fromfile=from_name,
+        tofile=to_name,
+    )
+    return "".join(lines)
+
+
+class StagedTree:
+    """What a verifier sees: the working tree with the overlay applied.
+
+    `read` and `exists` answer from the overlay first and the disk second,
+    which is all a parse-level check needs. `root` materialises a copy of
+    the tree (ignored directories excluded, the overlay written on top) for
+    verifiers that must run a real tool against real files; the copy is
+    made once, on first use, and removed when the transaction finishes.
+    """
+
+    def __init__(self, repo_root: Path, overlay: dict[str, StagedFile]) -> None:
+        self.repo_root = repo_root
+        self._overlay = overlay
+        self._materialised: Path | None = None
+
+    def exists(self, rel_path: str) -> bool:
+        staged = self._overlay.get(rel_path)
+        if staged is not None:
+            return staged.after is not None
+        return (self.repo_root / rel_path).is_file()
+
+    def read(self, rel_path: str) -> bytes | None:
+        staged = self._overlay.get(rel_path)
+        if staged is not None:
+            return staged.after
+        path = self.repo_root / rel_path
+        return path.read_bytes() if path.is_file() else None
+
+    def staged_paths(self) -> tuple[str, ...]:
+        return tuple(sorted(self._overlay))
+
+    @property
+    def root(self) -> Path:
+        if self._materialised is None:
+            self._materialised = self._materialise()
+        return self._materialised
+
+    def _materialise(self) -> Path:
+        target = Path(tempfile.mkdtemp(prefix=cs.EDIT_STAGING_PREFIX))
+        patterns = load_ignore_patterns(self.repo_root)
+        exclude = patterns.exclude
+        unignore = patterns.unignore
+        repo_root = self.repo_root
+
+        def ignore(directory: str, names: list[str]) -> set[str]:
+            here = Path(directory)
+            skipped: set[str] = set()
+            for name in names:
+                candidate = here / name
+                if name in cs.CGR_STATE_FILENAMES:
+                    skipped.add(name)
+                elif candidate.is_dir() and should_skip_path(
+                    candidate, repo_root, exclude, unignore, is_file=False
+                ):
+                    skipped.add(name)
+            return skipped
+
+        shutil.copytree(
+            repo_root, target, ignore=ignore, symlinks=True, dirs_exist_ok=True
+        )
+        for rel_path, staged in self._overlay.items():
+            path = target / rel_path
+            if staged.after is None:
+                path.unlink(missing_ok=True)
+            else:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(staged.after)
+        return target
+
+    def cleanup(self) -> None:
+        if self._materialised is not None:
+            shutil.rmtree(self._materialised, ignore_errors=True)
+            self._materialised = None
+
+
+class EditTransaction:
+    """Stage, verify, then apply a set of file edits atomically."""
+
+    def __init__(self, repo_root: Path, record: bool = True) -> None:
+        self.repo_root = repo_root.resolve()
+        self.transaction_id = uuid.uuid4().hex[: cs.EDIT_TRANSACTION_ID_LENGTH]
+        self._overlay: dict[str, StagedFile] = {}
+        self._record = record
+        self._finished = False
+
+    # --- staging ----------------------------------------------------------------
+
+    def _relative(self, rel_path: str | Path) -> str:
+        path = Path(rel_path)
+        if not path.is_absolute():
+            path = self.repo_root / path
+        try:
+            resolved = path.resolve()
+            inside = resolved.relative_to(self.repo_root)
+        except (OSError, ValueError) as error:
+            raise TransactionError(
+                ls.FILE_OUTSIDE_ROOT.format(action=cs.FileAction.EDIT)
+            ) from error
+        return inside.as_posix()
+
+    def _current(self, rel_path: str) -> bytes | None:
+        path = self.repo_root / rel_path
+        if not path.exists():
+            return None
+        if not path.is_file():
+            raise TransactionError(cs.EDIT_NOT_A_FILE.format(path=rel_path))
+        return path.read_bytes()
+
+    def read(self, rel_path: str | Path) -> bytes | None:
+        """The file as the transaction currently sees it (overlay first)."""
+        key = self._relative(rel_path)
+        staged = self._overlay.get(key)
+        return staged.after if staged is not None else self._current(key)
+
+    def stage(self, rel_path: str | Path, content: str | bytes | None) -> StagedFile:
+        """Set a file's full content; `None` deletes it. Later stages win."""
+        self._check_open()
+        key = self._relative(rel_path)
+        after = (
+            content.encode(cs.ENCODING_UTF8) if isinstance(content, str) else content
+        )
+        existing = self._overlay.get(key)
+        before = existing.before if existing is not None else self._current(key)
+        staged = StagedFile(key, before, after)
+        if before == after:
+            # Staging what is already there is not an edit; forgetting a
+            # no-op also lets a later real stage of the same path start
+            # from the disk state again.
+            self._overlay.pop(key, None)
+        else:
+            self._overlay[key] = staged
+        return staged
+
+    def unstage(self, rel_path: str | Path) -> None:
+        self._overlay.pop(self._relative(rel_path), None)
+
+    @property
+    def staged(self) -> tuple[StagedFile, ...]:
+        return tuple(self._overlay[k] for k in sorted(self._overlay))
+
+    def diff(self) -> str:
+        """The combined unified diff of everything staged."""
+        return "".join(unified_diff(s) for s in self.staged)
+
+    def tree(self) -> StagedTree:
+        return StagedTree(self.repo_root, dict(self._overlay))
+
+    # --- commit / rollback ------------------------------------------------------
+
+    def rollback(self) -> None:
+        """Discard the staging; the tree was never touched."""
+        self._overlay.clear()
+        self._finished = True
+
+    def _check_open(self) -> None:
+        if self._finished:
+            raise TransactionError(cs.EDIT_TRANSACTION_FINISHED)
+
+    def _check_unchanged(self) -> None:
+        # Verification and application read the tree as it is NOW; a file
+        # that moved since it was staged would make the diff a lie and the
+        # undo record wrong, so the whole transaction refuses.
+        for staged in self._overlay.values():
+            if self._current(staged.path) != staged.before:
+                raise TransactionConflict(cs.EDIT_CONFLICT.format(path=staged.path))
+
+    def commit(self, verify: Verifier | None = None) -> TransactionOutcome:
+        """Verify the staged tree, then apply every file or none of them."""
+        self._check_open()
+        diff = self.diff()
+        files = tuple(sorted(self._overlay))
+        if not files:
+            self._finished = True
+            return TransactionOutcome(
+                self.transaction_id,
+                False,
+                (),
+                "",
+                VerificationResult(True),
+                cs.EDIT_NOTHING_STAGED,
+            )
+        with _repo_lock(self.repo_root):
+            self._check_unchanged()
+            tree = self.tree()
+            try:
+                verification = _run_verifier(verify, tree)
+            finally:
+                tree.cleanup()
+            if not verification.ok:
+                self.rollback()
+                logger.info(
+                    ls.EDIT_TX_REJECTED,
+                    tx=self.transaction_id,
+                    why=verification.message,
+                )
+                return TransactionOutcome(
+                    self.transaction_id,
+                    False,
+                    files,
+                    diff,
+                    verification,
+                    cs.EDIT_VERIFICATION_FAILED.format(reason=verification.message),
+                )
+            self._apply_all()
+            if self._record:
+                record_transaction(
+                    self.repo_root, self.transaction_id, self.staged, verification
+                )
+        self._finished = True
+        logger.info(ls.EDIT_TX_APPLIED, tx=self.transaction_id, count=len(files))
+        return TransactionOutcome(
+            self.transaction_id,
+            True,
+            files,
+            diff,
+            verification,
+            cs.EDIT_APPLIED.format(count=len(files)),
+        )
+
+    def _apply_all(self) -> None:
+        done: list[StagedFile] = []
+        try:
+            for staged in self.staged:
+                _write_file(self.repo_root / staged.path, staged.after)
+                done.append(staged)
+        except Exception:
+            # Best-effort restore of what already landed, so the caller sees
+            # either every file or the tree it started from.
+            for staged in reversed(done):
+                try:
+                    _write_file(self.repo_root / staged.path, staged.before)
+                except OSError as error:  # pragma: no cover - disk failure
+                    logger.error(
+                        ls.EDIT_TX_RESTORE_FAILED, path=staged.path, error=error
+                    )
+            raise
+
+
+def _run_verifier(verify: Verifier | None, tree: StagedTree) -> VerificationResult:
+    if verify is None:
+        return VerificationResult(True)
+    try:
+        result = verify(tree)
+    except Exception as error:
+        return VerificationResult(False, cs.EDIT_VERIFIER_RAISED.format(error=error))
+    if result is None or result is True:
+        return VerificationResult(True)
+    if result is False:
+        return VerificationResult(False, cs.EDIT_VERIFIER_FALSE)
+    return result
+
+
+def _write_file(path: Path, content: bytes | None) -> None:
+    if content is None:
+        path.unlink(missing_ok=True)
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f"{path.name}{cs.TMP_EXTENSION}")
+    try:
+        temp_path.write_bytes(content)
+        os.replace(temp_path, path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+# --- history ------------------------------------------------------------------
+
+
+def history_path(repo_root: Path) -> Path:
+    return repo_root / cs.EDIT_HISTORY_FILENAME
+
+
+def _b64(data: bytes | None) -> str | None:
+    return None if data is None else base64.b64encode(data).decode("ascii")
+
+
+def _unb64(data: str | None) -> bytes | None:
+    return None if data is None else base64.b64decode(data)
+
+
+def load_history(repo_root: Path) -> list[dict]:
+    path = history_path(repo_root)
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding=cs.ENCODING_UTF8))
+    except (OSError, ValueError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _save_history(repo_root: Path, entries: list[dict]) -> None:
+    _write_file(
+        history_path(repo_root),
+        json.dumps(entries[-cs.EDIT_HISTORY_LIMIT :], indent=2).encode(
+            cs.ENCODING_UTF8
+        ),
+    )
+
+
+def record_transaction(
+    repo_root: Path,
+    transaction_id: str,
+    staged: tuple[StagedFile, ...],
+    verification: VerificationResult,
+) -> None:
+    entries = load_history(repo_root)
+    entries.append(
+        {
+            cs.EDIT_KEY_ID: transaction_id,
+            cs.EDIT_KEY_AT: datetime.now(UTC).isoformat(timespec="seconds"),
+            cs.EDIT_KEY_FILES: [
+                {
+                    cs.KEY_PATH: s.path,
+                    cs.EDIT_KEY_BEFORE: _b64(s.before),
+                    cs.EDIT_KEY_AFTER: _b64(s.after),
+                }
+                for s in staged
+            ],
+            cs.EDIT_KEY_VERIFICATION: {
+                cs.EDIT_KEY_OK: verification.ok,
+                cs.EDIT_KEY_MESSAGE: verification.message,
+            },
+        }
+    )
+    _save_history(repo_root, entries)
+
+
+def entry_files(entry: dict) -> list[StagedFile]:
+    return [
+        StagedFile(
+            f[cs.KEY_PATH],
+            _unb64(f.get(cs.EDIT_KEY_BEFORE)),
+            _unb64(f.get(cs.EDIT_KEY_AFTER)),
+        )
+        for f in entry.get(cs.EDIT_KEY_FILES, [])
+    ]
+
+
+def entry_diff(entry: dict) -> str:
+    return "".join(unified_diff(s) for s in entry_files(entry))
+
+
+def undo_last(repo_root: Path, count: int = 1) -> list[TransactionOutcome]:
+    """Reverse the last `count` recorded transactions, newest first.
+
+    Each undo is itself a transaction staging `after -> before`; it refuses
+    (and stops the run) if a file no longer holds what the transaction
+    wrote, so an undo never clobbers later hand edits.
+    """
+    root = repo_root.resolve()
+    outcomes: list[TransactionOutcome] = []
+    for _ in range(count):
+        entries = load_history(root)
+        if not entries:
+            break
+        entry = entries[-1]
+        reverse = EditTransaction(root, record=False)
+        for staged in entry_files(entry):
+            reverse._overlay[staged.path] = StagedFile(
+                staged.path, staged.after, staged.before
+            )
+        outcome = reverse.commit()
+        outcomes.append(
+            outcome._replace(transaction_id=str(entry.get(cs.EDIT_KEY_ID, "")))
+        )
+        if not outcome.applied and outcome.message != cs.EDIT_NOTHING_STAGED:
+            break
+        _save_history(root, entries[:-1])
+    return outcomes
+
+
+@contextmanager
+def transaction(repo_root: Path) -> Iterator[EditTransaction]:
+    """`with transaction(root) as tx: tx.stage(...)`; rolls back on exception."""
+    tx = EditTransaction(repo_root)
+    try:
+        yield tx
+    except BaseException:
+        if not tx._finished:
+            tx.rollback()
+        raise

--- a/codebase_rag/editing/transaction.py
+++ b/codebase_rag/editing/transaction.py
@@ -20,14 +20,15 @@ import difflib
 import json
 import os
 import shutil
+import sys
 import tempfile
 import threading
 import uuid
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import NamedTuple
+from typing import IO, NamedTuple
 
 from loguru import logger
 
@@ -74,17 +75,54 @@ class TransactionError(ValueError):
     """The transaction could not be prepared (bad path, unreadable file)."""
 
 
-# One lock per repo root: two transactions committing into the same tree must
-# serialise their read-verify-write windows, the same invariant FileEditor keeps
-# for single-file writes.
+# Two transactions committing into the same tree must serialise their
+# read-verify-write windows, and `cgr edits undo` may run in another process
+# than the agent's server: the lock is an OS advisory lock on a file at the
+# repo root, held across the baseline check, the verifier, the writes and the
+# history update. A thread lock per root sits in front of it so threads of
+# one process queue rather than contend for the file.
 _REPO_LOCKS: dict[str, threading.Lock] = {}
 _REPO_LOCKS_GUARD = threading.Lock()
 
 
-def _repo_lock(root: Path) -> threading.Lock:
+def _thread_lock(root: Path) -> threading.Lock:
     key = str(root)
     with _REPO_LOCKS_GUARD:
         return _REPO_LOCKS.setdefault(key, threading.Lock())
+
+
+def _lock_file(handle: IO[bytes]) -> None:
+    if sys.platform == cs.PLATFORM_WINDOWS:  # pragma: no cover - platform
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(handle: IO[bytes]) -> None:
+    if sys.platform == cs.PLATFORM_WINDOWS:  # pragma: no cover - platform
+        import msvcrt
+
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _repo_lock(root: Path) -> Iterator[None]:
+    with _thread_lock(root):
+        lock_path = root / cs.EDIT_LOCK_FILENAME
+        with lock_path.open("ab") as handle:
+            _lock_file(handle)
+            try:
+                yield
+            finally:
+                _unlock_file(handle)
 
 
 def _decode(data: bytes | None) -> list[str]:
@@ -150,6 +188,8 @@ class StagedTree:
         unignore = patterns.unignore
         repo_root = self.repo_root
 
+        resolved_root = repo_root.resolve()
+
         def ignore(directory: str, names: list[str]) -> set[str]:
             here = Path(directory)
             skipped: set[str] = set()
@@ -157,14 +197,20 @@ class StagedTree:
                 candidate = here / name
                 if name in cs.CGR_STATE_FILENAMES:
                     skipped.add(name)
+                elif candidate.is_symlink() and not _inside(candidate, resolved_root):
+                    # A link out of the repo would let a verifier write
+                    # through the copy into the live tree or beyond it.
+                    skipped.add(name)
                 elif candidate.is_dir() and should_skip_path(
                     candidate, repo_root, exclude, unignore, is_file=False
                 ):
                     skipped.add(name)
             return skipped
 
+        # symlinks=False: in-repo links are copied as the files they point
+        # at, so nothing under `root` reaches outside the staging copy.
         shutil.copytree(
-            repo_root, target, ignore=ignore, symlinks=True, dirs_exist_ok=True
+            repo_root, target, ignore=ignore, symlinks=False, dirs_exist_ok=True
         )
         for rel_path, staged in self._overlay.items():
             path = target / rel_path
@@ -179,6 +225,13 @@ class StagedTree:
         if self._materialised is not None:
             shutil.rmtree(self._materialised, ignore_errors=True)
             self._materialised = None
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        return path.resolve().is_relative_to(root)
+    except OSError:
+        return False
 
 
 class EditTransaction:
@@ -272,7 +325,9 @@ class EditTransaction:
             if self._current(staged.path) != staged.before:
                 raise TransactionConflict(cs.EDIT_CONFLICT.format(path=staged.path))
 
-    def commit(self, verify: Verifier | None = None) -> TransactionOutcome:
+    def commit(
+        self, verify: Verifier | None = None, *, _lock: bool = True
+    ) -> TransactionOutcome:
         """Verify the staged tree, then apply every file or none of them."""
         self._check_open()
         diff = self.diff()
@@ -287,7 +342,7 @@ class EditTransaction:
                 VerificationResult(True),
                 cs.EDIT_NOTHING_STAGED,
             )
-        with _repo_lock(self.repo_root):
+        with _repo_lock(self.repo_root) if _lock else nullcontext():
             self._check_unchanged()
             tree = self.tree()
             try:
@@ -309,11 +364,7 @@ class EditTransaction:
                     verification,
                     cs.EDIT_VERIFICATION_FAILED.format(reason=verification.message),
                 )
-            self._apply_all()
-            if self._record:
-                record_transaction(
-                    self.repo_root, self.transaction_id, self.staged, verification
-                )
+            self._apply_all(verification)
         self._finished = True
         logger.info(ls.EDIT_TX_APPLIED, tx=self.transaction_id, count=len(files))
         return TransactionOutcome(
@@ -325,23 +376,33 @@ class EditTransaction:
             cs.EDIT_APPLIED.format(count=len(files)),
         )
 
-    def _apply_all(self) -> None:
+    def _apply_all(self, verification: VerificationResult) -> None:
+        # One recovery path for the writes AND the history record: a failure
+        # anywhere after the first write restores every file already landed,
+        # so a caller never sees changed files without their history entry
+        # (a later undo could not know about them).
         done: list[StagedFile] = []
         try:
             for staged in self.staged:
                 _write_file(self.repo_root / staged.path, staged.after)
                 done.append(staged)
+            if self._record:
+                record_transaction(
+                    self.repo_root, self.transaction_id, self.staged, verification
+                )
         except Exception:
-            # Best-effort restore of what already landed, so the caller sees
-            # either every file or the tree it started from.
-            for staged in reversed(done):
-                try:
-                    _write_file(self.repo_root / staged.path, staged.before)
-                except OSError as error:  # pragma: no cover - disk failure
-                    logger.error(
-                        ls.EDIT_TX_RESTORE_FAILED, path=staged.path, error=error
-                    )
+            _restore(self.repo_root, done)
             raise
+
+
+def _restore(repo_root: Path, applied: list[StagedFile]) -> None:
+    # Best-effort, newest first, so the tree returns to what it was before
+    # the first write; a disk that fails here is logged, not masked.
+    for staged in reversed(applied):
+        try:
+            _write_file(repo_root / staged.path, staged.before)
+        except OSError as error:  # pragma: no cover - disk failure
+            logger.error(ls.EDIT_TX_RESTORE_FAILED, path=staged.path, error=error)
 
 
 def _run_verifier(verify: Verifier | None, tree: StagedTree) -> VerificationResult:
@@ -455,7 +516,9 @@ def undo_last(repo_root: Path, count: int = 1) -> list[TransactionOutcome]:
 
     Each undo is itself a transaction staging `after -> before`; it refuses
     (and stops the run) if a file no longer holds what the transaction
-    wrote, so an undo never clobbers later hand edits.
+    wrote, so an undo never clobbers later hand edits. A history entry
+    naming a path outside the repo is rejected whole: the history file is
+    data on disk, not a trusted instruction.
     """
     root = repo_root.resolve()
     outcomes: list[TransactionOutcome] = []
@@ -466,16 +529,24 @@ def undo_last(repo_root: Path, count: int = 1) -> list[TransactionOutcome]:
         entry = entries[-1]
         reverse = EditTransaction(root, record=False)
         for staged in entry_files(entry):
-            reverse._overlay[staged.path] = StagedFile(
-                staged.path, staged.after, staged.before
-            )
-        outcome = reverse.commit()
+            key = reverse._relative(staged.path)
+            reverse._overlay[key] = StagedFile(key, staged.after, staged.before)
+        reversed_files = reverse.staged
+        with _repo_lock(root):
+            outcome = reverse.commit(_lock=False)
+            if outcome.applied:
+                try:
+                    _save_history(root, entries[:-1])
+                except Exception:
+                    # The reversal landed but its record did not go: put the
+                    # files back as the entry says, so history and tree agree.
+                    _restore(root, list(reversed_files))
+                    raise
         outcomes.append(
             outcome._replace(transaction_id=str(entry.get(cs.EDIT_KEY_ID, "")))
         )
         if not outcome.applied and outcome.message != cs.EDIT_NOTHING_STAGED:
             break
-        _save_history(root, entries[:-1])
     return outcomes
 
 

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -266,6 +266,9 @@ DEBOUNCE_MAX_WAIT_ADJUSTED = (
 )
 DELETION_QUERY = "Ran deletion query for path: {path}"
 RECALC_CALLS = "Recalculating all function call relationships for consistency..."
+EDIT_TX_REJECTED = "Edit transaction {tx} rejected by verification: {why}"
+EDIT_TX_APPLIED = "Edit transaction {tx} applied {count} file(s)"
+EDIT_TX_RESTORE_FAILED = "Edit transaction could not restore {path}: {error}"
 GRAPH_UPDATED = "Graph updated successfully for change in: {name}"
 INITIAL_SCAN = "Performing initial full codebase scan..."
 INITIAL_SCAN_DONE = "Initial scan complete. Starting real-time watcher."

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -655,3 +655,12 @@ def test_undo_rejects_history_entries_naming_state_files(repo: Path) -> None:
     with pytest.raises(TransactionError):
         undo_last(repo)
     assert len(load_history(repo)) == 1
+
+
+def test_containment_accepts_a_filesystem_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A repo at `/` must not reject every child through a doubled separator."""
+    from codebase_rag.editing.transaction import _contained
+
+    root = Path(Path.cwd().anchor)
+    child = _contained(root, "some/file.py")
+    assert child == (root / "some" / "file.py").resolve()

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -40,11 +40,11 @@ def _tree_digest(root: Path) -> dict[str, str]:
 def repo(tmp_path: Path) -> Path:
     root = tmp_path / "repo"
     (root / "pkg").mkdir(parents=True)
-    (root / "pkg" / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
-    (root / "pkg" / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
-    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / "pkg" / "a.py").write_bytes(b"def a():\n    return 1\n")
+    (root / "pkg" / "b.py").write_bytes(b"def b():\n    return 2\n")
+    (root / "README.md").write_bytes(b"# repo\n")
     (root / "node_modules").mkdir()
-    (root / "node_modules" / "junk.js").write_text("x", encoding="utf-8")
+    (root / "node_modules" / "junk.js").write_bytes(b"x")
     return root
 
 
@@ -183,7 +183,7 @@ def test_paths_outside_the_repo_are_refused(repo: Path) -> None:
 def test_a_file_changed_after_staging_makes_commit_refuse(repo: Path) -> None:
     tx = EditTransaction(repo)
     tx.stage("pkg/a.py", "mine\n")
-    (repo / "pkg" / "a.py").write_text("someone else\n", encoding="utf-8")
+    (repo / "pkg" / "a.py").write_bytes(b"someone else\n")
     before = _tree_digest(repo)
     with pytest.raises(TransactionConflict):
         tx.commit()
@@ -301,7 +301,7 @@ def test_undo_stops_at_a_file_that_changed_since(repo: Path) -> None:
     tx2 = EditTransaction(repo)
     tx2.stage("pkg/b.py", "two\n")
     tx2.commit()
-    (repo / "pkg" / "b.py").write_text("hand edit\n", encoding="utf-8")
+    (repo / "pkg" / "b.py").write_bytes(b"hand edit\n")
 
     with pytest.raises(TransactionConflict):
         undo_last(repo, count=2)
@@ -377,7 +377,7 @@ def test_cli_undo_conflict_exits_nonzero(repo: Path) -> None:
     tx = EditTransaction(repo)
     tx.stage("pkg/a.py", "v1\n")
     tx.commit()
-    (repo / "pkg" / "a.py").write_text("hand edit\n", encoding="utf-8")
+    (repo / "pkg" / "a.py").write_bytes(b"hand edit\n")
     result = CliRunner().invoke(edits_cli, ["undo", "--repo-path", str(repo)])
     assert result.exit_code == 1
     assert (repo / "pkg" / "a.py").read_text() == "hand edit\n"
@@ -392,7 +392,7 @@ def test_escaping_symlink_cannot_reach_the_live_tree_from_the_staging_copy(
     """A verifier writing through a symlink in `tree.root` must never touch
     the working tree (or anything outside it) when it then fails."""
     outside = tmp_path / "outside.txt"
-    outside.write_text("keep\n", encoding="utf-8")
+    outside.write_bytes(b"keep\n")
     (repo / "escape").symlink_to(outside)
     (repo / "inner").symlink_to(repo / "README.md")
     before = _tree_digest(repo)
@@ -403,8 +403,8 @@ def test_escaping_symlink_cannot_reach_the_live_tree_from_the_staging_copy(
         # An in-repo link is a plain copy: writing to it changes the staging
         # tree only.
         assert not (root / "inner").is_symlink()
-        (root / "inner").write_text("scribble\n", encoding="utf-8")
-        (root / "README.md").write_text("scribble\n", encoding="utf-8")
+        (root / "inner").write_bytes(b"scribble\n")
+        (root / "README.md").write_bytes(b"scribble\n")
         return VerificationResult(False, "no")
 
     tx = EditTransaction(repo)
@@ -420,7 +420,7 @@ def test_undo_rejects_history_paths_outside_the_repo(
     repo: Path, tmp_path: Path
 ) -> None:
     victim = tmp_path / "victim.txt"
-    victim.write_text("keep\n", encoding="utf-8")
+    victim.write_bytes(b"keep\n")
     history = repo / cs.EDIT_HISTORY_FILENAME
     history.write_text(
         json.dumps(
@@ -520,7 +520,7 @@ def test_replacing_an_executable_keeps_its_mode(repo: Path) -> None:
     import stat
 
     script = repo / "run.sh"
-    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.write_bytes(b"#!/bin/sh\necho one\n")
     script.chmod(0o755)
     tx = EditTransaction(repo)
     tx.stage("run.sh", "#!/bin/sh\necho two\n")
@@ -568,7 +568,8 @@ def test_materialise_failure_removes_the_staging_copy(
     tree = StagedTree(repo, {})
     with pytest.raises(OSError):
         _ = tree.root
-    assert made and not made[0].exists()
+    assert made
+    assert not made[0].exists()
 
 
 def test_reserved_state_files_cannot_be_staged(repo: Path) -> None:
@@ -584,7 +585,7 @@ def test_deleted_executable_is_restored_executable(repo: Path) -> None:
     import stat
 
     script = repo / "run.sh"
-    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.write_bytes(b"#!/bin/sh\necho one\n")
     script.chmod(0o755)
     tx = EditTransaction(repo)
     tx.stage("run.sh", None)

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -373,3 +373,135 @@ def test_cli_undo_conflict_exits_nonzero(repo: Path) -> None:
     result = CliRunner().invoke(edits_cli, ["undo", "--repo-path", str(repo)])
     assert result.exit_code == 1
     assert (repo / "pkg" / "a.py").read_text() == "hand edit\n"
+
+
+# --- Review findings on PR #1540 ----------------------------------------------
+
+
+def test_escaping_symlink_cannot_reach_the_live_tree_from_the_staging_copy(
+    repo: Path, tmp_path: Path
+) -> None:
+    """A verifier writing through a symlink in `tree.root` must never touch
+    the working tree (or anything outside it) when it then fails."""
+    outside = tmp_path / "outside.txt"
+    outside.write_text("keep\n", encoding="utf-8")
+    (repo / "escape").symlink_to(outside)
+    (repo / "inner").symlink_to(repo / "README.md")
+    before = _tree_digest(repo)
+
+    def verify(tree: StagedTree) -> VerificationResult:
+        root = tree.root
+        assert not (root / "escape").exists(), "escaping link is not copied"
+        # An in-repo link is a plain copy: writing to it changes the staging
+        # tree only.
+        assert not (root / "inner").is_symlink()
+        (root / "inner").write_text("scribble\n", encoding="utf-8")
+        (root / "README.md").write_text("scribble\n", encoding="utf-8")
+        return VerificationResult(False, "no")
+
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "x\n")
+    outcome = tx.commit(verify)
+    assert outcome.applied is False
+    assert outside.read_text() == "keep\n"
+    assert (repo / "README.md").read_text() == "# repo\n"
+    assert _tree_digest(repo) == before
+
+
+def test_undo_rejects_history_paths_outside_the_repo(
+    repo: Path, tmp_path: Path
+) -> None:
+    victim = tmp_path / "victim.txt"
+    victim.write_text("keep\n", encoding="utf-8")
+    history = repo / cs.EDIT_HISTORY_FILENAME
+    history.write_text(
+        json.dumps(
+            [
+                {
+                    cs.EDIT_KEY_ID: "evil",
+                    cs.EDIT_KEY_AT: "now",
+                    cs.EDIT_KEY_FILES: [
+                        {
+                            cs.KEY_PATH: str(victim),
+                            cs.EDIT_KEY_BEFORE: None,
+                            cs.EDIT_KEY_AFTER: "a2VlcAo=",
+                        }
+                    ],
+                    cs.EDIT_KEY_VERIFICATION: {
+                        cs.EDIT_KEY_OK: True,
+                        cs.EDIT_KEY_MESSAGE: "",
+                    },
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(TransactionError):
+        undo_last(repo)
+    assert victim.read_text() == "keep\n"
+    assert len(load_history(repo)) == 1
+
+
+def test_commit_holds_an_os_level_lock_file(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "x\n")
+    seen: dict[str, bool] = {}
+
+    def verify(tree: StagedTree) -> bool:
+        seen["lock_exists"] = (repo / cs.EDIT_LOCK_FILENAME).exists()
+        return True
+
+    tx.commit(verify)
+    assert seen["lock_exists"] is True
+    assert cs.EDIT_LOCK_FILENAME in cs.CGR_STATE_FILENAMES
+
+
+def test_history_record_failure_restores_the_files(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib
+
+    module = importlib.import_module("codebase_rag.editing.transaction")
+
+    def broken(*args: object, **kwargs: object) -> None:
+        raise OSError("history disk full")
+
+    monkeypatch.setattr(module, "record_transaction", broken)
+    before = _tree_digest(repo)
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "changed\n")
+    tx.stage("pkg/new.py", "new\n")
+    with pytest.raises(OSError):
+        tx.commit()
+    assert _tree_digest(repo) == before
+    assert not (repo / "pkg" / "new.py").exists()
+
+
+def test_undo_history_truncation_failure_restores_the_reversal(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib
+
+    module = importlib.import_module("codebase_rag.editing.transaction")
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "v1\n")
+    tx.commit()
+    original_save = module._save_history
+
+    def broken(root: Path, entries: list[dict]) -> None:
+        if entries == []:
+            raise OSError("history disk full")
+        original_save(root, entries)
+
+    monkeypatch.setattr(module, "_save_history", broken)
+    with pytest.raises(OSError):
+        undo_last(repo)
+    # The reversal was put back: tree and history still agree.
+    assert (repo / "pkg" / "a.py").read_text() == "v1\n"
+    assert len(load_history(repo)) == 1
+
+
+def test_cli_counts_must_be_positive(repo: Path) -> None:
+    for args in (["show", "-n", "0"], ["undo", "-n", "0"], ["undo", "-n", "-2"]):
+        result = CliRunner().invoke(edits_cli, [*args, "--repo-path", str(repo)])
+        assert result.exit_code == 2, args

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -1,0 +1,375 @@
+# Transactional multi-file edits (issue #1528): stage, verify, then apply all
+# files or none; every applied transaction is recorded so it can be shown and
+# undone. The acceptance criteria are byte-identity of the tree after a failed
+# verification and atomic application (plus the combined diff) on success.
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from codebase_rag import constants as cs
+from codebase_rag.editing import (
+    EditTransaction,
+    StagedTree,
+    TransactionConflict,
+    TransactionError,
+    VerificationResult,
+    transaction,
+    undo_last,
+)
+from codebase_rag.editing.cli import cli as edits_cli
+from codebase_rag.editing.transaction import load_history
+
+
+def _tree_digest(root: Path) -> dict[str, str]:
+    """path -> sha256 of every regular file, history file excluded."""
+    digest: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.name not in cs.CGR_STATE_FILENAMES:
+            digest[path.relative_to(root).as_posix()] = hashlib.sha256(
+                path.read_bytes()
+            ).hexdigest()
+    return digest
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    (root / "pkg" / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    (root / "node_modules").mkdir()
+    (root / "node_modules" / "junk.js").write_text("x", encoding="utf-8")
+    return root
+
+
+# --- acceptance ----------------------------------------------------------------
+
+
+def test_failed_verification_leaves_the_tree_byte_identical(repo: Path) -> None:
+    before = _tree_digest(repo)
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "def a():\n    return 10\n")
+    tx.stage("pkg/new.py", "def n():\n    return 0\n")
+    tx.stage("pkg/b.py", None)
+
+    outcome = tx.commit(lambda tree: VerificationResult(False, "tests failed"))
+
+    assert outcome.applied is False
+    assert "tests failed" in outcome.message
+    assert outcome.files == ("pkg/a.py", "pkg/b.py", "pkg/new.py")
+    assert _tree_digest(repo) == before
+    assert not (repo / cs.EDIT_HISTORY_FILENAME).exists()
+
+
+def test_successful_commit_applies_every_file_and_returns_the_diff(
+    repo: Path,
+) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "def a():\n    return 10\n")
+    tx.stage("pkg/new.py", "def n():\n    return 0\n")
+    tx.stage("pkg/b.py", None)
+
+    outcome = tx.commit(lambda tree: True)
+
+    assert outcome.applied is True
+    assert outcome.files == ("pkg/a.py", "pkg/b.py", "pkg/new.py")
+    assert (repo / "pkg" / "a.py").read_text() == "def a():\n    return 10\n"
+    assert (repo / "pkg" / "new.py").read_text() == "def n():\n    return 0\n"
+    assert not (repo / "pkg" / "b.py").exists()
+    assert "--- a/pkg/a.py" in outcome.diff and "+++ b/pkg/a.py" in outcome.diff
+    assert "-    return 1\n+    return 10\n" in outcome.diff
+    assert f"--- {cs.DIFF_DEV_NULL}\n+++ b/pkg/new.py" in outcome.diff
+    assert f"--- a/pkg/b.py\n+++ {cs.DIFF_DEV_NULL}" in outcome.diff
+    # No temp siblings left behind by the atomic writes.
+    assert not list(repo.rglob(f"*{cs.TMP_EXTENSION}"))
+
+
+# --- staging semantics --------------------------------------------------------
+
+
+def test_staged_tree_reads_overlay_first_and_disk_second(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "changed\n")
+    tx.stage("pkg/b.py", None)
+    tree = tx.tree()
+    assert tree.read("pkg/a.py") == b"changed\n"
+    assert tree.read("pkg/b.py") is None
+    assert tree.exists("pkg/b.py") is False
+    assert tree.read("README.md") == b"# repo\n"
+    assert tree.staged_paths() == ("pkg/a.py", "pkg/b.py")
+    # The working tree is untouched until commit.
+    assert (repo / "pkg" / "a.py").read_text() == "def a():\n    return 1\n"
+
+
+def test_materialised_tree_has_the_overlay_and_skips_ignored_dirs(
+    repo: Path,
+) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "changed\n")
+    tx.stage("pkg/b.py", None)
+    tx.stage("deep/new.py", "new\n")
+    tree = tx.tree()
+    root = tree.root
+    try:
+        assert root != repo
+        assert (root / "pkg" / "a.py").read_text() == "changed\n"
+        assert not (root / "pkg" / "b.py").exists()
+        assert (root / "deep" / "new.py").read_text() == "new\n"
+        assert (root / "README.md").read_text() == "# repo\n"
+        assert not (root / "node_modules").exists()
+        assert tree.root == root, "materialised once"
+    finally:
+        tree.cleanup()
+    assert not root.exists()
+
+
+def test_verifier_sees_the_staged_tree_and_can_run_a_tool(repo: Path) -> None:
+    seen: dict[str, object] = {}
+
+    def verify(tree: StagedTree) -> VerificationResult:
+        seen["overlay"] = tree.read("pkg/a.py")
+        seen["disk"] = (tree.root / "pkg" / "a.py").read_bytes()
+        seen["root"] = tree.root
+        return VerificationResult(True, "ok")
+
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "verified\n")
+    outcome = tx.commit(verify)
+    assert outcome.applied
+    assert seen["overlay"] == b"verified\n" == seen["disk"]
+    assert not Path(str(seen["root"])).exists(), "staging copy removed after commit"
+
+
+def test_staging_the_current_content_is_not_an_edit(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "def a():\n    return 1\n")
+    assert tx.staged == ()
+    outcome = tx.commit()
+    assert outcome.applied is False
+    assert outcome.message == cs.EDIT_NOTHING_STAGED
+    assert not (repo / cs.EDIT_HISTORY_FILENAME).exists()
+
+
+def test_later_stage_of_the_same_file_wins_but_keeps_the_disk_baseline(
+    repo: Path,
+) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "first\n")
+    tx.stage("pkg/a.py", "second\n")
+    (staged,) = tx.staged
+    assert staged.before == b"def a():\n    return 1\n"
+    assert staged.after == b"second\n"
+    tx.unstage("pkg/a.py")
+    assert tx.staged == ()
+
+
+def test_paths_outside_the_repo_are_refused(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    with pytest.raises(TransactionError):
+        tx.stage("../escape.py", "x")
+    with pytest.raises(TransactionError):
+        tx.stage(repo.parent / "other.py", "x")
+    with pytest.raises(TransactionError):
+        tx.stage("pkg", "x")  # a directory
+
+
+def test_a_file_changed_after_staging_makes_commit_refuse(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "mine\n")
+    (repo / "pkg" / "a.py").write_text("someone else\n", encoding="utf-8")
+    before = _tree_digest(repo)
+    with pytest.raises(TransactionConflict):
+        tx.commit()
+    assert _tree_digest(repo) == before
+
+
+def test_verifier_exceptions_and_false_count_as_failure(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "x\n")
+
+    def boom(tree: StagedTree) -> bool:
+        raise RuntimeError("kaboom")
+
+    outcome = tx.commit(boom)
+    assert outcome.applied is False
+    assert "kaboom" in outcome.verification.message
+
+    tx2 = EditTransaction(repo)
+    tx2.stage("pkg/a.py", "x\n")
+    outcome = tx2.commit(lambda tree: False)
+    assert outcome.applied is False
+    assert outcome.verification.message == cs.EDIT_VERIFIER_FALSE
+    assert (repo / "pkg" / "a.py").read_text() == "def a():\n    return 1\n"
+
+
+def test_finished_transactions_cannot_be_reused(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "x\n")
+    tx.rollback()
+    assert tx.staged == ()
+    with pytest.raises(TransactionError):
+        tx.stage("pkg/a.py", "y\n")
+    with pytest.raises(TransactionError):
+        tx.commit()
+
+
+def test_context_manager_rolls_back_on_exception(repo: Path) -> None:
+    with pytest.raises(RuntimeError), transaction(repo) as tx:
+        tx.stage("pkg/a.py", "x\n")
+        raise RuntimeError("abort")
+    assert tx.staged == ()
+    assert (repo / "pkg" / "a.py").read_text() == "def a():\n    return 1\n"
+
+
+def test_a_write_failure_midway_restores_what_already_landed(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib
+
+    module = importlib.import_module("codebase_rag.editing.transaction")
+
+    original = module._write_file
+    calls: list[str] = []
+
+    def flaky(path: Path, content: bytes | None) -> None:
+        calls.append(path.name)
+        if path.name == "b.py":
+            raise OSError("disk full")
+        original(path, content)
+
+    monkeypatch.setattr(module, "_write_file", flaky)
+    before = _tree_digest(repo)
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "changed\n")
+    tx.stage("pkg/b.py", "changed\n")
+    with pytest.raises(OSError):
+        tx.commit()
+    monkeypatch.setattr(module, "_write_file", original)
+    assert calls[:2] == ["a.py", "b.py"]
+    assert _tree_digest(repo) == before
+
+
+# --- history and undo ---------------------------------------------------------
+
+
+def test_commit_records_the_patch_set_and_undo_reverses_it(repo: Path) -> None:
+    original = _tree_digest(repo)
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "v2\n")
+    tx.stage("pkg/new.py", "new\n")
+    tx.stage("pkg/b.py", None)
+    outcome = tx.commit(lambda tree: VerificationResult(True, "12 tests passed"))
+
+    entries = load_history(repo)
+    assert [e[cs.EDIT_KEY_ID] for e in entries] == [outcome.transaction_id]
+    entry = entries[0]
+    assert [f[cs.KEY_PATH] for f in entry[cs.EDIT_KEY_FILES]] == [
+        "pkg/a.py",
+        "pkg/b.py",
+        "pkg/new.py",
+    ]
+    assert entry[cs.EDIT_KEY_VERIFICATION] == {
+        cs.EDIT_KEY_OK: True,
+        cs.EDIT_KEY_MESSAGE: "12 tests passed",
+    }
+
+    undone = undo_last(repo)
+    assert [u.applied for u in undone] == [True]
+    assert undone[0].transaction_id == outcome.transaction_id
+    assert _tree_digest(repo) == original
+    assert load_history(repo) == []
+
+
+def test_undo_stops_at_a_file_that_changed_since(repo: Path) -> None:
+    tx1 = EditTransaction(repo)
+    tx1.stage("pkg/a.py", "one\n")
+    tx1.commit()
+    tx2 = EditTransaction(repo)
+    tx2.stage("pkg/b.py", "two\n")
+    tx2.commit()
+    (repo / "pkg" / "b.py").write_text("hand edit\n", encoding="utf-8")
+
+    with pytest.raises(TransactionConflict):
+        undo_last(repo, count=2)
+
+    # Nothing was undone: the newest transaction conflicted first.
+    assert (repo / "pkg" / "a.py").read_text() == "one\n"
+    assert (repo / "pkg" / "b.py").read_text() == "hand edit\n"
+    assert len(load_history(repo)) == 2
+
+
+def test_undo_count_walks_newest_first(repo: Path) -> None:
+    for i in range(3):
+        tx = EditTransaction(repo)
+        tx.stage("pkg/a.py", f"v{i}\n")
+        tx.commit()
+    outcomes = undo_last(repo, count=2)
+    assert [o.applied for o in outcomes] == [True, True]
+    assert (repo / "pkg" / "a.py").read_text() == "v0\n"
+    assert len(load_history(repo)) == 1
+
+
+def test_history_is_capped(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cs, "EDIT_HISTORY_LIMIT", 2)
+    for i in range(4):
+        tx = EditTransaction(repo)
+        tx.stage("pkg/a.py", f"v{i}\n")
+        tx.commit()
+    entries = load_history(repo)
+    assert len(entries) == 2
+    raw = json.loads((repo / cs.EDIT_HISTORY_FILENAME).read_text())
+    assert len(raw) == 2
+
+
+def test_history_file_is_not_indexed() -> None:
+    assert cs.EDIT_HISTORY_FILENAME in cs.CGR_STATE_FILENAMES
+
+
+# --- cgr edits ----------------------------------------------------------------
+
+
+def test_cli_show_lists_transactions_newest_first(repo: Path) -> None:
+    ids = []
+    for i in range(2):
+        tx = EditTransaction(repo)
+        tx.stage("pkg/a.py", f"v{i}\n")
+        ids.append(tx.commit().transaction_id)
+    result = CliRunner().invoke(edits_cli, ["show", "--repo-path", str(repo), "--diff"])
+    assert result.exit_code == 0, result.output
+    assert result.output.index(ids[1]) < result.output.index(ids[0])
+    assert "pkg/a.py" in result.output
+    assert "+v1" in result.output
+
+
+def test_cli_show_with_no_history(repo: Path) -> None:
+    result = CliRunner().invoke(edits_cli, ["show", "--repo-path", str(repo)])
+    assert result.exit_code == 0
+    assert cs.EDIT_SHOW_NONE in result.output
+
+
+def test_cli_undo_reverses_and_reports(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "v1\n")
+    tx_id = tx.commit().transaction_id
+    result = CliRunner().invoke(edits_cli, ["undo", "--repo-path", str(repo)])
+    assert result.exit_code == 0, result.output
+    assert tx_id in result.output
+    assert (repo / "pkg" / "a.py").read_text() == "def a():\n    return 1\n"
+    again = CliRunner().invoke(edits_cli, ["undo", "--repo-path", str(repo)])
+    assert cs.EDIT_UNDO_NONE in again.output
+
+
+def test_cli_undo_conflict_exits_nonzero(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "v1\n")
+    tx.commit()
+    (repo / "pkg" / "a.py").write_text("hand edit\n", encoding="utf-8")
+    result = CliRunner().invoke(edits_cli, ["undo", "--repo-path", str(repo)])
+    assert result.exit_code == 1
+    assert (repo / "pkg" / "a.py").read_text() == "hand edit\n"

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -515,6 +516,7 @@ def test_cli_counts_must_be_positive(repo: Path) -> None:
         assert result.exit_code == 2, args
 
 
+@pytest.mark.skipif(sys.platform == cs.PLATFORM_WINDOWS, reason="no executable bit")
 def test_replacing_an_executable_keeps_its_mode(repo: Path) -> None:
     import os
     import stat
@@ -580,6 +582,7 @@ def test_reserved_state_files_cannot_be_staged(repo: Path) -> None:
         tx.stage(cs.EDIT_HISTORY_FILENAME, "[]")
 
 
+@pytest.mark.skipif(sys.platform == cs.PLATFORM_WINDOWS, reason="no executable bit")
 def test_deleted_executable_is_restored_executable(repo: Path) -> None:
     import os
     import stat

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -505,3 +505,20 @@ def test_cli_counts_must_be_positive(repo: Path) -> None:
     for args in (["show", "-n", "0"], ["undo", "-n", "0"], ["undo", "-n", "-2"]):
         result = CliRunner().invoke(edits_cli, [*args, "--repo-path", str(repo)])
         assert result.exit_code == 2, args
+
+
+def test_replacing_an_executable_keeps_its_mode(repo: Path) -> None:
+    import os
+    import stat
+
+    script = repo / "run.sh"
+    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.chmod(0o755)
+    tx = EditTransaction(repo)
+    tx.stage("run.sh", "#!/bin/sh\necho two\n")
+    assert tx.commit().applied
+    assert stat.S_IMODE(os.stat(script).st_mode) == 0o755
+    (undone,) = undo_last(repo)
+    assert undone.applied
+    assert script.read_text() == "#!/bin/sh\necho one\n"
+    assert stat.S_IMODE(os.stat(script).st_mode) == 0o755

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -82,7 +82,8 @@ def test_successful_commit_applies_every_file_and_returns_the_diff(
     assert (repo / "pkg" / "a.py").read_text() == "def a():\n    return 10\n"
     assert (repo / "pkg" / "new.py").read_text() == "def n():\n    return 0\n"
     assert not (repo / "pkg" / "b.py").exists()
-    assert "--- a/pkg/a.py" in outcome.diff and "+++ b/pkg/a.py" in outcome.diff
+    assert "--- a/pkg/a.py" in outcome.diff
+    assert "+++ b/pkg/a.py" in outcome.diff
     assert "-    return 1\n+    return 10\n" in outcome.diff
     assert f"--- {cs.DIFF_DEV_NULL}\n+++ b/pkg/new.py" in outcome.diff
     assert f"--- a/pkg/b.py\n+++ {cs.DIFF_DEV_NULL}" in outcome.diff
@@ -220,10 +221,17 @@ def test_finished_transactions_cannot_be_reused(repo: Path) -> None:
 
 
 def test_context_manager_rolls_back_on_exception(repo: Path) -> None:
-    with pytest.raises(RuntimeError), transaction(repo) as tx:
-        tx.stage("pkg/a.py", "x\n")
-        raise RuntimeError("abort")
-    assert tx.staged == ()
+    holder: dict[str, EditTransaction] = {}
+
+    def abort() -> None:
+        with transaction(repo) as tx:
+            holder["tx"] = tx
+            tx.stage("pkg/a.py", "x\n")
+            raise RuntimeError("abort")
+
+    with pytest.raises(RuntimeError):
+        abort()
+    assert holder["tx"].staged == ()
     assert (repo / "pkg" / "a.py").read_text() == "def a():\n    return 1\n"
 
 
@@ -237,11 +245,11 @@ def test_a_write_failure_midway_restores_what_already_landed(
     original = module._write_file
     calls: list[str] = []
 
-    def flaky(path: Path, content: bytes | None) -> None:
+    def flaky(path: Path, content: bytes | None, mode: int | None = None) -> None:
         calls.append(path.name)
         if path.name == "b.py":
             raise OSError("disk full")
-        original(path, content)
+        original(path, content, mode)
 
     monkeypatch.setattr(module, "_write_file", flaky)
     before = _tree_digest(repo)
@@ -522,3 +530,96 @@ def test_replacing_an_executable_keeps_its_mode(repo: Path) -> None:
     assert undone.applied
     assert script.read_text() == "#!/bin/sh\necho one\n"
     assert stat.S_IMODE(os.stat(script).st_mode) == 0o755
+
+
+def test_dangling_symlink_does_not_break_staging(repo: Path) -> None:
+    (repo / "broken").symlink_to(repo / "does-not-exist")
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "x\n")
+    seen: dict[str, bool] = {}
+
+    def verify(tree: StagedTree) -> bool:
+        seen["broken"] = (tree.root / "broken").exists()
+        seen["a"] = (tree.root / "pkg" / "a.py").read_text() == "x\n"
+        return True
+
+    assert tx.commit(verify).applied
+    assert seen == {"broken": False, "a": True}
+
+
+def test_materialise_failure_removes_the_staging_copy(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib
+
+    module = importlib.import_module("codebase_rag.editing.transaction")
+    made: list[Path] = []
+    original = module.tempfile.mkdtemp
+
+    def tracking_mkdtemp(*args: object, **kwargs: object) -> str:
+        path = original(*args, **kwargs)
+        made.append(Path(path))
+        return path
+
+    monkeypatch.setattr(module.tempfile, "mkdtemp", tracking_mkdtemp)
+    monkeypatch.setattr(
+        module.shutil, "copytree", lambda *a, **k: (_ for _ in ()).throw(OSError("no"))
+    )
+    tree = StagedTree(repo, {})
+    with pytest.raises(OSError):
+        _ = tree.root
+    assert made and not made[0].exists()
+
+
+def test_reserved_state_files_cannot_be_staged(repo: Path) -> None:
+    tx = EditTransaction(repo)
+    with pytest.raises(TransactionError):
+        tx.stage(cs.EDIT_LOCK_FILENAME, "x")
+    with pytest.raises(TransactionError):
+        tx.stage(cs.EDIT_HISTORY_FILENAME, "[]")
+
+
+def test_deleted_executable_is_restored_executable(repo: Path) -> None:
+    import os
+    import stat
+
+    script = repo / "run.sh"
+    script.write_text("#!/bin/sh\necho one\n", encoding="utf-8")
+    script.chmod(0o755)
+    tx = EditTransaction(repo)
+    tx.stage("run.sh", None)
+    assert tx.commit().applied
+    assert not script.exists()
+    (undone,) = undo_last(repo)
+    assert undone.applied
+    assert stat.S_IMODE(os.stat(script).st_mode) == 0o755
+
+
+def test_undo_reads_the_history_under_the_lock(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib
+
+    module = importlib.import_module("codebase_rag.editing.transaction")
+    tx = EditTransaction(repo)
+    tx.stage("pkg/a.py", "v1\n")
+    tx.commit()
+    state = {"locked": False, "loaded_locked": None}
+    original_lock = module._repo_lock
+    original_load = module.load_history
+
+    @module.contextmanager
+    def spy_lock(root: Path):  # type: ignore[no-untyped-def]
+        state["locked"] = True
+        with original_lock(root):
+            yield
+        state["locked"] = False
+
+    def spy_load(root: Path) -> list[dict]:
+        state["loaded_locked"] = state["locked"]
+        return original_load(root)
+
+    monkeypatch.setattr(module, "_repo_lock", spy_lock)
+    monkeypatch.setattr(module, "load_history", spy_load)
+    undo_last(repo)
+    assert state["loaded_locked"] is True

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -686,4 +686,5 @@ def test_a_planted_symlink_at_the_temp_path_cannot_redirect_the_write(
     assert outside.read_bytes() == b"untouched\n"
     assert not (repo / "README.md").is_symlink()
     assert (repo / "README.md").read_bytes() == b"# edited\n"
-    assert not planted.exists() and not planted.is_symlink()
+    assert not planted.exists()
+    assert not planted.is_symlink()

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -664,3 +664,26 @@ def test_containment_accepts_a_filesystem_root(monkeypatch: pytest.MonkeyPatch) 
     root = Path(Path.cwd().anchor)
     child = _contained(root, "some/file.py")
     assert child == (root / "some" / "file.py").resolve()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlinks need privileges")
+def test_a_planted_symlink_at_the_temp_path_cannot_redirect_the_write(
+    repo: Path, tmp_path: Path
+) -> None:
+    """The temp sibling is created exclusively, never opened through a
+    pre-existing symlink: a `README.md.tmp -> outside` planted before the
+    apply must neither receive the bytes nor become the file itself."""
+    outside = tmp_path / "outside.txt"
+    outside.write_bytes(b"untouched\n")
+    planted = repo / f"README.md{cs.TMP_EXTENSION}"
+    planted.symlink_to(outside)
+
+    tx = EditTransaction(repo)
+    tx.stage("README.md", "# edited\n")
+    outcome = tx.commit(lambda tree: True)
+
+    assert outcome.applied is True
+    assert outside.read_bytes() == b"untouched\n"
+    assert not (repo / "README.md").is_symlink()
+    assert (repo / "README.md").read_bytes() == b"# edited\n"
+    assert not planted.exists() and not planted.is_symlink()

--- a/codebase_rag/tests/test_edit_transaction.py
+++ b/codebase_rag/tests/test_edit_transaction.py
@@ -624,3 +624,31 @@ def test_undo_reads_the_history_under_the_lock(
     monkeypatch.setattr(module, "load_history", spy_load)
     undo_last(repo)
     assert state["loaded_locked"] is True
+
+
+def test_undo_rejects_history_entries_naming_state_files(repo: Path) -> None:
+    history = repo / cs.EDIT_HISTORY_FILENAME
+    history.write_bytes(
+        json.dumps(
+            [
+                {
+                    cs.EDIT_KEY_ID: "evil",
+                    cs.EDIT_KEY_AT: "now",
+                    cs.EDIT_KEY_FILES: [
+                        {
+                            cs.KEY_PATH: cs.EDIT_LOCK_FILENAME,
+                            cs.EDIT_KEY_BEFORE: "eA==",
+                            cs.EDIT_KEY_AFTER: None,
+                        }
+                    ],
+                    cs.EDIT_KEY_VERIFICATION: {
+                        cs.EDIT_KEY_OK: True,
+                        cs.EDIT_KEY_MESSAGE: "",
+                    },
+                }
+            ]
+        ).encode("utf-8")
+    )
+    with pytest.raises(TransactionError):
+        undo_last(repo)
+    assert len(load_history(repo)) == 1

--- a/docs/architecture/edit-transactions.md
+++ b/docs/architecture/edit-transactions.md
@@ -1,0 +1,68 @@
+---
+description: "How cgr applies multi-file edits atomically: stage in an overlay, verify, then commit or roll back, with a recorded history for show and undo."
+---
+
+# Edit Transactions
+
+An edit-algebra operation (a rename, a signature change, a move) touches
+many files at once. Those files must land completely or not at all, and a
+bad batch must be reversible. `codebase_rag.editing.EditTransaction` is the
+primitive every such operation goes through (issue #1528); agents do not
+drive it directly.
+
+## Lifecycle
+
+```python
+from codebase_rag.editing import EditTransaction, VerificationResult
+
+tx = EditTransaction(repo_root)
+tx.stage("pkg/models.py", new_models_source)   # full content, str or bytes
+tx.stage("pkg/old_helper.py", None)            # delete
+tx.stage("pkg/new_helper.py", helper_source)   # create
+
+def verify(tree):
+    # `tree.read(rel)` answers from the overlay first, the disk second;
+    # `tree.root` is a materialised copy for tools that need real files.
+    return VerificationResult(ok=parses(tree.read("pkg/models.py")), message="")
+
+outcome = tx.commit(verify)
+outcome.applied      # True only if every file was written
+outcome.diff         # the combined unified diff (a/ b/ style, /dev/null for create and delete)
+outcome.files        # repo-relative paths, sorted
+```
+
+- **Stage** collects the new content per file in an in-memory overlay keyed
+  by repo-relative path; the working tree is untouched. Staging the current
+  content is a no-op, a later stage of the same path wins, and the baseline
+  (`before`) is captured from disk at first stage. Paths that resolve outside
+  the repo are refused.
+- **Verify** runs the caller's callback against a `StagedTree`. Most checks
+  only need `read`/`exists`; a check that runs a real tool asks for `root`,
+  which copies the tree once (ignored directories and cgr state files
+  excluded) and writes the overlay on top. A verifier that returns `False`,
+  returns a failing `VerificationResult`, or raises rejects the transaction.
+- **Commit** first refuses (`TransactionConflict`) if any staged file no
+  longer holds the bytes it was staged on, then writes each file through a
+  temp sibling and `os.replace`, holding the originals so a failure part-way
+  restores what already landed. Commits to one repo serialise on a lock.
+  On a rejected verification the working tree is byte-identical to before.
+- **Rollback** discards the overlay. `with transaction(root) as tx:` rolls
+  back on an exception.
+
+## History, show and undo
+
+Every applied transaction is appended to `.cgr-edit-history.json` at the
+repo root (one of the `CGR_STATE_FILENAMES`, so it is never indexed): the
+id, timestamp, each file's before/after bytes and the verification outcome.
+The file keeps the last 50 transactions.
+
+```bash
+cgr edits show            # newest first; --diff prints each patch set
+cgr edits undo            # reverse the latest transaction
+cgr edits undo -n 3       # reverse the latest three, newest first
+```
+
+An undo is itself a transaction staging `after -> before`. It refuses, and
+stops the run, when a file no longer holds what the transaction wrote, so an
+undo never clobbers a later hand edit; the entry stays in the history until
+it is undone.

--- a/docs/architecture/edit-transactions.md
+++ b/docs/architecture/edit-transactions.md
@@ -39,13 +39,19 @@ outcome.files        # repo-relative paths, sorted
 - **Verify** runs the caller's callback against a `StagedTree`. Most checks
   only need `read`/`exists`; a check that runs a real tool asks for `root`,
   which copies the tree once (ignored directories and cgr state files
-  excluded) and writes the overlay on top. A verifier that returns `False`,
-  returns a failing `VerificationResult`, or raises rejects the transaction.
+  excluded, symlinks pointing outside the repo dropped, in-repo symlinks
+  copied as the files they point at) and writes the overlay on top, so
+  nothing a verifier writes under `root` can reach the working tree. A
+  verifier that returns `False`, returns a failing `VerificationResult`, or
+  raises rejects the transaction.
 - **Commit** first refuses (`TransactionConflict`) if any staged file no
   longer holds the bytes it was staged on, then writes each file through a
-  temp sibling and `os.replace`, holding the originals so a failure part-way
-  restores what already landed. Commits to one repo serialise on a lock.
-  On a rejected verification the working tree is byte-identical to before.
+  temp sibling and `os.replace` and records the history entry, holding the
+  originals so a failure anywhere after the first write (a later file, the
+  history record) restores what already landed. Commits to one repo
+  serialise on an OS-level lock (`.cgr-edit-lock`), so a `cgr edits undo`
+  in another process queues behind an agent's commit. On a rejected
+  verification the working tree is byte-identical to before.
 - **Rollback** discards the overlay. `with transaction(root) as tx:` rolls
   back on an exception.
 
@@ -65,4 +71,6 @@ cgr edits undo -n 3       # reverse the latest three, newest first
 An undo is itself a transaction staging `after -> before`. It refuses, and
 stops the run, when a file no longer holds what the transaction wrote, so an
 undo never clobbers a later hand edit; the entry stays in the history until
-it is undone.
+it is undone. History paths are validated against the repo root before they
+are staged (the file is data on disk, not a trusted instruction), and a
+reversal whose history update fails is put back so tree and history agree.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - Adding a Language Frontend: architecture/language-frontends.md
     - Security Model: architecture/security.md
     - Span-Preserving Patchers: architecture/patchers.md
+    - Edit Transactions: architecture/edit-transactions.md
   - Advanced:
     - Adding Languages: advanced/adding-languages.md
     - Ignore Patterns: advanced/ignore-patterns.md


### PR DESCRIPTION
## Summary
Implements #1528 (Epic #1521, T7). Closes #1528.

- `codebase_rag/editing/transaction.py`: `EditTransaction` collects full-file content per path in an in-memory overlay (repo-relative keys, the delombok-overlay idiom), refuses paths outside the repo, and exposes `stage`/`unstage`/`read`/`diff`/`tree`/`commit`/`rollback` plus a `transaction()` context manager that rolls back on exceptions.
- Verification: `commit(verify)` hands the callback a `StagedTree` (`read`/`exists` answer overlay-first, `root` lazily materialises a copy of the tree with ignored directories and cgr state files excluded and the overlay written on top, removed after commit). `False`, a failing `VerificationResult`, or an exception rejects the transaction and leaves the tree byte-identical.
- Atomic apply: refuses with `TransactionConflict` if any staged file changed since staging; writes each file through a temp sibling and `os.replace`; a failure part-way restores what already landed; commits to one repo serialise on a per-root lock. The outcome carries the combined unified diff.
- History: applied transactions are appended to `.cgr-edit-history.json` at the repo root (added to `CGR_STATE_FILENAMES` and `.gitignore`, capped at 50 entries) with the patch set and verification result. `undo_last` reverses the last N, newest first, as transactions that refuse on drift.
- CLI: `cgr edits show [-n N] [--diff]` and `cgr edits undo [-n N]` (click group delegated like `cgr trace`), registered in `CLI_COMMANDS`; `docs/architecture/edit-transactions.md` in the nav.

## Test plan
- [x] `codebase_rag/tests/test_edit_transaction.py`: failed verification leaves the tree byte-identical (create, modify, delete staged); successful commit applies every file and returns the diff; overlay-first reads; materialised tree honours ignores and the overlay; verifier can run a tool against `root`; no-op staging; later stage wins with the disk baseline; outside-repo refusal; conflict on drift; verifier exceptions/False; finished transactions are closed; context-manager rollback; mid-way write failure restores; history record + undo; undo stops on drift; undo count order; history cap; CLI show/undo/conflict
- [x] `ruff`, `ty` clean; full non-integration suite: 8748 passed, 34 skipped, 1 xfailed
- [ ] Memgraph integration tests (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added atomic multi-file editing with verification, rollback, and conflict protection.
  * Added `cgr edits show` to review recent transactions and optional diffs.
  * Added `cgr edits undo` to safely revert recent transactions.
  * Preserved file changes and permissions in edit history.
  * Added safeguards for reserved files, symlinks, invalid paths, and concurrent edits.

* **Documentation**
  * Added edit transaction architecture documentation and navigation.

* **Chores**
  * Excluded generated edit state and history files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->