### PR TITLE
feat: import statement rewriting for rename and move

### DIFF
--- a/codebase_rag/editing/__init__.py
+++ b/codebase_rag/editing/__init__.py
@@ -1,6 +1,7 @@
-"""Graph-aware editing primitives: span-preserving patchers (issue #1529) and
-transactions (issue #1528)."""
+"""Graph-aware editing primitives: span-preserving patchers (issue #1529),
+transactions (issue #1528) and import rewriting (issue #1530)."""
 
+from .imports import ImportRewriter, ImportSite, Rewrite, RewriteError, SymbolMove
 from .patcher import (
     Patcher,
     PatcherError,
@@ -25,12 +26,17 @@ from .transaction import (
 
 __all__ = [
     "EditTransaction",
+    "ImportRewriter",
+    "ImportSite",
     "PatchResult",
     "Patcher",
     "PatcherError",
+    "Rewrite",
+    "RewriteError",
     "SpanEdit",
     "StagedFile",
     "StagedTree",
+    "SymbolMove",
     "TransactionConflict",
     "TransactionError",
     "TransactionOutcome",

--- a/codebase_rag/editing/imports.py
+++ b/codebase_rag/editing/imports.py
@@ -230,6 +230,9 @@ def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
 
 _JS_SPEC = re.compile(r"""(?P<q>['"])(?P<spec>[^'"]+)(?P=q)""")
 _JS_NAMED = re.compile(r"\{(?P<names>[^}]*)\}")
+# The leading keyword only ("import ", "export ", with any indent), so a
+# default clause after it can be separated from the moved statement.
+_JS_KEYWORD = re.compile(r"\s*(?:import|export)\s+")
 
 
 def _js_rewrite(statement: str, move: SymbolMove, importer_path: str) -> str | None:
@@ -262,11 +265,23 @@ def _js_rewrite(statement: str, move: SymbolMove, importer_path: str) -> str | N
     head = statement[: named.start()]
     between = statement[named.end() : spec_match.start("spec")]
     tail = statement[spec_match.end("spec") :]
-    moved_stmt = f"{head}{{ {moved_entries} }}{between}{new_spec}{tail}"
-    if not kept:
-        return moved_stmt
-    kept_stmt = f"{head}{{ {', '.join(kept)} }}{between}{move.old_module}{tail}"
+    # `head` carries any default/namespace clause ("import def, "), which binds
+    # a name from the ORIGINAL module: it must stay there, never be redeclared
+    # in the moved statement nor follow the symbol to the new module.
+    keyword = _JS_KEYWORD.match(head)
+    moved_head = keyword.group(0) if keyword else head
+    moved_stmt = f"{moved_head}{{ {moved_entries} }}{between}{new_spec}{tail}"
     indent = re.match(r"\s*", statement).group(0)  # type: ignore[union-attr]
+    if not kept:
+        default_clause = head[len(moved_head) :].rstrip().rstrip(",").rstrip()
+        if not default_clause:
+            return moved_stmt
+        # The named list emptied but a default binding remains behind.
+        kept_stmt = (
+            f"{head[: len(moved_head)]}{default_clause}{between}{move.old_module}{tail}"
+        )
+        return f"{kept_stmt}\n{indent}{moved_stmt.lstrip()}"
+    kept_stmt = f"{head}{{ {', '.join(kept)} }}{between}{move.old_module}{tail}"
     return f"{kept_stmt}\n{indent}{moved_stmt.lstrip()}"
 
 

--- a/codebase_rag/editing/imports.py
+++ b/codebase_rag/editing/imports.py
@@ -230,9 +230,12 @@ def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
 
 _JS_SPEC = re.compile(r"""(?P<q>['"])(?P<spec>[^'"]+)(?P=q)""")
 _JS_NAMED = re.compile(r"\{(?P<names>[^}]*)\}")
-# The leading keyword only ("import ", "export ", with any indent), so a
-# default clause after it can be separated from the moved statement.
-_JS_KEYWORD = re.compile(r"\s*(?:import|export)\s+")
+# The leading keyword and any type-only modifier ("import ", "export type "),
+# so a default clause after it can be separated from the moved statement.
+# `type` must be absorbed here: left as residue it reads as a default binding,
+# and `import type from './util'` is VALID TypeScript (a default import named
+# `type`), so the patcher's parse gate would pass corrupt output through.
+_JS_KEYWORD = re.compile(r"\s*(?:import|export)\s+(?:type\s+)?")
 
 
 def _js_rewrite(statement: str, move: SymbolMove, importer_path: str) -> str | None:

--- a/codebase_rag/editing/imports.py
+++ b/codebase_rag/editing/imports.py
@@ -256,11 +256,13 @@ def _js_rewrite(statement: str, move: SymbolMove, importer_path: str) -> str | N
     if not moved:
         return None
     kept = [e for e in entries if _imported(e) != move.symbol]
-    moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
+    moved_entries = ", ".join(
+        _rewrite_entry(entry, move.new_name, keep_local=True) for entry in moved
+    )
     head = statement[: named.start()]
     between = statement[named.end() : spec_match.start("spec")]
     tail = statement[spec_match.end("spec") :]
-    moved_stmt = f"{head}{{ {moved_entry} }}{between}{new_spec}{tail}"
+    moved_stmt = f"{head}{{ {moved_entries} }}{between}{new_spec}{tail}"
     if not kept:
         return moved_stmt
     kept_stmt = f"{head}{{ {', '.join(kept)} }}{between}{move.old_module}{tail}"
@@ -341,8 +343,15 @@ def _rs_rewrite(statement: str, move: SymbolMove) -> str | None:
     if not moved:
         return None
     kept = [e for e in entries if _imported(e) != move.symbol]
-    moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
-    moved_stmt = f"{lead}{move.new_module}::{moved_entry}{tail}"
+    moved_entries = [
+        _rewrite_entry(entry, move.new_name, keep_local=True) for entry in moved
+    ]
+    moved_body = (
+        moved_entries[0]
+        if len(moved_entries) == 1
+        else "{" + ", ".join(moved_entries) + "}"
+    )
+    moved_stmt = f"{lead}{move.new_module}::{moved_body}{tail}"
     if not kept:
         return moved_stmt
     kept_body = kept[0] if len(kept) == 1 else "{" + ", ".join(kept) + "}"

--- a/codebase_rag/editing/imports.py
+++ b/codebase_rag/editing/imports.py
@@ -1,0 +1,383 @@
+"""Import statement rewriting for rename and move (issue #1530).
+
+`rename` and `move` must update the statements that import a symbol, not
+only the sites that use it. The `IMPORTS` edges know every statement
+(issue #1522: file, span, bound alias, imported symbol), so a rewrite is a
+span replacement per statement, applied through the span-preserving
+patcher (issue #1529) so nothing around the statement changes.
+
+Each language handler takes the statement text at the site and returns its
+replacement:
+
+- retarget a symbol to a new module (the move), keeping the alias and,
+  when the statement imported several names, splitting off the moved one;
+- rename the imported symbol, keeping the alias so use sites stay valid;
+- retarget a whole-module import when the module itself moved.
+
+Re-export chains: a barrel (`export { x } from './a'`, `from a import x` in
+an `__init__`) is an importer like any other and is retargeted at the leaf;
+its own re-export of the name is left intact, so files importing through the
+barrel keep working. `__all__` entries are string literals and are rewritten
+on a rename through the same span mechanism.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import NamedTuple
+
+from .. import constants as cs
+from ..language_spec import get_language_for_extension
+from .patcher import Patcher
+
+
+class ImportSite(NamedTuple):
+    """One IMPORTS edge: where a statement binds a name from a module."""
+
+    path: str
+    line: int
+    col: int
+    end_line: int
+    end_col: int
+    alias: str | None
+    imported_name: str | None
+
+
+class SymbolMove(NamedTuple):
+    """A symbol leaving `old_module` for `new_module`, optionally renamed.
+
+    Module names are language-native import paths (`pkg.util`, `./util`,
+    `crate::util`, `a.b`, `mod/pkg`), the form the statements spell them in;
+    `new_module_path` is the moved file's repo-relative path, needed for the
+    relative specifiers JS/TS write.
+    """
+
+    symbol: str
+    old_module: str
+    new_module: str
+    new_name: str | None = None
+    new_module_path: str | None = None
+
+
+class RewriteError(ValueError):
+    """The statement at a site could not be rewritten as asked."""
+
+
+class Rewrite(NamedTuple):
+    path: str
+    line: int
+    col: int
+    before: str
+    after: str
+
+
+# --- helpers ------------------------------------------------------------------
+
+
+def _span_bytes(source: bytes, site: ImportSite) -> tuple[int, int]:
+    from .patcher import line_col_to_byte
+
+    start = line_col_to_byte(source, site.line, site.col)
+    end = line_col_to_byte(source, site.end_line, site.end_col)
+    return start, end
+
+
+def _local_name(entry: str) -> str:
+    # `a as b` -> b, `a` -> a (Python/TS/Rust forms alike).
+    parts = re.split(r"\s+as\s+", entry.strip())
+    return parts[-1].strip()
+
+
+def _imported(entry: str) -> str:
+    return re.split(r"\s+as\s+", entry.strip())[0].strip()
+
+
+def _rewrite_entry(entry: str, new_name: str | None, keep_local: bool) -> str:
+    """`a as b` with the symbol renamed to `new_name`, keeping the local name.
+
+    A bare `a` renamed to `c` binds `c` unless `keep_local` asks to keep the
+    old local name through an alias (`c as a`).
+    """
+    imported = _imported(entry)
+    local = _local_name(entry)
+    target = new_name or imported
+    if local != imported or (keep_local and target != local):
+        return f"{target} as {local}"
+    return target
+
+
+def _relative_specifier(importer_path: str, target_path: str) -> str:
+    importer_dir = Path(importer_path).parent
+    target = Path(target_path)
+    rel = Path(*[".."] * 0)
+    try:
+        rel = target.relative_to(importer_dir)
+        spec = f"./{rel.as_posix()}"
+    except ValueError:
+        ups = []
+        current = importer_dir
+        while True:
+            try:
+                rel = target.relative_to(current)
+                break
+            except ValueError:
+                ups.append("..")
+                if current == Path():
+                    raise
+                current = current.parent
+        spec = "/".join([*ups, rel.as_posix()])
+    spec = re.sub(r"\.(ts|tsx|js|jsx|mjs|cjs)$", "", spec)
+    return spec[:-6] if spec.endswith("/index") else spec
+
+
+# --- Python -------------------------------------------------------------------
+
+_PY_FROM = re.compile(
+    r"^(?P<lead>\s*from\s+)(?P<module>[\w.]+)(?P<mid>\s+import\s+)(?P<names>.+?)(?P<tail>\s*)$",
+    re.S,
+)
+_PY_IMPORT = re.compile(
+    r"^(?P<lead>\s*import\s+)(?P<module>[\w.]+)(?P<rest>(?:\s+as\s+\w+)?\s*)$", re.S
+)
+
+
+def _split_names(names: str) -> tuple[list[str], str, str]:
+    # Returns the entries, the opening decoration (`(` + whitespace) and the
+    # closing one, so a parenthesised list keeps its shape.
+    stripped = names.strip()
+    open_deco = close_deco = ""
+    if stripped.startswith("("):
+        inner = stripped[1:-1]
+        open_deco = "(" + inner[: len(inner) - len(inner.lstrip())]
+        close_deco = inner[len(inner.rstrip()) :] + ")"
+        stripped = inner.strip().rstrip(",")
+    entries = [e.strip() for e in stripped.split(",") if e.strip()]
+    return entries, open_deco, close_deco
+
+
+def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
+    if m := _PY_FROM.match(statement):
+        if m.group("module") != move.old_module:
+            return None
+        entries, open_deco, close_deco = _split_names(m.group("names"))
+        moved = [e for e in entries if _imported(e) == move.symbol]
+        if not moved:
+            return None
+        kept = [e for e in entries if _imported(e) != move.symbol]
+        moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
+        moved_stmt = f"{m.group('lead')}{move.new_module}{m.group('mid')}{moved_entry}"
+        if not kept:
+            return f"{moved_stmt}{m.group('tail')}"
+        kept_stmt = (
+            f"{m.group('lead')}{m.group('module')}{m.group('mid')}"
+            f"{open_deco}{', '.join(kept)}{close_deco}"
+        )
+        indent = re.match(r"\s*", statement.splitlines()[0]).group(0)  # type: ignore[union-attr]
+        return f"{kept_stmt}\n{indent}{moved_stmt.lstrip()}{m.group('tail')}"
+    if (
+        (m := _PY_IMPORT.match(statement))
+        and m.group("module") == move.old_module
+        and move.symbol == move.old_module
+    ):
+        return f"{m.group('lead')}{move.new_module}{m.group('rest')}"
+    return None
+
+
+# --- JavaScript / TypeScript ---------------------------------------------------
+
+_JS_SPEC = re.compile(r"""(?P<q>['"])(?P<spec>[^'"]+)(?P=q)""")
+_JS_NAMED = re.compile(r"\{(?P<names>[^}]*)\}")
+
+
+def _js_rewrite(statement: str, move: SymbolMove, importer_path: str) -> str | None:
+    spec_match = _JS_SPEC.search(statement)
+    if spec_match is None or spec_match.group("spec") != move.old_module:
+        return None
+    if move.new_module_path is not None:
+        new_spec = _relative_specifier(importer_path, move.new_module_path)
+    else:
+        new_spec = move.new_module
+    named = _JS_NAMED.search(statement)
+    if named is None:
+        # Namespace, default or require of the whole module: retarget only
+        # when the module itself moved.
+        if move.symbol == move.old_module:
+            return (
+                statement[: spec_match.start("spec")]
+                + new_spec
+                + statement[spec_match.end("spec") :]
+            )
+        return None
+    entries = [e.strip() for e in named.group("names").split(",") if e.strip()]
+    moved = [e for e in entries if _imported(e) == move.symbol]
+    if not moved:
+        return None
+    kept = [e for e in entries if _imported(e) != move.symbol]
+    moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
+    head = statement[: named.start()]
+    between = statement[named.end() : spec_match.start("spec")]
+    tail = statement[spec_match.end("spec") :]
+    moved_stmt = f"{head}{{ {moved_entry} }}{between}{new_spec}{tail}"
+    if not kept:
+        return moved_stmt
+    kept_stmt = f"{head}{{ {', '.join(kept)} }}{between}{move.old_module}{tail}"
+    indent = re.match(r"\s*", statement).group(0)  # type: ignore[union-attr]
+    return f"{kept_stmt}\n{indent}{moved_stmt.lstrip()}"
+
+
+# --- Java / Go / Rust ----------------------------------------------------------
+
+_JAVA_IMPORT = re.compile(
+    r"^(?P<lead>\s*import\s+(?:static\s+)?)(?P<path>[\w.]+)(?P<tail>\s*;\s*)$", re.S
+)
+
+
+def _java_rewrite(statement: str, move: SymbolMove) -> str | None:
+    m = _JAVA_IMPORT.match(statement)
+    if m is None:
+        return None
+    path = m.group("path")
+    if path != f"{move.old_module}.{move.symbol}":
+        return None
+    return f"{m.group('lead')}{move.new_module}.{move.new_name or move.symbol}{m.group('tail')}"
+
+
+def _go_rewrite(statement: str, move: SymbolMove) -> str | None:
+    m = _JS_SPEC.search(statement)
+    if (
+        m is None
+        or m.group("spec") != move.old_module
+        or move.symbol != move.old_module
+    ):
+        return None
+    return statement[: m.start("spec")] + move.new_module + statement[m.end("spec") :]
+
+
+_RS_USE = re.compile(
+    r"^(?P<lead>\s*(?:pub(?:\([^)]*\))?\s+)?use\s+)(?P<path>[\w:]+)(?P<group>::\{(?P<names>[^}]*)\})?(?P<alias>\s+as\s+\w+)?(?P<tail>\s*;\s*)$",
+    re.S,
+)
+
+
+def _rs_rewrite(statement: str, move: SymbolMove) -> str | None:
+    m = _RS_USE.match(statement)
+    if m is None:
+        return None
+    path = m.group("path")
+    if m.group("group") is None:
+        if path != f"{move.old_module}::{move.symbol}":
+            return None
+        alias = m.group("alias") or ""
+        new_name = move.new_name or move.symbol
+        if not alias and move.new_name:
+            alias = f" as {move.symbol}"
+        return f"{m.group('lead')}{move.new_module}::{new_name}{alias}{m.group('tail')}"
+    if path != move.old_module:
+        return None
+    entries = [e.strip() for e in m.group("names").split(",") if e.strip()]
+    moved = [e for e in entries if _imported(e) == move.symbol]
+    if not moved:
+        return None
+    kept = [e for e in entries if _imported(e) != move.symbol]
+    moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
+    moved_stmt = f"{m.group('lead')}{move.new_module}::{moved_entry}{m.group('tail')}"
+    if not kept:
+        return moved_stmt
+    kept_body = kept[0] if len(kept) == 1 else "{" + ", ".join(kept) + "}"
+    kept_stmt = f"{m.group('lead')}{path}::{kept_body}{m.group('tail')}"
+    indent = re.match(r"\s*", statement).group(0)  # type: ignore[union-attr]
+    return f"{kept_stmt.rstrip()}\n{indent}{moved_stmt.lstrip()}"
+
+
+# --- the rewriter -------------------------------------------------------------
+
+
+class ImportRewriter:
+    """Rewrite the import statements the graph knows for a symbol move."""
+
+    def __init__(self, repo_root: Path, patcher: Patcher | None = None) -> None:
+        self.repo_root = repo_root.resolve()
+        self.patcher = patcher or Patcher(self.repo_root)
+        self.rewrites: list[Rewrite] = []
+        self.untouched: list[ImportSite] = []
+
+    def _statement(self, site: ImportSite) -> tuple[bytes, int, int]:
+        source = self.patcher.source(site.path)
+        start, end = _span_bytes(source, site)
+        return source, start, end
+
+    def retarget(self, sites: Iterable[ImportSite], move: SymbolMove) -> list[Rewrite]:
+        """Queue a replacement for every site that imports the moved symbol.
+
+        Sites whose statement does not import the symbol from the old module
+        (a same-named symbol from elsewhere, a wildcard) are left untouched
+        and listed in `untouched`, so the caller can see what the rewrite
+        deliberately did not do.
+        """
+        applied: list[Rewrite] = []
+        seen: set[tuple[str, int, int]] = set()
+        for site in sites:
+            # `from a import b as c, d` yields one edge per bound name with
+            # the same statement span; the statement is rewritten once.
+            span_key = (site.path, site.line, site.col)
+            if span_key in seen:
+                continue
+            seen.add(span_key)
+            language = get_language_for_extension(Path(site.path).suffix)
+            source, start, end = self._statement(site)
+            statement = source[start:end].decode(cs.ENCODING_UTF8)
+            replacement = self._rewrite_for(language, statement, move, site.path)
+            if replacement is None or replacement == statement:
+                self.untouched.append(site)
+                continue
+            self.patcher.replace_span(site.path, (start, end), replacement)
+            rewrite = Rewrite(site.path, site.line, site.col, statement, replacement)
+            applied.append(rewrite)
+            self.rewrites.append(rewrite)
+        return applied
+
+    @staticmethod
+    def _rewrite_for(
+        language: cs.SupportedLanguage | None,
+        statement: str,
+        move: SymbolMove,
+        importer_path: str,
+    ) -> str | None:
+        if language == cs.SupportedLanguage.PYTHON:
+            return _py_rewrite(statement, move)
+        if language in cs.JS_TS_LANGUAGES:
+            return _js_rewrite(statement, move, importer_path)
+        if language == cs.SupportedLanguage.JAVA:
+            return _java_rewrite(statement, move)
+        if language == cs.SupportedLanguage.GO:
+            return _go_rewrite(statement, move)
+        if language == cs.SupportedLanguage.RUST:
+            return _rs_rewrite(statement, move)
+        return None
+
+    def rename_in_all(self, path: str, old_name: str, new_name: str) -> int:
+        """Rewrite `"old_name"` entries of a Python `__all__` list in `path`."""
+        source = self.patcher.source(path)
+        text = source.decode(cs.ENCODING_UTF8)
+        count = 0
+        for m in re.finditer(
+            r"__all__\s*(?::[^=]+)?=\s*[\[(]([^\])]*)[\])]", text, re.S
+        ):
+            for literal in re.finditer(
+                r"""(['"])(?P<name>[A-Za-z_]\w*)\1""", m.group(1)
+            ):
+                if literal.group("name") != old_name:
+                    continue
+                start = m.start(1) + literal.start("name")
+                self.patcher.replace_span(
+                    path,
+                    (
+                        len(text[:start].encode(cs.ENCODING_UTF8)),
+                        len(text[: start + len(old_name)].encode(cs.ENCODING_UTF8)),
+                    ),
+                    new_name,
+                )
+                count += 1
+        return count

--- a/codebase_rag/editing/imports.py
+++ b/codebase_rag/editing/imports.py
@@ -84,19 +84,30 @@ def _span_bytes(source: bytes, site: ImportSite) -> tuple[int, int]:
     return start, end
 
 
-# Possessive quantifiers: a run of whitespace not followed by `as` must not
-# be re-tried at every shorter length (super-linear on long entries).
-_AS_SEPARATOR = re.compile(r"\s++as\s++")
+def _split_on_as(entry: str) -> list[str]:
+    # `a as b as c` -> ["a", "b", "c"] without a regex: scanning a
+    # whitespace-delimited pattern over a long run is super-linear (S8786),
+    # a single whitespace tokenisation is not.
+    tokens = entry.split()
+    parts: list[str] = []
+    current: list[str] = []
+    for index, token in enumerate(tokens):
+        if token == "as" and current and index < len(tokens) - 1:
+            parts.append(" ".join(current))
+            current = []
+        else:
+            current.append(token)
+    parts.append(" ".join(current))
+    return parts
 
 
 def _local_name(entry: str) -> str:
     # `a as b` -> b, `a` -> a (Python/TS/Rust forms alike).
-    parts = _AS_SEPARATOR.split(entry.strip())
-    return parts[-1].strip()
+    return _split_on_as(entry)[-1]
 
 
 def _imported(entry: str) -> str:
-    return _AS_SEPARATOR.split(entry.strip())[0].strip()
+    return _split_on_as(entry)[0]
 
 
 def _rewrite_entry(entry: str, new_name: str | None, keep_local: bool) -> str:
@@ -139,13 +150,31 @@ def _relative_specifier(importer_path: str, target_path: str) -> str:
 
 # --- Python -------------------------------------------------------------------
 
-# `names` runs to the end of the statement; the trailing whitespace is
-# split off in code rather than by a lazy `.+?` racing a `\s*$`, which
-# backtracks quadratically on a long name list.
-_PY_FROM = re.compile(
-    r"^(?P<lead>\s*from\s+)(?P<module>[\w.]+)(?P<mid>\s+import\s+)(?P<names>.+)$",
-    re.S,
-)
+# `from module import names` is matched in three anchored steps: each
+# sub-pattern is unambiguous at its own start position, so matching stays
+# linear where one statement-wide regex is super-linear (S8786), and the
+# names run to the end of the statement by construction.
+_PY_FROM_LEAD = re.compile(r"\s*from\s+")
+_PY_FROM_MODULE = re.compile(r"[\w.]+")
+_PY_FROM_MID = re.compile(r"\s+import\s+")
+
+
+def _match_py_from(statement: str) -> tuple[str, str, str, str] | None:
+    lead = _PY_FROM_LEAD.match(statement)
+    if lead is None:
+        return None
+    module = _PY_FROM_MODULE.match(statement, lead.end())
+    if module is None:
+        return None
+    mid = _PY_FROM_MID.match(statement, module.end())
+    if mid is None:
+        return None
+    names = statement[mid.end() :]
+    if not names:
+        return None
+    return lead.group(0), module.group(0), mid.group(0), names
+
+
 _PY_IMPORT = re.compile(
     r"^(?P<lead>\s*import\s+)(?P<module>[\w.]+)(?P<rest>(?:\s+as\s+\w+)?\s*)$", re.S
 )
@@ -166,10 +195,10 @@ def _split_names(names: str) -> tuple[list[str], str, str]:
 
 
 def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
-    if m := _PY_FROM.match(statement):
-        if m.group("module") != move.old_module:
+    if parsed := _match_py_from(statement):
+        lead, module, mid, raw_names = parsed
+        if module != move.old_module:
             return None
-        raw_names = m.group("names")
         names = raw_names.rstrip()
         tail = raw_names[len(names) :]
         entries, open_deco, close_deco = _split_names(names)
@@ -178,13 +207,10 @@ def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
             return None
         kept = [e for e in entries if _imported(e) != move.symbol]
         moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
-        moved_stmt = f"{m.group('lead')}{move.new_module}{m.group('mid')}{moved_entry}"
+        moved_stmt = f"{lead}{move.new_module}{mid}{moved_entry}"
         if not kept:
             return f"{moved_stmt}{tail}"
-        kept_stmt = (
-            f"{m.group('lead')}{m.group('module')}{m.group('mid')}"
-            f"{open_deco}{', '.join(kept)}{close_deco}"
-        )
+        kept_stmt = f"{lead}{module}{mid}{open_deco}{', '.join(kept)}{close_deco}"
         indent = re.match(r"\s*", statement.splitlines()[0]).group(0)  # type: ignore[union-attr]
         return f"{kept_stmt}\n{indent}{moved_stmt.lstrip()}{tail}"
     if (

--- a/codebase_rag/editing/imports.py
+++ b/codebase_rag/editing/imports.py
@@ -84,14 +84,19 @@ def _span_bytes(source: bytes, site: ImportSite) -> tuple[int, int]:
     return start, end
 
 
+# Possessive quantifiers: a run of whitespace not followed by `as` must not
+# be re-tried at every shorter length (super-linear on long entries).
+_AS_SEPARATOR = re.compile(r"\s++as\s++")
+
+
 def _local_name(entry: str) -> str:
     # `a as b` -> b, `a` -> a (Python/TS/Rust forms alike).
-    parts = re.split(r"\s+as\s+", entry.strip())
+    parts = _AS_SEPARATOR.split(entry.strip())
     return parts[-1].strip()
 
 
 def _imported(entry: str) -> str:
-    return re.split(r"\s+as\s+", entry.strip())[0].strip()
+    return _AS_SEPARATOR.split(entry.strip())[0].strip()
 
 
 def _rewrite_entry(entry: str, new_name: str | None, keep_local: bool) -> str:
@@ -134,8 +139,11 @@ def _relative_specifier(importer_path: str, target_path: str) -> str:
 
 # --- Python -------------------------------------------------------------------
 
+# `names` runs to the end of the statement; the trailing whitespace is
+# split off in code rather than by a lazy `.+?` racing a `\s*$`, which
+# backtracks quadratically on a long name list.
 _PY_FROM = re.compile(
-    r"^(?P<lead>\s*from\s+)(?P<module>[\w.]+)(?P<mid>\s+import\s+)(?P<names>.+?)(?P<tail>\s*)$",
+    r"^(?P<lead>\s*from\s+)(?P<module>[\w.]+)(?P<mid>\s+import\s+)(?P<names>.+)$",
     re.S,
 )
 _PY_IMPORT = re.compile(
@@ -161,7 +169,10 @@ def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
     if m := _PY_FROM.match(statement):
         if m.group("module") != move.old_module:
             return None
-        entries, open_deco, close_deco = _split_names(m.group("names"))
+        raw_names = m.group("names")
+        names = raw_names.rstrip()
+        tail = raw_names[len(names) :]
+        entries, open_deco, close_deco = _split_names(names)
         moved = [e for e in entries if _imported(e) == move.symbol]
         if not moved:
             return None
@@ -169,13 +180,13 @@ def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
         moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
         moved_stmt = f"{m.group('lead')}{move.new_module}{m.group('mid')}{moved_entry}"
         if not kept:
-            return f"{moved_stmt}{m.group('tail')}"
+            return f"{moved_stmt}{tail}"
         kept_stmt = (
             f"{m.group('lead')}{m.group('module')}{m.group('mid')}"
             f"{open_deco}{', '.join(kept)}{close_deco}"
         )
         indent = re.match(r"\s*", statement.splitlines()[0]).group(0)  # type: ignore[union-attr]
-        return f"{kept_stmt}\n{indent}{moved_stmt.lstrip()}{m.group('tail')}"
+        return f"{kept_stmt}\n{indent}{moved_stmt.lstrip()}{tail}"
     if (
         (m := _PY_IMPORT.match(statement))
         and m.group("module") == move.old_module
@@ -255,16 +266,35 @@ def _go_rewrite(statement: str, move: SymbolMove) -> str | None:
     return statement[: m.start("spec")] + move.new_module + statement[m.end("spec") :]
 
 
-_RS_USE = re.compile(
-    r"^(?P<lead>\s*(?:pub(?:\([^)]*\))?\s+)?use\s+)(?P<path>[\w:]+)(?P<group>::\{(?P<names>[^}]*)\})?(?P<alias>\s+as\s+\w+)?(?P<tail>\s*;\s*)$",
-    re.S,
+# The statement is taken apart in two steps (the `use` head, then the path
+# with its optional group and alias) rather than by one regex whose
+# alternation count trips the complexity bar.
+_RS_USE_HEAD = re.compile(r"^(?P<lead>\s*(?:pub(?:\([^)]*\))?\s+)?use\s+)")
+_RS_USE_BODY = re.compile(
+    r"^(?P<path>[\w:]+)(?P<group>::\{(?P<names>[^}]*)\})?(?P<alias>\s+as\s+\w+)?$"
 )
 
 
-def _rs_rewrite(statement: str, move: SymbolMove) -> str | None:
-    m = _RS_USE.match(statement)
-    if m is None:
+def _split_rs_use(statement: str) -> tuple[str, re.Match[str], str] | None:
+    """`(lead, body match, tail)` of a `use` statement, None if it is not one."""
+    head = _RS_USE_HEAD.match(statement)
+    if head is None:
         return None
+    rest = statement[head.end() :]
+    semicolon = rest.rfind(";")
+    if semicolon < 0 or rest[semicolon + 1 :].strip():
+        return None
+    body = _RS_USE_BODY.match(rest[:semicolon].rstrip())
+    if body is None:
+        return None
+    return head.group("lead"), body, rest[semicolon:]
+
+
+def _rs_rewrite(statement: str, move: SymbolMove) -> str | None:
+    parts = _split_rs_use(statement)
+    if parts is None:
+        return None
+    lead, m, tail = parts
     path = m.group("path")
     if m.group("group") is None:
         if path != f"{move.old_module}::{move.symbol}":
@@ -273,7 +303,7 @@ def _rs_rewrite(statement: str, move: SymbolMove) -> str | None:
         new_name = move.new_name or move.symbol
         if not alias and move.new_name:
             alias = f" as {move.symbol}"
-        return f"{m.group('lead')}{move.new_module}::{new_name}{alias}{m.group('tail')}"
+        return f"{lead}{move.new_module}::{new_name}{alias}{tail}"
     if path != move.old_module:
         return None
     entries = [e.strip() for e in m.group("names").split(",") if e.strip()]
@@ -282,11 +312,11 @@ def _rs_rewrite(statement: str, move: SymbolMove) -> str | None:
         return None
     kept = [e for e in entries if _imported(e) != move.symbol]
     moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
-    moved_stmt = f"{m.group('lead')}{move.new_module}::{moved_entry}{m.group('tail')}"
+    moved_stmt = f"{lead}{move.new_module}::{moved_entry}{tail}"
     if not kept:
         return moved_stmt
     kept_body = kept[0] if len(kept) == 1 else "{" + ", ".join(kept) + "}"
-    kept_stmt = f"{m.group('lead')}{path}::{kept_body}{m.group('tail')}"
+    kept_stmt = f"{lead}{path}::{kept_body}{tail}"
     indent = re.match(r"\s*", statement).group(0)  # type: ignore[union-attr]
     return f"{kept_stmt.rstrip()}\n{indent}{moved_stmt.lstrip()}"
 

--- a/codebase_rag/editing/imports.py
+++ b/codebase_rag/editing/imports.py
@@ -206,8 +206,12 @@ def _py_rewrite(statement: str, move: SymbolMove) -> str | None:
         if not moved:
             return None
         kept = [e for e in entries if _imported(e) != move.symbol]
-        moved_entry = _rewrite_entry(moved[0], move.new_name, keep_local=True)
-        moved_stmt = f"{lead}{move.new_module}{mid}{moved_entry}"
+        # Every entry binding the symbol moves: `helper, helper as h` binds it
+        # twice, and keeping only the first would drop the `h` binding.
+        moved_entries = [
+            _rewrite_entry(entry, move.new_name, keep_local=True) for entry in moved
+        ]
+        moved_stmt = f"{lead}{move.new_module}{mid}{', '.join(moved_entries)}"
         if not kept:
             return f"{moved_stmt}{tail}"
         kept_stmt = f"{lead}{module}{mid}{open_deco}{', '.join(kept)}{close_deco}"

--- a/codebase_rag/tests/test_import_rewrite.py
+++ b/codebase_rag/tests/test_import_rewrite.py
@@ -315,5 +315,6 @@ def test_missing_importer_file_is_an_error(tmp_path: Path, bad: ImportSite) -> N
     from codebase_rag.editing import PatcherError
 
     rewriter = ImportRewriter(tmp_path)
+    move = SymbolMove("x", "a", "b")
     with pytest.raises(PatcherError):
-        rewriter.retarget([bad], SymbolMove("x", "a", "b"))
+        rewriter.retarget([bad], move)

--- a/codebase_rag/tests/test_import_rewrite.py
+++ b/codebase_rag/tests/test_import_rewrite.py
@@ -329,10 +329,7 @@ def test_every_alias_of_the_moved_symbol_survives_the_move() -> None:
         "from pkg.util import helper, helper as h, other",
         SymbolMove("helper", "pkg.util", "pkg.new"),
     )
-    assert out is not None
-    assert "other" in out
-    assert "helper" in out
-    assert " as h" in out, f"the `h` alias was dropped: {out!r}"
+    assert out == "from pkg.util import other\nfrom pkg.new import helper, helper as h"
 
 
 def test_every_js_alias_of_the_moved_symbol_survives_the_move() -> None:
@@ -345,9 +342,10 @@ def test_every_js_alias_of_the_moved_symbol_survives_the_move() -> None:
         SymbolMove("helper", "./util", "./lib/helpers"),
         "src/app.ts",
     )
-    assert out is not None
-    assert "other" in out
-    assert " as h" in out, f"the `h` alias was dropped: {out!r}"
+    assert out == (
+        "import { other } from './util';\n"
+        "import { helper, helper as h } from './lib/helpers';"
+    )
 
 
 def test_every_rust_alias_of_the_moved_symbol_survives_the_move() -> None:
@@ -358,6 +356,22 @@ def test_every_rust_alias_of_the_moved_symbol_survives_the_move() -> None:
         "use pkg::util::{helper, helper as h, other};",
         SymbolMove("helper", "pkg::util", "pkg::new"),
     )
-    assert out is not None
-    assert "other" in out
-    assert " as h" in out, f"the `h` alias was dropped: {out!r}"
+    assert out == "use pkg::util::other;\nuse pkg::new::{helper, helper as h};"
+
+
+def test_a_default_binding_stays_with_its_original_module() -> None:
+    # `import def, { helper } from './util'` binds `def` to ./util. Moving
+    # `helper` must not redeclare `def` in the new statement, nor carry it to
+    # the new module when the named list empties.
+    from codebase_rag.editing.imports import _js_rewrite
+
+    move = SymbolMove("helper", "./util", "./new")
+    with_kept = _js_rewrite(
+        "import def, { helper, other } from './util';", move, "src/app.ts"
+    )
+    assert with_kept == (
+        "import def, { other } from './util';\nimport { helper } from './new';"
+    )
+
+    emptied = _js_rewrite("import def, { helper } from './util';", move, "src/app.ts")
+    assert emptied == ("import def from './util';\nimport { helper } from './new';")

--- a/codebase_rag/tests/test_import_rewrite.py
+++ b/codebase_rag/tests/test_import_rewrite.py
@@ -318,3 +318,18 @@ def test_missing_importer_file_is_an_error(tmp_path: Path, bad: ImportSite) -> N
     move = SymbolMove("x", "a", "b")
     with pytest.raises(PatcherError):
         rewriter.retarget([bad], move)
+
+
+def test_every_alias_of_the_moved_symbol_survives_the_move() -> None:
+    # `helper` and `helper as h` both bind the moved symbol; a rewrite that
+    # keeps only the first drops the `h` binding and breaks its call sites.
+    from codebase_rag.editing.imports import _py_rewrite
+
+    out = _py_rewrite(
+        "from pkg.util import helper, helper as h, other",
+        SymbolMove("helper", "pkg.util", "pkg.new"),
+    )
+    assert out is not None
+    assert "other" in out
+    assert "helper" in out
+    assert " as h" in out, f"the `h` alias was dropped: {out!r}"

--- a/codebase_rag/tests/test_import_rewrite.py
+++ b/codebase_rag/tests/test_import_rewrite.py
@@ -14,6 +14,14 @@ from codebase_rag.editing import ImportRewriter, ImportSite, SymbolMove
 from codebase_rag.tests.conftest import create_and_run_updater
 
 
+def _assert_parses(parses: bool | None, grammar: str) -> None:
+    # The patcher reports None when no grammar is installed for the file
+    # (the base install ships none for Rust and Go): nothing to verify then.
+    if parses is None:
+        pytest.skip(f"{grammar} grammar not installed")
+    assert parses is True
+
+
 def _write(root: Path, rel: str, text: str) -> Path:
     path = root / rel
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -283,7 +291,7 @@ def test_rust_use_single_grouped_and_aliased(tmp_path: Path) -> None:
         "use crate::helpers::assist as hh;",
     ]
     (result,) = rewriter.patcher.apply().values()
-    assert result.parses is True
+    _assert_parses(result.parses, "rust")
 
 
 def test_go_import_path_retarget(tmp_path: Path) -> None:
@@ -299,12 +307,13 @@ def test_go_import_path_retarget(tmp_path: Path) -> None:
     )
     assert rewrite.after == 'u "example.com/mod/core/util"'
     (result,) = rewriter.patcher.apply().values()
-    assert result.parses is True
+    _assert_parses(result.parses, "go")
 
 
 @pytest.mark.parametrize("bad", [ImportSite("nope.py", 1, 0, 1, 5, None, None)])
 def test_missing_importer_file_is_an_error(tmp_path: Path, bad: ImportSite) -> None:
     from codebase_rag.editing import PatcherError
 
+    rewriter = ImportRewriter(tmp_path)
     with pytest.raises(PatcherError):
-        ImportRewriter(tmp_path).retarget([bad], SymbolMove("x", "a", "b"))
+        rewriter.retarget([bad], SymbolMove("x", "a", "b"))

--- a/codebase_rag/tests/test_import_rewrite.py
+++ b/codebase_rag/tests/test_import_rewrite.py
@@ -375,3 +375,23 @@ def test_a_default_binding_stays_with_its_original_module() -> None:
 
     emptied = _js_rewrite("import def, { helper } from './util';", move, "src/app.ts")
     assert emptied == ("import def from './util';\nimport { helper } from './new';")
+
+
+def test_a_type_only_import_keeps_its_modifier() -> None:
+    # `type` is a modifier, not a default binding: it must stay attached to
+    # the braces on both statements. `import type from './util'` parses as a
+    # default import named `type`, so the patcher's parse gate cannot catch it.
+    from codebase_rag.editing.imports import _js_rewrite
+
+    move = SymbolMove("helper", "./util", "./new")
+    assert (
+        _js_rewrite("import type { helper } from './util';", move, "src/app.ts")
+        == "import type { helper } from './new';"
+    )
+    assert (
+        _js_rewrite("export type { helper } from './util';", move, "src/app.ts")
+        == "export type { helper } from './new';"
+    )
+    assert _js_rewrite(
+        "import type { helper, other } from './util';", move, "src/app.ts"
+    ) == ("import type { other } from './util';\nimport type { helper } from './new';")

--- a/codebase_rag/tests/test_import_rewrite.py
+++ b/codebase_rag/tests/test_import_rewrite.py
@@ -333,3 +333,31 @@ def test_every_alias_of_the_moved_symbol_survives_the_move() -> None:
     assert "other" in out
     assert "helper" in out
     assert " as h" in out, f"the `h` alias was dropped: {out!r}"
+
+
+def test_every_js_alias_of_the_moved_symbol_survives_the_move() -> None:
+    # `helper as h` in a named-import list binds the moved symbol too; losing
+    # it leaves `h()` in the body pointing at nothing.
+    from codebase_rag.editing.imports import _js_rewrite
+
+    out = _js_rewrite(
+        "import { helper, helper as h, other } from './util';",
+        SymbolMove("helper", "./util", "./lib/helpers"),
+        "src/app.ts",
+    )
+    assert out is not None
+    assert "other" in out
+    assert " as h" in out, f"the `h` alias was dropped: {out!r}"
+
+
+def test_every_rust_alias_of_the_moved_symbol_survives_the_move() -> None:
+    # Same defect in the Rust `use` list: `helper as h` must move with it.
+    from codebase_rag.editing.imports import _rs_rewrite
+
+    out = _rs_rewrite(
+        "use pkg::util::{helper, helper as h, other};",
+        SymbolMove("helper", "pkg::util", "pkg::new"),
+    )
+    assert out is not None
+    assert "other" in out
+    assert " as h" in out, f"the `h` alias was dropped: {out!r}"

--- a/codebase_rag/tests/test_import_rewrite.py
+++ b/codebase_rag/tests/test_import_rewrite.py
@@ -1,0 +1,310 @@
+# Import statement rewriting for rename/move (issue #1530): the IMPORTS edge
+# sites of issue #1522 name every statement to touch, and the span patcher of
+# issue #1529 keeps everything around them intact.
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.editing import ImportRewriter, ImportSite, SymbolMove
+from codebase_rag.tests.conftest import create_and_run_updater
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(text.encode("utf-8"))
+    return path
+
+
+def _site(
+    text: str, needle: str, path: str, alias: str | None = None, name: str | None = None
+) -> ImportSite:
+    """An ImportSite for the statement `needle` inside `text`, like the graph records it."""
+    idx = text.index(needle)
+    line = text.count("\n", 0, idx) + 1
+    col = idx - (text.rfind("\n", 0, idx) + 1)
+    end = idx + len(needle)
+    end_line = text.count("\n", 0, end) + 1
+    end_col = end - (text.rfind("\n", 0, end) + 1)
+    return ImportSite(path, line, col, end_line, end_col, alias, name)
+
+
+def _sites_from_graph(mock, importer_suffix: str) -> list[ImportSite]:
+    """The IMPORTS edges the indexer produced for one importer, as ImportSites."""
+    out = []
+    for c in mock.ensure_relationship_batch.call_args_list:
+        if str(c.args[1]) != cs.RelationshipType.IMPORTS:
+            continue
+        props = c.kwargs.get("properties") or {}
+        src = str(c.args[0][2])
+        if not src.endswith(importer_suffix) or cs.KEY_LINE not in props:
+            continue
+        out.append((props, src))
+    return out
+
+
+# --- Python ---------------------------------------------------------------------
+
+
+PY_APP = "from pkg.util import helper as h, other\nimport pkg.util\n\n\ndef run():\n    return h() + other() + pkg.util.other()\n"
+PY_INIT = 'from pkg.util import helper\n\n__all__ = ["helper", "other"]\n'
+
+
+def test_python_move_updates_aliased_import_and_splits_the_statement(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path, "pkg/app.py", PY_APP)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(
+        PY_APP, "from pkg.util import helper as h, other", "pkg/app.py", "h", "helper"
+    )
+    move = SymbolMove(symbol="helper", old_module="pkg.util", new_module="pkg.helpers")
+    (rewrite,) = rewriter.retarget([site], move)
+    assert (
+        rewrite.after
+        == "from pkg.util import other\nfrom pkg.helpers import helper as h"
+    )
+    (result,) = rewriter.patcher.apply().values()
+    assert result.parses is True
+    assert result.content.decode() == (
+        "from pkg.util import other\nfrom pkg.helpers import helper as h\nimport pkg.util\n\n\n"
+        "def run():\n    return h() + other() + pkg.util.other()\n"
+    )
+
+
+def test_python_rename_keeps_the_local_name_through_an_alias(tmp_path: Path) -> None:
+    src = "from pkg.util import helper\n"
+    _write(tmp_path, "pkg/app.py", src)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(src, "from pkg.util import helper", "pkg/app.py", "helper", "helper")
+    (rewrite,) = rewriter.retarget(
+        [site], SymbolMove("helper", "pkg.util", "pkg.util", new_name="assist")
+    )
+    assert rewrite.after == "from pkg.util import assist as helper"
+
+
+def test_python_module_import_is_retargeted_when_the_module_moves(
+    tmp_path: Path,
+) -> None:
+    src = "import pkg.util as u\n"
+    _write(tmp_path, "pkg/app.py", src)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(src, "import pkg.util as u", "pkg/app.py", "u", None)
+    (rewrite,) = rewriter.retarget(
+        [site], SymbolMove("pkg.util", "pkg.util", "pkg.core.util")
+    )
+    assert rewrite.after == "import pkg.core.util as u"
+
+
+def test_python_barrel_and_dunder_all(tmp_path: Path) -> None:
+    _write(tmp_path, "pkg/__init__.py", PY_INIT)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(
+        PY_INIT, "from pkg.util import helper", "pkg/__init__.py", "helper", "helper"
+    )
+    (rewrite,) = rewriter.retarget(
+        [site], SymbolMove("helper", "pkg.util", "pkg.helpers", new_name="assist")
+    )
+    # The barrel keeps exporting `helper`; only the leaf moved.
+    assert rewrite.after == "from pkg.helpers import assist as helper"
+    assert rewriter.rename_in_all("pkg/__init__.py", "other", "another") == 1
+    (result,) = rewriter.patcher.apply().values()
+    assert (
+        result.content.decode()
+        == 'from pkg.helpers import assist as helper\n\n__all__ = ["helper", "another"]\n'
+    )
+
+
+def test_unrelated_statements_are_left_untouched(tmp_path: Path) -> None:
+    src = "from pkg.util import other\nfrom elsewhere import helper\n"
+    _write(tmp_path, "pkg/app.py", src)
+    rewriter = ImportRewriter(tmp_path)
+    sites = [
+        _site(src, "from pkg.util import other", "pkg/app.py", "other", "other"),
+        _site(src, "from elsewhere import helper", "pkg/app.py", "helper", "helper"),
+    ]
+    assert (
+        rewriter.retarget(sites, SymbolMove("helper", "pkg.util", "pkg.helpers")) == []
+    )
+    assert len(rewriter.untouched) == 2
+    assert rewriter.patcher.pending == {}
+
+
+def test_python_move_from_graph_sites_still_imports(
+    tmp_path: Path, mock_ingestor
+) -> None:
+    """End to end: index a fixture, take the IMPORTS sites from the graph,
+    move the symbol, apply, and the package still imports (the acceptance's
+    smoke import)."""
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(
+        tmp_path,
+        "pkg/util.py",
+        "def helper():\n    return 1\n\n\ndef other():\n    return 2\n",
+    )
+    _write(tmp_path, "pkg/helpers.py", "def helper():\n    return 1\n")
+    _write(
+        tmp_path,
+        "pkg/app.py",
+        "from pkg.util import helper as h, other\n\n\ndef run():\n    return h() + other()\n",
+    )
+    _write(
+        tmp_path,
+        "pkg/cli.py",
+        "from pkg.util import (\n    helper,\n)\n\n\ndef main():\n    return helper()\n",
+    )
+    create_and_run_updater(tmp_path, mock_ingestor)
+
+    sites: list[ImportSite] = []
+    for props, _src in _sites_from_graph(mock_ingestor, ".pkg.app") + _sites_from_graph(
+        mock_ingestor, ".pkg.cli"
+    ):
+        # Recover the importer's path from the edge's module qn.
+        importer = "pkg/app.py" if "app" in _src else "pkg/cli.py"
+        sites.append(
+            ImportSite(
+                importer,
+                int(props[cs.KEY_LINE]),
+                int(props[cs.KEY_COL]),
+                int(props[cs.KEY_END_LINE]),
+                int(props[cs.KEY_END_COL]),
+                props.get(cs.KEY_ALIAS),
+                props.get(cs.KEY_IMPORTED_NAME),
+            )
+        )
+    assert len(sites) == 3, sites
+    rewriter = ImportRewriter(tmp_path)
+    rewrites = rewriter.retarget(sites, SymbolMove("helper", "pkg.util", "pkg.helpers"))
+    assert {r.path for r in rewrites} == {"pkg/app.py", "pkg/cli.py"}
+    for key, result in rewriter.patcher.apply().items():
+        assert result.parses is True, key
+        (tmp_path / key).write_bytes(result.content)
+    assert (
+        (tmp_path / "pkg" / "cli.py").read_text()
+        == "from pkg.helpers import helper\n\n\ndef main():\n    return helper()\n"
+    )
+    smoke = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import pkg.app, pkg.cli; assert pkg.app.run() == 3 and pkg.cli.main() == 1",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    assert smoke.returncode == 0, smoke.stderr
+
+
+# --- TypeScript / JavaScript -------------------------------------------------------
+
+
+def test_typescript_named_import_split_and_relative_specifier(tmp_path: Path) -> None:
+    src = "import { helper as h, other } from './util';\nexport const x = h();\n"
+    _write(tmp_path, "src/app.ts", src)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(
+        src, "import { helper as h, other } from './util';", "src/app.ts", "h", "helper"
+    )
+    move = SymbolMove("helper", "./util", "", new_module_path="src/lib/helpers.ts")
+    (rewrite,) = rewriter.retarget([site], move)
+    assert (
+        rewrite.after
+        == "import { other } from './util';\nimport { helper as h } from './lib/helpers';"
+    )
+
+
+def test_typescript_barrel_reexport_is_retargeted_at_the_leaf(tmp_path: Path) -> None:
+    src = "export { helper } from './util';\nexport { other } from './util';\n"
+    _write(tmp_path, "src/index.ts", src)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(
+        src, "export { helper } from './util';", "src/index.ts", "helper", "helper"
+    )
+    move = SymbolMove(
+        "helper", "./util", "", new_name="assist", new_module_path="src/helpers.ts"
+    )
+    (rewrite,) = rewriter.retarget([site], move)
+    # Consumers of the barrel keep importing `helper`.
+    assert rewrite.after == "export { assist as helper } from './helpers';"
+
+
+def test_typescript_specifier_climbs_directories(tmp_path: Path) -> None:
+    src = 'import * as util from "../util";\n'
+    _write(tmp_path, "src/deep/app.ts", src)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(
+        src, 'import * as util from "../util";', "src/deep/app.ts", "util", None
+    )
+    (rewrite,) = rewriter.retarget(
+        [site], SymbolMove("../util", "../util", "", new_module_path="lib/util.ts")
+    )
+    assert rewrite.after == 'import * as util from "../../lib/util";'
+
+
+# --- Java / Rust / Go ---------------------------------------------------------------
+
+
+def test_java_import_retarget_and_rename(tmp_path: Path) -> None:
+    src = "package app;\n\nimport util.Helper;\n"
+    _write(tmp_path, "app/App.java", src)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(src, "import util.Helper;", "app/App.java", "Helper", "Helper")
+    (rewrite,) = rewriter.retarget(
+        [site], SymbolMove("Helper", "util", "core.util", new_name="Assist")
+    )
+    assert rewrite.after == "import core.util.Assist;"
+
+
+def test_rust_use_single_grouped_and_aliased(tmp_path: Path) -> None:
+    src = "use crate::util::helper;\nuse crate::util::{helper as h, other};\nuse crate::util::helper as hh;\n"
+    _write(tmp_path, "src/main.rs", src)
+    rewriter = ImportRewriter(tmp_path)
+    sites = [
+        _site(src, "use crate::util::helper;", "src/main.rs", "helper", "helper"),
+        _site(
+            src, "use crate::util::{helper as h, other};", "src/main.rs", "h", "helper"
+        ),
+        _site(src, "use crate::util::helper as hh;", "src/main.rs", "hh", "helper"),
+    ]
+    rewrites = rewriter.retarget(
+        sites, SymbolMove("helper", "crate::util", "crate::helpers", new_name="assist")
+    )
+    assert [r.after for r in rewrites] == [
+        "use crate::helpers::assist as helper;",
+        "use crate::util::other;\nuse crate::helpers::assist as h;",
+        "use crate::helpers::assist as hh;",
+    ]
+    (result,) = rewriter.patcher.apply().values()
+    assert result.parses is True
+
+
+def test_go_import_path_retarget(tmp_path: Path) -> None:
+    src = 'package main\n\nimport (\n\tu "example.com/mod/util"\n\t"fmt"\n)\n'
+    _write(tmp_path, "main.go", src)
+    rewriter = ImportRewriter(tmp_path)
+    site = _site(src, 'u "example.com/mod/util"', "main.go", "u", None)
+    (rewrite,) = rewriter.retarget(
+        [site],
+        SymbolMove(
+            "example.com/mod/util", "example.com/mod/util", "example.com/mod/core/util"
+        ),
+    )
+    assert rewrite.after == 'u "example.com/mod/core/util"'
+    (result,) = rewriter.patcher.apply().values()
+    assert result.parses is True
+
+
+@pytest.mark.parametrize("bad", [ImportSite("nope.py", 1, 0, 1, 5, None, None)])
+def test_missing_importer_file_is_an_error(tmp_path: Path, bad: ImportSite) -> None:
+    from codebase_rag.editing import PatcherError
+
+    with pytest.raises(PatcherError):
+        ImportRewriter(tmp_path).retarget([bad], SymbolMove("x", "a", "b"))

--- a/docs/architecture/patchers.md
+++ b/docs/architecture/patchers.md
@@ -50,3 +50,31 @@ Tree-sitter grammars cover Python, TypeScript/JavaScript, Go, Java, Rust,
 C#, C/C++, PHP, Lua, Scala and Dart for the identifier check and the
 post-patch parse; Go and Rust add the formatter check. Files with no grammar
 take the generic byte-span path: bytes are verified, the tree is not.
+
+## Import rewriting for rename and move
+
+`codebase_rag.editing.ImportRewriter` (issue #1530) turns the `IMPORTS` edge
+sites (file, statement span, bound alias, imported symbol) into span edits
+on the patcher. Given a `SymbolMove(symbol, old_module, new_module,
+new_name=None, new_module_path=None)` and the sites the graph reports for
+the old module, `retarget(sites, move)` rewrites each importing statement
+once:
+
+- the moved symbol's entry is retargeted to the new module and, when the
+  statement imported several names, split off into its own statement so
+  the others stay where they were;
+- an alias is kept, and a renamed symbol keeps its local name through an
+  alias (`from a import new as old`, `{ new as old }`, `use a::new as old`),
+  so use sites and barrel consumers stay valid until a rename touches them;
+- a whole-module import (`import a.b as x`, `import * as ns from './a'`,
+  `u "mod/pkg"`) is retargeted when the module itself moved
+  (`symbol == old_module`);
+- JS/TS specifiers are recomputed relative to the importing file from
+  `new_module_path`.
+
+Languages: Python (`import`, `from ... import`, parenthesised lists, `__all__`
+entries via `rename_in_all`), TypeScript/JavaScript (named, default,
+namespace, `require`, barrel `export { x } from`), Java (`import a.b.C;`),
+Rust (`use a::b::c`, `use a::b::{c as d, e}`, `pub use`), Go (import path
+strings, grouped specs). Statements that do not import the symbol from the
+old module are reported in `untouched` rather than guessed at.


### PR DESCRIPTION
## Summary
Implements #1530 (Epic #1521, T10). Closes #1530. **Stacked on #1537 (T1) with #1541 (T8) merged in**; base is `feat/edge-site-properties` and will be retargeted as those merge.

- `codebase_rag/editing/imports.py`: `ImportRewriter.retarget(sites, SymbolMove)` turns the `IMPORTS` edge sites (file, statement span, alias, imported symbol) into span edits on the `Patcher`, one rewrite per statement (a statement binding several names has one site per name and is rewritten once).
- Per-language handlers: Python (`from a import b as c, d` split so the moved entry gets its own statement, `import a.b as x` module retarget, `__all__` entries via `rename_in_all`), TypeScript/JavaScript (named/default/namespace/`require`, barrel `export { x } from`, relative specifier recomputed from the importing file to `new_module_path`), Java (`import a.b.C;`), Rust (`use a::b::c`, `use a::b::{c as d, e}` split, `pub use`, aliases), Go (import path strings and grouped specs).
- Renames keep the local name through an alias (`from a import new as old`) so use sites and barrel consumers stay valid until a rename rewrites them; barrels are retargeted at the leaf and keep re-exporting the same name. Statements that do not import the symbol from the old module are listed in `untouched`, never guessed at.
- Docs: `docs/architecture/patchers.md` gains an "Import rewriting" section.

## Test plan
- [x] `codebase_rag/tests/test_import_rewrite.py`: Python aliased split (byte-exact output parses), rename keeps local name, module import retarget, barrel + `__all__`, unrelated statements untouched; an end-to-end move driven by the graph's own IMPORTS sites (parenthesised multi-line import included) followed by a smoke import of the package in a subprocess; TypeScript split with relative specifier, barrel re-export retarget, specifier climbing directories; Java retarget+rename; Rust single/grouped/aliased `use`; Go grouped spec; missing importer file is an error
- [x] `ruff`, `ty` clean; full non-integration suite: 8778 passed, 34 skipped, 1 xfailed (one encoding-guard fix in the new test)
- [ ] Memgraph integration tests (CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic import rewriting when symbols are renamed or moved across Python, JavaScript/TypeScript, Java, Go, and Rust files.
  * Preserves aliases, renamed local names, multi-item imports, module references, and relative paths.
  * Updates matching Python `__all__` entries and retains every alias for moved symbols.
  * Reports import sites that do not require changes and applies rewrites consistently.

* **Documentation**
  * Added guidance on supported languages and import-rewriting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->