### PR TITLE
fix: a reused updater drops a deleted file's in-memory state before Pass 2 and starts Pass 3 with empty resolver caches

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2182,6 +2182,14 @@ class GraphUpdater:
         qn_to_path = self.factory.definition_processor.module_qn_to_file_path
         for qn in [qn for qn, path in qn_to_path.items() if path == file_path]:
             del qn_to_path[qn]
+        # The paths read back from the graph for an earlier incremental run
+        # go with the registry entries: `_module_language` falls through to
+        # them for a definition qn, and a replacement in another language
+        # (util.rs -> util.py) would otherwise still answer RUST for the qn
+        # its new file re-registers (issue #1575).
+        rehydrated = self.factory.definition_processor.rehydrated_definition_paths
+        for qn in qns_to_remove:
+            rehydrated.pop(qn, None)
 
     def _existing_module_paths(self) -> frozenset[str] | None:
         """Paths of this project's Module nodes already in the graph.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2873,10 +2873,13 @@ class GraphUpdater:
             logger.info(ls.INCREMENTAL_DELETED, count=len(deleted_keys))
             for deleted_key in deleted_keys:
                 deleted_path = self.repo_path / deleted_key
-                self.remove_file_from_state(deleted_path)
-                # A key the up-front loop already cleared gets no second
-                # module delete; only the File node is still to go.
+                # A key cleared before the parse gets neither a second state
+                # drop nor a second module delete: the state drop keys on the
+                # module qn, which a same-stem replacement parsed since has
+                # taken over (its CommonJS export entry would go with it).
+                # Only the File node is still to go.
                 if deleted_key not in deleted_set:
+                    self.remove_file_from_state(deleted_path)
                     self._delete_module_entities(deleted_key)
                 if isinstance(self.ingestor, QueryProtocol):
                     # Keyed on the absolute path: a sibling project's File

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1197,6 +1197,11 @@ class GraphUpdater:
             logger.info("Resolved {} deferred containment parents", linked)
 
         logger.info(ls.FOUND_FUNCTIONS, count=len(self.function_registry))
+        # The resolver memoises name -> qn answers across files; on a reused
+        # updater (MCP server, watcher) those answers can name definitions
+        # this run deleted or renamed, so every run starts Pass 3 with empty
+        # caches, as reingest already does (issue #1575).
+        self.factory.call_processor.reset_resolution_caches()
         logger.info(ls.PASS_3_CALLS)
         self._process_function_calls()
 
@@ -2170,6 +2175,13 @@ class GraphUpdater:
                 self.simple_name_lookup[simple_name] = new_qn_set
                 logger.debug(ls.CLEANED_SIMPLE_NAME, name=simple_name)
 
+        # The file no longer owns any module qn: a replacement with the same
+        # stem (util.js -> util.ts) must take the bare qn a clean index gives
+        # it, and a re-parse re-registers its own entry (issue #1575).
+        qn_to_path = self.factory.definition_processor.module_qn_to_file_path
+        for qn in [qn for qn, path in qn_to_path.items() if path == file_path]:
+            del qn_to_path[qn]
+
     def _existing_module_paths(self) -> frozenset[str] | None:
         """Paths of this project's Module nodes already in the graph.
 
@@ -2774,6 +2786,13 @@ class GraphUpdater:
         pre_parsed = self._pre_parse_changed_files(changed_entries)
         for stale_key in (*reindexed_keys, *deleted_before_parse):
             self._delete_module_entities(stale_key)
+        # The in-memory side of a deleted file goes now as well: a reused
+        # updater (MCP server, watcher, reingest) otherwise resolves this
+        # run's re-parsed importers against the deleted definitions and
+        # suffixes a same-stem replacement's qn (issue #1575). The late
+        # deletion block repeats this harmlessly.
+        for deleted_key in deleted_before_parse:
+            self.remove_file_from_state(self.repo_path / deleted_key)
         first_failure: Exception | None = None
 
         with Progress(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1197,10 +1197,11 @@ class GraphUpdater:
             logger.info("Resolved {} deferred containment parents", linked)
 
         logger.info(ls.FOUND_FUNCTIONS, count=len(self.function_registry))
-        # The resolver memoises name -> qn answers across files; on a reused
-        # updater (MCP server, watcher) those answers can name definitions
+        # The resolver memoises name -> qn answers and module languages
+        # across files; on a reused updater (any caller that holds one across
+        # `run()` calls, as the tests do) those answers can name definitions
         # this run deleted or renamed, so every run starts Pass 3 with empty
-        # caches, as reingest already does (issue #1575).
+        # caches, as the watcher's per-event pass already does (issue #1575).
         self.factory.call_processor.reset_resolution_caches()
         logger.info(ls.PASS_3_CALLS)
         self._process_function_calls()
@@ -2787,7 +2788,8 @@ class GraphUpdater:
         for stale_key in (*reindexed_keys, *deleted_before_parse):
             self._delete_module_entities(stale_key)
         # The in-memory side of a deleted file goes now as well: a reused
-        # updater (MCP server, watcher, reingest) otherwise resolves this
+        # updater (the watcher's `remove_file_from_state` path, or any caller
+        # holding one across `run()` calls) otherwise resolves this
         # run's re-parsed importers against the deleted definitions and
         # suffixes a same-stem replacement's qn (issue #1575). The late
         # deletion block repeats this harmlessly.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2180,8 +2180,16 @@ class GraphUpdater:
         # stem (util.js -> util.ts) must take the bare qn a clean index gives
         # it, and a re-parse re-registers its own entry (issue #1575).
         qn_to_path = self.factory.definition_processor.module_qn_to_file_path
+        # The qn read back from the graph goes with the map entry, keyed on
+        # the qn the graph RECORDED (a disambiguated `util.py` beside
+        # `util.js`, a `mod.rs` directory), never on the path-derived prefix,
+        # which for a same-stem sibling names the SURVIVOR's qn.
+        # `known_module_paths` would otherwise keep offering the deleted
+        # module to deferred resolution as a live internal target on a
+        # reused updater (issue #1575).
         for qn in [qn for qn, path in qn_to_path.items() if path == file_path]:
             del qn_to_path[qn]
+            self._rehydrated_module_qns.discard(qn)
         # The paths read back from the graph for an earlier incremental run
         # go with the registry entries: `_module_language` falls through to
         # them for a definition qn, and a replacement in another language

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1556,6 +1556,7 @@ class CallProcessor:
 
     def reset_resolution_caches(self) -> None:
         self._resolver.reset_resolution_caches()
+        self._resolver.type_inference.reset_semantic_join_memos()
         # Both indexes are derived from module_qn_to_file_path and rebuilt
         # lazily: the package index only when the map's SIZE changes, the
         # path index never. A deleted module removed from the map and a new

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1556,6 +1556,14 @@ class CallProcessor:
 
     def reset_resolution_caches(self) -> None:
         self._resolver.reset_resolution_caches()
+        # Both indexes are derived from module_qn_to_file_path and rebuilt
+        # lazily: the package index only when the map's SIZE changes, the
+        # path index never. A deleted module removed from the map and a new
+        # one added in the same run leave the size unchanged, so a stale
+        # entry would survive into Pass 3 and raise on lookup.
+        self._package_index = {}
+        self._package_index_size = -1
+        self._path_to_module_qn = None
 
     def process_calls_in_file(
         self,

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -333,6 +333,12 @@ class CallResolver:
         self._subclass_map_cache = None
         self._protocol_classes_cache = None
         self._struct_impl_cache.clear()
+        # The qn -> language memo goes too: after a same-stem replacement
+        # across languages (`util.rs` deleted, `util.py` added) the bare qn
+        # `proj.util` now names a Python module, and a stale RUST answer
+        # makes `_languages_can_call` drop the candidate a clean index
+        # resolves (issue #1575).
+        self._module_language_cache.clear()
 
     def resolve_function_call(
         self,

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -339,6 +339,12 @@ class CallResolver:
         # makes `_languages_can_call` drop the candidate a clean index
         # resolves (issue #1575).
         self._module_language_cache.clear()
+        # The rel-path -> module qn inverse rebuilds only when its size
+        # differs from `module_qn_to_file_path`; a rename removes one entry
+        # and adds one, so the size is unchanged and the memo would keep the
+        # old path and never learn the new one, and every JEDI fact
+        # targeting the renamed file would miss its declared location.
+        self._py_rel_to_module.clear()
 
     def resolve_function_call(
         self,

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -319,6 +319,20 @@ class TypeInferenceEngine:
             self._dart_type_inference = DartTypeInferenceEngine()
         return self._dart_type_inference
 
+    def reset_semantic_join_memos(self) -> None:
+        # The Go, Java and C# engines each memoise rel-path -> module qn for
+        # the semantic join and rebuild it only when module_qn_to_file_path
+        # changes SIZE. A rename on a reused updater removes one qn and adds
+        # one, so the size holds and the memo would keep the old path; it
+        # is cleared with the resolver's other memos at the start of Pass 3.
+        for engine in (
+            self._go_type_inference,
+            self._java_type_inference,
+            self._csharp_type_inference,
+        ):
+            if engine is not None:
+                engine._rel_to_module.clear()
+
     @property
     def lua_type_inference(self) -> LuaTypeInferenceEngine:
         if self._lua_type_inference is None:

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -1,5 +1,6 @@
-# The MCP server, the watcher and reingest keep one GraphUpdater across
-# runs. A deleted file's in-memory state (registry entries, simple-name
+# A GraphUpdater can be reused across runs (the watcher keeps one and
+# removes deleted files from its state; a caller may hold one across `run()`
+# calls). A deleted file's in-memory state (registry entries, simple-name
 # lookup, module-qn map) used to be removed only in the late deletion block,
 # after Pass 2 had parsed the changed files, so a rename or move done in one
 # cycle resolved the re-parsed importer against the deleted definitions and a
@@ -137,3 +138,42 @@ def test_a_reused_updater_gives_a_same_stem_replacement_the_bare_qn(
     modules = {qn for (label, qn) in after[0] if label == cs.NodeLabel.MODULE.value}
     assert modules == {"proj.util", "proj.main"}
     assert after == _clean(temp_repo, JS_AFTER, cs.SupportedLanguage.JS)
+
+
+# `main.py` names `helper` without an import so the resolver's simple-name
+# fallback, which is where the module-language check lives, decides the edge.
+RS_PY_BEFORE = {
+    "util.rs": "pub fn helper() -> i32 { 1 }\n",
+    "main.py": "def go():\n    return helper()\n",
+}
+RS_PY_AFTER = {
+    "util.py": "def helper():\n    return 1\n",
+    "main.py": RS_PY_BEFORE["main.py"] + "\n",
+}
+
+
+def test_a_reused_updater_forgets_a_deleted_module_language(
+    temp_repo: Path,
+) -> None:
+    # `reset_resolution_caches` must also drop the qn -> language memo:
+    # after `util.rs` is replaced by `util.py`, the bare qn `proj.util` names
+    # a Python module, and a stale RUST answer makes the resolver refuse the
+    # Python -> Rust call a clean index resolves.
+    root = temp_repo / "proj"
+    _materialise(root, RS_PY_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    if cs.SupportedLanguage.RUST not in updater.parsers:
+        pytest.skip("rust parser not available")
+    updater.run(force=True)
+    (root / "util.rs").unlink()
+    (root / "util.py").write_text(RS_PY_AFTER["util.py"], encoding="utf-8")
+    (root / "main.py").write_text(RS_PY_AFTER["main.py"], encoding="utf-8")
+    _bump(root, "util.py")
+    _bump(root, "main.py")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    calls = {(e[1], e[4]) for e in after[1] if e[2] == cs.RelationshipType.CALLS.value}
+    assert ("proj.main.go", "proj.util.helper") in calls
+    assert after == _clean(temp_repo, RS_PY_AFTER, cs.SupportedLanguage.PYTHON)

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -227,6 +227,37 @@ def test_a_rehydrated_updater_forgets_a_deleted_definitions_language(
     assert after_snapshot == _clean(temp_repo, after, cs.SupportedLanguage.PYTHON)
 
 
+def test_a_rehydrated_updater_forgets_a_deleted_module_qn(temp_repo: Path) -> None:
+    # Module qns read back from the graph on an incremental first run feed
+    # `known_module_paths`, which deferred resolution treats as the set of
+    # live internal modules. Deleting the file must drop its qn from that
+    # set as well, or the reused updater keeps resolving against a module
+    # that no longer exists.
+    root = temp_repo / "proj"
+    before = {
+        "util.py": "def helper():\n    return 1\n",
+        "main.py": "from util import helper\n\n\ndef go():\n    return helper()\n",
+        "other.py": "def x():\n    return 1\n",
+    }
+    _materialise(root, before)
+    store = _StatefulIngestor()
+    _updater(store, root, cs.SupportedLanguage.PYTHON).run(force=True)
+
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    (root / "other.py").write_text("def x():\n    return 2\n", encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+    assert "proj.util" in updater._rehydrated_module_qns, "the shape did not rehydrate"
+    assert "proj.util" in updater.known_module_paths()
+
+    (root / "util.py").unlink()
+    (root / "main.py").write_text("def go():\n    return 1\n", encoding="utf-8")
+    _bump(root, "main.py")
+    updater.run(force=False)
+
+    assert "proj.util" not in updater.known_module_paths()
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -265,3 +265,75 @@ def test_a_reused_updater_relearns_a_renamed_module_under_jedi(
         {"core.py": JEDI_CORE, "main.py": JEDI_MAIN.format(module="core")},
         cs.SupportedLanguage.PYTHON,
     )
+
+
+# Two resolver indexes are derived from module_qn_to_file_path and rebuilt
+# lazily: the Go package index only when the map's size changes, the
+# path-to-module index never. Removing a deleted module from the map (rather
+# than leaving it, as before) means a rename keeps the size constant, so both
+# must be reset with the other memos at the start of Pass 3.
+GO_BEFORE = {
+    "pkg/types.go": "package pkg\n\ntype T struct{}\n",
+    "pkg/methods.go": "package pkg\n\nfunc (t T) M() int { return helper() }\n",
+    "pkg/util.go": "package pkg\n\nfunc helper() int { return 1 }\n",
+}
+GO_AFTER = {
+    "pkg/types.go": GO_BEFORE["pkg/types.go"],
+    "pkg/methods.go": GO_BEFORE["pkg/methods.go"],
+    "pkg/helpers.go": GO_BEFORE["pkg/util.go"],
+}
+
+
+def _calls(snapshot: Snapshot) -> set[tuple[str, str]]:
+    return {
+        (e[1], e[4]) for e in snapshot[1] if e[2] == cs.RelationshipType.CALLS.value
+    }
+
+
+def test_a_reused_updater_resolves_a_go_call_after_a_same_package_rename(
+    temp_repo: Path,
+) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, GO_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.GO)
+    updater.run(force=True)
+    (root / "pkg" / "util.go").rename(root / "pkg" / "helpers.go")
+    _bump(root, "pkg/helpers.go")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    # A stale package index lists the deleted `proj.pkg.util`, the receiver
+    # lookup raises on it, and methods.go then contributes no CALLS at all.
+    calls = _calls(after)
+    assert ("proj.pkg.types.T.M", "proj.pkg.helpers.helper") in calls
+    assert calls == _calls(_clean(temp_repo, GO_AFTER, cs.SupportedLanguage.GO))
+
+
+JS_ADD_AFTER = {
+    **JS_BEFORE,
+    "util.ts": (
+        "export function helper2(): number { return 1; }\n"
+        "export function helper2b(): number { return helper2(); }\n"
+    ),
+}
+
+
+def test_a_reused_updater_keys_a_new_same_stem_module_by_its_own_qn(
+    temp_repo: Path,
+) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, JS_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.JS)
+    updater.run(force=True)
+    (root / "util.ts").write_text(JS_ADD_AFTER["util.ts"], encoding="utf-8")
+    _bump(root, "util.ts")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    # A path index built on the first run has no entry for util.ts, so its
+    # calls were attributed to the JS module's qn (`proj.util.helper`).
+    calls = _calls(after)
+    assert ("proj.util.ts.helper2b", "proj.util.ts.helper2") in calls
+    assert after == _clean(temp_repo, JS_ADD_AFTER, cs.SupportedLanguage.JS)

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -14,8 +14,11 @@ from pathlib import Path
 import pytest
 
 from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.frontends import go as go_fe
+from codebase_rag.parsers.go_frontend import GoCallSite, GoSemanticFacts
 from evals.cgr_graph import _StatefulIngestor
 
 _ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}
@@ -337,3 +340,62 @@ def test_a_reused_updater_keys_a_new_same_stem_module_by_its_own_qn(
     calls = _calls(after)
     assert ("proj.util.ts.helper2b", "proj.util.ts.helper2") in calls
     assert after == _clean(temp_repo, JS_ADD_AFTER, cs.SupportedLanguage.JS)
+
+
+# The Go, Java and C# semantic-join engines memoise rel-path -> module qn
+# and rebuild only when module_qn_to_file_path changes size, so they go
+# stale on a rename exactly as the resolver's own memos did. Modelled on Go
+# with a synthetic fact standing in for the go/types frontend.
+GO_IFACE = (
+    "package sample\n\ntype Handler interface{ Handle() string }\n\n"
+    "func Run(h Handler) {\n\t_ = h.Handle()\n}\n"
+)
+GO_A = (
+    'package sample\n\ntype A struct{}\n\nfunc (a A) Handle() string { return "a" }\n'
+)
+GO_B = (
+    'package sample\n\ntype B struct{}\n\nfunc (b B) Handle() string { return "b" }\n'
+)
+GO_MOD = "module example.com/p\n\ngo 1.23\n"
+GO_FACT_BEFORE = {"go.mod": GO_MOD, "iface.go": GO_IFACE, "a.go": GO_A, "b.go": GO_B}
+GO_FACT_AFTER = {"go.mod": GO_MOD, "iface.go": GO_IFACE, "a.go": GO_A, "c.go": GO_B}
+GO_CALL_KEY = ("iface.go", 6, len("\t_ = h."), "Handle")
+GO_TARGET = (5, len("func (b B) "))
+
+
+def _go_facts(target_file: str) -> GoSemanticFacts:
+    return GoSemanticFacts(
+        call_sites={GO_CALL_KEY: GoCallSite("Handle", target_file, *GO_TARGET)},
+        external_sites=set(),
+        implements=[],
+    )
+
+
+def test_a_reused_updater_joins_a_go_fact_against_the_renamed_module(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    holder = {"facts": _go_facts("b.go")}
+    monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.GOTYPES)
+    monkeypatch.setattr(go_fe, "go_frontend_available", lambda: True)
+    monkeypatch.setattr(go_fe, "run_go_frontend", lambda repo_path: holder["facts"])
+
+    root = temp_repo / "proj"
+    _materialise(root, GO_FACT_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.GO)
+    updater.run(force=True)
+    first = _calls(_snapshot(store, root))
+    # Positive control: the fact, not the heuristic, decides the first run.
+    assert ("proj.iface.Run", "proj.b.B.Handle") in first, first
+    assert ("proj.iface.Run", "proj.a.A.Handle") not in first, first
+
+    (root / "b.go").rename(root / "c.go")
+    _bump(root, "c.go")
+    holder["facts"] = _go_facts("c.go")
+    updater.run(force=False)
+    after = _calls(_snapshot(store, root))
+
+    # With the memo stale the fact's target resolves to nothing and the
+    # heuristic binds Run to A.Handle instead.
+    assert ("proj.iface.Run", "proj.c.B.Handle") in after, after
+    assert after == _calls(_clean(temp_repo, GO_FACT_AFTER, cs.SupportedLanguage.GO))

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -18,7 +18,9 @@ from codebase_rag import graph_updater as gu
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.parsers.frontends import go as go_fe
+from codebase_rag.parsers.frontends import java as java_fe
 from codebase_rag.parsers.go_frontend import GoCallSite, GoSemanticFacts
+from codebase_rag.parsers.java_frontend import JavaCallSite, JavaSemanticFacts
 from evals.cgr_graph import _StatefulIngestor
 
 _ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}
@@ -399,3 +401,89 @@ def test_a_reused_updater_joins_a_go_fact_against_the_renamed_module(
     # heuristic binds Run to A.Handle instead.
     assert ("proj.iface.Run", "proj.c.B.Handle") in after, after
     assert after == _calls(_clean(temp_repo, GO_FACT_AFTER, cs.SupportedLanguage.GO))
+
+
+# Java twin of the Go test above: same declared_location join, same
+# rel-path memo on the Java engine. The fact is built after Pass 2 from the
+# registered span of B.handle in whichever file currently holds it.
+JAVA_HANDLER = "public interface Handler {\n    String handle();\n}\n"
+JAVA_A = (
+    "public class A implements Handler {\n"
+    '    public String handle() { return "a"; }\n}\n'
+)
+JAVA_B = (
+    "public class B implements Handler {\n"
+    '    public String handle() { return "b"; }\n}\n'
+)
+JAVA_RUN = (
+    "public class Run {\n    public static void run(Handler h) {\n"
+    "        h.handle();\n    }\n}\n"
+)
+JAVA_FACT_BEFORE = {
+    "Handler.java": JAVA_HANDLER,
+    "A.java": JAVA_A,
+    "B.java": JAVA_B,
+    "Run.java": JAVA_RUN,
+}
+JAVA_FACT_AFTER = {
+    "Handler.java": JAVA_HANDLER,
+    "A.java": JAVA_A,
+    "C.java": JAVA_B,
+    "Run.java": JAVA_RUN,
+}
+JAVA_CALL_KEY = ("Run.java", 3, len("        h."), "handle")
+
+
+def test_a_reused_updater_joins_a_java_fact_against_the_renamed_module(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "proj"
+    holder: dict[str, object] = {"target_file": "B.java"}
+
+    def facts(repo_path: Path) -> JavaSemanticFacts:
+        updater = holder["updater"]
+        assert isinstance(updater, GraphUpdater)
+        target_file = str(holder["target_file"])
+        dp = updater.factory.definition_processor
+        target_path = root / target_file
+        modules = {
+            qn for qn, path in dp.module_qn_to_file_path.items() if path == target_path
+        }
+        spans = sorted(
+            (line, col)
+            for (mod, line, col), loc in dp.function_locations.items()
+            if mod in modules and ".B.handle" in loc.qualified_name
+        )
+        assert spans, (modules, sorted(dp.function_locations))
+        line, col = spans[0]
+        return JavaSemanticFacts(
+            call_sites={JAVA_CALL_KEY: JavaCallSite("handle", target_file, line, col)},
+            external_sites=set(),
+        )
+
+    monkeypatch.setattr(gu.settings, "JAVA_FRONTEND", cs.JavaFrontend.JAVAC)
+    monkeypatch.setattr(java_fe, "java_frontend_available", lambda: True)
+    monkeypatch.setattr(java_fe, "run_java_frontend", facts)
+
+    _materialise(root, JAVA_FACT_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.JAVA)
+    holder["updater"] = updater
+    updater.run(force=True)
+    first = _calls(_snapshot(store, root))
+    # Positive control: the fact binds the call to B.handle on the first run.
+    assert any(t.startswith("proj.B.B.handle") for _, t in first), first
+
+    (root / "B.java").rename(root / "C.java")
+    _bump(root, "C.java")
+    holder["target_file"] = "C.java"
+    updater.run(force=False)
+    after = _calls(_snapshot(store, root))
+
+    assert any(
+        s.startswith("proj.Run.Run.run") and t.startswith("proj.C.B.handle")
+        for s, t in after
+    ), after
+    assert after == _calls(
+        _clean(temp_repo, JAVA_FACT_AFTER, cs.SupportedLanguage.JAVA)
+    )

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -177,3 +177,91 @@ def test_a_reused_updater_forgets_a_deleted_module_language(
     calls = {(e[1], e[4]) for e in after[1] if e[2] == cs.RelationshipType.CALLS.value}
     assert ("proj.main.go", "proj.util.helper") in calls
     assert after == _clean(temp_repo, RS_PY_AFTER, cs.SupportedLanguage.PYTHON)
+
+
+def test_a_rehydrated_updater_forgets_a_deleted_definitions_language(
+    temp_repo: Path,
+) -> None:
+    # The watcher's shape: a fresh updater whose FIRST run is incremental,
+    # so the untouched util.rs definitions are read back from the graph and
+    # `rehydrated_definition_paths` records them. `_module_language` falls
+    # through to those paths for a definition qn, so removing the file's
+    # state must drop them too, or the replacement util.py still answers
+    # RUST for `proj.util.helper` and the call it now provides is refused.
+    root = temp_repo / "proj"
+    before = {**RS_PY_BEFORE, "other.py": "def x():\n    return 1\n"}
+    after = {**RS_PY_AFTER, "other.py": "def x():\n    return 2\n"}
+    _materialise(root, before)
+    store = _StatefulIngestor()
+    first = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    if cs.SupportedLanguage.RUST not in first.parsers:
+        pytest.skip("rust parser not available")
+    first.run(force=True)
+
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    (root / "other.py").write_text(after["other.py"], encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+    rehydrated = updater.factory.definition_processor.rehydrated_definition_paths
+    assert "proj.util.helper" in rehydrated, "the shape did not rehydrate"
+
+    (root / "util.rs").unlink()
+    (root / "util.py").write_text(after["util.py"], encoding="utf-8")
+    (root / "main.py").write_text(after["main.py"], encoding="utf-8")
+    _bump(root, "util.py")
+    _bump(root, "main.py")
+    updater.run(force=False)
+    after_snapshot = _snapshot(store, root)
+
+    calls = {
+        (e[1], e[4])
+        for e in after_snapshot[1]
+        if e[2] == cs.RelationshipType.CALLS.value
+    }
+    assert ("proj.main.go", "proj.util.helper") in calls
+    assert after_snapshot == _clean(temp_repo, after, cs.SupportedLanguage.PYTHON)
+
+
+JEDI_CORE = (
+    "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
+    "    return Base()\n"
+)
+JEDI_MAIN = (
+    "from {module} import build\n\nhandlers = {{'a': build}}\n\n\ndef go():\n"
+    "    return handlers['a']().run()\n"
+)
+
+
+def test_a_reused_updater_relearns_a_renamed_module_under_jedi(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The rel-path -> module qn memo the JEDI join reads rebuilds only when
+    # its size differs from `module_qn_to_file_path`. A rename removes one
+    # entry and adds one, so without an explicit reset the memo keeps
+    # `base.py`, never learns `core.py`, and every fact targeting the
+    # renamed file loses its declared location.
+    pytest.importorskip("jedi")
+    from codebase_rag.config import settings
+
+    monkeypatch.setattr(settings, "PYTHON_FRONTEND", cs.PythonFrontend.JEDI)
+    root = temp_repo / "proj"
+    _materialise(
+        root, {"base.py": JEDI_CORE, "main.py": JEDI_MAIN.format(module="base")}
+    )
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    updater.run(force=True)
+    (root / "base.py").rename(root / "core.py")
+    (root / "main.py").write_text(JEDI_MAIN.format(module="core"), encoding="utf-8")
+    _bump(root, "core.py")
+    _bump(root, "main.py")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    calls = {(e[1], e[4]) for e in after[1] if e[2] == cs.RelationshipType.CALLS.value}
+    assert ("proj.main.go", "proj.core.Base.run") in calls
+    assert after == _clean(
+        temp_repo,
+        {"core.py": JEDI_CORE, "main.py": JEDI_MAIN.format(module="core")},
+        cs.SupportedLanguage.PYTHON,
+    )

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -1,0 +1,139 @@
+# The MCP server, the watcher and reingest keep one GraphUpdater across
+# runs. A deleted file's in-memory state (registry entries, simple-name
+# lookup, module-qn map) used to be removed only in the late deletion block,
+# after Pass 2 had parsed the changed files, so a rename or move done in one
+# cycle resolved the re-parsed importer against the deleted definitions and a
+# same-stem replacement got a suffixed qn. A fresh updater never saw this
+# (issue #1575).
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+_ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}
+Snapshot = tuple[frozenset[tuple[str, str]], frozenset[tuple[str, ...]]]
+
+
+def _snapshot(store: _StatefulIngestor, root: Path) -> Snapshot:
+    prefix = root.resolve().as_posix() + "/"
+
+    def norm(label: str, uid: str) -> str:
+        return (
+            uid[len(prefix) :] if label in _ABSOLUTE and uid.startswith(prefix) else uid
+        )
+
+    nodes = frozenset(
+        (label, norm(label, str(uid)))
+        for (label, uid) in store.nodes
+        if label != cs.NodeLabel.FILE.value
+    )
+    edges = frozenset(
+        (str(fl), norm(str(fl), str(fv)), str(rel), str(tl), norm(str(tl), str(tv)))
+        for (fl, fv, rel, tl, tv) in store.edges
+        if cs.NodeLabel.FILE.value not in (fl, tl)
+    )
+    return nodes, edges
+
+
+def _materialise(root: Path, files: dict[str, str]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for rel, text in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+
+def _updater(
+    store: _StatefulIngestor, repo: Path, language: cs.SupportedLanguage
+) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    if language not in parsers:
+        pytest.skip(f"{language} parser not available")
+    return GraphUpdater(
+        ingestor=store,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+def _bump(root: Path, rel: str) -> None:
+    cache_mtime = (root / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    os.utime(root / rel, (cache_mtime + 1, cache_mtime + 1))
+
+
+def _clean(
+    temp_repo: Path, files: dict[str, str], language: cs.SupportedLanguage
+) -> Snapshot:
+    root = temp_repo / "clean" / "proj"
+    _materialise(root, files)
+    store = _StatefulIngestor()
+    _updater(store, root, language).run(force=True)
+    return _snapshot(store, root)
+
+
+PY_BEFORE = {
+    "base.py": "class Base:\n    pass\n",
+    "main.py": "from base import Base\n\ndef go():\n    return Base()\n",
+}
+PY_AFTER = {
+    "core.py": "class Base:\n    pass\n",
+    "main.py": "from core import Base\n\ndef go():\n    return Base()\n",
+}
+JS_BEFORE = {
+    "util.js": "export function helper() { return 1; }\n",
+    "main.js": "import { helper } from './util';\nexport function go() { return helper(); }\n",
+}
+JS_AFTER = {
+    "util.ts": "export function helper(): number { return 1; }\n",
+    "main.js": JS_BEFORE["main.js"],
+}
+
+
+def test_a_reused_updater_resolves_a_rename_against_the_new_module(
+    temp_repo: Path,
+) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, PY_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    updater.run(force=True)
+    (root / "base.py").rename(root / "core.py")
+    (root / "main.py").write_text(PY_AFTER["main.py"], encoding="utf-8")
+    _bump(root, "core.py")
+    _bump(root, "main.py")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    instantiates = {
+        e[4] for e in after[1] if e[2] == cs.RelationshipType.INSTANTIATES.value
+    }
+    assert instantiates == {"proj.core.Base"}
+    assert after == _clean(temp_repo, PY_AFTER, cs.SupportedLanguage.PYTHON)
+
+
+def test_a_reused_updater_gives_a_same_stem_replacement_the_bare_qn(
+    temp_repo: Path,
+) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, JS_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.JS)
+    updater.run(force=True)
+    (root / "util.js").unlink()
+    (root / "util.ts").write_text(JS_AFTER["util.ts"], encoding="utf-8")
+    _bump(root, "util.ts")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    modules = {qn for (label, qn) in after[0] if label == cs.NodeLabel.MODULE.value}
+    assert modules == {"proj.util", "proj.main"}
+    assert after == _clean(temp_repo, JS_AFTER, cs.SupportedLanguage.JS)

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -487,3 +487,38 @@ def test_a_reused_updater_joins_a_java_fact_against_the_renamed_module(
     assert after == _calls(
         _clean(temp_repo, JAVA_FACT_AFTER, cs.SupportedLanguage.JAVA)
     )
+
+
+# A same-stem replacement takes over the deleted file's module qn, and the
+# CommonJS export registry keys on that qn: dropping the deleted file's state
+# a second time after the parse would strip the replacement's entry and the
+# whole-module alias call below would lose its edge.
+CJS_BEFORE = {
+    "util.js": "module.exports = function helper() { return 1; };\n",
+    "main.js": "const f = require('./util');\nfunction go() { return f(); }\n",
+}
+CJS_AFTER = {
+    "util.ts": CJS_BEFORE["util.js"],
+    "main.js": CJS_BEFORE["main.js"],
+}
+
+
+def test_a_reused_updater_keeps_a_same_stem_replacements_commonjs_export(
+    temp_repo: Path,
+) -> None:
+    root = temp_repo / "proj"
+    _materialise(root, CJS_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.JS)
+    updater.run(force=True)
+    first = _calls(_snapshot(store, root))
+    assert ("proj.main.go", "proj.util.helper") in first, first
+
+    (root / "util.js").unlink()
+    (root / "util.ts").write_text(CJS_AFTER["util.ts"], encoding="utf-8")
+    _bump(root, "util.ts")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    assert ("proj.main.go", "proj.util.helper") in _calls(after), _calls(after)
+    assert after == _clean(temp_repo, CJS_AFTER, cs.SupportedLanguage.JS)


### PR DESCRIPTION
Closes #1575. Seventh layer of stack #1562, on #1573.

## What happens

With one `GraphUpdater` reused across runs, as the MCP server, the watcher and `reingest` do: rename `base.py` to `core.py` and update `main.py`'s import in the same cycle, and the re-parsed `main.py` gets `go INSTANTIATES proj.base.Base`, the deleted file's class; replace `util.js` with `util.ts` and the new module is named `proj.util.ts`. A fresh updater per run gives the clean result (`proj.core.Base`, `proj.util`).

## Why

Two pieces of the deleted file survived into the run:

- `remove_file_from_state` ran for deleted files only in the late deletion block, after Pass 2, so the deleted file's `module_qn_to_file_path` entry still made the disambiguator suffix its same-stem replacement. It also never dropped that map entry for languages other than Rust and C#.
- The call resolver memoises name-to-qn answers across files and the batch path never reset them (`reingest` does), so Pass 3 served the previous run's `Base -> proj.base.Base`.

## Fix

- Deleted files leave the in-memory state right after their subtrees are deleted, before any file of the run is parsed (the late block repeats it harmlessly), and `remove_file_from_state` drops every module-qn map entry that points at the file.
- `run()` resets the resolver caches before Pass 3 on every run.

## Test

`test_incremental_deleted_state.py` drives both scenarios through one updater and asserts the binding (`INSTANTIATES` target set, module qn set) and the whole snapshot equal a clean index of the resulting tree. Both red before, green after; the resolver reset is what turns the rename case green, the state drop the same-stem case. 982 emulator, incremental and updater tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved incremental updates so deleted, renamed, and replaced files no longer leave stale code-resolution data behind.
  - Same-name files replaced across languages now resolve to the correct module and language.
  - Renamed modules and their references are resolved correctly after subsequent updates.
  - Rehydrated projects now discard outdated definitions and resolve against current files.
  - Updates continue processing remaining files while preserving the initial failure for reporting.

- **Tests**
  - Added coverage for incremental updates across Python, JavaScript, Rust, Go, and Java, including language-specific resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->