### PR TITLE
feat: concrete-syntax-preserving patchers per language

### DIFF
--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -480,6 +480,20 @@ INTERACTIVE_BFS_MAX_DEPTH = 10
 INTERACTIVE_DEFAULT_GROUP = "."
 
 MSG_SURGICAL_SUCCESS = "Successfully applied surgical code replacement in: {path}"
+# Span-preserving patchers (issue #1529).
+PATCH_BAD_POSITION = "No such position: line {line}, column {col}"
+PATCH_BAD_OFFSET = "Byte offset {offset} is outside the file"
+PATCH_BAD_SPAN = "Span ({start}, {end}) is outside the file or reversed"
+PATCH_OVERLAP = "Edit ({start}, {end}) overlaps an earlier edit in the same file"
+PATCH_OUTSIDE_ROOT = "Path is outside the repository: {path}"
+PATCH_NO_FILE = "No such file to patch: {path}"
+PATCH_IDENTIFIER_MISMATCH = (
+    "{path}:{line}:{col} holds {found!r}, not the identifier {expected!r}"
+)
+PATCH_NOT_AN_IDENTIFIER = "{path}:{line}:{col} is not a whole identifier"
+PATCH_PARSE_FAILED = "{path} no longer parses after the patch"
+PATCH_FORMAT_DRIFT = "{path} applied, but {tool} would reformat it"
+PATCH_OK = "{path}: {count} edit(s) applied"
 MSG_SURGICAL_FAILED = (
     "Failed to apply surgical replacement in {path}. "
     "Target code not found or patches failed."

--- a/codebase_rag/constants/lang_tooling.py
+++ b/codebase_rag/constants/lang_tooling.py
@@ -150,6 +150,18 @@ LANG_TABLE_PLACEHOLDER = "—"
 
 LANG_MSG_AVAILABLE_NODES = "Available nodes for mapping:"
 LANG_ELLIPSIS = "..."
+# Span-preserving patchers (issue #1529): formatter checks and the identifier
+# node types a rename may target beyond the shared `identifier` family.
+PATCH_GOFMT = "gofmt"
+PATCH_GOFMT_LIST_FLAG = "-l"
+PATCH_RUSTFMT = "rustfmt"
+PATCH_RUSTFMT_CHECK_FLAG = "--check"
+PATCH_RUSTFMT_EDITION_FLAG = "--edition"
+PATCH_RUSTFMT_EDITION = "2021"
+PATCH_FORMATTER_TIMEOUT_S = 60
+PATCH_TS_FIELD_IDENTIFIER = "field_identifier"
+PATCH_TS_NAMESPACE_IDENTIFIER = "namespace_identifier"
+PATCH_TS_STATEMENT_IDENTIFIER = "statement_identifier"
 LANG_GIT_SUFFIX = ".git"
 LANG_GITMODULES_FILE = ".gitmodules"
 LANG_CALL_KEYWORD_EXCLUDE = "call"

--- a/codebase_rag/editing/__init__.py
+++ b/codebase_rag/editing/__init__.py
@@ -1,0 +1,23 @@
+"""Graph-aware editing primitives: span-preserving patchers (issue #1529)."""
+
+from .patcher import (
+    Patcher,
+    PatcherError,
+    PatchResult,
+    SpanEdit,
+    apply_span_edits,
+    byte_to_line_col,
+    formatter_check,
+    line_col_to_byte,
+)
+
+__all__ = [
+    "PatchResult",
+    "Patcher",
+    "PatcherError",
+    "SpanEdit",
+    "apply_span_edits",
+    "byte_to_line_col",
+    "formatter_check",
+    "line_col_to_byte",
+]

--- a/codebase_rag/editing/patcher.py
+++ b/codebase_rag/editing/patcher.py
@@ -1,0 +1,348 @@
+"""Concrete-syntax-preserving patchers (issue #1529).
+
+A rewrite that re-emits a file from an AST loses comments, whitespace and
+style, and turns every rename into a diff nobody wants to review. The
+patcher never re-emits: it replaces exact byte spans of the original file
+and leaves everything around them untouched.
+
+Every edit is expressed against the ORIGINAL bytes of the file, so a batch
+of edits to one file needs no offset bookkeeping by the caller: the batch
+is applied in one pass from the end of the file backwards, which makes the
+result independent of the order the edits were queued in. Overlapping spans
+are refused rather than guessed.
+
+After patching, the file is re-parsed with its tree-sitter grammar and the
+result records whether it still parses; for Go and Rust a formatter check
+(`gofmt -l`, `rustfmt --check`) runs when the tool is installed, so a patch
+that broke the language's canonical formatting is reported (not rewritten:
+the patcher's promise is to touch only what it was asked to touch).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import NamedTuple, Protocol
+
+from tree_sitter import Node, Parser
+
+from .. import constants as cs
+from ..language_spec import get_language_for_extension
+from ..parser_loader import load_parsers
+
+
+class SpanEdit(NamedTuple):
+    """Replace `source[start:end]` (byte offsets into the original) with `text`."""
+
+    start: int
+    end: int
+    text: bytes
+
+
+class PatchResult(NamedTuple):
+    """One file after its batch of edits was applied in memory."""
+
+    path: str
+    content: bytes
+    edits: int
+    parses: bool | None
+    formatter: str | None
+    formatted: bool | None
+    message: str
+
+
+class PatcherError(ValueError):
+    """An edit could not be queued or applied as asked."""
+
+
+class _Stager(Protocol):
+    def stage(self, rel_path: str | Path, content: str | bytes | None) -> object: ...
+
+
+# --- offsets ------------------------------------------------------------------
+
+
+def line_col_to_byte(source: bytes, line: int, col: int) -> int:
+    """Byte offset of (1-based line, 0-based byte column), the graph's convention."""
+    if line < 1:
+        raise PatcherError(cs.PATCH_BAD_POSITION.format(line=line, col=col))
+    offset = 0
+    for _ in range(line - 1):
+        newline = source.find(b"\n", offset)
+        if newline == -1:
+            raise PatcherError(cs.PATCH_BAD_POSITION.format(line=line, col=col))
+        offset = newline + 1
+    line_end = source.find(b"\n", offset)
+    line_len = (len(source) if line_end == -1 else line_end) - offset
+    if col < 0 or col > line_len:
+        raise PatcherError(cs.PATCH_BAD_POSITION.format(line=line, col=col))
+    return offset + col
+
+
+def byte_to_line_col(source: bytes, offset: int) -> tuple[int, int]:
+    """(1-based line, 0-based byte column) of a byte offset."""
+    if offset < 0 or offset > len(source):
+        raise PatcherError(cs.PATCH_BAD_OFFSET.format(offset=offset))
+    line = source.count(b"\n", 0, offset) + 1
+    line_start = source.rfind(b"\n", 0, offset) + 1
+    return line, offset - line_start
+
+
+def apply_span_edits(source: bytes, edits: Iterable[SpanEdit]) -> bytes:
+    """Apply a batch of original-offset edits in one pass, any queue order.
+
+    Sorted by start descending so earlier spans are never shifted by later
+    replacements; two edits touching the same byte are an overlap and refused
+    (an insertion at a boundary shared with a deletion is the one exception
+    worth allowing, so equal `start == end` inserts are kept, applied after
+    the replacement that starts there).
+    """
+    ordered = sorted(edits, key=lambda e: (e.start, e.end))
+    previous_end = -1
+    for edit in ordered:
+        if edit.start < 0 or edit.end > len(source) or edit.start > edit.end:
+            raise PatcherError(cs.PATCH_BAD_SPAN.format(start=edit.start, end=edit.end))
+        if edit.start < previous_end:
+            raise PatcherError(cs.PATCH_OVERLAP.format(start=edit.start, end=edit.end))
+        previous_end = max(previous_end, edit.end)
+    out = bytearray(source)
+    for edit in reversed(ordered):
+        out[edit.start : edit.end] = edit.text
+    return bytes(out)
+
+
+# --- validation ---------------------------------------------------------------
+
+_IDENTIFIER_TYPES = frozenset(
+    {
+        cs.TS_IDENTIFIER,
+        cs.TS_TYPE_IDENTIFIER,
+        cs.TS_PROPERTY_IDENTIFIER,
+        cs.TS_SHORTHAND_PROPERTY_IDENTIFIER,
+        cs.TS_PRIVATE_PROPERTY_IDENTIFIER,
+        cs.TS_GO_FIELD_IDENTIFIER,
+        cs.TS_GO_PACKAGE_IDENTIFIER,
+        cs.TS_RS_FIELD_IDENTIFIER,
+        cs.TS_PY_IDENTIFIER,
+        cs.PATCH_TS_FIELD_IDENTIFIER,
+        cs.PATCH_TS_NAMESPACE_IDENTIFIER,
+        cs.PATCH_TS_STATEMENT_IDENTIFIER,
+    }
+)
+
+_FORMATTERS: dict[cs.SupportedLanguage, tuple[str, tuple[str, ...]]] = {
+    # gofmt -l prints the file name when it would reformat it.
+    cs.SupportedLanguage.GO: (cs.PATCH_GOFMT, (cs.PATCH_GOFMT_LIST_FLAG,)),
+    cs.SupportedLanguage.RUST: (
+        cs.PATCH_RUSTFMT,
+        (
+            cs.PATCH_RUSTFMT_CHECK_FLAG,
+            cs.PATCH_RUSTFMT_EDITION_FLAG,
+            cs.PATCH_RUSTFMT_EDITION,
+        ),
+    ),
+}
+
+
+def _language_for(path: Path) -> cs.SupportedLanguage | None:
+    language = get_language_for_extension(path.suffix)
+    return language if isinstance(language, cs.SupportedLanguage) else None
+
+
+def _identifier_at(root: Node, start: int, end: int) -> Node | None:
+    """The identifier node spanning exactly [start, end), or None.
+
+    A wrapper with the same span (a scoped or dotted name around the token)
+    is walked up so the identifier inside it is what gets checked; any other
+    node at that span (a string's content, a keyword) is not an identifier.
+    """
+    # tree-sitter's range end is inclusive; `end` here is exclusive.
+    node = root.named_descendant_for_byte_range(start, max(start, end - 1))
+    while node is not None and (node.start_byte, node.end_byte) == (start, end):
+        if node.type in _IDENTIFIER_TYPES:
+            return node
+        node = node.parent
+    return None
+
+
+def formatter_check(
+    language: cs.SupportedLanguage | None, content: bytes, suffix: str
+) -> tuple[str | None, bool | None]:
+    """(tool name, formatted?) for languages with a canonical formatter.
+
+    `None, None` when the language has none or the tool is not installed;
+    the check reports, it never rewrites.
+    """
+    if language is None or language not in _FORMATTERS:
+        return None, None
+    tool, flags = _FORMATTERS[language]
+    executable = shutil.which(tool)
+    if executable is None:
+        return tool, None
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
+        handle.write(content)
+        temp_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            [executable, *flags, str(temp_path)],
+            capture_output=True,
+            text=True,
+            encoding=cs.ENCODING_UTF8,
+            check=False,
+            timeout=cs.PATCH_FORMATTER_TIMEOUT_S,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return tool, None
+    finally:
+        temp_path.unlink(missing_ok=True)
+    if language == cs.SupportedLanguage.GO:
+        return tool, completed.returncode == 0 and not completed.stdout.strip()
+    return tool, completed.returncode == 0
+
+
+# --- the patcher --------------------------------------------------------------
+
+
+class Patcher:
+    """Queue span and identifier edits per file, then apply them in memory.
+
+    Sources are read once per file (from `overlay` when given, so a batch
+    can build on an `EditTransaction`'s staged content, else from disk).
+    `apply()` returns the patched bytes per file together with the parse and
+    formatter verdicts; `stage_into(tx)` hands them to a transaction.
+    """
+
+    def __init__(
+        self,
+        repo_root: Path,
+        parsers: dict[cs.SupportedLanguage, Parser] | None = None,
+        overlay: dict[str, bytes] | None = None,
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self._parsers = parsers
+        self._overlay = overlay or {}
+        self._sources: dict[str, bytes] = {}
+        self._edits: dict[str, list[SpanEdit]] = {}
+
+    def _relative(self, file: str | Path) -> str:
+        path = Path(file)
+        if not path.is_absolute():
+            path = self.repo_root / path
+        try:
+            return path.resolve().relative_to(self.repo_root).as_posix()
+        except (OSError, ValueError) as error:
+            raise PatcherError(cs.PATCH_OUTSIDE_ROOT.format(path=file)) from error
+
+    def source(self, file: str | Path) -> bytes:
+        key = self._relative(file)
+        if key not in self._sources:
+            staged = self._overlay.get(key)
+            if staged is not None:
+                self._sources[key] = staged
+            else:
+                path = self.repo_root / key
+                if not path.is_file():
+                    raise PatcherError(cs.PATCH_NO_FILE.format(path=key))
+                self._sources[key] = path.read_bytes()
+        return self._sources[key]
+
+    def _parser(self, key: str) -> tuple[cs.SupportedLanguage | None, Parser | None]:
+        language = _language_for(Path(key))
+        if language is None:
+            return None, None
+        if self._parsers is None:
+            parsers, _queries = load_parsers()
+            self._parsers = dict(parsers)
+        return language, self._parsers.get(language)
+
+    def replace_span(
+        self, file: str | Path, span: tuple[int, int], text: str | bytes
+    ) -> None:
+        """Replace original bytes `span=(start, end)` of `file` with `text`."""
+        key = self._relative(file)
+        source = self.source(key)
+        start, end = span
+        if start < 0 or end > len(source) or start > end:
+            raise PatcherError(cs.PATCH_BAD_SPAN.format(start=start, end=end))
+        payload = text.encode(cs.ENCODING_UTF8) if isinstance(text, str) else text
+        self._edits.setdefault(key, []).append(SpanEdit(start, end, payload))
+
+    def replace_identifier_at(
+        self, file: str | Path, line: int, col: int, old: str, new: str
+    ) -> None:
+        """Rename the identifier that starts at (line, col) from `old` to `new`.
+
+        The position is checked against the source (and, when a grammar is
+        available, against the syntax tree): the bytes there must be exactly
+        `old` as a whole identifier, or the edit is refused. So a stale
+        location from the graph can never rename the wrong token.
+        """
+        key = self._relative(file)
+        source = self.source(key)
+        start = line_col_to_byte(source, line, col)
+        old_bytes = old.encode(cs.ENCODING_UTF8)
+        end = start + len(old_bytes)
+        if source[start:end] != old_bytes:
+            raise PatcherError(
+                cs.PATCH_IDENTIFIER_MISMATCH.format(
+                    path=key,
+                    line=line,
+                    col=col,
+                    expected=old,
+                    found=source[start:end].decode(cs.ENCODING_UTF8, errors="replace"),
+                )
+            )
+        _language, parser = self._parser(key)
+        if parser is not None:
+            root = parser.parse(source).root_node
+            node = _identifier_at(root, start, end)
+            if node is None or (node.start_byte, node.end_byte) != (start, end):
+                raise PatcherError(
+                    cs.PATCH_NOT_AN_IDENTIFIER.format(path=key, line=line, col=col)
+                )
+        self._edits.setdefault(key, []).append(
+            SpanEdit(start, end, new.encode(cs.ENCODING_UTF8))
+        )
+
+    @property
+    def pending(self) -> dict[str, int]:
+        return {key: len(edits) for key, edits in self._edits.items()}
+
+    def apply(self) -> dict[str, PatchResult]:
+        """Every queued file patched in memory, with its parse and format verdicts."""
+        results: dict[str, PatchResult] = {}
+        for key in sorted(self._edits):
+            edits = self._edits[key]
+            content = apply_span_edits(self.source(key), edits)
+            language, parser = self._parser(key)
+            parses: bool | None = None
+            if parser is not None:
+                parses = not parser.parse(content).root_node.has_error
+            tool, formatted = formatter_check(language, content, Path(key).suffix)
+            if parses is False:
+                message = cs.PATCH_PARSE_FAILED.format(path=key)
+            elif formatted is False:
+                message = cs.PATCH_FORMAT_DRIFT.format(path=key, tool=tool)
+            else:
+                message = cs.PATCH_OK.format(path=key, count=len(edits))
+            results[key] = PatchResult(
+                key, content, len(edits), parses, tool, formatted, message
+            )
+        return results
+
+    def stage_into(self, transaction: _Stager) -> dict[str, PatchResult]:
+        """Apply, then stage every result that still parses into `transaction`.
+
+        A file whose patch no longer parses is not staged: the batch's
+        transaction then has nothing from it and the caller sees the
+        result's message. Formatter drift is staged (it is the caller's
+        rename that changed the alignment) and reported.
+        """
+        results = self.apply()
+        for key, result in results.items():
+            if result.parses is not False:
+                transaction.stage(key, result.content)
+        return results

--- a/codebase_rag/tests/test_patcher.py
+++ b/codebase_rag/tests/test_patcher.py
@@ -35,9 +35,11 @@ PY_SRC = (
 
 
 def _write(root: Path, rel: str, text: str) -> Path:
+    # Bytes, not text: the patcher's promise is byte-exactness, and a text
+    # write would turn every "\n" into "\r\n" on Windows.
     path = root / rel
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text, encoding="utf-8")
+    path.write_bytes(text.encode("utf-8"))
     return path
 
 

--- a/codebase_rag/tests/test_patcher.py
+++ b/codebase_rag/tests/test_patcher.py
@@ -1,0 +1,332 @@
+# Concrete-syntax-preserving patchers (issue #1529): a rename touches only
+# the identifier occurrences, a batch of edits to one file applies correctly
+# in any order, and the result is re-parsed (and format-checked where a
+# canonical formatter exists).
+from __future__ import annotations
+
+import difflib
+import shutil
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.editing import (
+    Patcher,
+    PatcherError,
+    SpanEdit,
+    apply_span_edits,
+    byte_to_line_col,
+    formatter_check,
+    line_col_to_byte,
+)
+from codebase_rag.parser_loader import load_parsers
+
+PY_SRC = (
+    "# leading comment  \n"
+    "def helper(a,   b,):   # odd spacing, trailing comma\n"
+    "\tresult = helper(a, b)  # recursive, tab-indented\n"
+    "\treturn result\n"
+    "\n"
+    "\n"
+    "x = {'helper': helper,\n"
+    "     'other': 1,   }\n"
+)
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _changed_lines(before: str, after: str) -> list[str]:
+    return [
+        line
+        for line in difflib.unified_diff(
+            before.splitlines(keepends=True), after.splitlines(keepends=True), n=0
+        )
+        if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+    ]
+
+
+def _grammar(name: str) -> None:
+    parsers, _ = load_parsers()
+    if name not in {str(lang) for lang in parsers}:
+        pytest.skip(f"{name} parser not available")
+
+
+# --- offsets ------------------------------------------------------------------
+
+
+def test_offset_conversions_round_trip() -> None:
+    src = b"ab\ncd\xc3\xa9f\n\nlast"
+    for offset in range(len(src) + 1):
+        line, col = byte_to_line_col(src, offset)
+        assert line_col_to_byte(src, line, col) == offset
+    assert line_col_to_byte(src, 1, 0) == 0
+    assert line_col_to_byte(src, 4, 4) == len(src)
+    with pytest.raises(PatcherError):
+        line_col_to_byte(src, 0, 0)
+    with pytest.raises(PatcherError):
+        line_col_to_byte(src, 2, 99)
+    with pytest.raises(PatcherError):
+        line_col_to_byte(src, 9, 0)
+    with pytest.raises(PatcherError):
+        byte_to_line_col(src, len(src) + 1)
+
+
+def test_span_edits_apply_in_any_order() -> None:
+    src = b"aaa bbb ccc ddd"
+    edits = [
+        SpanEdit(8, 11, b"C"),
+        SpanEdit(0, 3, b"AAAA"),
+        SpanEdit(12, 15, b"D"),
+        SpanEdit(4, 7, b"B"),
+    ]
+    expected = b"AAAA B C D"
+    assert apply_span_edits(src, edits) == expected
+    assert apply_span_edits(src, reversed(edits)) == expected
+    assert apply_span_edits(src, sorted(edits, key=lambda e: e.text)) == expected
+
+
+def test_span_edits_refuse_overlap_and_bad_spans() -> None:
+    src = b"0123456789"
+    with pytest.raises(PatcherError, match="overlaps"):
+        apply_span_edits(src, [SpanEdit(0, 5, b"x"), SpanEdit(4, 6, b"y")])
+    with pytest.raises(PatcherError, match="outside"):
+        apply_span_edits(src, [SpanEdit(0, 11, b"x")])
+    with pytest.raises(PatcherError, match="outside"):
+        apply_span_edits(src, [SpanEdit(5, 2, b"x")])
+    # Adjacent spans are fine, and an insertion at a boundary is kept.
+    assert apply_span_edits(src, [SpanEdit(0, 5, b"a"), SpanEdit(5, 10, b"b")]) == b"ab"
+    assert (
+        apply_span_edits(src, [SpanEdit(5, 5, b"-"), SpanEdit(0, 5, b"a")])
+        == b"a-56789"
+    )
+
+
+# --- rename preserving concrete syntax ----------------------------------------
+
+
+def test_python_rename_touches_only_the_identifier_occurrences(tmp_path: Path) -> None:
+    _grammar("python")
+    _write(tmp_path, "mod.py", PY_SRC)
+    patcher = Patcher(tmp_path)
+    # Occurrences: definition (line 2), recursive call (line 3), dict value (line 7).
+    patcher.replace_identifier_at("mod.py", 2, 4, "helper", "assist")
+    patcher.replace_identifier_at("mod.py", 3, 10, "helper", "assist")
+    patcher.replace_identifier_at("mod.py", 7, 15, "helper", "assist")
+    (result,) = patcher.apply().values()
+
+    after = result.content.decode()
+    assert result.parses is True
+    assert result.edits == 3
+    changed = _changed_lines(PY_SRC, after)
+    assert len(changed) == 6, changed
+    assert all("helper" in line for line in changed if line.startswith("-"))
+    assert all("assist" in line for line in changed if line.startswith("+"))
+    # Everything around the identifiers survived byte for byte.
+    assert after.replace("assist", "helper") == PY_SRC
+    assert "'helper': assist" in after  # the string key is not an identifier
+
+
+def test_identifier_position_must_hold_the_identifier(tmp_path: Path) -> None:
+    _grammar("python")
+    _write(tmp_path, "mod.py", PY_SRC)
+    patcher = Patcher(tmp_path)
+    with pytest.raises(PatcherError, match="not the identifier"):
+        patcher.replace_identifier_at("mod.py", 2, 0, "helper", "x")
+    # A prefix of the identifier: the bytes match, the tree says otherwise.
+    with pytest.raises(PatcherError, match="not a whole identifier"):
+        patcher.replace_identifier_at("mod.py", 2, 4, "help", "x")
+    # The string literal 'helper' is not an identifier node.
+    with pytest.raises(PatcherError, match="not a whole identifier"):
+        patcher.replace_identifier_at("mod.py", 7, 6, "helper", "x")
+    assert patcher.pending == {}
+
+
+def test_replace_span_and_identifier_edits_mix_in_one_file(tmp_path: Path) -> None:
+    _grammar("python")
+    src = "def f(a, b):\n    return a + b\n"
+    _write(tmp_path, "m.py", src)
+    patcher = Patcher(tmp_path)
+    patcher.replace_span("m.py", (src.index("a + b"), src.index("a + b") + 5), "a - b")
+    patcher.replace_identifier_at("m.py", 1, 4, "f", "g")
+    (result,) = patcher.apply().values()
+    assert result.content == b"def g(a, b):\n    return a - b\n"
+    assert result.parses is True
+    assert result.message == cs.PATCH_OK.format(path="m.py", count=2)
+
+
+def test_parse_failure_is_reported_and_not_staged(tmp_path: Path) -> None:
+    _grammar("python")
+    _write(tmp_path, "m.py", "def f():\n    return 1\n")
+    patcher = Patcher(tmp_path)
+    patcher.replace_span("m.py", (0, 3), "de")
+
+    class Stub:
+        staged: dict[str, bytes] = {}
+
+        def stage(self, rel_path: str | Path, content: str | bytes | None) -> None:
+            self.staged[str(rel_path)] = content  # type: ignore[assignment]
+
+    stub = Stub()
+    results = patcher.stage_into(stub)
+    assert results["m.py"].parses is False
+    assert results["m.py"].message == cs.PATCH_PARSE_FAILED.format(path="m.py")
+    assert stub.staged == {}
+
+
+def test_results_stage_into_a_transaction_like_object(tmp_path: Path) -> None:
+    _grammar("python")
+    _write(tmp_path, "a.py", "x = 1\n")
+    _write(tmp_path, "b.py", "y = 2\n")
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("a.py", 1, 0, "x", "xx")
+    patcher.replace_identifier_at("b.py", 1, 0, "y", "yy")
+    staged: dict[str, bytes] = {}
+
+    class Stub:
+        def stage(self, rel_path: str | Path, content: str | bytes | None) -> None:
+            assert isinstance(content, bytes)
+            staged[str(rel_path)] = content
+
+    results = patcher.stage_into(Stub())
+    assert set(results) == {"a.py", "b.py"}
+    assert staged == {"a.py": b"xx = 1\n", "b.py": b"yy = 2\n"}
+
+
+def test_overlay_content_is_the_base_for_chained_batches(tmp_path: Path) -> None:
+    _grammar("python")
+    _write(tmp_path, "m.py", "old = 1\n")
+    patcher = Patcher(tmp_path, overlay={"m.py": b"new = 1\n"})
+    patcher.replace_identifier_at("m.py", 1, 0, "new", "newer")
+    (result,) = patcher.apply().values()
+    assert result.content == b"newer = 1\n"
+
+
+def test_paths_outside_the_repo_and_missing_files_are_refused(tmp_path: Path) -> None:
+    patcher = Patcher(tmp_path)
+    with pytest.raises(PatcherError, match="outside"):
+        patcher.replace_span("../x.py", (0, 0), "")
+    with pytest.raises(PatcherError, match="No such file"):
+        patcher.replace_span("missing.py", (0, 0), "")
+
+
+def test_generic_fallback_for_a_language_without_a_grammar(tmp_path: Path) -> None:
+    _write(tmp_path, "notes.txt", "alpha beta\n")
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("notes.txt", 1, 6, "beta", "gamma")
+    (result,) = patcher.apply().values()
+    assert result.content == b"alpha gamma\n"
+    assert result.parses is None
+    assert result.formatter is None
+
+
+# --- other languages ----------------------------------------------------------
+
+
+TS_SRC = (
+    "export function helper(a: number, /* c */ b: number,): number {\n"
+    "  return helper(a, b) + 1; // recursion\n"
+    "}\n"
+    "const obj = { helper, other: 2, };\n"
+)
+
+
+def test_typescript_rename_preserves_syntax(tmp_path: Path) -> None:
+    _grammar("typescript")
+    _write(tmp_path, "m.ts", TS_SRC)
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("m.ts", 1, 16, "helper", "assist")
+    patcher.replace_identifier_at("m.ts", 2, 9, "helper", "assist")
+    patcher.replace_identifier_at("m.ts", 4, 14, "helper", "assist")
+    (result,) = patcher.apply().values()
+    assert result.parses is True
+    assert result.content.decode().replace("assist", "helper") == TS_SRC
+    assert result.content.count(b"assist") == 3
+
+
+JAVA_SRC = "class A {\n    int helper(int a,  int b) { return helper(a, b); } // r\n}\n"
+
+
+def test_java_rename_preserves_syntax(tmp_path: Path) -> None:
+    _grammar("java")
+    _write(tmp_path, "A.java", JAVA_SRC)
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("A.java", 2, 8, "helper", "assist")
+    patcher.replace_identifier_at("A.java", 2, 39, "helper", "assist")
+    (result,) = patcher.apply().values()
+    assert result.parses is True
+    assert result.content.decode().replace("assist", "helper") == JAVA_SRC
+
+
+GO_SRC = "package main\n\nfunc helper(a, b int) int { return helper(a, b) }\n"
+
+
+def test_go_rename_runs_the_gofmt_check(tmp_path: Path) -> None:
+    _grammar("go")
+    _write(tmp_path, "m.go", GO_SRC)
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("m.go", 3, 5, "helper", "assist")
+    patcher.replace_identifier_at("m.go", 3, 35, "helper", "assist")
+    (result,) = patcher.apply().values()
+    assert result.parses is True
+    assert result.content.decode().replace("assist", "helper") == GO_SRC
+    assert result.formatter == cs.PATCH_GOFMT
+    if shutil.which(cs.PATCH_GOFMT):
+        assert result.formatted is True
+    else:
+        assert result.formatted is None
+
+
+RUST_SRC = "fn helper(a: u32) -> u32 {\n    helper(a) // r\n}\n"
+
+
+def test_rust_rename_runs_the_rustfmt_check(tmp_path: Path) -> None:
+    _grammar("rust")
+    _write(tmp_path, "m.rs", RUST_SRC)
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("m.rs", 1, 3, "helper", "assist")
+    patcher.replace_identifier_at("m.rs", 2, 4, "helper", "assist")
+    (result,) = patcher.apply().values()
+    assert result.parses is True
+    assert result.content.decode().replace("assist", "helper") == RUST_SRC
+    assert result.formatter == cs.PATCH_RUSTFMT
+    if shutil.which(cs.PATCH_RUSTFMT):
+        assert result.formatted is True
+    else:
+        assert result.formatted is None
+
+
+def test_formatter_drift_is_reported_not_rewritten(tmp_path: Path) -> None:
+    if not shutil.which(cs.PATCH_GOFMT):
+        pytest.skip("gofmt not installed")
+    _grammar("go")
+    _write(tmp_path, "m.go", GO_SRC)
+    patcher = Patcher(tmp_path)
+    # Two spaces after `func` still parses but is not gofmt-canonical.
+    patcher.replace_span(
+        "m.go", (GO_SRC.index("func "), GO_SRC.index("func ") + 5), "func  "
+    )
+    (result,) = patcher.apply().values()
+    assert result.parses is True
+    assert result.formatted is False
+    assert result.message == cs.PATCH_FORMAT_DRIFT.format(
+        path="m.go", tool=cs.PATCH_GOFMT
+    )
+    assert b"func  helper" in result.content
+
+
+def test_formatter_check_without_the_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    assert formatter_check(cs.SupportedLanguage.GO, b"package main\n", ".go") == (
+        cs.PATCH_GOFMT,
+        None,
+    )
+    assert formatter_check(cs.SupportedLanguage.PYTHON, b"x = 1\n", ".py") == (
+        None,
+        None,
+    )

--- a/codebase_rag/tests/test_patcher.py
+++ b/codebase_rag/tests/test_patcher.py
@@ -95,12 +95,15 @@ def test_span_edits_apply_in_any_order() -> None:
 
 def test_span_edits_refuse_overlap_and_bad_spans() -> None:
     src = b"0123456789"
+    overlapping = [SpanEdit(0, 5, b"x"), SpanEdit(4, 6, b"y")]
+    past_end = [SpanEdit(0, 11, b"x")]
+    reversed_span = [SpanEdit(5, 2, b"x")]
     with pytest.raises(PatcherError, match="overlaps"):
-        apply_span_edits(src, [SpanEdit(0, 5, b"x"), SpanEdit(4, 6, b"y")])
+        apply_span_edits(src, overlapping)
     with pytest.raises(PatcherError, match="outside"):
-        apply_span_edits(src, [SpanEdit(0, 11, b"x")])
+        apply_span_edits(src, past_end)
     with pytest.raises(PatcherError, match="outside"):
-        apply_span_edits(src, [SpanEdit(5, 2, b"x")])
+        apply_span_edits(src, reversed_span)
     # Adjacent spans are fine, and an insertion at a boundary is kept.
     assert apply_span_edits(src, [SpanEdit(0, 5, b"a"), SpanEdit(5, 10, b"b")]) == b"ab"
     assert (

--- a/docs/architecture/patchers.md
+++ b/docs/architecture/patchers.md
@@ -1,0 +1,52 @@
+---
+description: "How cgr rewrites source without re-emitting it: byte-span patches against the original file, batched with order-independent offsets, re-parsed and format-checked."
+---
+
+# Span-Preserving Patchers
+
+A rewrite that re-emits a file from its AST loses comments, whitespace and
+style, so every rename becomes a noisy diff. `codebase_rag.editing.Patcher`
+(issue #1529) never re-emits: it replaces exact byte spans of the original
+file and leaves everything around them byte-for-byte intact.
+
+## Interface
+
+```python
+from codebase_rag.editing import Patcher
+
+patcher = Patcher(repo_root)
+patcher.replace_span("pkg/a.py", (start_byte, end_byte), "new text")
+patcher.replace_identifier_at("pkg/a.py", line=12, col=4, old="helper", new="assist")
+results = patcher.apply()            # {rel_path: PatchResult}, nothing written
+results = patcher.stage_into(tx)     # or hand the patched files to an EditTransaction
+```
+
+- Positions follow the graph's convention: 1-based lines, 0-based byte
+  columns (`start_line` / `start_col` on nodes, `line` / `col` on edges).
+- Every edit is expressed against the **original** bytes of the file. A
+  batch to one file is applied in one pass from the end backwards, so the
+  result does not depend on the order the edits were queued in and callers
+  never track shifting offsets. Overlapping spans are refused.
+- `replace_identifier_at` checks that the bytes at the position are exactly
+  `old` and, when a tree-sitter grammar exists for the file, that the syntax
+  tree has a whole identifier node spanning exactly that range. A stale
+  location from the graph, a prefix of a longer name, or a string literal
+  that happens to contain the name is refused rather than patched.
+- `PatchResult` carries the patched bytes, the edit count, `parses` (the
+  file re-parsed with its grammar; `None` when there is no grammar, the
+  generic byte-span fallback), and for Go and Rust the formatter verdict
+  (`gofmt -l`, `rustfmt --check`, run only when installed). Formatter
+  drift is reported, never silently rewritten: a rename that changed the
+  width of an aligned column is the caller's decision to reformat.
+- `stage_into` stages every result that still parses into an
+  `EditTransaction`; a file that no longer parses is left out of the batch
+  and reported through its result message.
+- `Patcher(repo_root, overlay={...})` reads base content from an overlay
+  first, so a second batch can build on a transaction's staged content.
+
+## Languages
+
+Tree-sitter grammars cover Python, TypeScript/JavaScript, Go, Java, Rust,
+C#, C/C++, PHP, Lua, Scala and Dart for the identifier check and the
+post-patch parse; Go and Rust add the formatter check. Files with no grammar
+take the generic byte-span path: bytes are verified, the tree is not.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
     - Language Support: architecture/language-support.md
     - Adding a Language Frontend: architecture/language-frontends.md
     - Security Model: architecture/security.md
+    - Span-Preserving Patchers: architecture/patchers.md
   - Advanced:
     - Adding Languages: advanced/adding-languages.md
     - Ignore Patterns: advanced/ignore-patterns.md


### PR DESCRIPTION
## Summary
Implements #1529 (Epic #1521, T8). Closes #1529.

- `codebase_rag/editing/patcher.py`: `Patcher.replace_span(file, (start, end), text)` and `Patcher.replace_identifier_at(file, line, col, old, new)`; every edit is expressed against the original bytes and a file's batch is applied in one pass from the end backwards, so multiple edits to one file apply correctly in any queue order with no caller-side offset bookkeeping. Overlapping spans are refused. Positions use the graph's convention (1-based line, 0-based byte column).
- `replace_identifier_at` checks the bytes at the position are exactly `old` and, with a tree-sitter grammar, that a whole identifier node spans exactly that range (a prefix of a longer name, a string literal containing the name, or a stale location is refused).
- Post-patch re-parse with the file's tree-sitter grammar (`parses` in the result); Go and Rust add `gofmt -l` / `rustfmt --check` when installed (reported as `formatted`, never rewritten). Files without a grammar take the generic byte-span fallback.
- `apply()` returns the patched bytes per file; `stage_into(tx)` hands every still-parsing result to an `EditTransaction` (#1528, duck-typed so the branches merge independently); an `overlay` lets a second batch build on staged content.
- No LibCST/ts-morph/recast: none are dependencies here, and byte-span + re-validation meets the acceptance without adding one; the Python/TypeScript/Java/Go/Rust paths all go through the same span engine with language-specific identifier types and formatter checks. Docs: `docs/architecture/patchers.md`.

## Test plan
- [x] `codebase_rag/tests/test_patcher.py`: offset conversions round-trip (multi-byte); span batches apply identically in any order; overlap/bad spans refused; Python rename in a file with comments, trailing commas and tab indentation changes only the identifier lines and leaves everything else byte-identical (the string key `'helper'` untouched); position must hold the identifier (byte mismatch, prefix, string literal); mixed span + identifier edits; parse failure reported and not staged; staging into a transaction-like object; overlay base; outside-repo/missing files refused; generic fallback; TypeScript, Java, Go (gofmt) and Rust (rustfmt) renames; formatter drift reported not rewritten; formatter absent
- [x] `ruff`, `ty` clean; full non-integration suite: 8743 passed, 34 skipped, 1 xfailed
- [ ] Memgraph integration tests (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added span-preserving source editing for precise text and identifier replacements.
  * Supports batched edits, overlays, validation, parse checks, and transaction staging.
  * Supports Python, TypeScript, Java, Go, and Rust source updates.
  * Added Go and Rust formatter checks with reporting for formatting drift.
  * Provides results for applied edits, parse status, formatter status, and validation errors.

* **Documentation**
  * Added architecture documentation and navigation for patching workflows, supported languages, and staging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->