### PR TITLE
fix(evals): emulate the affected-caller query so the incremental emulation re-parses dependents like production

### DIFF
--- a/codebase_rag/tests/test_incremental_inbound_deferred_targets.py
+++ b/codebase_rag/tests/test_incremental_inbound_deferred_targets.py
@@ -9,6 +9,7 @@
 # index and a production run keep both edges (issue #1560).
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -70,6 +71,16 @@ def _index(
     ).run(force=force)
 
 
+def _touch_after_cache(path: Path, root: Path) -> None:
+    # The incremental pass skips a cached file whose mtime is not newer than
+    # the hash cache's, without hashing it; on a coarse-timestamp filesystem
+    # a write landing in the cache's own tick would be skipped and the test
+    # would pass without re-parsing anything. Place the edit past the cache.
+    cache_mtime = (root / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    path.write_text(path.read_text(encoding="utf-8") + "// touched\n")
+    os.utime(path, (cache_mtime + 1, cache_mtime + 1))
+
+
 @pytest.mark.parametrize(
     ("language", "fixture", "edited", "call"),
     [
@@ -97,8 +108,7 @@ def test_incremental_reindex_keeps_inbound_calls_to_deferred_targets(
     # A trailing comment changes the hash but not the AST: the defining file
     # re-parses and the caller joins it as a dependent, so its edge into the
     # re-indexed file is recomputed rather than restored.
-    path = root / edited
-    path.write_text(path.read_text(encoding="utf-8") + "// touched\n")
+    _touch_after_cache(root / edited, root)
     _index(store, root, language, force=False)
     after = _snapshot(store)
 

--- a/codebase_rag/tests/test_incremental_inbound_deferred_targets.py
+++ b/codebase_rag/tests/test_incremental_inbound_deferred_targets.py
@@ -1,0 +1,106 @@
+# An incremental run re-parses every file holding a dependency edge into a
+# re-indexed file (issue #1229 phase 4) and restores the remaining inbound
+# edges verbatim (issue #532). The eval's in-memory graph stand-in used to
+# answer the dependents query with nothing, so under it no file was ever
+# re-parsed as a dependent and every cross-file edge relied on the restore,
+# which cannot carry an edge whose target is registered only after Pass 2
+# (a Go receiver method) or whose node the delete cascade took from another
+# file (a C++ method declared in a header and defined out of class). A clean
+# index and a production run keep both edges (issue #1560).
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+GO_FIXTURE: dict[str, str] = {
+    "go.mod": "module example.com/app\n\ngo 1.21\n",
+    "base.go": "package app\n\ntype Base struct{ X int }\n\nfunc (b Base) Run() int { return b.X }\n",
+    "derived.go": (
+        "package app\n\ntype Derived struct { Base }\n\n"
+        "func Make() int { d := Derived{}; return d.Run() }\n"
+    ),
+}
+GO_CALL = ("proj.derived.Make", "proj.base.Base.Run")
+
+CPP_FIXTURE: dict[str, str] = {
+    "shape.h": "namespace geo {\nclass Shape {\n public:\n  virtual int area();\n};\n}\n",
+    "shape.cpp": (
+        '#include "shape.h"\nnamespace geo {\nint Shape::area() { return 0; }\n}\n'
+        "int use() { geo::Shape s; return s.area(); }\n"
+    ),
+}
+CPP_CALL = ("proj.shape.use", "proj.shape.h.geo.Shape.area")
+
+Snapshot = tuple[frozenset[tuple[str, str]], frozenset[tuple[str, ...]]]
+
+
+def _snapshot(store: _StatefulIngestor) -> Snapshot:
+    nodes = frozenset((label, str(uid)) for (label, uid) in store.nodes)
+    edges = frozenset(
+        (str(fl), str(fv), str(rel), str(tl), str(tv))
+        for (fl, fv, rel, tl, tv) in store.edges
+    )
+    return nodes, edges
+
+
+def _calls(snapshot: Snapshot) -> set[tuple[str, str]]:
+    return {
+        (e[1], e[4]) for e in snapshot[1] if e[2] == cs.RelationshipType.CALLS.value
+    }
+
+
+def _index(
+    store: _StatefulIngestor, repo: Path, language: cs.SupportedLanguage, force: bool
+) -> None:
+    parsers, queries = load_parsers()
+    if language not in parsers:
+        pytest.skip(f"{language} parser not available")
+    GraphUpdater(
+        ingestor=store,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run(force=force)
+
+
+@pytest.mark.parametrize(
+    ("language", "fixture", "edited", "call"),
+    [
+        (cs.SupportedLanguage.GO, GO_FIXTURE, "base.go", GO_CALL),
+        (cs.SupportedLanguage.CPP, CPP_FIXTURE, "shape.h", CPP_CALL),
+    ],
+    ids=["go-receiver-method", "cpp-header-declared-method"],
+)
+def test_incremental_reindex_keeps_inbound_calls_to_deferred_targets(
+    temp_repo: Path,
+    language: cs.SupportedLanguage,
+    fixture: dict[str, str],
+    edited: str,
+    call: tuple[str, str],
+) -> None:
+    root = temp_repo / "proj"
+    root.mkdir()
+    for rel, text in fixture.items():
+        (root / rel).write_text(text, encoding="utf-8")
+    store = _StatefulIngestor()
+    _index(store, root, language, force=True)
+    clean = _snapshot(store)
+    assert call in _calls(clean), "fixture must produce the cross-file call"
+
+    # A trailing comment changes the hash but not the AST: the defining file
+    # re-parses and the caller joins it as a dependent, so its edge into the
+    # re-indexed file is recomputed rather than restored.
+    path = root / edited
+    path.write_text(path.read_text(encoding="utf-8") + "// touched\n")
+    _index(store, root, language, force=False)
+    after = _snapshot(store)
+
+    assert call in _calls(after)
+    assert after == clean

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -87,6 +87,19 @@ _INBOUND_DEPENDENT_RELS = frozenset(
         cs.RelationshipType.OVERRIDES.value,
     }
 )
+# The dependency relations CYPHER_AFFECTED_CALLER_PATHS walks: a file holding
+# one of these into a re-indexed file is re-parsed rather than restored
+# verbatim (issue #1229 phase 4). REFERENCES is in, OVERRIDES is out, exactly
+# as in the production query.
+_AFFECTED_CALLER_RELS = frozenset(
+    {
+        cs.RelationshipType.CALLS.value,
+        cs.RelationshipType.REFERENCES.value,
+        cs.RelationshipType.INSTANTIATES.value,
+        cs.RelationshipType.IMPORTS.value,
+        cs.RelationshipType.INHERITS.value,
+    }
+)
 _INHERITS_REL = cs.RelationshipType.INHERITS.value
 
 
@@ -147,6 +160,39 @@ class _StatefulIngestor:
                 return self._path_rows(_FILE_LABEL)
             case cs.CYPHER_ALL_FOLDER_PATHS:
                 return self._path_rows(_FOLDER_LABEL)
+            case cs.CYPHER_AFFECTED_CALLER_PATHS:
+                # Without this case the updater saw no dependents and every
+                # cross-file edge into a re-indexed file relied on the verbatim
+                # restore, which production never does for a file that holds
+                # a dependency edge: it re-parses that file (issue #1560).
+                raw_paths = params.get(cs.CYPHER_PARAM_PATHS) if params else None
+                reindexed: set[str] = (
+                    set(raw_paths) if isinstance(raw_paths, list) else set()
+                )
+                prefix = params.get(cs.KEY_PROJECT_PREFIX) if params else None
+                if not isinstance(prefix, str):
+                    return []
+                affected: set[str] = set()
+                for edge in self.edges:
+                    from_label, from_val, rel_type, to_label, to_val = edge
+                    if rel_type not in _AFFECTED_CALLER_RELS:
+                        continue
+                    target = self.nodes.get((to_label, to_val))
+                    caller = self.nodes.get((from_label, from_val))
+                    if target is None or caller is None:
+                        continue
+                    caller_path = caller.get(cs.KEY_PATH)
+                    if not isinstance(caller_path, str) or caller_path in reindexed:
+                        continue
+                    if target.get(cs.KEY_PATH) not in reindexed:
+                        continue
+                    if not (
+                        str(_text(from_val)).startswith(prefix)
+                        and str(_text(to_val)).startswith(prefix)
+                    ):
+                        continue
+                    affected.add(caller_path)
+                return [{cs.KEY_CALLER_PATH: path} for path in sorted(affected)]
             case cs.CYPHER_INBOUND_EDGES:
                 raw_paths = params.get(cs.CYPHER_PARAM_PATHS) if params else None
                 changed: set[str] = (


### PR DESCRIPTION
Closes #1560. Stacked on #1559 (the C++ case's equality assertion needs that fix; this PR retargets to `main` once it merges).

## What happens

`evals.cgr_graph._StatefulIngestor`, the in-memory graph store the incremental eval and the incremental tests compare against a clean re-index, has no `fetch_all` case for `CYPHER_AFFECTED_CALLER_PATHS`, so it answers `[]`. `GraphUpdater._affected_caller_keys` therefore never finds a dependent under the emulator and every cross-file edge into a re-indexed file has to survive through the verbatim inbound restore. Production Memgraph answers the query and re-parses the dependents (issue #1229 phase 4), so the emulation under-reports edges a real run keeps.

Two measured losses, both absent from a production run:

- Go, same package: touching `base.go` dropped `derived.Make CALLS base.Base.Run`. The restore cannot carry it because `Base.Run` is a deferred receiver method not yet registered when Pass 2 restores; production re-parses `derived.go` instead.
- C++: touching `shape.h` dropped `use CALLS geo.Shape.area`. The header's delete cascades through `DEFINES_METHOD` into the `area` node whose `path` is `shape.cpp`, so the path-keyed capture never sees the edge; production re-parses `shape.cpp` (it IMPORTS the header).

## Fix

The emulator now answers `CYPHER_AFFECTED_CALLER_PATHS` the way the production query does: distinct `caller_path` for every `CALLS|REFERENCES|INSTANTIATES|IMPORTS|INHERITS` edge whose target's `path` is in the re-indexed set, whose caller's `path` is set and not in that set, and whose both qns start with the project prefix (`REFERENCES` in, `OVERRIDES` out, as in the query).

## Test

`test_incremental_inbound_deferred_targets.py` indexes each fixture, touches the defining file, runs an incremental update and asserts the cross-file CALLS edge is present and the snapshot equals the clean index. Both cases red before the emulator change, green after. The existing 86 emulator and incremental tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental indexing reliability when files define deferred cross-file call targets.
  * Preserved inbound call relationships and complete code graphs after incremental updates.

* **Tests**
  * Added regression coverage for incremental reindexing scenarios in Go and C++ projects.
  * Expanded validation of affected dependency paths during reindexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->