### PR TITLE
chore: drop the claimed label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -99,6 +99,3 @@
 - name: rejected
   color: "000000"
   description: Automated vetting did not accept this for implementation
-- name: claimed
-  color: b60205
-  description: An agent/session is actively working this — check before taking it over


### PR DESCRIPTION
Removes the `claimed` label from `labels.yml`. The cross-session lock it implemented created more confusion than it prevented; the label has been stripped from every open and closed PR and issue, and the agent notes (untracked `CLAUDE.md`) no longer describe it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete `claimed` label from the project’s issue-label configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->