### PR TITLE
docs: explain how indexing treats a git submodule

### DIFF
--- a/docs/advanced/git-submodules.md
+++ b/docs/advanced/git-submodules.md
@@ -1,0 +1,89 @@
+---
+description: "How Code-Graph-RAG indexes repositories containing Git submodules, and how to exclude or scope them."
+---
+
+# Git Submodules
+
+Code-Graph-RAG has no special handling for Git submodules. A submodule is an
+ordinary directory on disk, so its files are walked and indexed exactly like
+the rest of the repository.
+
+That is usually not what you want, and this page describes what actually
+happens so you can decide.
+
+## Submodule files become part of the parent project
+
+Indexing a repository whose `sub/` directory is a submodule produces module
+nodes for the submodule's files, qualified under the **parent** project:
+
+```
+MODULE nodes: testproj.parentmod
+              testproj.sub.childmod
+```
+
+There is no separate project, and nothing marks those nodes as belonging to
+another repository. Calls, imports and inheritance across the boundary
+resolve as if the submodule's code were first-party.
+
+The consequence to be aware of: dead-code and duplicate reports cover
+submodule code too, and a `1.0` precision figure measured over such a
+repository was measured over vendored code as well as your own.
+
+## A submodule's own `.gitignore` is **not** consulted
+
+Only the **repository root's** `.gitignore` and `.cgrignore` are read. A
+`.gitignore` inside the submodule has no effect:
+
+```
+sub/.gitignore contains "artifacts/"
+walk sees: parentmod.py, sub/artifacts/gen.py, sub/childmod.py
+```
+
+`sub/artifacts/gen.py` is indexed despite the submodule excluding it. Build
+output and generated code inside a submodule therefore reach the graph
+unless the parent excludes them.
+
+Note this is separate from the built-in exclusions. Names like `build`,
+`dist` and `node_modules` are skipped everywhere, including inside
+submodules, because they are default exclusions rather than anything read
+from a `.gitignore`. It is the submodule-specific rules that are lost.
+
+## Excluding a submodule
+
+Put the rule in the **parent** repository's `.cgrignore`. Root-level rules do
+reach into submodule directories:
+
+```
+# .cgrignore in the parent repository root
+sub/
+```
+
+To keep the submodule but drop its generated output, name the path from the
+parent root:
+
+```
+sub/artifacts/
+```
+
+Both work because the walk treats the submodule as an ordinary subdirectory,
+which is the same reason its own ignore file is skipped.
+
+## Indexing a submodule as its own project
+
+If you want the submodule analysed separately, index it as its own
+repository, pointing at the submodule directory. It is a working tree with
+its own history, so the usual commands apply, and its root `.gitignore` is
+then honoured because it is the root.
+
+For querying both together, see [Multi-Project](../guide/multi-project.md).
+
+## Summary
+
+| Question | Answer |
+|---|---|
+| Are submodule files indexed? | Yes, as part of the parent project |
+| Are they marked as external? | No |
+| Is the submodule's `.gitignore` read? | No, only the repository root's |
+| Do default exclusions apply inside it? | Yes |
+| Do parent-root `.cgrignore` rules apply inside it? | Yes |
+| Is `.gitmodules` parsed? | No |

--- a/docs/advanced/git-submodules.md
+++ b/docs/advanced/git-submodules.md
@@ -16,7 +16,7 @@ happens so you can decide.
 Indexing a repository whose `sub/` directory is a submodule produces module
 nodes for the submodule's files, qualified under the **parent** project:
 
-```
+```text
 MODULE nodes: testproj.parentmod
               testproj.sub.childmod
 ```
@@ -34,7 +34,7 @@ repository was measured over vendored code as well as your own.
 Only the **repository root's** `.gitignore` and `.cgrignore` are read. A
 `.gitignore` inside the submodule has no effect:
 
-```
+```text
 sub/.gitignore contains "artifacts/"
 walk sees: parentmod.py, sub/artifacts/gen.py, sub/childmod.py
 ```
@@ -53,7 +53,7 @@ from a `.gitignore`. It is the submodule-specific rules that are lost.
 Put the rule in the **parent** repository's `.cgrignore`. Root-level rules do
 reach into submodule directories:
 
-```
+```gitignore
 # .cgrignore in the parent repository root
 sub/
 ```
@@ -61,7 +61,7 @@ sub/
 To keep the submodule but drop its generated output, name the path from the
 parent root:
 
-```
+```gitignore
 sub/artifacts/
 ```
 

--- a/docs/advanced/ignore-patterns.md
+++ b/docs/advanced/ignore-patterns.md
@@ -31,3 +31,7 @@ fixtures/**
 ## Default Exclusions
 
 Code-Graph-RAG automatically excludes common non-source directories such as `.git`, `node_modules`, `__pycache__`, `dist`, `build`, and similar.
+
+## Scope
+
+Only the **repository root's** `.cgrignore` and `.gitignore` are read. Ignore files in subdirectories are not, and that includes a Git submodule's own `.gitignore` -- its files are indexed as part of the parent project unless the parent excludes them. See [Git Submodules](git-submodules.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
   - Advanced:
     - Adding Languages: advanced/adding-languages.md
     - Ignore Patterns: advanced/ignore-patterns.md
+    - Git Submodules: advanced/git-submodules.md
     - Building Binaries: advanced/building-binaries.md
     - Troubleshooting: advanced/troubleshooting.md
   - Roadmap: roadmap.md


### PR DESCRIPTION
Closes #1589, which asked to investigate submodule behaviour and add a docs section.

Everything below was **measured on a real submodule fixture**, not read off the source. Docs-only change; no behaviour is modified.

## What the investigation found

A parent repo with `sub/` as a genuine submodule (`sub/.git` is a file, not a directory):

**Submodule files are indexed as part of the parent project.**

```
MODULE nodes: testproj.parentmod
              testproj.sub.childmod
```

No separate project, nothing marking them external. Cross-boundary calls, imports and inheritance resolve as first-party. So dead-code and duplicate reports cover vendored code, and an eval figure measured over such a repo covers it too.

**The submodule's own `.gitignore` is not consulted.** Only the repository root's `.gitignore`/`.cgrignore` is read:

```
sub/.gitignore contains "artifacts/"
walk sees: parentmod.py, sub/artifacts/gen.py, sub/childmod.py
```

**A parent-root rule does reach in**, which is the remedy:

```
with parent-root .gitignore containing "artifacts/"
walk sees: parentmod.py, sub/childmod.py
```

**`.gitmodules` is not parsed.** Nothing in the indexer references it; every `submodule` hit in the codebase is a Rust submodule, a Python submodule, or the tree-sitter grammar submodule.

## The fixture had to be corrected before it could answer anything

My first attempt used `build/` as the submodule-ignored directory. It was absent from the walk, which looks like a clean "the submodule's .gitignore is honoured" result. It is not:

```
build in built-in IGNORE_PATTERNS?      True
artifacts in built-in IGNORE_PATTERNS?  False
```

`build` is a **default exclusion**, skipped everywhere regardless of any ignore file, so that fixture could not distinguish "the submodule's rule was applied" from "a built-in rule was applied". Re-running with `artifacts/` isolates the question and gives the opposite answer.

Recording it because the corrected finding is the one in the docs, and because a reader checking this themselves with an obvious directory name would reach the wrong conclusion the same way.

## What shipped

- `docs/advanced/git-submodules.md` — the behaviour, why it happens, how to exclude a submodule or keep it while dropping its generated output, and how to index one as its own project instead. Ends with a summary table.
- `docs/advanced/ignore-patterns.md` — a short **Scope** section stating that only the repository root's ignore files are read, since that page currently implies no scope limit and is where a reader looks first.
- `mkdocs.yml` — nav entry.

## Not changed

The behaviour itself. Treating a submodule as external, or reading its ignore file, are product decisions rather than obvious fixes: some users vendor a submodule precisely because they want it analysed. Documenting the current behaviour answers the issue as written; if the behaviour should change, that wants its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how Git submodules are indexed within a parent project.
  * Clarified which `.gitignore` and `.cgrignore` files apply to submodules and nested paths.
  * Documented how to exclude submodules or generated files and how to index a submodule independently.
  * Added the new Git Submodules page to the Advanced documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->