### PR TITLE
fix: same-stem siblings get the module qns a clean index gives them when one is added or deleted

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -556,7 +556,7 @@ CYPHER_INBOUND_EDGES = (
     "RETURN head(labels(caller)) AS caller_label, "
     "caller.qualified_name AS caller_qn, type(r) AS rel, "
     "head(labels(target)) AS target_label, target.qualified_name AS target_qn, "
-    "properties(r) AS props"
+    "caller.path AS caller_path, properties(r) AS props"
 )
 # Files whose code DEPENDS on a re-indexed file (issue #1229 phase 4): a
 # change there can rebind their calls (a new override shadowing an inherited

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2757,8 +2757,9 @@ class GraphUpdater:
         # earlier claims the survivor's old module qn, the MERGE lands on the
         # old node and rewrites its path, and the per-file delete by path
         # then finds nothing, leaving the old definitions beside the new
-        # ones (issue #1569). The per-file delete below stays as a no-op
-        # guard for the cacheless full build.
+        # ones (issue #1569). This loop is the only graph delete on the
+        # re-parse path: every non-new entry is in reindexed_keys, so the
+        # per-file loop below only clears local state.
         for stale_key in (*reindexed_keys, *deleted_before_parse):
             self._delete_module_entities(stale_key)
 
@@ -2783,7 +2784,6 @@ class GraphUpdater:
                         and cached_relative_path(filepath, self.repo_path).as_posix()
                         in self._cpp_frontend_covered,
                     )
-                    self._delete_module_entities(file_key)
 
                 changed_count += 1
                 self._process_single_file(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -280,6 +280,11 @@ def _save_parser_fingerprint(stamp_path: Path, fingerprint: str) -> None:
         logger.warning(ls.PARSER_FINGERPRINT_SAVE_FAILED, path=stamp_path, error=e)
 
 
+def _stem_key(file_key: str) -> str:
+    """The relative path without its extension: what same-stem siblings share."""
+    return Path(file_key).with_suffix("").as_posix()
+
+
 def _load_dir_mtimes(cache_path: Path) -> DirMtimesCache:
     if not cache_path.is_file():
         return {}
@@ -1666,7 +1671,11 @@ class GraphUpdater:
                 self._rehydrated_module_qns.add(qn)
         self._rehydrate_class_inheritance_from_graph()
 
-    def _seed_module_qns_from_graph(self, eligible_paths: set[str]) -> None:
+    def _seed_module_qns_from_graph(
+        self,
+        eligible_paths: set[str],
+        flux_stems: frozenset[str] | set[str] = frozenset(),
+    ) -> None:
         # Cross-language module-qn disambiguation (definition_processor.
         # _disambiguate_module_qn) only sees files processed this run. On an
         # incremental ADD of a file whose basename collides with an already-
@@ -1693,6 +1702,9 @@ class GraphUpdater:
             # eligible_paths, so a same-basename ADD (delete shapes.rs + add
             # shapes.cpp) takes the bare qn a clean index would give it.
             if path not in eligible_paths:
+                continue
+            # A survivor of a stem in flux re-parses unseeded (issue #1569).
+            if _stem_key(path) in flux_stems:
                 continue
             module_map.setdefault(qn, self.repo_path / path)
 
@@ -2528,8 +2540,22 @@ class GraphUpdater:
 
         eligible_files = self._collect_eligible_files()
 
+        # Stems with a same-stem sibling added or deleted this run: their
+        # survivors are not seeded and re-parse below, so the bare qn goes to
+        # whichever file the clean rule (first in walk order) gives it,
+        # rather than to whichever file was indexed first (issue #1569).
+        eligible_keys = {key for _fp, key in eligible_files}
+        flux_stems = (
+            set()
+            if is_full_build
+            else {
+                _stem_key(key)
+                for key in (eligible_keys - old_hashes.keys())
+                | (old_hashes.keys() - eligible_keys)
+            }
+        )
         if not is_full_build:
-            self._seed_module_qns_from_graph({key for _fp, key in eligible_files})
+            self._seed_module_qns_from_graph(eligible_keys, flux_stems)
         # A full build can still land on a graph that already holds this
         # project: the cache lives in the repo working tree, the graph does
         # not, so a fresh clone of an indexed repo (or a force run) parses
@@ -2673,7 +2699,8 @@ class GraphUpdater:
         siblings = {
             key
             for key in eligible_by_key
-            if flipped_dirs and Path(key).parent.as_posix() in flipped_dirs
+            if (flipped_dirs and Path(key).parent.as_posix() in flipped_dirs)
+            or (flux_stems and _stem_key(key) in flux_stems)
         }
         affected = 0
         for caller_key in sorted(
@@ -2702,10 +2729,34 @@ class GraphUpdater:
             reindexed_keys = sorted(
                 file_key for _fp, file_key, is_new, _b in changed_entries if not is_new
             )
-        captured_inbound = self._capture_inbound_edges(reindexed_keys)
+        # Pass 2 order decides which same-stem file claims the bare module
+        # qn; a clean build processes files in walk order, so the re-parse
+        # set follows it too instead of the order the dependents were found.
+        eligible_order = {key: i for i, (_fp, key) in enumerate(eligible_files)}
+        changed_entries.sort(key=lambda entry: eligible_order.get(entry[1], -1))
+        # A caller that lives in a DELETED file must not be restored: its
+        # module is gone, and if a surviving same-stem sibling has just taken
+        # over its qn the restore would hang the dead file's edge on the
+        # survivor (issue #1569).
+        deleted_set = set(deleted_before_parse)
+        captured_inbound = [
+            row
+            for row in self._capture_inbound_edges(reindexed_keys)
+            if row.get(cs.KEY_CALLER_PATH) not in deleted_set
+        ]
         self._reparsed_file_keys = {
             file_key for _fp, file_key, _new, _b in changed_entries
         }
+
+        # Every old subtree goes BEFORE any file of this run is parsed, not
+        # one by one as each file is reached: a same-stem sibling parsed
+        # earlier claims the survivor's old module qn, the MERGE lands on the
+        # old node and rewrites its path, and the per-file delete by path
+        # then finds nothing, leaving the old definitions beside the new
+        # ones (issue #1569). The per-file delete below stays as a no-op
+        # guard for the cacheless full build.
+        for stale_key in (*reindexed_keys, *deleted_before_parse):
+            self._delete_module_entities(stale_key)
 
         pre_parsed = self._pre_parse_changed_files(changed_entries)
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2702,11 +2702,15 @@ class GraphUpdater:
             if (flipped_dirs and Path(key).parent.as_posix() in flipped_dirs)
             or (flux_stems and _stem_key(key) in flux_stems)
         }
+        # The siblings join the dependents query: a flux-stem survivor's
+        # module qn changes on this run, so a file that includes or calls it
+        # must re-parse too, or its captured inbound edges are restored
+        # against the old qn (a wrong IMPORTS edge, a dropped CALLS edge).
         affected = 0
         for caller_key in sorted(
             {
                 *self._affected_caller_keys(
-                    sorted({*reindexed_keys, *deleted_before_parse})
+                    sorted({*reindexed_keys, *deleted_before_parse, *siblings})
                 ),
                 *siblings,
             }

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2684,8 +2684,18 @@ class GraphUpdater:
         # absent from the cache set here and never join the dependents query.
         # Union them back in; the walk-eligible subtraction below drops the
         # ones that still exist (issue #1567).
+        # A file the graph still holds but neither the cache nor the walk
+        # names (a cacheless or forced rebuild over an existing graph) must
+        # go before the parse too, for the same-stem reason as above: a
+        # surviving sibling parsed first would otherwise claim its qn and
+        # the post-parse delete by path would find nothing.
+        graph_only_gone = (
+            preexisting_paths - eligible_by_key.keys() - unreadable_keys
+            if preexisting_paths
+            else frozenset()
+        )
         deleted_before_parse = sorted(
-            (set(old_hashes) | self._delombok_stale_keys)
+            (set(old_hashes) | self._delombok_stale_keys | graph_only_gone)
             - eligible_by_key.keys()
             - unreadable_keys
         )
@@ -2759,11 +2769,12 @@ class GraphUpdater:
         # then finds nothing, leaving the old definitions beside the new
         # ones (issue #1569). This loop is the only graph delete on the
         # re-parse path: every non-new entry is in reindexed_keys, so the
-        # per-file loop below only clears local state.
+        # per-file loop below only clears local state. It runs only once
+        # every changed file has pre-parsed: a parse failure then leaves
+        # the old subtrees in place instead of an emptied graph.
+        pre_parsed = self._pre_parse_changed_files(changed_entries)
         for stale_key in (*reindexed_keys, *deleted_before_parse):
             self._delete_module_entities(stale_key)
-
-        pre_parsed = self._pre_parse_changed_files(changed_entries)
 
         with Progress(
             SpinnerColumn(),

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2823,7 +2823,10 @@ class GraphUpdater:
             for deleted_key in deleted_keys:
                 deleted_path = self.repo_path / deleted_key
                 self.remove_file_from_state(deleted_path)
-                self._delete_module_entities(deleted_key)
+                # A key the up-front loop already cleared gets no second
+                # module delete; only the File node is still to go.
+                if deleted_key not in deleted_set:
+                    self._delete_module_entities(deleted_key)
                 if isinstance(self.ingestor, QueryProtocol):
                     # Keyed on the absolute path: a sibling project's File
                     # node can share the relative path (issue #897).

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -998,15 +998,14 @@ class GraphUpdater:
         self._graph_state_unknown = False
         # Per-run for the same reason (issue #1620's shape): a run that raised
         # between `_process_files` and the commit point leaves its cache
-        # stashed on the instance. No test covers this because no such write is
-        # reachable, and the argument is structural rather than a survey of
-        # paths: `_process_files` contains no `return` and no `raise`, and
-        # `run` returns only at the in-sync fast path below, which is above the
-        # commit point. All three stashes are unconditional top-level
-        # statements of `_process_files`, so every path that reaches the commit
-        # point has re-stashed all three before getting there. Reset anyway: the
-        # guarantee is a property of those two functions' control flow, and
-        # the first early `return` added to either one silently ends it.
+        # stashed on the instance. `_process_files` has exactly one raise, the
+        # deferred first parse failure, and it sits AFTER the observed-at
+        # stash and BEFORE the two cache stashes, so a raising run leaves
+        # `_pending_cache_observed_at` set and the other two None; `run`
+        # returns only at the in-sync fast path below, above the commit
+        # point. This reset is what makes that leftover harmless on a reused
+        # instance, and the first early `return` added to either function
+        # is covered by it too.
         self._pending_hash_cache = None
         self._pending_dir_mtimes = None
         self._pending_cache_observed_at = None
@@ -2775,6 +2774,7 @@ class GraphUpdater:
         pre_parsed = self._pre_parse_changed_files(changed_entries)
         for stale_key in (*reindexed_keys, *deleted_before_parse):
             self._delete_module_entities(stale_key)
+        first_failure: Exception | None = None
 
         with Progress(
             SpinnerColumn(),
@@ -2797,11 +2797,22 @@ class GraphUpdater:
                     )
 
                 changed_count += 1
-                self._process_single_file(
-                    filepath,
-                    file_bytes=file_bytes,
-                    pre_parsed=pre_parsed.get(filepath),
-                )
+                # Every stale subtree went in the loop above, so a failure
+                # here must not abort this loop: every module after it would
+                # stay deleted and never be rebuilt. The remaining files are
+                # processed, the deletion reconciliation and inbound-edge
+                # restore below still run, and the first error is re-raised
+                # before the cache commit so the next run retries the lot.
+                try:
+                    self._process_single_file(
+                        filepath,
+                        file_bytes=file_bytes,
+                        pre_parsed=pre_parsed.get(filepath),
+                    )
+                except Exception as exc:
+                    logger.error(ls.INCREMENTAL_FILE_FAILED, path=filepath, error=exc)
+                    if first_failure is None:
+                        first_failure = exc
 
                 processed_since_flush += 1
                 if processed_since_flush >= settings.FILE_FLUSH_INTERVAL:
@@ -2854,6 +2865,8 @@ class GraphUpdater:
             logger.info(ls.INCREMENTAL_CHANGED, count=changed_count)
         if unreadable_count > 0:
             logger.info(ls.INCREMENTAL_UNREADABLE, count=unreadable_count)
+        if first_failure is not None:
+            raise first_failure
 
         # Deferred to the post-flush commit point in `run` (issue #1615). The
         # deletions above are execute_write calls that only become durable at

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -877,6 +877,10 @@ INCREMENTAL_AFFECTED_CALLERS = (
     "Re-parsing {count} dependent caller file(s) of re-indexed targets"
 )
 INCREMENTAL_DELETED = "Removed state for {count} deleted files"
+INCREMENTAL_FILE_FAILED = (
+    "Failed to index {path}; the remaining changed files are still rebuilt "
+    "before the error is raised: {error}"
+)
 INCREMENTAL_FORCE = "Force mode enabled, bypassing hash cache"
 HASH_CACHE_ORPHANED = (
     "Hash cache exists but project '{project}' has no modules in the graph; "

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from loguru import logger
 
 from codebase_rag import constants as cs
 from codebase_rag import graph_updater as graph_updater_module
@@ -1489,6 +1490,53 @@ def test_a_graph_only_module_is_deleted_before_the_first_parse(
     assert deleted_at_first_parse, "no file was parsed"
     assert "module_c.py" in deleted_at_first_parse[0]
     assert _deleted_module_counts(mock_ingestor)["module_c.py"] == 1
+
+
+def test_a_parse_failure_still_rebuilds_the_other_changed_modules(
+    py_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # Every changed module's old subtree is deleted before the first parse,
+    # so a file that fails to parse must not abort the loop: the modules
+    # after it would stay deleted and never be rebuilt. The error still
+    # surfaces once the remaining files are processed.
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    ).run()
+    cache_mtime = (py_project / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    for name in ("module_a.py", "module_b.py"):
+        path = py_project / name
+        path.write_text(path.read_text() + "\n")
+        os.utime(path, (cache_mtime + 1, cache_mtime + 1))
+
+    mock_ingestor.reset_mock()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    )
+    real_parse = updater._process_single_file
+    parsed: list[str] = []
+
+    def flaky(filepath: Path, *args: object, **kwargs: object) -> None:
+        if filepath.name == "module_a.py":
+            raise RuntimeError("parse died")
+        parsed.append(filepath.name)
+        real_parse(filepath, *args, **kwargs)
+
+    updater._process_single_file = flaky  # type: ignore[method-assign]
+    errors: list[str] = []
+    sink_id = logger.add(lambda message: errors.append(str(message)), level="ERROR")
+    try:
+        with pytest.raises(RuntimeError, match="parse died"):
+            updater.run()
+    finally:
+        logger.remove(sink_id)
+
+    # Both subtrees were deleted up front; only the survivor was rebuilt.
+    assert {"module_a.py", "module_b.py"} <= _deleted_module_paths(mock_ingestor)
+    assert "module_b.py" in parsed
+    # The re-raised error carries the message, not the file: only the log
+    # names which file failed.
+    assert any("module_a.py" in line and "parse died" in line for line in errors)
 
 
 def test_a_pre_parse_failure_leaves_the_old_subtrees_in_place(

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1451,3 +1451,70 @@ class TestSlots:
         cache = BoundedASTCache()
         with pytest.raises(AttributeError):
             cache.nonexistent_attr = "value"  # type: ignore[attr-defined]
+
+
+def test_a_graph_only_module_is_deleted_before_the_first_parse(
+    py_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # Cacheless rebuild over an existing graph: module_c.py is gone from
+    # disk and was never in a cache, only the graph names it. Its subtree
+    # must go before any file is parsed, or a same-stem survivor parsed
+    # first claims its qn and the later delete by path finds nothing.
+    parsers, queries = load_parsers()
+
+    def module_paths(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_PROJECT_MODULE_PATHS:
+            return [
+                {cs.KEY_PATH: "module_a.py"},
+                {cs.KEY_PATH: "module_b.py"},
+                {cs.KEY_PATH: "module_c.py"},
+            ]
+        return []
+
+    mock_ingestor.fetch_all.side_effect = module_paths
+    updater = GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    )
+    deleted_at_first_parse: list[set[str]] = []
+    real_parse = updater._process_single_file
+
+    def spy(*args: object, **kwargs: object) -> None:
+        if not deleted_at_first_parse:
+            deleted_at_first_parse.append(_deleted_module_paths(mock_ingestor))
+        real_parse(*args, **kwargs)
+
+    updater._process_single_file = spy  # type: ignore[method-assign]
+    updater.run()
+
+    assert deleted_at_first_parse, "no file was parsed"
+    assert "module_c.py" in deleted_at_first_parse[0]
+    assert _deleted_module_counts(mock_ingestor)["module_c.py"] == 1
+
+
+def test_a_pre_parse_failure_leaves_the_old_subtrees_in_place(
+    py_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # The stale-subtree deletes run only once every changed file has
+    # pre-parsed; a failure there must not leave an emptied graph behind.
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    ).run()
+    module_a = py_project / "module_a.py"
+    module_a.write_text(module_a.read_text() + "\n")
+    cache_mtime = (py_project / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    os.utime(module_a, (cache_mtime + 1, cache_mtime + 1))
+
+    mock_ingestor.reset_mock()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    )
+    with (
+        patch.object(
+            updater, "_pre_parse_changed_files", side_effect=RuntimeError("parse died")
+        ),
+        pytest.raises(RuntimeError, match="parse died"),
+    ):
+        updater.run()
+
+    assert _deleted_module_paths(mock_ingestor) == set()

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -96,6 +96,27 @@ def test_an_edited_file_is_deleted_exactly_once(
     assert all(n == 1 for n in counts.values()), dict(counts)
 
 
+def test_a_deleted_file_is_deleted_exactly_once(
+    py_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # The up-front loop clears a deleted file's subtree before the parse;
+    # the post-parse reconciliation must not issue the same delete again.
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    ).run()
+    (py_project / "module_a.py").unlink()
+
+    mock_ingestor.reset_mock()
+    GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    ).run()
+
+    counts = _deleted_module_counts(mock_ingestor)
+    assert counts["module_a.py"] == 1, dict(counts)
+    assert all(n == 1 for n in counts.values()), dict(counts)
+
+
 @pytest.fixture
 def excludable_project(tmp_path: Path) -> Path:
     """A project whose module_a carries a Module, a Class and a Method.

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -2,6 +2,7 @@ import errno
 import json
 import os
 import time
+from collections import Counter
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -58,12 +59,41 @@ def _module_path_queries(mock_ingestor: MagicMock) -> int:
     )
 
 
-def _deleted_module_paths(mock_ingestor: MagicMock) -> set[str]:
-    return {
+def _deleted_module_counts(mock_ingestor: MagicMock) -> Counter[str]:
+    return Counter(
         call.args[1][cs.KEY_PATH]
         for call in mock_ingestor.execute_write.call_args_list
         if call.args and call.args[0] == cs.CYPHER_DELETE_MODULE
-    }
+    )
+
+
+def _deleted_module_paths(mock_ingestor: MagicMock) -> set[str]:
+    return set(_deleted_module_counts(mock_ingestor))
+
+
+def test_an_edited_file_is_deleted_exactly_once(
+    py_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # The up-front stale-subtree loop is the only delete on the re-parse
+    # path; a second per-file delete inside the parse loop is a wasted
+    # write per re-indexed file, and a set-typed check cannot see it.
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    ).run()
+    module_a = py_project / "module_a.py"
+    module_a.write_text(module_a.read_text() + "\n")
+    cache_mtime = (py_project / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    os.utime(module_a, (cache_mtime + 1, cache_mtime + 1))
+
+    mock_ingestor.reset_mock()
+    GraphUpdater(
+        ingestor=mock_ingestor, repo_path=py_project, parsers=parsers, queries=queries
+    ).run()
+
+    counts = _deleted_module_counts(mock_ingestor)
+    assert "module_a.py" in counts
+    assert all(n == 1 for n in counts.values()), dict(counts)
 
 
 @pytest.fixture

--- a/codebase_rag/tests/test_incremental_cross_language_collision.py
+++ b/codebase_rag/tests/test_incremental_cross_language_collision.py
@@ -91,7 +91,11 @@ def test_incremental_add_of_cross_language_sibling_does_not_collide(
     assert len(set(modules.values())) == 2, (
         f"cross-language module qn collision on incremental add: {modules}"
     )
-    assert modules["shapes.rs"] == "proj.shapes", modules
+    # Which sibling holds the bare qn follows the clean rule (walk order),
+    # not index history: a clean index of the final tree agrees (issue #1569).
+    clean = _StatefulIngestor()
+    _index(clean, temp_repo, force=True)
+    assert modules == _shapes_modules(clean)
 
 
 @pytest.mark.usefixtures("_needs_rust_cpp")

--- a/codebase_rag/tests/test_incremental_stem_siblings.py
+++ b/codebase_rag/tests/test_incremental_stem_siblings.py
@@ -24,17 +24,22 @@ CPP: dict[str, str] = {
         '#include "shape.h"\nnamespace geo {\nint Shape::area() { return 0; }\n}\n'
         "int use() { geo::Shape s; return s.area(); }\n"
     ),
-    # A third file that depends on the pair: its IMPORTS and CALLS edges name
-    # the survivor's module qn, which changes when the sibling is added or
-    # deleted, so it must be re-parsed with the pair rather than restored.
-    "main.cpp": '#include "shape.h"\nint main() { geo::Shape s; return s.area(); }\n',
+    # A dependent whose only edges reach the survivor: `all.h` includes the
+    # header, and `main.cpp` reaches the pair through it. A direct includer
+    # that calls `area()` would already be found through the DELETED file
+    # (the out-of-line definition owns the method's path), so it pins the
+    # add direction only; this shape pins both.
+    "all.h": '#include "shape.h"\n',
+    "main.cpp": '#include "all.h"\nint main() { geo::Shape s; return s.area(); }\n',
 }
 C: dict[str, str] = {
-    "util.h": "int add(int a, int b);\n",
+    "util.h": (
+        "int add(int a, int b);\nstatic inline int twice(int a) { return a * 2; }\n"
+    ),
     "util.c": '#include "util.h"\nint add(int a, int b) { return a + b; }\n',
-    # Include-only dependent: no CALLS edge reaches the pair, so only the
-    # IMPORTS edge to the survivor's changing qn ties this file to the run.
-    "main.c": '#include "util.h"\nint main(void) { return 0; }\n',
+    # A `.c` includer emits no IMPORTS edge, so only a CALLS edge into the
+    # header's inline function ties this file to the survivor's changing qn.
+    "main.c": '#include "util.h"\nint main(void) { return twice(1); }\n',
 }
 _ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}
 
@@ -122,7 +127,8 @@ def test_deleting_the_bare_qn_holder_hands_the_qn_to_the_surviving_sibling(
 
     header_only = {rel: text for rel, text in fixture.items() if rel != source}
     clean = _clean(temp_repo, "clean", header_only, language)
-    assert _modules(after) == {bare_qn, "proj.main"}
+    assert bare_qn in _modules(after)
+    assert _modules(after) == _modules(clean)
     assert after == clean
 
 
@@ -139,9 +145,7 @@ def test_adding_a_sibling_that_wins_the_bare_qn_renames_the_existing_one(
     _materialise(root, header_only)
     store = _StatefulIngestor()
     _index(store, root, language, force=True)
-    assert _modules(_snapshot(store, root)) == {bare_qn, "proj.main"}, (
-        "alone, the header owns it"
-    )
+    assert bare_qn in _modules(_snapshot(store, root)), "alone, the header owns it"
     added = root / source
     added.write_text(fixture[source], encoding="utf-8")
     cache_mtime = (root / cs.HASH_CACHE_FILENAME).stat().st_mtime

--- a/codebase_rag/tests/test_incremental_stem_siblings.py
+++ b/codebase_rag/tests/test_incremental_stem_siblings.py
@@ -24,10 +24,17 @@ CPP: dict[str, str] = {
         '#include "shape.h"\nnamespace geo {\nint Shape::area() { return 0; }\n}\n'
         "int use() { geo::Shape s; return s.area(); }\n"
     ),
+    # A third file that depends on the pair: its IMPORTS and CALLS edges name
+    # the survivor's module qn, which changes when the sibling is added or
+    # deleted, so it must be re-parsed with the pair rather than restored.
+    "main.cpp": '#include "shape.h"\nint main() { geo::Shape s; return s.area(); }\n',
 }
 C: dict[str, str] = {
     "util.h": "int add(int a, int b);\n",
     "util.c": '#include "util.h"\nint add(int a, int b) { return a + b; }\n',
+    # Include-only dependent: no CALLS edge reaches the pair, so only the
+    # IMPORTS edge to the survivor's changing qn ties this file to the run.
+    "main.c": '#include "util.h"\nint main(void) { return 0; }\n',
 }
 _ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}
 
@@ -115,7 +122,7 @@ def test_deleting_the_bare_qn_holder_hands_the_qn_to_the_surviving_sibling(
 
     header_only = {rel: text for rel, text in fixture.items() if rel != source}
     clean = _clean(temp_repo, "clean", header_only, language)
-    assert _modules(after) == {bare_qn}
+    assert _modules(after) == {bare_qn, "proj.main"}
     assert after == clean
 
 
@@ -132,7 +139,9 @@ def test_adding_a_sibling_that_wins_the_bare_qn_renames_the_existing_one(
     _materialise(root, header_only)
     store = _StatefulIngestor()
     _index(store, root, language, force=True)
-    assert _modules(_snapshot(store, root)) == {bare_qn}, "alone, the header owns it"
+    assert _modules(_snapshot(store, root)) == {bare_qn, "proj.main"}, (
+        "alone, the header owns it"
+    )
     added = root / source
     added.write_text(fixture[source], encoding="utf-8")
     cache_mtime = (root / cs.HASH_CACHE_FILENAME).stat().st_mtime

--- a/codebase_rag/tests/test_incremental_stem_siblings.py
+++ b/codebase_rag/tests/test_incremental_stem_siblings.py
@@ -1,0 +1,145 @@
+# Two files sharing a stem (shape.h / shape.cpp) strip to one module qn; the
+# disambiguator gives the bare qn to the first one processed and suffixes the
+# other, and an incremental run seeds the taken qns from the graph so an
+# added file cannot overwrite a sibling's module (issue #897). The seed also
+# froze the CLAIMANT: after the bare-qn holder was deleted, or a sibling that
+# would win the bare qn was added, the survivor kept the qn it was first
+# given, so every qualified name in the pair depended on index history rather
+# than on the tree (issue #1569).
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+CPP: dict[str, str] = {
+    "shape.h": "namespace geo {\nclass Shape {\n public:\n  virtual int area();\n};\n}\n",
+    "shape.cpp": (
+        '#include "shape.h"\nnamespace geo {\nint Shape::area() { return 0; }\n}\n'
+        "int use() { geo::Shape s; return s.area(); }\n"
+    ),
+}
+C: dict[str, str] = {
+    "util.h": "int add(int a, int b);\n",
+    "util.c": '#include "util.h"\nint add(int a, int b) { return a + b; }\n',
+}
+_ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}
+
+Snapshot = tuple[frozenset[tuple[str, str]], frozenset[tuple[str, ...]]]
+
+
+def _snapshot(store: _StatefulIngestor, root: Path) -> Snapshot:
+    prefix = root.resolve().as_posix() + "/"
+
+    def norm(label: str, uid: str) -> str:
+        return (
+            uid[len(prefix) :] if label in _ABSOLUTE and uid.startswith(prefix) else uid
+        )
+
+    nodes = frozenset(
+        (label, norm(label, str(uid)))
+        for (label, uid) in store.nodes
+        if label != cs.NodeLabel.FILE.value
+    )
+    edges = frozenset(
+        (str(fl), norm(str(fl), str(fv)), str(rel), str(tl), norm(str(tl), str(tv)))
+        for (fl, fv, rel, tl, tv) in store.edges
+        if cs.NodeLabel.FILE.value not in (fl, tl)
+    )
+    return nodes, edges
+
+
+def _materialise(root: Path, files: dict[str, str]) -> None:
+    root.mkdir(parents=True)
+    for rel, text in files.items():
+        (root / rel).write_text(text, encoding="utf-8")
+
+
+def _index(
+    store: _StatefulIngestor, repo: Path, language: cs.SupportedLanguage, force: bool
+) -> None:
+    parsers, queries = load_parsers()
+    if language not in parsers:
+        pytest.skip(f"{language} parser not available")
+    GraphUpdater(
+        ingestor=store,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run(force=force)
+
+
+def _clean(
+    temp_repo: Path, name: str, files: dict[str, str], language: cs.SupportedLanguage
+) -> Snapshot:
+    root = temp_repo / name / "proj"
+    _materialise(root, files)
+    store = _StatefulIngestor()
+    _index(store, root, language, force=True)
+    return _snapshot(store, root)
+
+
+def _modules(snapshot: Snapshot) -> set[str]:
+    return {qn for (label, qn) in snapshot[0] if label == cs.NodeLabel.MODULE.value}
+
+
+CASES = [
+    (cs.SupportedLanguage.CPP, CPP, "shape.cpp", "proj.shape"),
+    (cs.SupportedLanguage.C, C, "util.c", "proj.util"),
+]
+
+
+@pytest.mark.parametrize(("language", "fixture", "source", "bare_qn"), CASES)
+def test_deleting_the_bare_qn_holder_hands_the_qn_to_the_surviving_sibling(
+    temp_repo: Path,
+    language: cs.SupportedLanguage,
+    fixture: dict[str, str],
+    source: str,
+    bare_qn: str,
+) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, fixture)
+    store = _StatefulIngestor()
+    _index(store, root, language, force=True)
+    assert bare_qn in _modules(_snapshot(store, root)), "the source owns the bare qn"
+    (root / source).unlink()
+    _index(store, root, language, force=False)
+    after = _snapshot(store, root)
+
+    header_only = {rel: text for rel, text in fixture.items() if rel != source}
+    clean = _clean(temp_repo, "clean", header_only, language)
+    assert _modules(after) == {bare_qn}
+    assert after == clean
+
+
+@pytest.mark.parametrize(("language", "fixture", "source", "bare_qn"), CASES)
+def test_adding_a_sibling_that_wins_the_bare_qn_renames_the_existing_one(
+    temp_repo: Path,
+    language: cs.SupportedLanguage,
+    fixture: dict[str, str],
+    source: str,
+    bare_qn: str,
+) -> None:
+    root = temp_repo / "proj"
+    header_only = {rel: text for rel, text in fixture.items() if rel != source}
+    _materialise(root, header_only)
+    store = _StatefulIngestor()
+    _index(store, root, language, force=True)
+    assert _modules(_snapshot(store, root)) == {bare_qn}, "alone, the header owns it"
+    added = root / source
+    added.write_text(fixture[source], encoding="utf-8")
+    cache_mtime = (root / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    os.utime(added, (cache_mtime + 1, cache_mtime + 1))
+    _index(store, root, language, force=False)
+    after = _snapshot(store, root)
+
+    clean = _clean(temp_repo, "clean", fixture, language)
+    assert _modules(after) == _modules(clean)
+    assert after == clean

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -224,6 +224,7 @@ class _StatefulIngestor:
                             cs.KEY_REL: rel_type,
                             cs.KEY_TARGET_LABEL: to_label,
                             cs.KEY_TARGET_QN: _text(to_val),
+                            cs.KEY_CALLER_PATH: _text(caller_path),
                             cs.KEY_PROPS: dict(self.edge_props.get(edge, {})),
                         }
                     )


### PR DESCRIPTION
Closes #1569. Sixth layer of stack #1562, on #1572.

## What happens

`shape.h` + `shape.cpp` (or `util.h` + `util.c`) strip to one module qn. Delete the source and update incrementally: the header stays `proj.shape.h`, where a clean index names it `proj.shape`. Index the header alone, add the source, update: the source becomes `proj.shape.cpp` and the header keeps `proj.shape`, the reverse of a clean index. Every definition qn under the pair follows.

## Why

The disambiguator gives the bare qn to the first same-stem file processed and suffixes the rest; an incremental run seeds the taken qns from the graph (issue #897) so an added file cannot overwrite a sibling, which also freezes the claimant whatever the clean rule (walk order) would say now. Two further defects surfaced once the survivor re-parsed:

- the old subtrees were deleted per file as each was reached, so a sibling parsed earlier MERGEd onto the survivor's old Module node (same qn, path rewritten) and the survivor's delete-by-path then found nothing, leaving its old definitions beside the new ones;
- the inbound restore re-emitted a deleted file's edges under the qn a survivor had just taken over.

## Fix

- Stems with a sibling added or deleted this run are "in flux": their survivors are not seeded and join the re-parse set, and Pass 2 processes the run's files in walk order, so the bare qn lands where a clean index puts it.
- Every re-indexed and deleted file's subtree is deleted before Pass 2 parses anything; the per-file delete stays as the cacheless-full-build guard.
- `CYPHER_INBOUND_EDGES` also returns `caller.path`, and rows whose caller lives in a deleted file are dropped before the restore. The emulator mirrors the column.
- `test_incremental_cross_language_collision.py` asserted the history-dependent outcome (`shapes.rs` keeps the bare qn after `shapes.cpp` is added); it now asserts distinct qns plus agreement with a clean index, matching its sibling test.

## Test

`test_incremental_stem_siblings.py` covers C++ and C in both directions and asserts the module set and the whole snapshot equal a clean index of the resulting tree. All four red before, green after. 487 emulator, incremental, updater and Cypher-compat tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental indexing when same-stem files are added, edited, or deleted.
  * Preserved correct module ownership and graph results across sibling-file changes.
  * Removed stale graph data before rebuilding and prevented duplicate cleanup.
  * Continued processing remaining changed files when one fails, while reporting the failure afterward.
  * Improved restoration of inbound relationships by retaining caller path information.

* **Tests**
  * Added coverage for same-stem files across C and C++.
  * Verified incremental indexes match clean re-indexing results.
  * Added coverage for stale-module cleanup and partial rebuild failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->