### PR TITLE
fix: honour .cgrignore on both sides of every eval arm

### DIFF
--- a/codebase_rag/tests/test_evals_honour_cgrignore.py
+++ b/codebase_rag/tests/test_evals_honour_cgrignore.py
@@ -1,0 +1,94 @@
+"""Grading must cover the file set indexing covers, not a wider one.
+
+No eval arm consulted `.cgrignore`, so a reported precision/recall was
+measured over files the product would never put in a graph (issue #1520).
+An excluded directory is usually vendored or generated code whose shape
+differs from first-party source, so the error is not benign in either
+direction.
+
+Every test here carries a VISIBLE row as a control. An empty result cannot
+distinguish "excluded correctly" from "the fixture produced nothing", and
+the issue reports a first attempt that passed for exactly that wrong
+reason: the fixture returned `[]` with and without `.cgrignore`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.inheritance import cgr_inheritance, oracle_inheritance
+
+_VISIBLE = "class Base2:\n    pass\n\n\nclass Vis(Base2):\n    pass\n"
+_HIDDEN = "class B3:\n    pass\n\n\nclass Hid2(B3):\n    pass\n"
+
+_VISIBLE_EDGE = ("proj.visible.Vis", "proj.visible.Base2")
+_HIDDEN_EDGE = ("proj.ignored.hidden.Hid2", "proj.ignored.hidden.B3")
+
+
+def _make_repo(root: Path, *, cgrignore: str | None) -> None:
+    (root / "ignored").mkdir(parents=True)
+    (root / "visible.py").write_text(_VISIBLE, encoding="utf-8")
+    (root / "ignored" / "hidden.py").write_text(_HIDDEN, encoding="utf-8")
+    if cgrignore is not None:
+        (root / ".cgrignore").write_text(cgrignore, encoding="utf-8")
+
+
+def test_the_oracle_without_cgrignore_sees_both(tmp_path: Path) -> None:
+    """The control. Without it, exclusion and an empty fixture look alike."""
+    src = tmp_path / "proj"
+    _make_repo(src, cgrignore=None)
+
+    inherits = oracle_inheritance(src, "proj").inherits
+
+    assert _VISIBLE_EDGE in inherits, inherits
+    assert _HIDDEN_EDGE in inherits, inherits
+
+
+def test_the_oracle_honours_cgrignore(tmp_path: Path) -> None:
+    src = tmp_path / "proj"
+    _make_repo(src, cgrignore="ignored/\n")
+
+    inherits = oracle_inheritance(src, "proj").inherits
+
+    assert _VISIBLE_EDGE in inherits, "the fixture stopped producing any row"
+    assert _HIDDEN_EDGE not in inherits, inherits
+
+
+def test_cgr_without_cgrignore_sees_both(tmp_path: Path) -> None:
+    """The control for the cgr side."""
+    src = tmp_path / "proj"
+    _make_repo(src, cgrignore=None)
+
+    inherits = cgr_inheritance(src, "proj").inherits
+
+    assert _VISIBLE_EDGE in inherits, inherits
+    assert _HIDDEN_EDGE in inherits, inherits
+
+
+def test_cgr_honours_cgrignore(tmp_path: Path) -> None:
+    src = tmp_path / "proj"
+    _make_repo(src, cgrignore="ignored/\n")
+
+    inherits = cgr_inheritance(src, "proj").inherits
+
+    assert _VISIBLE_EDGE in inherits, "the fixture stopped producing any row"
+    assert _HIDDEN_EDGE not in inherits, inherits
+
+
+def test_both_sides_agree_under_cgrignore(tmp_path: Path) -> None:
+    """The halves must move together or grading regresses.
+
+    Excluding only the cgr capture drops true positives while the oracle
+    still emits the ignored row, which scores as a recall regression and
+    reads like a grading bug rather than a scope fix. A test that changes
+    one side would look like it caught something and have made it worse.
+    """
+    src = tmp_path / "proj"
+    _make_repo(src, cgrignore="ignored/\n")
+
+    oracle = oracle_inheritance(src, "proj").inherits
+    cgr = cgr_inheritance(src, "proj").inherits
+
+    assert _VISIBLE_EDGE in oracle and _VISIBLE_EDGE in cgr
+    assert _HIDDEN_EDGE not in oracle
+    assert _HIDDEN_EDGE not in cgr

--- a/codebase_rag/tests/test_evals_honour_cgrignore.py
+++ b/codebase_rag/tests/test_evals_honour_cgrignore.py
@@ -93,3 +93,36 @@ def test_both_sides_agree_under_cgrignore(tmp_path: Path) -> None:
     assert _VISIBLE_EDGE in cgr, "cgr stopped producing any row"
     assert _HIDDEN_EDGE not in oracle, oracle
     assert _HIDDEN_EDGE not in cgr, cgr
+    assert oracle == cgr, oracle ^ cgr
+
+
+_RESCUED = "class B4:\n    pass\n\n\nclass Res(B4):\n    pass\n"
+_RESCUED_EDGE = ("proj.build.keep.Res", "proj.build.keep.B4")
+
+
+def test_an_unignored_file_under_a_built_in_ignored_dir_reaches_both(
+    tmp_path: Path,
+) -> None:
+    """The case a second filter cannot rescue.
+
+    `build/` is a built-in ignore, and `should_skip_path` applies those only
+    AFTER `unignore_paths` has had its say, so `!build/keep.py` reaches the
+    graph. A pre-filter running before it drops the file from the oracle
+    only, which is the oracle-versus-cgr divergence this issue closes,
+    reintroduced one layer up (CodeRabbit, PR #1563).
+
+    The visible edge is asserted alongside so a fixture that produced
+    nothing cannot satisfy this by emptiness.
+    """
+    src = tmp_path / "proj"
+    (src / "build").mkdir(parents=True)
+    (src / "visible.py").write_text(_VISIBLE, encoding="utf-8")
+    (src / "build" / "keep.py").write_text(_RESCUED, encoding="utf-8")
+    (src / ".cgrignore").write_text("!build/keep.py\n", encoding="utf-8")
+
+    oracle = oracle_inheritance(src, "proj").inherits
+    cgr = cgr_inheritance(src, "proj").inherits
+
+    assert _VISIBLE_EDGE in oracle, "the fixture stopped producing any row"
+    assert _RESCUED_EDGE in oracle, f"the oracle dropped the rescued file: {oracle}"
+    assert _RESCUED_EDGE in cgr, f"cgr dropped the rescued file: {cgr}"

--- a/codebase_rag/tests/test_evals_honour_cgrignore.py
+++ b/codebase_rag/tests/test_evals_honour_cgrignore.py
@@ -89,6 +89,7 @@ def test_both_sides_agree_under_cgrignore(tmp_path: Path) -> None:
     oracle = oracle_inheritance(src, "proj").inherits
     cgr = cgr_inheritance(src, "proj").inherits
 
-    assert _VISIBLE_EDGE in oracle and _VISIBLE_EDGE in cgr
-    assert _HIDDEN_EDGE not in oracle
-    assert _HIDDEN_EDGE not in cgr
+    assert _VISIBLE_EDGE in oracle, "the oracle stopped producing any row"
+    assert _VISIBLE_EDGE in cgr, "cgr stopped producing any row"
+    assert _HIDDEN_EDGE not in oracle, oracle
+    assert _HIDDEN_EDGE not in cgr, cgr

--- a/evals/ast_oracle.py
+++ b/evals/ast_oracle.py
@@ -208,17 +208,20 @@ def _base_name(expr: ast.expr) -> str | None:
 
 
 def _iter_py_files(target: Path) -> Iterator[Path]:
-    # `.cgrignore`/`.gitignore` are consulted through the indexer's own
-    # predicate rather than reimplemented here, so the oracle grades the file
-    # set the graph would actually contain (issue #1520). A second copy of the
-    # rule would agree on today's fixtures and drift silently afterwards.
+    # `should_skip_path` is the SINGLE filter, not one of two. It is the
+    # indexer's own predicate, so the oracle grades the file set the graph
+    # would actually contain (issue #1520).
+    #
+    # The `ec.IGNORE_DIRS` and egg-info pre-filters that used to run above it
+    # are gone rather than kept alongside. They ran BEFORE it and so could not
+    # be rescued: `should_skip_path` applies the built-in ignores only after
+    # `unignore_paths` has had its say, so `!vendor/keep.py` under an ignored
+    # `vendor/` reaches the graph while a pre-filter dropped it from the
+    # oracle. Two filters that disagree on one file are the same
+    # oracle-versus-cgr divergence this issue exists to close, reintroduced
+    # one layer up (CodeRabbit, PR #1563).
     exclude_paths, unignore_paths = ignore_rules(target)
     for path in target.rglob(f"*{ec.PY_SUFFIX}"):
-        parts = path.relative_to(target).parts
-        if set(parts) & ec.IGNORE_DIRS:
-            continue
-        if any(part.endswith(ec.EGG_INFO_SUFFIX) for part in parts):
-            continue
         if should_skip_path(path, target, exclude_paths, unignore_paths, is_file=True):
             continue
         yield path

--- a/evals/ast_oracle.py
+++ b/evals/ast_oracle.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from loguru import logger
 
 from codebase_rag import constants as cs
+from codebase_rag.utils.path_utils import should_skip_path
 
 from . import constants as ec
 from . import logs as ls
+from .ignore_rules import ignore_rules
 from .types_defs import DefNode, EdgeKey, GraphData, NameEdge, NodeKey
 
 _MODULE = cs.NodeLabel.MODULE.value
@@ -206,11 +208,18 @@ def _base_name(expr: ast.expr) -> str | None:
 
 
 def _iter_py_files(target: Path) -> Iterator[Path]:
+    # `.cgrignore`/`.gitignore` are consulted through the indexer's own
+    # predicate rather than reimplemented here, so the oracle grades the file
+    # set the graph would actually contain (issue #1520). A second copy of the
+    # rule would agree on today's fixtures and drift silently afterwards.
+    exclude_paths, unignore_paths = ignore_rules(target)
     for path in target.rglob(f"*{ec.PY_SUFFIX}"):
         parts = path.relative_to(target).parts
         if set(parts) & ec.IGNORE_DIRS:
             continue
         if any(part.endswith(ec.EGG_INFO_SUFFIX) for part in parts):
+            continue
+        if should_skip_path(path, target, exclude_paths, unignore_paths, is_file=True):
             continue
         yield path
 

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -6,6 +6,7 @@ from codebase_rag.parser_loader import load_parsers
 from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
 
 from . import constants as ec
+from .ignore_rules import ignore_rules
 from .types_defs import DefNode, EdgeKey, GraphData, NameEdge, NodeKey
 
 _RelTuple = tuple[str, PropertyValue, str, str, PropertyValue]
@@ -318,11 +319,14 @@ class _StatefulIngestor:
 def _capture(target: Path, project_name: str) -> _CapturingIngestor:
     parsers, queries = load_parsers()
     ingestor = _CapturingIngestor()
+    exclude_paths, unignore_paths = ignore_rules(target)
     GraphUpdater(
         ingestor=ingestor,
         repo_path=target,
         parsers=parsers,
         queries=queries,
+        exclude_paths=exclude_paths,
+        unignore_paths=unignore_paths,
         project_name=project_name,
     ).run(force=True)
     return ingestor

--- a/evals/ignore_rules.py
+++ b/evals/ignore_rules.py
@@ -1,0 +1,24 @@
+# The eligible-file rules for a graded target, read from the same place the
+# indexer reads them so grading covers the file set indexing covers.
+#
+# Both sides of every arm must consult this. Applying it to the cgr capture
+# alone would drop true positives while the oracle still emitted rows for an
+# excluded file, scoring as a recall regression that reads like a grading bug
+# rather than a scope fix (issue #1520).
+from pathlib import Path
+
+from codebase_rag.config import load_ignore_patterns
+
+IgnoreRules = tuple[frozenset[str] | None, frozenset[str] | None]
+
+
+def ignore_rules(target: Path) -> IgnoreRules:
+    """`(exclude_paths, unignore_paths)` for `target`, or `(None, None)`.
+
+    `None` rather than an empty frozenset because that is what the indexer's
+    own callers pass when a repository configures nothing, and what
+    `GraphUpdater` and `should_skip_path` treat as "no rules"; an empty set
+    is not equivalent everywhere downstream.
+    """
+    patterns = load_ignore_patterns(target)
+    return (patterns.exclude or None, patterns.unignore or None)


### PR DESCRIPTION
Closes #1520.

No eval arm consulted `.cgrignore`, so grading covered files the indexer excludes and a reported precision/recall was measured over a different file set than the graph a user actually builds.

## Both sides move together

The issue is explicit that this is the constraint, and it is the reason the change touches two files rather than one. Excluding only the cgr capture would drop true positives while the oracle still emitted rows for the ignored file: a recall regression that reads like a grading bug rather than a scope fix.

- **cgr side** — `_capture` in `evals/cgr_graph.py` now passes `exclude_paths`/`unignore_paths` to `GraphUpdater`. It already accepted both and was simply never given them, so this arm needed no new logic. It covers **every** language arm at once, since all of them capture through `_capture`.
- **oracle side** — `_iter_py_files` in `evals/ast_oracle.py` now filters through `should_skip_path`, the predicate the indexer itself uses.

`should_skip_path` is called rather than reimplemented deliberately. A second copy of the rule would agree on today's fixtures and drift silently afterwards, which is the defect `walk_eligible_files` was extracted to remove in #1511.

**`evals/ignore_rules.py`** loads the patterns once for both sides, so the two cannot diverge on *which* rules they apply, only on how they apply them. It returns `None` rather than an empty frozenset when a repository configures nothing, because that is what the indexer's own callers pass and what `GraphUpdater` and `should_skip_path` treat as "no rules".

## Tests, and why the controls are load-bearing

Five tests, all verified RED before the fix. Three failed, and **two passed from the start on purpose**.

The issue documents a first attempt that passed for the wrong reason: a fixture returning `[]` with `.cgrignore` present looks exactly like correct exclusion, and removing `.cgrignore` also returned `[]` because an unresolved import meant the fixture never produced a row at all. An empty result cannot distinguish "excluded correctly" from "found nothing".

So each side carries a control asserting the visible row is present **without** `.cgrignore`:

```
test_the_oracle_without_cgrignore_sees_both   PASSED before and after
test_cgr_without_cgrignore_sees_both          PASSED before and after
test_the_oracle_honours_cgrignore             RED -> green
test_cgr_honours_cgrignore                    RED -> green
test_both_sides_agree_under_cgrignore         RED -> green
```

The controls passing throughout is the evidence that the three transitions are real. Every assertion also names the visible edge positively, not merely the absence of the ignored one, so a fixture that stopped producing rows fails rather than passing silently.

The fixture uses same-file inheritance (`class Vis(Base2)` beside its base), which avoids the unresolved-import trap that made the issue author's first attempt vacuous.

The fifth test exists only to pin the constraint above: it asserts the visible edge is on both sides and the ignored edge is on neither, so a future change that moves one half fails here rather than showing up as a score regression.

## Scope I could not verify, stated rather than implied

`_capture` covers the cgr side of every arm, and the Python oracle is fixed. **The Java, C++, C# and TypeScript oracles walk their own targets and are not covered by this change**, so their oracle halves may still see ignored files.

I did not extend to them here because I cannot execute them in this container to verify: `dotnet build` of the C# oracle exits 1 and `ruby_ast.js` exits 1, and the same failures occur unchanged at `origin/main`. Shipping an unverified traversal change to four oracles I cannot run would be exactly the partial fix this issue warns against, with the additional hazard that the loud half is the one I would be repairing. The acceptance criterion asking every `--language` arm to be covered is therefore only partly met, and the remaining arms want either a follow-up from someone with those toolchains or a fixture that does not need them.

## Consequence worth knowing before merge

`load_ignore_patterns` merges the root `.gitignore` as well as `.cgrignore`. Running the evals against a real repository will now exclude gitignored paths, so published numbers will move. That is the intent of the issue rather than a side effect, but it means the next reported figures are not comparable with the previous ones.

## Checks

The five new tests pass. `-k "eval or oracle or import or inherit or ignore"` gives 1080 passed with 23 failures and 4 errors, every one of them `dotnet build` or `ruby_ast.js exited 1`. Verified pre-existing by running the same files at `origin/main`, where the Ruby oracle fails 8 for 8 identically. No `AssertionError` anywhere in the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation results now honor `.cgrignore` and `.gitignore` rules.
  * Precision and recall grading consistently uses the same eligible files as indexing.
  * Ignored files are excluded from inheritance comparisons, while explicitly unignored files continue to be evaluated.

* **Tests**
  * Added coverage for ignored files, visible files, unignored files, and configurations without ignore rules.
  * Evaluation results now verify complete agreement between grading methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->