### PR TITLE
fix: guard grammar-dependent tests on the production loader, not on importability (#1591)

### DIFF
--- a/codebase_rag/tests/test_definition_processor.py
+++ b/codebase_rag/tests/test_definition_processor.py
@@ -1,4 +1,3 @@
-from importlib.util import find_spec
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -971,7 +970,13 @@ def standalone():
         assert len(module_nodes) >= 1
 
 
-RUST_AVAILABLE = find_spec("tree_sitter_rust") is not None
+# Ask the production loader, not `find_spec`. A grammar wheel whose ABI does
+# not match the installed `tree_sitter` imports fine and then raises from
+# `Language(lang_lib())` (`parser_loader.py:379`), which `_process_language`
+# catches -- so the language never lands in the store while `find_spec` still
+# reports it present. Guarding on importability leaves these tests running
+# against a parser that does not exist, failing instead of skipping (#1591).
+RUST_AVAILABLE = "rust" in load_parsers()[0]
 
 
 @pytest.mark.skipif(not RUST_AVAILABLE, reason="tree-sitter-rust not available")

--- a/codebase_rag/tests/test_js_ts_module_system.py
+++ b/codebase_rag/tests/test_js_ts_module_system.py
@@ -1,13 +1,20 @@
-import importlib.util
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+from codebase_rag.parser_loader import load_parsers
 from codebase_rag.tests.conftest import run_updater
 
-JS_AVAILABLE = importlib.util.find_spec("tree_sitter_javascript") is not None
-TS_AVAILABLE = importlib.util.find_spec("tree_sitter_typescript") is not None
+# Ask the production loader, not `find_spec`. A grammar wheel whose ABI does
+# not match the installed `tree_sitter` imports fine and then raises from
+# `Language(lang_lib())` (`parser_loader.py:379`), which `_process_language`
+# catches -- so the language never lands in the store while `find_spec` still
+# reports it present. Guarding on importability leaves these tests running
+# against a parser that does not exist, failing instead of skipping (#1591).
+_PARSERS = load_parsers()[0]
+JS_AVAILABLE = "javascript" in _PARSERS
+TS_AVAILABLE = "typescript" in _PARSERS
 
 
 @pytest.fixture

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -18,12 +18,12 @@
 # to a `minus_metadata` node, which `document_tier` currently ignores.
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+from codebase_rag.parsers import document_tier
 from codebase_rag.parsers.document_tier import parse_front_matter
 
 
@@ -351,9 +351,21 @@ class TestIngestion:
     they pin is easiest to break unnoticed.
     """
 
+    # Guard on the production loader, not on importability. `find_spec` sees
+    # only the ImportError path; a wheel whose ABI does not match the installed
+    # `tree_sitter` imports fine and then raises from `Language(...)`, which
+    # `_load_parser` catches and reports as None. Asking `find_spec` leaves the
+    # guard constant True while production flips, so the tier degrades to plain
+    # File nodes and these tests FAIL rather than skip -- a platform-dependent
+    # missing optional dependency reported as a product defect (#1591).
+    #
+    # `_load_inline_parser` is deliberately NOT consulted: per its docstring the
+    # inline grammar's absence disables link edges alone and never disables the
+    # tier, and front matter comes off the block parser. Guarding on both would
+    # skip these tests over a failure that cannot affect them.
     pytestmark = pytest.mark.skipif(
-        importlib.util.find_spec("tree_sitter_markdown") is None,
-        reason="markdown grammar ships in the treesitter-full extra",
+        document_tier._load_parser() is None,
+        reason="markdown grammar unavailable (absent, or an incompatible wheel)",
     )
 
     def test_front_matter_becomes_module_properties(


### PR DESCRIPTION
Closes #1591.

Test guards used `importlib.util.find_spec("tree_sitter_<lang>")` to mean "the grammar is usable", but every tree-sitter grammar has **two** failure modes and `find_spec` sees only one:

- **mode 1** the module is absent, `ImportError` — `find_spec` sees this
- **mode 2** the module imports and `Language(lang_lib())` then raises (ABI mismatch, `Incompatible Language version`) — `find_spec` is blind

In mode 2 the guard says "run", the grammar is unusable, and the tests **fail instead of skipping**: a platform-dependent missing optional dependency reported as a product defect.

The defect is in the guard **pattern**, not in anything markdown-specific, so this covers every instance on `main` rather than only the file #1591 names (scope widened deliberately).

| site | old guard | new guard |
|---|---|---|
| `test_markdown_front_matter.py` | `find_spec("tree_sitter_markdown")` | `document_tier._load_parser() is None` |
| `test_definition_processor.py` | `find_spec("tree_sitter_rust")` | `"rust" in load_parsers()[0]` |
| `test_js_ts_module_system.py` | `find_spec("tree_sitter_javascript"/`"…typescript")` | `"javascript"/"typescript" in load_parsers()[0]` |

`parser_loader.py:379` does `Language(lang_lib())` inside `try/except Exception`, structurally identical to `document_tier._load_parser()`, so Rust and JS/TS had the same blind spot.

### Why two guard styles

Store membership is *slightly stronger* than `_load_parser() is not None`: `_process_language` pops the parser back out if query compilation fails (`parser_loader.py:390`), so membership means **constructible AND queryable**. It also matches the idiom `conftest.py:166-170` already uses (`lang not in parsers`).

The markdown guard deliberately does **not** consult `_load_inline_parser()`: per its docstring the inline grammar's absence disables link edges alone and never disables the tier, and front matter comes off the block parser — guarding on both would over-skip. Verified by running `DocumentTier.process_file` with the inline grammar poisoned: the Module node is still emitted with front matter fully populated.

### Measured

Simulating the ABI mismatch against the real loader (patching the resolved loader in `_loader_cache`, since `_reset_parser_cache()` does not clear it):

```
state                    find_spec   production loader
grammar working            True            True
installed but UNUSABLE     True            False
restored                   True            True
```

The production warning fires in the middle row (`_process_language:391`, `_load_parser:846`), confirming the real code path rather than a stub; every restore verified. Mode 1 is not regressed — a genuinely absent grammar still reads unavailable — so the new guards strictly dominate the old ones. All flags remain `True` on a healthy install, so no test is newly skipped.

### Deliberately left alone

`test_contract_operations.py:73` (PyYAML) and `test_vector_store.py:384` (`milvus_lite`) are pure-Python importability checks with no `Language(...)` construction step, so `find_spec` is the right question there.

The ~12 `try: import tree_sitter_X` guards share the blind spot in principle but are backed by conftest's autouse fixtures; converting them would be its own PR.

### Note on collection cost

Membership is evaluated at module scope, which loads only the 3 named grammars (~85ms) rather than all 14. conftest's autouse `_unavailable_grammars()` probe already loads all 14 in any pytest run, so this adds no cost the suite was not already paying. `test_lazy_parser_loading.py` is unaffected — both order-sensitive tests were replayed against the collection-time guards and pass, since each resets the cache and save/restores the query globals itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved optional language support detection for Rust, JavaScript, TypeScript, and Markdown.
  - Tests now correctly skip when parsers are unavailable or incompatible, preventing misleading failures.
  - Updated availability checks to reflect whether parsers can actually load successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->