### PR TITLE
fix: bind an incrementally re-parsed C++ out-of-class method to the class in its unchanged header

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1001,6 +1001,19 @@ class GraphUpdater:
             self._run_cpp_frontend()
         self._run_emitting_frontends(FrontendPhase.AFTER_DEFINITIONS)
 
+        go_methods = self.factory.definition_processor.resolve_deferred_go_methods()
+        if go_methods:
+            logger.info("Resolved {} Go receiver methods", go_methods)
+
+        if not force:
+            self._rehydrate_registry_from_graph()
+
+        # After rehydration: an incremental run re-parses the `.cpp` holding
+        # an out-of-class method while its class stays in an unchanged
+        # header, and the class is only known once the registry is read back
+        # from the graph. Resolving earlier bound such a method to a
+        # module-anchored fallback qn beside its class-anchored node, in a
+        # parse-order-dependent way (issue #1552).
         corrected = self.factory.definition_processor.resolve_deferred_cpp_methods()
         if corrected:
             logger.info("Resolved {} deferred C++ out-of-class methods", corrected)
@@ -1013,13 +1026,6 @@ class GraphUpdater:
         # is recorded only once its class binding resolves, and a macro use
         # inside such a method must attribute to it, not the Module.
         self._resolve_hybrid_macro_calls()
-
-        go_methods = self.factory.definition_processor.resolve_deferred_go_methods()
-        if go_methods:
-            logger.info("Resolved {} Go receiver methods", go_methods)
-
-        if not force:
-            self._rehydrate_registry_from_graph()
 
         # After rehydration: an expansion call's callee join needs spans
         # for unchanged files too.

--- a/codebase_rag/tests/test_cpp_incremental_out_of_class_method.py
+++ b/codebase_rag/tests/test_cpp_incremental_out_of_class_method.py
@@ -1,0 +1,96 @@
+# On the batch incremental path, deferred out-of-class C++ methods used to be
+# resolved BEFORE the registry was rehydrated from the graph. A re-parsed
+# `.cpp` whose class lives in an unchanged header therefore could not find the
+# class, fell back to a module-anchored qn (`proj.derived.Derived.run` beside
+# the clean index's `proj.derived.h.Derived.run`) and was anchored to its
+# Module with DEFINES: a phantom second node whose presence depended on parse
+# order (issue #1552).
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+FIXTURE: dict[str, str] = {
+    "base.h": "class Base {\n public:\n  virtual int run();\n};\n",
+    "derived.h": (
+        '#include "base.h"\n\nclass Derived : public Base {\n public:\n'
+        "  int run() override;\n};\n"
+    ),
+    "derived.cpp": '#include "derived.h"\n\nint Derived::run() { return 1; }\n',
+}
+
+Snapshot = tuple[frozenset[tuple[str, str]], frozenset[tuple[str, ...]]]
+
+
+def _snapshot(store: _StatefulIngestor) -> Snapshot:
+    nodes = frozenset((label, str(uid)) for (label, uid) in store.nodes)
+    edges = frozenset(
+        (str(fl), str(fv), str(rel), str(tl), str(tv))
+        for (fl, fv, rel, tl, tv) in store.edges
+    )
+    return nodes, edges
+
+
+def _index(store: _StatefulIngestor, repo: Path, force: bool) -> None:
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.CPP not in parsers:
+        pytest.skip("cpp parser not available")
+    GraphUpdater(
+        ingestor=store,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run(force=force)
+
+
+@pytest.mark.parametrize("edited", ["derived.cpp", "derived.h", "base.h"])
+def test_incremental_reparse_registers_out_of_class_method_once(
+    temp_repo: Path, edited: str
+) -> None:
+    root = temp_repo / "proj"
+    root.mkdir()
+    for rel, text in FIXTURE.items():
+        (root / rel).write_text(text, encoding="utf-8")
+    store = _StatefulIngestor()
+    _index(store, root, force=True)
+    clean = _snapshot(store)
+    class_qn = "proj.derived.h.Derived"
+    method_qn = f"{class_qn}.run"
+    assert (cs.NodeLabel.METHOD.value, method_qn) in clean[0]
+
+    # A trailing comment changes the hash but not the AST, so only the edited
+    # file re-parses; the others are rehydration-only.
+    path = root / edited
+    path.write_text(path.read_text(encoding="utf-8") + "// touched\n")
+    _index(store, root, force=False)
+    nodes, edges = _snapshot(store)
+
+    methods = {
+        qn
+        for (label, qn) in nodes
+        if label == cs.NodeLabel.METHOD.value and qn.endswith(".Derived.run")
+    }
+    assert methods == {method_qn}
+    assert (
+        cs.NodeLabel.CLASS.value,
+        class_qn,
+        cs.RelationshipType.DEFINES_METHOD.value,
+        cs.NodeLabel.METHOD.value,
+        method_qn,
+    ) in edges
+    module_defines_method = {
+        e
+        for e in edges
+        if e[0] == cs.NodeLabel.MODULE.value
+        and e[2] == cs.RelationshipType.DEFINES.value
+        and e[3] == cs.NodeLabel.METHOD.value
+    }
+    assert module_defines_method == set()
+    assert (nodes, edges) == clean

--- a/codebase_rag/tests/test_cpp_incremental_out_of_class_method.py
+++ b/codebase_rag/tests/test_cpp_incremental_out_of_class_method.py
@@ -80,7 +80,8 @@ def test_incremental_reparse_registers_out_of_class_method_once(
     # file re-parses; the others are rehydration-only.
     _touch_after_cache(root / edited, root)
     _index(store, root, force=False)
-    nodes, edges = _snapshot(store)
+    after = _snapshot(store)
+    nodes, edges = after
 
     methods = {
         qn
@@ -103,4 +104,4 @@ def test_incremental_reparse_registers_out_of_class_method_once(
         and e[3] == cs.NodeLabel.METHOD.value
     }
     assert module_defines_method == set()
-    assert (nodes, edges) == clean
+    assert after == clean

--- a/codebase_rag/tests/test_cpp_incremental_out_of_class_method.py
+++ b/codebase_rag/tests/test_cpp_incremental_out_of_class_method.py
@@ -7,6 +7,7 @@
 # order (issue #1552).
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -50,6 +51,16 @@ def _index(store: _StatefulIngestor, repo: Path, force: bool) -> None:
     ).run(force=force)
 
 
+def _touch_after_cache(path: Path, root: Path) -> None:
+    # The incremental pass skips a cached file whose mtime is not newer than
+    # the hash cache's, without hashing it; on a coarse-timestamp filesystem
+    # a write landing in the cache's own tick would be skipped and the test
+    # would pass without re-parsing anything. Place the edit past the cache.
+    cache_mtime = (root / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    path.write_text(path.read_text(encoding="utf-8") + "// touched\n")
+    os.utime(path, (cache_mtime + 1, cache_mtime + 1))
+
+
 @pytest.mark.parametrize("edited", ["derived.cpp", "derived.h", "base.h"])
 def test_incremental_reparse_registers_out_of_class_method_once(
     temp_repo: Path, edited: str
@@ -67,8 +78,7 @@ def test_incremental_reparse_registers_out_of_class_method_once(
 
     # A trailing comment changes the hash but not the AST, so only the edited
     # file re-parses; the others are rehydration-only.
-    path = root / edited
-    path.write_text(path.read_text(encoding="utf-8") + "// touched\n")
+    _touch_after_cache(root / edited, root)
     _index(store, root, force=False)
     nodes, edges = _snapshot(store)
 


### PR DESCRIPTION
Closes #1552.

## What happens

On the batch incremental path, re-parsing a `.cpp` holding `int Derived::run() { ... }` while `Derived` lives in an unchanged header registered the method a second time under a module-anchored fallback qn (`proj.derived.Derived.run` beside the clean index's `proj.derived.h.Derived.run`), anchored to its Module with `DEFINES`. A clean full index of the same tree never produced that node, so incremental equality with a clean index could not be asserted for C++ fixtures.

## Why

`resolve_deferred_cpp_methods` ran before `_rehydrate_registry_from_graph`. On an incremental run the registry holds only the re-parsed files, so the class in the unchanged header was unknown at resolution time and the deferred entry took its fallback. Deferred INHERITS resolution already runs after rehydration for the same reason.

## Fix

`GraphUpdater.run` now resolves deferred C++ out-of-class methods, their nested containments and the hybrid macro-call attribution after rehydration. Nothing between the old and new position consumed those registrations (the Go receiver-method pass and the rehydration read only the graph and the Pass-2 registry), and the expansion-call join that needs the same spans already ran after rehydration.

## Test

`test_cpp_incremental_out_of_class_method.py` indexes a header/source pair, touches each file in turn, runs an incremental update and asserts the method exists exactly once under its class qn, that no `Module DEFINES Method` edge appears, and that the node and edge sets equal the clean index. Red on `main` for the `derived.cpp` case (two `Derived.run` methods), green with the fix. 1686 C++/incremental/updater tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incremental C++ indexing for out-of-class methods.
  * Methods remain correctly associated with their declared classes when only part of a project is reprocessed.
  * Prevented duplicate method entries and incorrect module-level associations during incremental updates.
  * Improved consistency between incremental updates and clean project indexing.

* **Tests**
  * Added regression coverage for incremental reparsing and changed file timestamps.
  * Verified reliable results when comparing incremental and clean indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->