### PR TITLE
fix: report an unverifiable patch distinctly from a verified one

### DIFF
--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -499,7 +499,18 @@ PATCH_OK = "{path}: {count} edit(s) applied"
 # what turned an unverifiable write into an apparently verified one; the
 # write itself is still allowed, since refusing would make edits a silent
 # no-op on a base install where Rust and Go grammars are absent (#1580).
-PATCH_UNVERIFIED = "{path}: {count} edit(s) applied, unverified (no parser for it)"
+# The one wording for "checked by nothing", shared so the two messages that
+# carry it cannot drift apart and a caller can match on either.
+PATCH_UNVERIFIED_FRAGMENT = "unverified (no parser for it)"
+PATCH_UNVERIFIED = "{path}: {count} edit(s) applied, " + PATCH_UNVERIFIED_FRAGMENT
+# Both facts, because either alone is misleading here: drift on its own reads
+# as "parsed fine, just reformat it", and a language with no grammar is
+# exactly the case that also has a formatter installed (Rust, Go).
+PATCH_UNVERIFIED_DRIFT = (
+    "{path}: {count} edit(s) applied, "
+    + PATCH_UNVERIFIED_FRAGMENT
+    + "; {tool} would also reformat it"
+)
 # Edit transactions (issue #1528).
 EDIT_NOT_A_FILE = "Staged path is not a regular file: {path}"
 EDIT_RESERVED_PATH = "Path is cgr state, not part of the tree: {path}"

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -494,6 +494,12 @@ PATCH_NOT_AN_IDENTIFIER = "{path}:{line}:{col} is not a whole identifier"
 PATCH_PARSE_FAILED = "{path} no longer parses after the patch"
 PATCH_FORMAT_DRIFT = "{path} applied, but {tool} would reformat it"
 PATCH_OK = "{path}: {count} edit(s) applied"
+# `parses is None` means no grammar was available, so the patch was checked
+# by nothing. Reported apart from PATCH_OK because reporting both as OK is
+# what turned an unverifiable write into an apparently verified one; the
+# write itself is still allowed, since refusing would make edits a silent
+# no-op on a base install where Rust and Go grammars are absent (#1580).
+PATCH_UNVERIFIED = "{path}: {count} edit(s) applied, unverified (no parser for it)"
 # Edit transactions (issue #1528).
 EDIT_NOT_A_FILE = "Staged path is not a regular file: {path}"
 EDIT_RESERVED_PATH = "Path is cgr state, not part of the tree: {path}"

--- a/codebase_rag/editing/patcher.py
+++ b/codebase_rag/editing/patcher.py
@@ -324,6 +324,16 @@ class Patcher:
             tool, formatted = formatter_check(language, content, Path(key).suffix)
             if parses is False:
                 message = cs.PATCH_PARSE_FAILED.format(path=key)
+            elif parses is None and formatted is False:
+                # The two conditions are independent, so the message has to
+                # carry both. Reporting drift alone here would say the file
+                # merely needs reformatting while hiding that nothing checked
+                # it -- and this pair is not exotic: a language with no
+                # grammar loaded is precisely one whose formatter IS often
+                # installed (Rust, Go on a base install).
+                message = cs.PATCH_UNVERIFIED_DRIFT.format(
+                    path=key, count=len(edits), tool=tool
+                )
             elif formatted is False:
                 message = cs.PATCH_FORMAT_DRIFT.format(path=key, tool=tool)
             elif parses is None:
@@ -355,7 +365,8 @@ class Patcher:
 
         That is a decision about what to WRITE, and it is safe only because
         it is paired with a decision about what to SAY: `apply` reports
-        those files as `PATCH_UNVERIFIED`, not `PATCH_OK`. Staging a file
+        those files as `PATCH_UNVERIFIED`, or `PATCH_UNVERIFIED_DRIFT` when
+        a formatter also objects, never as `PATCH_OK`. Staging a file
         checked by nothing is defensible; telling the caller it was checked
         is not (issue #1580).
         """

--- a/codebase_rag/editing/patcher.py
+++ b/codebase_rag/editing/patcher.py
@@ -326,6 +326,11 @@ class Patcher:
                 message = cs.PATCH_PARSE_FAILED.format(path=key)
             elif formatted is False:
                 message = cs.PATCH_FORMAT_DRIFT.format(path=key, tool=tool)
+            elif parses is None:
+                # Three states, three messages. `parses` is `bool | None`, and
+                # folding None into the OK branch told the caller a file had
+                # been checked when nothing had checked it (issue #1580).
+                message = cs.PATCH_UNVERIFIED.format(path=key, count=len(edits))
             else:
                 message = cs.PATCH_OK.format(path=key, count=len(edits))
             results[key] = PatchResult(
@@ -340,6 +345,19 @@ class Patcher:
         transaction then has nothing from it and the caller sees the
         result's message. Formatter drift is staged (it is the caller's
         rename that changed the alignment) and reported.
+
+        `parses` is `bool | None` and this gate is two-valued, so the third
+        state has to be assigned deliberately rather than by omission. It
+        is assigned to STAGING, and the reason is that refusing would be
+        worse: `None` means no grammar was loaded for the language, which
+        on a base install is the ordinary case for Rust and Go, and a
+        refusal there turns a working edit into a silent no-op.
+
+        That is a decision about what to WRITE, and it is safe only because
+        it is paired with a decision about what to SAY: `apply` reports
+        those files as `PATCH_UNVERIFIED`, not `PATCH_OK`. Staging a file
+        checked by nothing is defensible; telling the caller it was checked
+        is not (issue #1580).
         """
         results = self.apply()
         for key, result in results.items():

--- a/codebase_rag/tests/test_patcher.py
+++ b/codebase_rag/tests/test_patcher.py
@@ -230,6 +230,66 @@ def test_generic_fallback_for_a_language_without_a_grammar(tmp_path: Path) -> No
     assert result.formatter is None
 
 
+def test_an_unverifiable_patch_is_staged_but_reported_as_unverified(
+    tmp_path: Path,
+) -> None:
+    """`parses is None` means "could not check", not "checked and fine".
+
+    `stage_into` gates on `parses is not False`, which is two-valued over a
+    tri-state and so assigns the third value to the WRITING side: a file
+    whose language has no grammar is staged having been checked by nothing
+    (issue #1580). On a base install that is the common case, not an edge
+    one, because the Rust and Go grammars are absent there.
+
+    Staging is kept -- refusing would turn a working edit into a silent
+    no-op on exactly that install. What must not survive is the false
+    assurance: the caller has to be able to tell "verified" from
+    "unverifiable", and both arriving as PATCH_OK is what makes the gate
+    unsafe rather than merely weak.
+    """
+    _write(tmp_path, "notes.txt", "alpha beta\n")
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("notes.txt", 1, 6, "beta", "gamma")
+
+    class Stub:
+        staged: dict[str, bytes] = {}
+
+        def stage(self, rel_path: str | Path, content: str | bytes | None) -> None:
+            self.staged[str(rel_path)] = content  # type: ignore[assignment]
+
+    stub = Stub()
+    results = patcher.stage_into(stub)
+    result = results["notes.txt"]
+
+    assert result.parses is None
+    assert stub.staged == {"notes.txt": b"alpha gamma\n"}, (
+        "an unverifiable patch must still be staged, or base installs "
+        "silently stop applying edits"
+    )
+    assert result.message != cs.PATCH_OK.format(path="notes.txt", count=1), (
+        "unverifiable reported as OK is the false assurance this fixes"
+    )
+    assert result.message == cs.PATCH_UNVERIFIED.format(path="notes.txt", count=1)
+
+
+def test_a_verified_patch_still_reports_ok(tmp_path: Path) -> None:
+    """The control: only the unverifiable case changes message.
+
+    Without it, a change that reported UNVERIFIED for everything would
+    satisfy the assertion above while destroying the distinction it exists
+    to create.
+    """
+    _grammar("python")
+    _write(tmp_path, "m.py", "x = 1\n")
+    patcher = Patcher(tmp_path)
+    patcher.replace_identifier_at("m.py", 1, 0, "x", "xx")
+
+    (result,) = patcher.apply().values()
+
+    assert result.parses is True
+    assert result.message == cs.PATCH_OK.format(path="m.py", count=1)
+
+
 # --- other languages ----------------------------------------------------------
 
 

--- a/codebase_rag/tests/test_patcher.py
+++ b/codebase_rag/tests/test_patcher.py
@@ -272,6 +272,72 @@ def test_an_unverifiable_patch_is_staged_but_reported_as_unverified(
     assert result.message == cs.PATCH_UNVERIFIED.format(path="notes.txt", count=1)
 
 
+def test_a_supported_language_with_no_grammar_is_staged_and_unverified(
+    tmp_path: Path,
+) -> None:
+    """The Rust/Go base-install case, which the `.txt` test does not reach.
+
+    `notes.txt` has no SupportedLanguage at all, so `_parser` returns early
+    and the formatter is never consulted. A `.rs` file with `parsers={}`
+    takes the other branch: the language resolves, the grammar is missing,
+    and `formatter_check` runs for real. Same `parses is None`, different
+    path, and it is the path issue #1580 is actually about.
+    """
+    _write(tmp_path, "m.rs", "fn helper() -> i32 { 1 }\n")
+    patcher = Patcher(tmp_path, parsers={})
+    patcher.replace_identifier_at("m.rs", 1, 3, "helper", "assist")
+
+    staged: dict[str, bytes] = {}
+
+    class Stub:
+        def stage(self, rel_path: str | Path, content: str | bytes | None) -> None:
+            assert isinstance(content, bytes)
+            staged[str(rel_path)] = content
+
+    results = patcher.stage_into(Stub())
+    result = results["m.rs"]
+
+    assert result.parses is None
+    assert staged == {"m.rs": b"fn assist() -> i32 { 1 }\n"}
+    assert cs.PATCH_UNVERIFIED_FRAGMENT in result.message, result.message
+    assert result.message != cs.PATCH_OK.format(path="m.rs", count=1)
+
+
+def test_unverified_and_format_drift_are_both_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drift must not swallow "nothing checked this".
+
+    `formatted is False` was tested before `parses is None`, so a Rust or Go
+    file with no grammar and an installed formatter reported only
+    PATCH_FORMAT_DRIFT -- which reads as "it parsed, it just needs
+    reformatting" (CodeRabbit, PR #1595). The two conditions are
+    independent and this is the pair the issue is about, since a language
+    whose grammar is absent is one whose formatter is often present.
+
+    `formatter_check` is stubbed rather than relying on a real rustfmt, so
+    the branch is exercised on every machine instead of only where the tool
+    happens to be installed and happens to object.
+    """
+    monkeypatch.setattr(
+        "codebase_rag.editing.patcher.formatter_check",
+        lambda _language, _content, _suffix: (cs.PATCH_RUSTFMT, False),
+    )
+    _write(tmp_path, "m.rs", "fn helper() -> i32 { 1 }\n")
+    patcher = Patcher(tmp_path, parsers={})
+    patcher.replace_identifier_at("m.rs", 1, 3, "helper", "assist")
+
+    (result,) = patcher.apply().values()
+
+    assert result.parses is None
+    assert result.formatted is False
+    assert result.message == cs.PATCH_UNVERIFIED_DRIFT.format(
+        path="m.rs", count=1, tool=cs.PATCH_RUSTFMT
+    )
+    assert cs.PATCH_UNVERIFIED_FRAGMENT in result.message
+    assert cs.PATCH_RUSTFMT in result.message
+
+
 def test_a_verified_patch_still_reports_ok(tmp_path: Path) -> None:
     """The control: only the unverifiable case changes message.
 


### PR DESCRIPTION
Closes #1580.

`stage_into` gates on `if result.parses is not False`. `parses` is `bool | None`, so a two-valued branch over three states assigns the third — "could not check" — to the **writing** side. A file whose language has no grammar was staged having been checked by nothing, and `apply` reported it as `PATCH_OK`.

## The decision, and why this one

The issue offered three options and reserved the choice. Taking **option 2**: keep staging on `None`, report it distinctly.

**Option 1 (require `parses is True`) is the one that looks safest and is not.** `None` means no grammar was loaded, which on a base install is the ordinary case for Rust and Go — CI's own base-install job shows `assert None is True` failures in `test_import_rewrite.py` for exactly those languages. Refusing there would turn a working edit into a **silent no-op** on the configuration the issue identifies as most affected. Option 3 moves the tri-state to every call site, which changes the edit algebra's postcondition contract (#1531) — a wider commitment than this defect warrants.

So the write is unchanged and only the report changes. The distinction that matters:

> Staging a file checked by nothing is defensible. Telling the caller it was checked is not.

## What changed

```python
elif parses is None:
    message = cs.PATCH_UNVERIFIED.format(path=key, count=len(edits))
```

plus `PATCH_UNVERIFIED` and a `stage_into` docstring recording that the third state is assigned to staging **deliberately**, with the reason, so the next reader sees a choice rather than an oversight. That also lets the pair be found: the write decision and the report decision are only jointly safe.

No production caller branches on `PATCH_OK` — checked; the only non-test references are the definition and the patcher itself.

## Tests

Written first, verified RED. The failure showed the defect exactly:

```
assert 'notes.txt: 1 edit(s) applied' != 'notes.txt: 1 edit(s) applied'
  where PatchResult(..., parses=None, ..., message='notes.txt: 1 edit(s) applied')
```

`parses=None` with a message byte-identical to `PATCH_OK`.

Two tests, and the second is a control:

- `test_an_unverifiable_patch_is_staged_but_reported_as_unverified` asserts **both** halves — the file is still staged (so a regression to option 1 fails here) and the message is no longer `PATCH_OK`.
- `test_a_verified_patch_still_reports_ok` exists because a change that reported UNVERIFIED for *everything* would satisfy the first test while destroying the distinction it creates.

Reaching the `None` case uses a `.txt` file rather than relying on an absent grammar, so it exercises the same branch on every configuration instead of only on base install.

## A note on the issue's own evidence

Its sweep for this pattern reported three hits. Re-run on current `main`, there is **one**:

```
codebase_rag/editing/patcher.py:346:  if result.parses is not False:
```

The two in `scripts/vet_issue.py` are gone — that file was deleted in #1587 when the issue-vetting scheme was retired. So the patcher is now the sole instance, and the "same collapse exists elsewhere" section is stale rather than wrong.

## Checks

`test_patcher.py`: 17 passed, 1 skipped, 1 failed. The failure is `test_rust_rename_runs_the_rustfmt_check` (`assert result.formatted is True`), and it is **pre-existing**: it fails identically at `origin/main`, and this diff touches `formatted`/`formatter_check` zero times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patch results now distinguish verified edits from edits applied without an available parser.
  * Files without language support are still updated while clearly reporting that verification was unavailable.
  * Unverified edits with formatting drift now display both warnings.
  * Verified patches continue to be reported as successful.

* **Tests**
  * Added coverage for unverified patches, formatting drift, supported languages without parsers, and verified patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->