### PR TITLE
test: order delegate phases by call site so extracting run's stages cannot make the guard vacuous

### DIFF
--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -250,7 +250,25 @@ _ORDER: tuple[tuple[str, str, str, str], ...] = (
 )
 
 
+# `run` may delegate its deferred-resolution stages to a helper so that the
+# scoped re-ingest path (#1524) can reuse the same sequence. The ordering
+# constraints hold wherever those stages LIVE, not only in `run`, so the
+# guard scans `run` plus the helpers it delegates to. Without this, extracting
+# the block would make every pinned pair vacuous -- the anti-vacuity test
+# catches that as a loud failure, and this is the correct response to it.
+#
+# `_DELEGATES` is a name this file READS rather than calls, so a rename here
+# yields an empty enumeration rather than an error -- and an empty
+# enumeration is zero violations, which is indistinguishable from
+# compliance. That is why `test_every_pinned_phase_is_actually_called` is
+# load-bearing twice over: it catches a pinned phase leaving `run`, AND a
+# delegate name going stale. Verified: renaming the helper makes all three
+# tests fail loudly rather than pass vacuously.
+_DELEGATES = ("_resolve_deferred_definitions",)
+
+
 def _run_function() -> ast.FunctionDef:
+    """`GraphUpdater.run`, the entry point whose phase order is pinned."""
     tree = ast.parse(_SOURCE.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == "GraphUpdater":
@@ -258,6 +276,27 @@ def _run_function() -> ast.FunctionDef:
                 if isinstance(item, ast.FunctionDef) and item.name == "run":
                     return item
     raise AssertionError("GraphUpdater.run not found in graph_updater.py")
+
+
+def _ordered_functions() -> list[ast.FunctionDef]:
+    """`run` and any delegate helper, in source order.
+
+    Source order matters: the pinned pairs are compared by line number, and a
+    helper defined ABOVE `run` still executes where `run` calls it. Sorting by
+    `lineno` keeps a constraint spanning both bodies meaningful.
+    """
+    tree = ast.parse(_SOURCE.read_text(encoding="utf-8"))
+    found: list[ast.FunctionDef] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "GraphUpdater":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and (
+                    item.name == "run" or item.name in _DELEGATES
+                ):
+                    found.append(item)
+    if not found:
+        raise AssertionError("GraphUpdater.run not found in graph_updater.py")
+    return sorted(found, key=lambda f: f.lineno)
 
 
 def _call_lines() -> dict[str, list[int]]:
@@ -269,9 +308,10 @@ def _call_lines() -> dict[str, list[int]]:
     depends on.
     """
     lines: dict[str, list[int]] = {}
-    for node in ast.walk(_run_function()):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-            lines.setdefault(node.func.attr, []).append(node.func.lineno)
+    for fn in _ordered_functions():
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                lines.setdefault(node.func.attr, []).append(node.func.lineno)
     return {name: sorted(found) for name, found in lines.items()}
 
 

--- a/codebase_rag/tests/test_graph_updater_phase_order.py
+++ b/codebase_rag/tests/test_graph_updater_phase_order.py
@@ -264,55 +264,91 @@ _ORDER: tuple[tuple[str, str, str, str], ...] = (
 # load-bearing twice over: it catches a pinned phase leaving `run`, AND a
 # delegate name going stale. Verified: renaming the helper makes all three
 # tests fail loudly rather than pass vacuously.
+#
+# A delegate's statements are ordered at the line where `run` CALLS it, not
+# where it is defined -- see `_execution_positions`. Ordering by definition
+# line would be wrong in both directions, because the helper is defined
+# above `run` and invoked from the middle of it.
 _DELEGATES = ("_resolve_deferred_definitions",)
 
 
-def _run_function() -> ast.FunctionDef:
-    """`GraphUpdater.run`, the entry point whose phase order is pinned."""
+def _class_body() -> list[ast.FunctionDef]:
+    """Every method of `GraphUpdater`, so callers can locate `run` and delegates."""
     tree = ast.parse(_SOURCE.read_text(encoding="utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == "GraphUpdater":
-            for item in node.body:
-                if isinstance(item, ast.FunctionDef) and item.name == "run":
-                    return item
-    raise AssertionError("GraphUpdater.run not found in graph_updater.py")
+            return [f for f in node.body if isinstance(f, ast.FunctionDef)]
+    raise AssertionError("class GraphUpdater not found in graph_updater.py")
 
 
-def _ordered_functions() -> list[ast.FunctionDef]:
-    """`run` and any delegate helper, in source order.
+def _execution_positions() -> list[tuple[ast.FunctionDef, int]]:
+    """`run` and its delegates, each tagged with where it EXECUTES in `run`.
 
-    Source order matters: the pinned pairs are compared by line number, and a
-    helper defined ABOVE `run` still executes where `run` calls it. Sorting by
-    `lineno` keeps a constraint spanning both bodies meaningful.
+    A delegate is defined wherever it happens to sit in the file -- in the
+    extraction of #1524 the helper is defined at 904 while `run` starts at
+    1032 and only CALLS it at 1131. Sorting by definition line would model
+    the helper as running before all of `run`, which is false in both
+    directions: a pinned pair spanning the boundary would then pass while
+    genuinely violated, or be reported violated while correct.
+
+    So each function is tagged with its execution position instead: `run`'s
+    own statements keep their line, and a delegate's body is spliced in at
+    the line where `run` invokes it. `_position_key` turns that into a
+    sortable pair.
     """
-    tree = ast.parse(_SOURCE.read_text(encoding="utf-8"))
-    found: list[ast.FunctionDef] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == "GraphUpdater":
-            for item in node.body:
-                if isinstance(item, ast.FunctionDef) and (
-                    item.name == "run" or item.name in _DELEGATES
-                ):
-                    found.append(item)
-    if not found:
+    methods = _class_body()
+    run = next((f for f in methods if f.name == "run"), None)
+    if run is None:
         raise AssertionError("GraphUpdater.run not found in graph_updater.py")
-    return sorted(found, key=lambda f: f.lineno)
+    out: list[tuple[ast.FunctionDef, int]] = [(run, 0)]
+    by_name = {f.name: f for f in methods}
+    for node in ast.walk(run):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _DELEGATES
+            and node.func.attr in by_name
+        ):
+            out.append((by_name[node.func.attr], node.func.lineno))
+    return out
 
 
-def _call_lines() -> dict[str, list[int]]:
-    """Every attribute call in `run`, mapped to the lines it is called on.
+def _call_lines() -> dict[str, list[tuple[int, int]]]:
+    """Every attribute call reachable from `run`, mapped to EXECUTION positions.
 
     Keyed by attribute name only: these phases are reached through several
     receivers (`self`, `self.factory.definition_processor`,
     `self.factory.import_processor`) and the receiver is not what the order
     depends on.
     """
-    lines: dict[str, list[int]] = {}
-    for fn in _ordered_functions():
+    lines: dict[str, list[tuple[int, int]]] = {}
+    for fn, callsite in _execution_positions():
         for node in ast.walk(fn):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
-                lines.setdefault(node.func.attr, []).append(node.func.lineno)
+                # `run`'s own statements sort by their own line (callsite 0);
+                # a delegate's statements sort at the line `run` calls it,
+                # then by position within the delegate. So a pair spanning
+                # the boundary compares by EXECUTION order, not by where the
+                # helper happens to be defined.
+                key = (
+                    (node.func.lineno, 0)
+                    if callsite == 0
+                    else (callsite, node.func.lineno)
+                )
+                lines.setdefault(node.func.attr, []).append(key)
     return {name: sorted(found) for name, found in lines.items()}
+
+
+def _source_line(position: tuple[int, int]) -> int:
+    """The real source line of an execution position.
+
+    `run`'s own statements carry `(line, 0)`; a delegate's carry
+    `(callsite, line)`. Either way the source line is the last non-zero
+    component -- which is what `_comment_above` needs, since a comment sits
+    above the statement where it is WRITTEN, not where it executes.
+    """
+    callsite, inner = position
+    return inner or callsite
 
 
 def _comment_above(line: int) -> str:
@@ -414,9 +450,11 @@ def test_every_pinned_dependency_is_still_explained_at_its_call_site() -> None:
     unexplained: list[str] = []
     for earlier, later, marker, _reason in _ORDER:
         if marker.startswith("earlier:"):
-            marker, site, line = marker[len("earlier:") :], earlier, called[earlier][-1]
+            marker, site = marker[len("earlier:") :], earlier
+            line = _source_line(called[earlier][-1])
         else:
-            site, line = later, called[later][0]
+            site = later
+            line = _source_line(called[later][0])
         comment = _comment_above(line).lower()
         if marker not in comment:
             unexplained.append(
@@ -456,9 +494,11 @@ def test_resolution_phases_keep_their_documented_order() -> None:
         # Compare the LAST call of `earlier` against the FIRST of `later`:
         # the dependency is that every `earlier` has completed, so a second
         # `earlier` after `later` breaks it just as a swap does.
-        earlier_line = called[earlier][-1]
-        later_line = called[later][0]
-        if earlier_line > later_line:
+        earlier_pos = called[earlier][-1]
+        later_pos = called[later][0]
+        earlier_line = _source_line(earlier_pos)
+        later_line = _source_line(later_pos)
+        if earlier_pos > later_pos:
             violations.append(
                 f"{earlier} (line {earlier_line}) must run BEFORE {later} "
                 f"(line {later_line}): {reason}"


### PR DESCRIPTION
The phase-order guard added in #1583 scans `GraphUpdater.run` only. The Agent IDE epic chain (#1521) extracts run's deferred-resolution stages into `_resolve_deferred_definitions` so the scoped re-ingest path (#1524) can reuse them — so on all eleven layers of that chain, the 12 pinned phase names are no longer *in* `run` and every pinned pair would be vacuous.

The guard's anti-vacuity assertion catches this and fails loudly rather than passing on nothing, which is the assertion working as designed on a case it was written for. This is the correct response to it.

## What it does

Scans `run` **plus its delegates**, ordering each delegate's statements at the line where `run` *calls* it:

- `_execution_positions()` returns `(function, callsite_line)` — `run` tagged `0`, each delegate tagged with its invocation line.
- `_call_lines()` keys call sites as `(line, 0)` for `run`'s own statements, `(callsite, inner_line)` for a delegate's.
- `_source_line()` recovers the real line where one is needed (the drift check's comment lookup, and failure messages).

## Why not order by definition line

The first version did, and it was wrong in both directions. The helper is **defined** at 904–1030 while `run` spans 1032+ and **invokes** it at 1131 — so 8 pinned names in `run` genuinely execute *before* the helper's 12 phases, and a definition-line sort puts them after.

That produced a **false pass**: injecting an extra `resolve_deferred_parent_links()` into `run` at line 1098 genuinely violates "every node-registering pass must finish before parent qns are verified", and the old model reported `3 passed`. It also produced a **false alarm**, reporting a violation for the genuinely-correct pair `_process_files → resolve_deferred_go_methods`.

Both are fixed and both were reproduced independently in review.

## Verification

| case | before | after |
|---|---|---|
| false pass — extra call in `run` at 1098 | `3 passed` | **2 failed**, naming line 1098 |
| false alarm — correct cross-boundary pair | violation reported | **passes** |
| real defect — reorder *inside* the delegate | 3 violations | 3 violations (no regression) |
| cross-boundary violation, other direction | — | **2 violations**, lines 1131 vs 943/1019 |
| `main` (no delegate present) | 3 passed | 3 passed — backward compatible |

Also confirmed in review: a stale `_DELEGATES` entry fails loudly rather than silently unpinning (it is a name the file *reads*, so an empty enumeration would otherwise be indistinguishable from compliance); making the delegate `async` fails loudly too, since `_class_body()` matches `FunctionDef` and not `AsyncFunctionDef`; and 12 of the 25 pinned names resolve inside the delegate, so the extraction really would have unpinned all of them.

## Test plan

- `uv run python -m pytest codebase_rag/tests/test_graph_updater_phase_order.py` — 3 passed
- Full suite: 8933 passed, 53 skipped, 1 xfailed (257 errors are pre-existing Docker-dependent integration tests, identical on base)
- `ruff check` / `ruff format --check` clean
- No production code changed

Local review: 5/5, no findings, at this exact head.

## Effect

Merging this clears the known guard red on all eleven epic layers at once (#1539, #1542, #1543, #1545, #1546, #1547, #1548, #1549, #1550, #1551, and the chain top). Those branches deliberately did **not** patch the guard file — suppressing the red there would be indistinguishable from fixing it, and the fix belongs where every layer inherits it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for execution-phase ordering.
  * Added validation for deferred-resolution stages and their call positions.
  * Enhanced drift detection to identify changes in the expected execution sequence.
  * No end-user-facing behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->