### PR TITLE
test: cover the project scope component boundary with a discriminating fixture

### DIFF
--- a/codebase_rag/tests/test_mcp_project_scoping.py
+++ b/codebase_rag/tests/test_mcp_project_scoping.py
@@ -88,6 +88,52 @@ class TestTheFilter:
 
         assert [r["qualified_name"] for r in kept] == [f"{base}.real.Thing"]
 
+    def test_a_project_named_after_another_projects_name_is_still_excluded(
+        self, tmp_path: Path
+    ) -> None:
+        """The pair above cannot fail if the separator is dropped.
+
+        `alpha` and `alpha_extra` derive to `alpha__<digest>` and
+        `alpha_extra__<digest>`, which diverge before the digest -- so a bare
+        `startswith` excludes the sibling anyway and the fixture proves
+        nothing about the separator. Deleting it leaves the whole suite
+        green.
+
+        A directory named after an EXISTING project's derived name does
+        produce a strict prefix, because the digest is appended to a base
+        that may itself already end in one:
+
+            alpha                    -> alpha__11912daa
+            alpha__11912daa_extra    -> alpha__11912daa_extra__f71503af
+
+        Both match the generator's own `<base>__<8 hex digits>` shape, and
+        the second starts with the first. Without the separator, that row
+        would be served to a caller scoped to the first project.
+        """
+        from codebase_rag.tools.codebase_query import scope_rows_to_project
+        from codebase_rag.utils.path_utils import derive_project_name
+
+        base_dir = tmp_path / "alpha"
+        base_dir.mkdir()
+        base = derive_project_name(base_dir)
+
+        nested_dir = tmp_path / f"{base}_extra"
+        nested_dir.mkdir()
+        nested = derive_project_name(nested_dir)
+
+        # The premise: without this the test could pass for the same
+        # non-reason the fixture above does.
+        assert nested.startswith(base), (base, nested)
+
+        rows = [
+            {"qualified_name": f"{base}.real.Thing"},
+            {"qualified_name": f"{nested}.other.Thing"},
+        ]
+
+        kept = scope_rows_to_project(rows, base)
+
+        assert [r["qualified_name"] for r in kept] == [f"{base}.real.Thing"]
+
     def test_a_row_keyed_on_something_other_than_qualified_name_is_scoped(
         self,
     ) -> None:

--- a/codebase_rag/tools/codebase_query.py
+++ b/codebase_rag/tools/codebase_query.py
@@ -156,6 +156,11 @@ def scope_rows_to_project(
     """
     if not project_name:
         return rows
+    # The separator makes this a COMPONENT-boundary match, so one project
+    # cannot swallow another whose name extends it. Reachable: a directory
+    # named after an existing project's derived name derives again, giving
+    # `alpha__11912daa` and `alpha__11912daa_extra__f71503af` -- a genuine
+    # strict prefix, both in the generator's own shape.
     prefix = f"{project_name}{cs.SEPARATOR_DOT}"
     kept: list[ResultRow] = []
     for row in rows:


### PR DESCRIPTION
## What

Closes a **pre-existing coverage gap on `main`**: the component-boundary separator in `scope_rows_to_project` had no test that could tell it from a bare prefix match. Deleting `cs.SEPARATOR_DOT` from the prefix left the entire suite green.

Adds `test_a_project_named_after_another_projects_name_is_still_excluded`, plus a comment recording why the branch is reachable.

## Why the existing fixture missed it

The old fixture used `alpha` / `alpha_extra`. Those derive to names that **diverge at index 6 — before the digest marker ends** — so a bare `startswith` already excludes the sibling. It never exercised the separator at all.

A genuine strict prefix needs a directory named after an existing project's *derived name*, because `derive_project_name` appends its digest to the directory's name and that base may already end in a digest:

```
alpha                        -> alpha__11912daa
alpha__11912daa_extra        -> alpha__11912daa_extra__f71503af
```

Both match the generator's own `_PROJECT_NAME_RE`. The test derives both names at runtime rather than hardcoding them, and asserts `nested.startswith(base)` as an explicit premise.

## Verification

- **Mutation:** dropping the separator (`f"{project_name}{cs.SEPARATOR_DOT}"` -> `f"{project_name}"`) fails this test and **only** this test: `1 failed, 161 passed`. The failure is on the row assertion with the sibling leaking through, not on the premise.
- **Premise is structural, not lucky:** 300 independent `tmp_path` iterations, zero non-strict-prefix cases; the boundary character is never `.`.
- **No regression:** 162 passed on the branch vs 161 on `main` — exactly the one added test.
- `ruff check` / `format` clean.

## Note on the docstring

The illustrative digests (`11912daa`, `f71503af`) show the *shape* and are not reproducible from a fixed path. Nothing depends on them: both names match the real regex, and the test hardcodes neither.

Follow-up to #1578 (issue #1508). The filter itself is unchanged and was already correct — this only adds the fixture that can prove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project scoping to prevent similarly named projects from being incorrectly included in results.
  * Added regression coverage for project names that are prefixes of longer derived names.

* **Documentation**
  * Clarified project-name boundary behavior to support accurate result filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->