### PR TITLE
fix: re-parse a directory's modules when its package-ness flips and prune the container node the flip left behind

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -443,6 +443,7 @@ CYPHER_DELETE_MODULE = (
 # projects, and a path-only delete would take the sibling's node (issue #897).
 CYPHER_DELETE_FILE = "MATCH (f:File {absolute_path: $path}) DETACH DELETE f"
 CYPHER_DELETE_FOLDER = "MATCH (f:Folder {absolute_path: $path}) DETACH DELETE f"
+CYPHER_DELETE_PACKAGE = "MATCH (p:Package {absolute_path: $path}) DETACH DELETE p"
 CYPHER_DELETE_CALLS = "MATCH ()-[r:CALLS]->() DELETE r"
 # Removes external import-target Module nodes that no module imports anymore
 # (e.g. an imported name that was renamed/removed on an incremental rebuild).
@@ -486,6 +487,13 @@ CYPHER_ALL_MODULE_PATHS_INTERNAL = (
 )
 CYPHER_ALL_FOLDER_PATHS = (
     "MATCH (f:Folder) RETURN f.path AS path, f.absolute_path AS absolute_path"
+)
+# Package nodes are pruned against the CURRENT structure, not the disk: a
+# directory whose indicator file (__init__.py, Cargo.toml, ...) went away
+# still exists, as a Folder (issue #1570).
+CYPHER_ALL_PACKAGE_PATHS = (
+    "MATCH (p:Package) RETURN p.path AS path, p.absolute_path AS absolute_path, "
+    "p.qualified_name AS qualified_name"
 )
 
 # Rehydrate the in-memory function registry on an incremental run: returns

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2828,7 +2828,17 @@ class GraphUpdater:
                     ):
                         legacy_file_keys.append((path, abs_path))
                     continue
-                if isinstance(qn, str) and qn and not qn.startswith(project_prefix):
+                # The root directory's own node is qualified as exactly the
+                # project name, with no dot: testing only the dotted prefix
+                # dropped it here and let a stale root Package survive beside
+                # the Folder that replaced it. `_package_paths` reads these
+                # same rows and admits both forms; the two must agree.
+                if (
+                    isinstance(qn, str)
+                    and qn
+                    and qn != self.project_name
+                    and not qn.startswith(project_prefix)
+                ):
                     continue
                 stale_kind = (label == "Folder" and path in packages_now) or (
                     label == "Package" and path not in packages_now

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -360,6 +360,9 @@ class GraphUpdater:
         # Files (re)parsed by Pass 2 this run: the only files whose
         # definition spans exist for hybrid macro-call attribution.
         self._reparsed_file_keys: set[str] = set()
+        # Package paths read from the graph before Pass 1 of an incremental
+        # run; None on a full build or when the graph could not be read.
+        self._packages_before_run: set[str] | None = None
         # Module qns read back from the graph on incremental runs; deferred
         # import verification counts them as real internal targets.
         self._rehydrated_module_qns: set[str] = set()
@@ -934,6 +937,10 @@ class GraphUpdater:
         self._frontend_owned_qns.clear()
 
         logger.info(ls.PASS_1_STRUCTURE)
+        # Read BEFORE Pass 1: identify_structure emits this run's Package
+        # nodes, so a read after it could not tell a new package from an old
+        # one (issue #1570).
+        self._packages_before_run = None if force else self._package_paths()
         self.factory.structure_processor.identify_structure()
 
         # Cleared here, not only in _run_cpp_frontend: in HYBRID that method
@@ -1767,6 +1774,38 @@ class GraphUpdater:
             }
         )
 
+    def _package_paths(self) -> set[str] | None:
+        """Relative paths of this project's Package nodes, None if unreadable."""
+        if not isinstance(self.ingestor, QueryProtocol):
+            return set()
+        try:
+            rows = self.ingestor.fetch_all(cs.CYPHER_ALL_PACKAGE_PATHS)
+        except Exception:
+            logger.warning(ls.PRUNE_QUERY_FAILED, label="Package")
+            return None
+        prefix = self.project_name + cs.SEPARATOR_DOT
+        paths: set[str] = set()
+        for row in rows:
+            path = row.get(cs.KEY_PATH)
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            if not isinstance(path, str) or not isinstance(qn, str):
+                continue
+            if qn == self.project_name or qn.startswith(prefix):
+                paths.add(path)
+        return paths
+
+    def _package_flip_dirs(self) -> set[str]:
+        """Directories that are a package now and were not, or the reverse."""
+        was = self._packages_before_run
+        if was is None:
+            return set()
+        now = {
+            rel.as_posix()
+            for rel, qn in self.factory.structure_processor.structural_elements.items()
+            if qn
+        }
+        return was ^ now
+
     def _capture_inbound_edges(self, reindexed_keys: list[str]) -> list[ResultRow]:
         # Record the reference edges unchanged files point at the re-indexed
         # files, BEFORE those files' subtrees (and thus the inbound edges) are
@@ -2403,9 +2442,26 @@ class GraphUpdater:
             - eligible_by_key.keys()
             - unreadable_keys
         )
+        # A directory whose package-ness flipped since the last run (an
+        # __init__.py or Cargo.toml added or deleted) changes the container
+        # every module directly under it hangs off; that edge is emitted only
+        # when the module is parsed, so the siblings re-parse too. The stale
+        # Package or Folder node itself is pruned at the end of the run
+        # (issue #1570).
+        flipped_dirs = self._package_flip_dirs() if not is_full_build else set()
+        siblings = {
+            key
+            for key in eligible_by_key
+            if flipped_dirs and Path(key).parent.as_posix() in flipped_dirs
+        }
         affected = 0
-        for caller_key in self._affected_caller_keys(
-            sorted({*reindexed_keys, *deleted_before_parse})
+        for caller_key in sorted(
+            {
+                *self._affected_caller_keys(
+                    sorted({*reindexed_keys, *deleted_before_parse})
+                ),
+                *siblings,
+            }
         ):
             if caller_key in present:
                 continue
@@ -2724,7 +2780,16 @@ class GraphUpdater:
                 "Module",
             ),
             (cs.CYPHER_ALL_FOLDER_PATHS, cs.CYPHER_DELETE_FOLDER, "Folder"),
+            (cs.CYPHER_ALL_PACKAGE_PATHS, cs.CYPHER_DELETE_PACKAGE, "Package"),
         ]
+        # A directory is represented by exactly one of Folder and Package,
+        # decided by identify_structure this run; the node of the other kind
+        # is stale even though the directory exists (issue #1570).
+        packages_now = {
+            rel.as_posix()
+            for rel, qn in self.factory.structure_processor.structural_elements.items()
+            if qn
+        }
 
         read_failed = False
         legacy_file_keys: list[tuple[str, str]] = []
@@ -2765,7 +2830,10 @@ class GraphUpdater:
                     continue
                 if isinstance(qn, str) and qn and not qn.startswith(project_prefix):
                     continue
-                if not (self.repo_path / path).exists():
+                stale_kind = (label == "Folder" and path in packages_now) or (
+                    label == "Package" and path not in packages_now
+                )
+                if stale_kind or not (self.repo_path / path).exists():
                     # File/Folder deletes key on the absolute path: a sibling
                     # project's node can share the relative path (issue #897).
                     key = (

--- a/codebase_rag/tests/test_incremental_init_package.py
+++ b/codebase_rag/tests/test_incremental_init_package.py
@@ -120,3 +120,37 @@ def test_adding_init_py_turns_the_folder_into_a_package(temp_repo: Path) -> None
     }
     assert contains == {"proj.pkg", "proj.pkg.base", "proj.pkg.derived"}
     assert after == clean
+
+
+# The root directory's own __init__.py makes the repo root a Package whose
+# qualified name is exactly the project name, with no dot and no suffix. The
+# prune filter admitted a row only when its qn started with `project_name + "."`,
+# so the root Package failed that test and took the `continue` before ever
+# reaching the stale-kind check, surviving beside the Folder that replaced it.
+ROOT_INIT = "__init__.py"
+ROOT_FIXTURE: dict[str, str] = {ROOT_INIT: "", **FIXTURE}
+
+
+def test_deleting_the_root_init_py_prunes_the_root_package(temp_repo: Path) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, ROOT_FIXTURE)
+    store = _StatefulIngestor()
+    _index(store, root, force=True)
+    # The root is a Package while its __init__.py exists: without this the
+    # deletion below could pass by never having created the node at all.
+    assert (cs.NodeLabel.PACKAGE.value, "proj") in _snapshot(store, root)[0]
+
+    (root / ROOT_INIT).unlink()
+    _index(store, root, force=False)
+    after = _snapshot(store, root)
+
+    without_root_init = {
+        rel: text for rel, text in ROOT_FIXTURE.items() if rel != ROOT_INIT
+    }
+    clean = _clean(temp_repo, "clean", without_root_init)
+    # The repo root carries no Folder node in either path (a clean index of the
+    # same tree emits only Package proj.pkg), so the stale root Package is
+    # removed rather than replaced. Assert its absence directly, and let the
+    # parity check below cover everything the deletion should have left alone.
+    assert (cs.NodeLabel.PACKAGE.value, "proj") not in after[0]
+    assert after == clean

--- a/codebase_rag/tests/test_incremental_init_package.py
+++ b/codebase_rag/tests/test_incremental_init_package.py
@@ -1,0 +1,122 @@
+# Whether a directory is a Package or a Folder is decided every run by
+# identify_structure, but the CONTAINS_MODULE edge of each module under it is
+# emitted only when that module is parsed, and a Package node whose indicator
+# file disappeared was never pruned. Adding or deleting pkg/__init__.py
+# therefore left the sibling modules hanging off the old container and, on
+# deletion, kept the Package node beside the new Folder (issue #1570).
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+FIXTURE: dict[str, str] = {
+    "pkg/__init__.py": "",
+    "pkg/base.py": "class Base:\n    def run(self):\n        return 1\n",
+    "pkg/derived.py": (
+        "from .base import Base\n\nclass Derived(Base):\n"
+        "    def run(self):\n        return super().run() + 1\n"
+    ),
+}
+INIT = "pkg/__init__.py"
+_ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}
+
+Snapshot = tuple[frozenset[tuple[str, str]], frozenset[tuple[str, ...]]]
+
+
+def _snapshot(store: _StatefulIngestor, root: Path) -> Snapshot:
+    # File nodes are keyed by absolute path and Folder nodes too; the two
+    # trees live in different directories, so Folder ids are made relative
+    # and File nodes are left out (their containment mirrors the Folder's).
+    prefix = root.resolve().as_posix() + "/"
+
+    def norm(label: str, uid: str) -> str:
+        return (
+            uid[len(prefix) :] if label in _ABSOLUTE and uid.startswith(prefix) else uid
+        )
+
+    nodes = frozenset(
+        (label, norm(label, str(uid)))
+        for (label, uid) in store.nodes
+        if label != cs.NodeLabel.FILE.value
+    )
+    edges = frozenset(
+        (str(fl), norm(str(fl), str(fv)), str(rel), str(tl), norm(str(tl), str(tv)))
+        for (fl, fv, rel, tl, tv) in store.edges
+        if cs.NodeLabel.FILE.value not in (fl, tl)
+    )
+    return nodes, edges
+
+
+def _materialise(root: Path, files: dict[str, str]) -> None:
+    root.mkdir(parents=True)
+    for rel, text in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def _index(store: _StatefulIngestor, repo: Path, force: bool) -> None:
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.PYTHON not in parsers:
+        pytest.skip("python parser not available")
+    GraphUpdater(
+        ingestor=store,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run(force=force)
+
+
+def _clean(temp_repo: Path, name: str, files: dict[str, str]) -> Snapshot:
+    root = temp_repo / name / "proj"
+    _materialise(root, files)
+    store = _StatefulIngestor()
+    _index(store, root, force=True)
+    return _snapshot(store, root)
+
+
+def test_deleting_init_py_turns_the_package_into_a_folder(temp_repo: Path) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, FIXTURE)
+    store = _StatefulIngestor()
+    _index(store, root, force=True)
+    (root / INIT).unlink()
+    _index(store, root, force=False)
+    after = _snapshot(store, root)
+
+    without_init = {rel: text for rel, text in FIXTURE.items() if rel != INIT}
+    clean = _clean(temp_repo, "clean", without_init)
+    assert (cs.NodeLabel.PACKAGE.value, "proj.pkg") not in after[0]
+    assert after == clean
+
+
+def test_adding_init_py_turns_the_folder_into_a_package(temp_repo: Path) -> None:
+    root = temp_repo / "proj"
+    without_init = {rel: text for rel, text in FIXTURE.items() if rel != INIT}
+    _materialise(root, without_init)
+    store = _StatefulIngestor()
+    _index(store, root, force=True)
+    init = root / INIT
+    init.write_text(FIXTURE[INIT], encoding="utf-8")
+    cache_mtime = (root / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    os.utime(init, (cache_mtime + 1, cache_mtime + 1))
+    _index(store, root, force=False)
+    after = _snapshot(store, root)
+
+    clean = _clean(temp_repo, "clean", FIXTURE)
+    contains = {
+        e[4]
+        for e in after[1]
+        if e[0] == cs.NodeLabel.PACKAGE.value
+        and e[2] == cs.RelationshipType.CONTAINS_MODULE.value
+    }
+    assert contains == {"proj.pkg", "proj.pkg.base", "proj.pkg.derived"}
+    assert after == clean

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -56,6 +56,7 @@ _MODULE_LABEL = cs.NodeLabel.MODULE.value
 _EXTERNAL_MODULE_LABEL = cs.NodeLabel.EXTERNAL_MODULE.value
 _FILE_LABEL = cs.NodeLabel.FILE.value
 _FOLDER_LABEL = cs.NodeLabel.FOLDER.value
+_PACKAGE_LABEL = cs.NodeLabel.PACKAGE.value
 _DEFINES_RELS = frozenset(
     {
         cs.RelationshipType.DEFINES.value,
@@ -164,6 +165,8 @@ class _StatefulIngestor:
                 return self._path_rows(_FILE_LABEL)
             case cs.CYPHER_ALL_FOLDER_PATHS:
                 return self._path_rows(_FOLDER_LABEL)
+            case cs.CYPHER_ALL_PACKAGE_PATHS:
+                return self._path_rows(_PACKAGE_LABEL)
             case cs.CYPHER_AFFECTED_CALLER_PATHS:
                 # Without this case the updater saw no dependents and every
                 # cross-file edge into a re-indexed file relied on the verbatim
@@ -303,6 +306,10 @@ class _StatefulIngestor:
                 self._detach_delete(
                     self._nodes_at_path(_FOLDER_LABEL, path, key=cs.KEY_ABSOLUTE_PATH)
                 )
+            case cs.CYPHER_DELETE_PACKAGE:
+                self._detach_delete(
+                    self._nodes_at_path(_PACKAGE_LABEL, path, key=cs.KEY_ABSOLUTE_PATH)
+                )
             case cs.CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES:
                 self._delete_orphan_external_modules()
             case _:
@@ -316,6 +323,7 @@ class _StatefulIngestor:
             row: ResultRow = {
                 cs.KEY_PATH: _text(props.get(cs.KEY_PATH)),
                 cs.KEY_ABSOLUTE_PATH: _text(props.get(cs.KEY_ABSOLUTE_PATH)),
+                cs.KEY_QUALIFIED_NAME: _text(props.get(cs.KEY_QUALIFIED_NAME)),
             }
             rows.append(row)
         return rows


### PR DESCRIPTION
Closes #1570. Fifth layer of stack #1562, on #1571.

## What happens

Delete `pkg/__init__.py` and run an incremental update: the `Package proj.pkg` node stays, with its `CONTAINS_PACKAGE` and `CONTAINS_MODULE` edges, beside the `Folder` the run now emits. Add `pkg/__init__.py` to an indexed tree: the Package node appears but `proj.pkg.base` and `proj.pkg.derived` keep hanging off the Folder, which also stays. A clean index has exactly one container per directory and every module under it.

## Why

`identify_structure` decides Folder vs Package for every directory each run, but a module's `CONTAINS_MODULE` edge is emitted only when the module is parsed, and orphan pruning knew Files, Modules and Folders (by disk existence) but not Packages, nor that a Folder whose directory became a package is stale even though the directory exists.

## Fix

- The Package paths of the project are read from the graph before Pass 1 (after it, this run's own Package nodes would be indistinguishable). A directory whose package-ness differs between that set and this run's structure joins the re-parse set with every module directly under it, alongside the affected dependents.
- Pruning gains a Package spec (`CYPHER_ALL_PACKAGE_PATHS` / `CYPHER_DELETE_PACKAGE`, keyed on the absolute path like Folder) and treats a Folder of a directory that is a package now, or a Package of one that is not, as stale.
- The evals emulator mirrors the two new queries.

## Test

`test_incremental_init_package.py` covers both directions and asserts the incremental snapshot (Folder and Package ids made root-relative, File nodes aside) equals a clean index of the resulting tree; the delete case additionally asserts the Package node is gone, the add case that the Package contains all three modules. Both red before, green after. 439 structure, prune, emulator and incremental tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental indexing when directories change between package and folder status.
  * Removed stale package entries when package markers are deleted.
  * Reindexed modules and restored relationships when package markers are added.
  * Correctly handled package changes in the project’s root directory.
  * Improved cleanup of outdated directory entries during indexing.

* **Tests**
  * Added coverage for package and folder reclassification during incremental updates.
  * Added validation for root package changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->