### PR TITLE
test: pin GraphUpdater.run's documented resolution-phase order (#1552)

### DIFF
--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -30,6 +30,13 @@ handler-lock guard is (see `test_mcp_read_handler_lock.py`):
   one reordering whose fixture it owns. This catches any reordering of any
   pinned pair, including in code paths no fixture reaches.
 
+The table is NOT a complete census of `run`'s ordering constraints, and a
+green run here is not evidence that an unpinned reordering is safe. Two
+constraints are deliberately unpinnable (see the note above `_ORDER`), and
+a constraint whose prose sits above neither call site could not be pinned
+without weakening the drift check. Treat this as a ratchet: when you find
+a documented dependency that is not in the table, add it.
+
 Each pair below is a dependency stated in `graph_updater.py`'s own
 comments, quoted in the `reason`. This deliberately pins PAIRS rather than
 freezing the whole sequence: inserting a new phase, or reordering two steps
@@ -156,7 +163,10 @@ _ORDER: tuple[tuple[str, str, str, str], ...] = (
     (
         "finalise_rust_mod_scope_uses",
         "resolve_deferred_inherits",
-        "full registry",
+        # Stated above the EARLIER call, and "inline-mod" is unique to it --
+        # the later call's comment is about registry completeness generally
+        # and would match a generic marker without being about this pair.
+        "earlier:inline-mod",
         "inline-mod import maps commit before the deferred inheritance pass, "
         "which re-resolves module-anchored trait guesses through them",
     ),
@@ -273,19 +283,33 @@ def test_every_pinned_dependency_is_still_explained_at_its_call_site() -> None:
     a real dependency decays into cargo that the next reader reorders or
     deletes because nothing says it matters.
 
-    This checks only that the `later` call site still carries SOME comment
-    naming its dependency, not that the wording matches: pinning exact
-    prose would fail on every copy-edit, and a guard that punishes
-    legitimate edits gets deleted rather than obeyed.
+    This checks only that the call site still carries SOME comment naming
+    its dependency, not that the wording matches: pinning exact prose would
+    fail on every copy-edit, and a guard that punishes legitimate edits gets
+    deleted rather than obeyed.
+
+    Which call site carries the justification is per pair. Most state it
+    above the LATER call ("After rehydration: ..."), but a constraint phrased
+    forwards states it above the EARLIER one ("Inline-mod import maps commit
+    BEFORE the deferred inheritance pass below"). A marker prefixed
+    `earlier:` is checked against the earlier call's comment instead.
+    Getting this wrong makes a pair VACUOUS rather than loud: checking the
+    wrong side matched a neighbouring comment about something else, so
+    deleting the only prose that justified the Rust pair left this test
+    green.
     """
     called = _call_lines()
     unexplained: list[str] = []
     for earlier, later, marker, _reason in _ORDER:
-        comment = _comment_above(called[later][0]).lower()
+        if marker.startswith("earlier:"):
+            marker, site, line = marker[len("earlier:") :], earlier, called[earlier][-1]
+        else:
+            site, line = later, called[later][0]
+        comment = _comment_above(line).lower()
         if marker not in comment:
             unexplained.append(
-                f"the call to {later} (line {called[later][0]}) depends on "
-                f"{earlier}, but the comment above it no longer says "
+                f"the {earlier} -> {later} dependency is stated above "
+                f"{site} (line {line}), but that comment no longer says "
                 f"{marker!r}: {comment[:110]!r}"
             )
     assert not unexplained, (

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -46,13 +46,17 @@ from pathlib import Path
 
 _SOURCE = Path(__file__).resolve().parents[1] / "graph_updater.py"
 
-# (earlier, later, reason). `earlier` must be called before `later` in
-# `GraphUpdater.run`. Every reason is quoted from the comment that states
-# the dependency at the call site.
-_ORDER: tuple[tuple[str, str, str], ...] = (
+# (earlier, later, marker, reason). `earlier` must be called before `later`
+# in `GraphUpdater.run`. `marker` is the phrase the comment above the `later`
+# call uses to name that dependency -- the source states several of these in
+# prose ("After rehydration", "After artifact resolution") rather than by
+# attribute name, so the phrase is recorded per pair instead of guessed from
+# the identifier. `reason` is the dependency itself, quoted from that comment.
+_ORDER: tuple[tuple[str, str, str, str], ...] = (
     (
         "_rehydrate_registry_from_graph",
         "resolve_deferred_cpp_methods",
+        "after rehydration",
         "an out-of-class method's class is only known once the registry is "
         "read back from the graph; resolving earlier binds it to a "
         "module-anchored fallback qn (issue #1552)",
@@ -60,6 +64,7 @@ _ORDER: tuple[tuple[str, str, str], ...] = (
     (
         "resolve_deferred_cpp_methods",
         "_resolve_hybrid_macro_calls",
+        "after resolve_deferred_cpp_methods",
         "an out-of-class method's span is recorded only once its class "
         "binding resolves, and a macro use inside such a method must "
         "attribute to it, not the Module",
@@ -67,11 +72,13 @@ _ORDER: tuple[tuple[str, str, str], ...] = (
     (
         "_rehydrate_registry_from_graph",
         "_resolve_hybrid_expansion_calls",
+        "after rehydration",
         "an expansion call's callee join needs spans for unchanged files too",
     ),
     (
         "_rehydrate_registry_from_graph",
         "resolve_deferred_forward_declarations",
+        "after rehydration",
         'the "does a real definition exist?" check must see definitions in '
         "files an incremental run did not re-parse, or a forward declaration "
         "whose definition lives in an unchanged file is kept as a phantom",
@@ -79,47 +86,55 @@ _ORDER: tuple[tuple[str, str, str], ...] = (
     (
         "resolve_deferred_forward_declarations",
         "resolve_deferred_cpp_artifacts",
+        "forward declarations",
         "a kept forward-declared TYPE also proves the name is a class, not a macro",
     ),
     (
         "resolve_deferred_cpp_artifacts",
         "resolve_deferred_cpp_prototypes",
+        "after artifact resolution",
         "a recovery-registered definition also counts when dropping a "
         "prototype that duplicates a bodied definition",
     ),
     (
         "resolve_deferred_forward_declarations",
         "resolve_deferred_cpp_inherits",
+        "after forward declarations",
         "a base whose only representation is a kept forward declaration "
         "still resolves to a real node",
     ),
     (
         "finalise_rust_mod_scope_uses",
         "resolve_deferred_inherits",
+        "full registry",
         "inline-mod import maps commit before the deferred inheritance pass, "
         "which re-resolves module-anchored trait guesses through them",
     ),
     (
         "resolve_deferred_cpp_methods",
         "resolve_deferred_parent_links",
+        "deferred c++ methods",
         "every node-registering pass must finish before parent qns are "
         "verified against the registry",
     ),
     (
         "resolve_deferred_go_methods",
         "resolve_deferred_parent_links",
+        "go receivers",
         "every node-registering pass must finish before parent qns are "
         "verified against the registry",
     ),
     (
         "resolve_deferred_forward_declarations",
         "resolve_deferred_parent_links",
+        "forward declarations",
         "every node-registering pass must finish before parent qns are "
         "verified against the registry",
     ),
     (
         "_process_function_calls",
         "flush_deferred_import_edges",
+        "after pass 3",
         "a C# namespace import lands on the modules the file actually "
         "resolved entities from, and those resolutions are recorded during "
         "call processing (issue #1347)",
@@ -152,6 +167,61 @@ def _call_lines() -> dict[str, list[int]]:
     return {name: sorted(found) for name, found in lines.items()}
 
 
+def _comment_above(line: int) -> str:
+    """The contiguous `#` comment block immediately above `line`.
+
+    The call may be an assignment wrapped over several lines
+    (`x = (\\n    self.factory...`), so skip back over any continuation
+    lines before looking for the comment block.
+    """
+    source = _SOURCE.read_text(encoding="utf-8").splitlines()
+    index = line - 1  # `line` is 1-based
+    while index > 0:
+        stripped = source[index - 1].strip()
+        if stripped.startswith("#") or not stripped:
+            break
+        if stripped.endswith("(") or stripped.endswith("="):
+            index -= 1
+            continue
+        break
+    block: list[str] = []
+    while index > 0 and source[index - 1].strip().startswith("#"):
+        block.insert(0, source[index - 1].strip().lstrip("#").strip())
+        index -= 1
+    return " ".join(block)
+
+
+def test_every_pinned_dependency_is_still_explained_at_its_call_site() -> None:
+    """The constraint and the prose that justifies it must not drift apart.
+
+    `_ORDER` records WHY each pair is ordered, quoted from the comment at
+    the call site. If that comment is deleted or rewritten to say something
+    else, the table keeps asserting an order whose reason no longer exists
+    anywhere in the source -- and an unexplained ordering constraint is how
+    a real dependency decays into cargo that the next reader reorders or
+    deletes because nothing says it matters.
+
+    This checks only that the `later` call site still carries SOME comment
+    naming its dependency, not that the wording matches: pinning exact
+    prose would fail on every copy-edit, and a guard that punishes
+    legitimate edits gets deleted rather than obeyed.
+    """
+    called = _call_lines()
+    unexplained: list[str] = []
+    for earlier, later, marker, _reason in _ORDER:
+        comment = _comment_above(called[later][0]).lower()
+        if marker not in comment:
+            unexplained.append(
+                f"the call to {later} (line {called[later][0]}) depends on "
+                f"{earlier}, but the comment above it no longer says "
+                f"{marker!r}: {comment[:110]!r}"
+            )
+    assert not unexplained, (
+        "A pinned ordering dependency lost the comment that justifies it:\n"
+        + "\n".join(unexplained)
+    )
+
+
 def test_every_pinned_phase_is_actually_called() -> None:
     """A renamed or deleted phase must fail here, not silently unpin itself.
 
@@ -160,7 +230,7 @@ def test_every_pinned_phase_is_actually_called() -> None:
     which is the failure mode `test_mcp_read_handler_lock.py` documents.
     """
     called = _call_lines()
-    pinned = {name for earlier, later, _ in _ORDER for name in (earlier, later)}
+    pinned = {name for earlier, later, _m, _r in _ORDER for name in (earlier, later)}
     missing = sorted(name for name in pinned if name not in called)
     assert not missing, (
         f"{missing} are pinned by this test but no longer called in "
@@ -174,7 +244,7 @@ def test_resolution_phases_keep_their_documented_order() -> None:
     """Each documented dependency holds in the source order of `run`."""
     called = _call_lines()
     violations: list[str] = []
-    for earlier, later, reason in _ORDER:
+    for earlier, later, _marker, reason in _ORDER:
         # Compare the LAST call of `earlier` against the FIRST of `later`:
         # the dependency is that every `earlier` has completed, so a second
         # `earlier` after `later` breaks it just as a swap does.

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -307,6 +307,13 @@ def test_every_pinned_dependency_is_still_explained_at_its_call_site() -> None:
     projection, but a comment is free prose that must stay editable, and a
     guard failing on every copy-edit gets deleted rather than obeyed.
 
+    Moving a pinned call is fine as long as its comment travels with it:
+    relocating `_resolve_hybrid_expansion_calls` together with its two
+    comment lines passes, while moving the call alone fails here naming that
+    call. That is deliberate, not a false alarm -- an ordering constraint
+    stranded from its explanation is the state this test exists to prevent,
+    and the remedy is to bring the comment along, not to relax the check.
+
     That limit is acceptable only because it is not the load-bearing guard.
     `test_resolution_phases_keep_their_documented_order` reads no prose at
     all, so the CODE-corrupting defect -- the reordering itself -- is caught

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -53,34 +53,49 @@ from pathlib import Path
 
 _SOURCE = Path(__file__).resolve().parents[1] / "graph_updater.py"
 
-# Two real constraints in `run` are deliberately NOT pinned, because the
-# phase is called more than once and a line-number comparison cannot express
-# "this particular call":
+# Real constraints in `run` that are deliberately NOT pinned. Recorded
+# rather than silently omitted: a reader who finds these comments and no
+# matching entry should know they were considered and why they were left
+# out. Each would need the check weakened in a way that costs more than the
+# pair is worth.
 #
 # * "LIBCLANG must run before Pass 2" / "HYBRID must run after Pass 2" --
 #   both are `_run_cpp_frontend`, called at two sites under opposite mode
-#   gates, so neither ordering holds of the name.
+#   gates, so neither ordering holds of the NAME, which is all a
+#   line-number comparison can see.
 # * "The delombok state commits ONLY here, after every pass and the graph
 #   flush" -- `flush_all` is called twice, so it is a poor anchor.
-#
-# Recorded rather than silently omitted: a reader who finds these comments
-# and no matching entry should know they were considered.
+# * "The C# Roslyn frontend must run before Pass 2" and the Go equivalent --
+#   stated above the frontends, not above `_process_files`. A "before"
+#   constraint whose prose sits above the earlier call is expressible via
+#   the `earlier:` prefix below, but only when that prose sits directly
+#   above the call.
+# * "Before the partial join on an incremental run: rebuild the type
+#   locations for unchanged .cs files" (#1229) -- a genuine
+#   `_rehydrate_csharp_type_locations` -> `_join_csharp_partials`
+#   dependency, but the comment sits above the enclosing `if`, not above
+#   the call. `_comment_above` reads the block directly above a call, and
+#   widening it to look through an enclosing statement would risk
+#   attaching a neighbouring phase's comment.
 #
 # (earlier, later, marker, reason). `earlier` must be called before `later`
-# in `GraphUpdater.run`. `marker` is the phrase the comment above the `later`
-# call uses to name that dependency -- the source states several of these in
-# prose ("After rehydration", "After artifact resolution") rather than by
-# attribute name, so the phrase is recorded per pair instead of guessed from
-# the identifier. `reason` is the dependency itself, quoted from that comment.
-# NOTE: "LIBCLANG/Roslyn/Go must run BEFORE Pass 2" is stated in comments
-# above those frontends, not above `_process_files`. This table's drift check
-# requires the justification above the LATER call, so a "before" constraint
-# whose prose sits above the EARLIER call cannot be expressed here without
-# weakening that check for every entry. Left unpinned rather than pinned
-# without its explanation; the "after Pass 2" constraints below are pinned
-# because their prose does sit above the later call.
+# in `GraphUpdater.run`. `marker` is the phrase the call-site comment uses to
+# name that dependency -- the source states several in prose ("After
+# rehydration", "After artifact resolution") rather than by attribute name,
+# so the phrase is recorded per pair instead of guessed from the identifier.
+# A marker prefixed `earlier:` is checked above the EARLIER call instead.
+# `reason` is the dependency itself, quoted from that comment.
 _ORDER: tuple[tuple[str, str, str, str], ...] = (
     # -- around Pass 2 (`_process_files`) --
+    (
+        "_rehydrate_go_type_locations",
+        "_join_go_implements",
+        # Stated above the earlier call, in the block that follows it.
+        "earlier:col-keyed indexes",
+        "the Go IMPLEMENTS join resolves against locations Pass 2 filled "
+        "only for re-parsed files, so the col-keyed indexes must be "
+        "rehydrated first (issue #1240)",
+    ),
     (
         "_process_files",
         "_join_csharp_partials",

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -65,11 +65,6 @@ _SOURCE = Path(__file__).resolve().parents[1] / "graph_updater.py"
 #   line-number comparison can see.
 # * "The delombok state commits ONLY here, after every pass and the graph
 #   flush" -- `flush_all` is called twice, so it is a poor anchor.
-# * "The C# Roslyn frontend must run before Pass 2" and the Go equivalent --
-#   stated above the frontends, not above `_process_files`. A "before"
-#   constraint whose prose sits above the earlier call is expressible via
-#   the `earlier:` prefix below, but only when that prose sits directly
-#   above the call.
 # * "Before the partial join on an incremental run: rebuild the type
 #   locations for unchanged .cs files" (#1229) -- a genuine
 #   `_rehydrate_csharp_type_locations` -> `_join_csharp_partials`
@@ -87,6 +82,21 @@ _SOURCE = Path(__file__).resolve().parents[1] / "graph_updater.py"
 # `reason` is the dependency itself, quoted from that comment.
 _ORDER: tuple[tuple[str, str, str, str], ...] = (
     # -- around Pass 2 (`_process_files`) --
+    (
+        "_run_csharp_frontend",
+        "_process_files",
+        "earlier:must run before pass 2",
+        "the Roslyn frontend produces a base-classification oracle that "
+        "split_csharp_bases consults while ingesting each type's "
+        "INHERITS/IMPLEMENTS edges during Pass 2",
+    ),
+    (
+        "_run_go_frontend",
+        "_process_files",
+        "earlier:before pass 2",
+        "Go facts are read at Pass 3 and the name-alias target index is "
+        "filled during Pass 2, so they must load before it",
+    ),
     (
         "_rehydrate_go_type_locations",
         "_join_go_implements",

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -297,6 +297,23 @@ def test_every_pinned_dependency_is_still_explained_at_its_call_site() -> None:
     wrong side matched a neighbouring comment about something else, so
     deleting the only prose that justified the Rust pair left this test
     green.
+
+    KNOWN LIMIT, measured rather than assumed. `marker in comment` is a
+    MEMBERSHIP test, so it sees what the comment lacks but not what it says
+    IN ADDITION. A rewrite that keeps the marker word and reverses the claim
+    ("After rehydration this used to matter, but the registry is now
+    populated eagerly, so the ordering is no longer load-bearing") passes
+    here. Whole-value equality would close that, as it does for a Cypher
+    projection, but a comment is free prose that must stay editable, and a
+    guard failing on every copy-edit gets deleted rather than obeyed.
+
+    That limit is acceptable only because it is not the load-bearing guard.
+    `test_resolution_phases_keep_their_documented_order` reads no prose at
+    all, so the CODE-corrupting defect -- the reordering itself -- is caught
+    whatever the comments say (verified: reversing `1ba25c7e`'s hunk with
+    every comment left pristine still fails it). What this test adds is that
+    a constraint cannot silently lose its explanation; what it does not
+    promise is that the surviving explanation is still TRUE.
     """
     called = _call_lines()
     unexplained: list[str] = []

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -1,0 +1,190 @@
+"""`GraphUpdater.run` resolution phases must keep their documented order.
+
+`run` ends in a long resolution pipeline whose steps depend on each other:
+a pass reads state that an earlier pass registers. Every one of those
+dependencies is currently recorded ONLY as a prose comment ("After
+rehydration: ...", "Last containment step: ..."). Prose does not fail a
+build, and reordering two of these steps corrupts the graph SILENTLY --
+no exception, just wrong nodes.
+
+That is not hypothetical. Issue #1552: `resolve_deferred_cpp_methods` ran
+BEFORE `_rehydrate_registry_from_graph`, so an incremental re-parse of a
+`.cpp` whose class lives in an unchanged header could not see the class,
+fell back to a module-anchored qn, and left a phantom second node for one
+method. Commit `1ba25c7e` fixed it by moving the call after rehydration.
+
+The order is also easy to revert by ACCIDENT, and the accident survives
+every cheap review check. A merge resolution that keeps every call -- an
+identical call multiset, nothing deleted, a clean `git diff --stat` --
+can still restore the pre-fix sequence, because order is a property of the
+SEQUENCE and membership queries cannot see it.
+
+The test is STRUCTURAL, over the AST of `run`, for the same reasons the
+handler-lock guard is (see `test_mcp_read_handler_lock.py`):
+
+- The behavioural test for #1552 needs a C++ parser and SKIPS without one,
+  so on a base install nothing guards the order at all.
+- A behavioural test per constraint would need a fixture per language that
+  happens to exercise the path; most of these constraints have none.
+- Most importantly, this guards the RULE. A behavioural test catches the
+  one reordering whose fixture it owns. This catches any reordering of any
+  pinned pair, including in code paths no fixture reaches.
+
+Each pair below is a dependency stated in `graph_updater.py`'s own
+comments, quoted in the `reason`. This deliberately pins PAIRS rather than
+freezing the whole sequence: inserting a new phase, or reordering two steps
+with no dependency between them, is legitimate and must stay easy. Only the
+documented dependencies are load-bearing, so only those are enforced -- a
+guard that failed on every legitimate edit would be deleted rather than
+obeyed.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SOURCE = Path(__file__).resolve().parents[1] / "graph_updater.py"
+
+# (earlier, later, reason). `earlier` must be called before `later` in
+# `GraphUpdater.run`. Every reason is quoted from the comment that states
+# the dependency at the call site.
+_ORDER: tuple[tuple[str, str, str], ...] = (
+    (
+        "_rehydrate_registry_from_graph",
+        "resolve_deferred_cpp_methods",
+        "an out-of-class method's class is only known once the registry is "
+        "read back from the graph; resolving earlier binds it to a "
+        "module-anchored fallback qn (issue #1552)",
+    ),
+    (
+        "resolve_deferred_cpp_methods",
+        "_resolve_hybrid_macro_calls",
+        "an out-of-class method's span is recorded only once its class "
+        "binding resolves, and a macro use inside such a method must "
+        "attribute to it, not the Module",
+    ),
+    (
+        "_rehydrate_registry_from_graph",
+        "_resolve_hybrid_expansion_calls",
+        "an expansion call's callee join needs spans for unchanged files too",
+    ),
+    (
+        "_rehydrate_registry_from_graph",
+        "resolve_deferred_forward_declarations",
+        'the "does a real definition exist?" check must see definitions in '
+        "files an incremental run did not re-parse, or a forward declaration "
+        "whose definition lives in an unchanged file is kept as a phantom",
+    ),
+    (
+        "resolve_deferred_forward_declarations",
+        "resolve_deferred_cpp_artifacts",
+        "a kept forward-declared TYPE also proves the name is a class, not a macro",
+    ),
+    (
+        "resolve_deferred_cpp_artifacts",
+        "resolve_deferred_cpp_prototypes",
+        "a recovery-registered definition also counts when dropping a "
+        "prototype that duplicates a bodied definition",
+    ),
+    (
+        "resolve_deferred_forward_declarations",
+        "resolve_deferred_cpp_inherits",
+        "a base whose only representation is a kept forward declaration "
+        "still resolves to a real node",
+    ),
+    (
+        "finalise_rust_mod_scope_uses",
+        "resolve_deferred_inherits",
+        "inline-mod import maps commit before the deferred inheritance pass, "
+        "which re-resolves module-anchored trait guesses through them",
+    ),
+    (
+        "resolve_deferred_cpp_methods",
+        "resolve_deferred_parent_links",
+        "every node-registering pass must finish before parent qns are "
+        "verified against the registry",
+    ),
+    (
+        "resolve_deferred_go_methods",
+        "resolve_deferred_parent_links",
+        "every node-registering pass must finish before parent qns are "
+        "verified against the registry",
+    ),
+    (
+        "resolve_deferred_forward_declarations",
+        "resolve_deferred_parent_links",
+        "every node-registering pass must finish before parent qns are "
+        "verified against the registry",
+    ),
+    (
+        "_process_function_calls",
+        "flush_deferred_import_edges",
+        "a C# namespace import lands on the modules the file actually "
+        "resolved entities from, and those resolutions are recorded during "
+        "call processing (issue #1347)",
+    ),
+)
+
+
+def _run_function() -> ast.FunctionDef:
+    tree = ast.parse(_SOURCE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "GraphUpdater":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == "run":
+                    return item
+    raise AssertionError("GraphUpdater.run not found in graph_updater.py")
+
+
+def _call_lines() -> dict[str, list[int]]:
+    """Every attribute call in `run`, mapped to the lines it is called on.
+
+    Keyed by attribute name only: these phases are reached through several
+    receivers (`self`, `self.factory.definition_processor`,
+    `self.factory.import_processor`) and the receiver is not what the order
+    depends on.
+    """
+    lines: dict[str, list[int]] = {}
+    for node in ast.walk(_run_function()):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            lines.setdefault(node.func.attr, []).append(node.func.lineno)
+    return {name: sorted(found) for name, found in lines.items()}
+
+
+def test_every_pinned_phase_is_actually_called() -> None:
+    """A renamed or deleted phase must fail here, not silently unpin itself.
+
+    Without this, the ordering test below would pass vacuously for any pair
+    whose calls no longer exist -- the guard would go green by not looking,
+    which is the failure mode `test_mcp_read_handler_lock.py` documents.
+    """
+    called = _call_lines()
+    pinned = {name for earlier, later, _ in _ORDER for name in (earlier, later)}
+    missing = sorted(name for name in pinned if name not in called)
+    assert not missing, (
+        f"{missing} are pinned by this test but no longer called in "
+        "GraphUpdater.run. If a phase was renamed or removed, update _ORDER "
+        "-- do not delete the constraint without checking the dependency it "
+        "records is genuinely gone."
+    )
+
+
+def test_resolution_phases_keep_their_documented_order() -> None:
+    """Each documented dependency holds in the source order of `run`."""
+    called = _call_lines()
+    violations: list[str] = []
+    for earlier, later, reason in _ORDER:
+        # Compare the LAST call of `earlier` against the FIRST of `later`:
+        # the dependency is that every `earlier` has completed, so a second
+        # `earlier` after `later` breaks it just as a swap does.
+        earlier_line = called[earlier][-1]
+        later_line = called[later][0]
+        if earlier_line > later_line:
+            violations.append(
+                f"{earlier} (line {earlier_line}) must run BEFORE {later} "
+                f"(line {later_line}): {reason}"
+            )
+    assert not violations, "GraphUpdater.run phase order violated:\n" + "\n".join(
+        violations
+    )

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -46,13 +46,63 @@ from pathlib import Path
 
 _SOURCE = Path(__file__).resolve().parents[1] / "graph_updater.py"
 
+# Two real constraints in `run` are deliberately NOT pinned, because the
+# phase is called more than once and a line-number comparison cannot express
+# "this particular call":
+#
+# * "LIBCLANG must run before Pass 2" / "HYBRID must run after Pass 2" --
+#   both are `_run_cpp_frontend`, called at two sites under opposite mode
+#   gates, so neither ordering holds of the name.
+# * "The delombok state commits ONLY here, after every pass and the graph
+#   flush" -- `flush_all` is called twice, so it is a poor anchor.
+#
+# Recorded rather than silently omitted: a reader who finds these comments
+# and no matching entry should know they were considered.
+#
 # (earlier, later, marker, reason). `earlier` must be called before `later`
 # in `GraphUpdater.run`. `marker` is the phrase the comment above the `later`
 # call uses to name that dependency -- the source states several of these in
 # prose ("After rehydration", "After artifact resolution") rather than by
 # attribute name, so the phrase is recorded per pair instead of guessed from
 # the identifier. `reason` is the dependency itself, quoted from that comment.
+# NOTE: "LIBCLANG/Roslyn/Go must run BEFORE Pass 2" is stated in comments
+# above those frontends, not above `_process_files`. This table's drift check
+# requires the justification above the LATER call, so a "before" constraint
+# whose prose sits above the EARLIER call cannot be expressed here without
+# weakening that check for every entry. Left unpinned rather than pinned
+# without its explanation; the "after Pass 2" constraints below are pinned
+# because their prose does sit above the later call.
 _ORDER: tuple[tuple[str, str, str, str], ...] = (
+    # -- around Pass 2 (`_process_files`) --
+    (
+        "_process_files",
+        "_join_csharp_partials",
+        "after pass 2",
+        "the Roslyn declaration locations resolve against the Class qns "
+        "Pass 2 just registered",
+    ),
+    (
+        "_process_files",
+        "_join_go_implements",
+        "after pass 2",
+        "both ends resolve against the go_type_locations index Pass 2 just registered",
+    ),
+    (
+        "_process_files",
+        "_run_python_frontend",
+        "after pass 2",
+        "the Jedi facts join Pass 3 calls against the function_locations "
+        "Pass 2 filled, and it needs the parsed-file list Pass 2 produced "
+        "(issue #1183)",
+    ),
+    (
+        "_process_files",
+        "_run_java_frontend",
+        "pass 2 registered",
+        "the Java facts resolve against the method name-token locations "
+        "Pass 2 registered (issue #1181)",
+    ),
+    # -- the deferred-resolution pipeline --
     (
         "_rehydrate_registry_from_graph",
         "resolve_deferred_cpp_methods",
@@ -130,6 +180,28 @@ _ORDER: tuple[tuple[str, str, str, str], ...] = (
         "forward declarations",
         "every node-registering pass must finish before parent qns are "
         "verified against the registry",
+    ),
+    (
+        "_process_function_calls",
+        "_emit_csharp_query_calls",
+        "after pass 3",
+        "LINQ query-operator edges join after Pass 3 with the complete "
+        "function-location registry: both ends must be registered nodes",
+    ),
+    (
+        "_process_files",
+        "_emit_pending_endpoints",
+        "every module is parsed now",
+        "router mount prefixes may be cross-module, so every module must be "
+        "parsed before they can resolve (issue #877)",
+    ),
+    (
+        "_process_files",
+        "analyze",
+        "definition pass already emitted",
+        "the ast-grep findings post-pass links to the Modules the definition "
+        "pass already emitted, so it cannot run before them without leaving "
+        "dangling edges",
     ),
     (
         "_process_function_calls",

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -343,6 +343,14 @@ def test_every_pinned_dependency_is_still_explained_at_its_call_site() -> None:
     `analyze()`) makes both the ordering and drift tests FAIL loudly. A
     false positive someone must investigate, never a silent pass.
 
+    That membership limit is REACHABLE, not theoretical: the rewrite above
+    is an ordinary English sentence someone writes on believing a constraint
+    was superseded, and it passes all three tests. What makes it tolerable
+    is measured, not argued -- rewrite the comment that way AND then act on
+    it by moving the call, and
+    `test_resolution_phases_keep_their_documented_order` FAILS. The prose
+    can be made to lie; the order cannot.
+
     That limit is acceptable only because it is not the load-bearing guard.
     `test_resolution_phases_keep_their_documented_order` reads no prose at
     all, so the CODE-corrupting defect -- the reordering itself -- is caught

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -329,6 +329,20 @@ def test_every_pinned_dependency_is_still_explained_at_its_call_site() -> None:
     stranded from its explanation is the state this test exists to prevent,
     and the remedy is to bring the comment along, not to relax the check.
 
+    SECOND KNOWN LIMIT: `_call_lines` keys on the attribute NAME and ignores
+    the receiver, because these phases are reached through several
+    (`self`, `self.factory.definition_processor`,
+    `self.factory.import_processor`, `self.finding_analyzer`) and the
+    receiver is not what the order depends on. Eleven of the pinned names
+    are not `GraphUpdater` methods at all, so this file never checks they
+    exist on the object that owns them -- a rename on a processor class
+    would leave these tests green while `run` calls something absent. That
+    is caught by running the code, not here.
+    The collision direction is fail-SAFE, verified rather than assumed: an
+    unrelated receiver gaining a same-named call inside `run` (e.g. a second
+    `analyze()`) makes both the ordering and drift tests FAIL loudly. A
+    false positive someone must investigate, never a silent pass.
+
     That limit is acceptable only because it is not the load-bearing guard.
     `test_resolution_phases_keep_their_documented_order` reads no prose at
     all, so the CODE-corrupting defect -- the reordering itself -- is caught

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -31,11 +31,12 @@ handler-lock guard is (see `test_mcp_read_handler_lock.py`):
   pinned pair, including in code paths no fixture reaches.
 
 The table is NOT a complete census of `run`'s ordering constraints, and a
-green run here is not evidence that an unpinned reordering is safe. Two
-constraints are deliberately unpinnable (see the note above `_ORDER`), and
-a constraint whose prose sits above neither call site could not be pinned
-without weakening the drift check. Treat this as a ratchet: when you find
-a documented dependency that is not in the table, add it.
+green run here is not evidence that an unpinned reordering is safe. Three
+constraints are left unpinned, each named with its reason in the note above
+`_ORDER`. Treat this as a ratchet: when you find a documented dependency
+that is not in the table, add it -- two of the entries below were added
+that way after a review showed the note's reason for excluding them no
+longer held.
 
 Each pair below is a dependency stated in `graph_updater.py`'s own
 comments, quoted in the `reason`. This deliberately pins PAIRS rather than


### PR DESCRIPTION
`GraphUpdater.run` ends in a long resolution pipeline whose steps depend on each other: a pass reads state an earlier pass registers. Every one of those dependencies is recorded **only as a prose comment** ("After rehydration: ...", "Last containment step: ..."). Prose does not fail a build, and reordering two of these steps corrupts the graph silently — no exception, just wrong nodes.

This adds one test file (417 lines, no production code) pinning 22 of those constraints structurally.

## Why now

Issue #1552 was exactly this bug: `resolve_deferred_cpp_methods` ran before `_rehydrate_registry_from_graph`, so an incremental re-parse of a `.cpp` whose class lives in an unchanged header could not see the class, fell back to a module-anchored qn, and left a phantom second node. Fixed by `1ba25c7e`.

The fix restored the order and nothing stops the next merge reverting it. That is not hypothetical — a session resolving a conflict in `graph_updater.py` did revert it while keeping every call. The call multiset was **identical**, nothing was deleted, `git diff --stat` was clean, and the reversal was invisible to every one of those checks, because order is a property of the sequence and membership queries cannot see it. It surfaced as 3 failed / 8917 passed, one C++ method registered under two qualified names.

`1ba25c7e` shipped a behavioural test, but it `pytest.skip`s without a C++ parser — so on a base install nothing guarded the order at all, which is the configuration where that merge was verified.

## What it does

Three AST guards over `run`:

1. **`test_resolution_phases_keep_their_documented_order`** — the load-bearing one. 22 pinned `(earlier, later)` pairs, each carrying the source comment that justifies it. Reads no prose, so it catches a reordering whatever the comments say.
2. **`test_every_pinned_phase_is_actually_called`** — anti-vacuity: a renamed or deleted phase fails loudly instead of silently unpinning its constraint.
3. **`test_every_pinned_dependency_is_still_explained_at_its_call_site`** — the constraint and its justification must not drift apart. An unexplained ordering constraint is how a real dependency decays into cargo the next reader deletes.

It pins **pairs, not the sequence**. Inserting a phase, or reordering two steps with no dependency between them, is legitimate and stays easy — a guard that failed on every legitimate edit would be deleted rather than obeyed.

## Verification

Every claim below was run, not reasoned about. `graph_updater.py` was restored and checksum-verified after each mutation, and is byte-identical to `main` on this branch.

**Catches (RED):**
- reversing `1ba25c7e`'s hunk — the genuine pre-#1552 order — naming the constraint, both line numbers and the issue
- each of the 22 pairs reordered individually
- blanking the justifying comment for any of the 22, on whichever side states it
- renaming a pinned phase

**Accommodates (explicit `PASSED`, verified with `-rA` rather than a summary):**
- inserting a brand-new unrelated phase mid-pipeline
- rewording a comment's tail
- moving a pinned call **together with** its comment block

## Documented limits

These are in the file's docstring rather than papered over:

- The drift check is `marker in comment`, a **membership** test, so a rewrite keeping the marker word and reversing the claim passes. Measured, not theoretical — it is an ordinary English sentence. What bounds it is also measured: do that **and** act on it by moving the call, and the ordering test fails. The prose can be made to lie; the order cannot.
- `_call_lines` keys on attribute **name**, ignoring the receiver; 11 pinned names are not `GraphUpdater` methods, so a rename on a processor class leaves these green. The collision direction is verified fail-**safe**: an unrelated receiver gaining a same-named call makes both tests fail loudly, never pass silently.
- Three constraints are left **unpinned**, each recorded with its reason: two phases called twice under opposite mode gates (`_run_cpp_frontend`, `flush_all`), where no ordering holds of the name; and #1229's `_rehydrate_csharp_type_locations` -> `_join_csharp_partials`, whose comment sits above the enclosing `if` rather than the call, so pinning it would mean loosening the comment lookup for every entry.

The table is explicitly **not** a complete census, and the docstring says so: treat it as a ratchet and add constraints as they are found.

## Test plan

- `uv run python -m pytest codebase_rag/tests/test_graph_updater_phase_order.py` — 3 passed
- Full non-integration suite: 8868 passed, 49 skipped, 1 xfailed, 0 failed
- `ruff check` / `ruff format --check` clean
- No production code changed: `git diff origin/main -- codebase_rag/graph_updater.py` is empty

Local review: 5/5, no findings, at this exact head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added structural checks to preserve the documented execution order of the graph resolution pipeline.
  * Added validation that required pipeline phases and their explanatory comments remain present.
  * Added coverage for frontend processing order before file processing.
  * Documented intentionally untested ordering constraints and known test limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
