### PR TITLE
fix: clear the read-only bit when removing a temp repo so Windows teardown succeeds (#1586)

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -4,12 +4,13 @@ import builtins
 import functools
 import os
 import shutil
+import stat
 import sys
 import tempfile
 from collections.abc import Generator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, Self
+from typing import TYPE_CHECKING, Any, Protocol, Self
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -290,12 +291,30 @@ def _isolate_cgr_home(
     yield home
 
 
+def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
+    """Retry a failed removal after clearing the read-only bit.
+
+    On Windows `os.unlink` refuses a read-only file outright, so a tree
+    containing one cannot be removed; POSIX only needs write permission on
+    the containing DIRECTORY, which is why this never fires there. Git sets
+    that bit on every loose object it writes, so any fixture that runs
+    `git init` inside the temp repo leaves `.git/objects/**` unremovable
+    (issue #1586).
+    """
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
 @pytest.fixture
 def temp_repo() -> Generator[Path, None, None]:
     """Creates a temporary repository path for a test and cleans up afterward."""
     temp_dir = tempfile.mkdtemp()
     yield Path(temp_dir)
-    shutil.rmtree(temp_dir)
+    # `onexc` rather than a bare rmtree: see `_clear_readonly`. Teardown
+    # failures surface as an ERROR on a test that already passed, which is
+    # why this is worth handling here rather than per fixture -- `temp_repo`
+    # is used by 327 test modules and any of them may write a read-only file.
+    shutil.rmtree(temp_dir, onexc=_clear_readonly)
 
 
 class _MockIngestor:

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -300,8 +300,20 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     that bit on every loose object it writes, so any fixture that runs
     `git init` inside the temp repo leaves `.git/objects/**` unremovable
     (issue #1586).
+
+    The mode is ADDED to the existing bits rather than replacing them.
+    `chmod(path, S_IWRITE)` sets the mode to exactly `0o200`, which on a
+    DIRECTORY strips the search bit and makes it permanently untraversable --
+    so a removal that failed for any other reason leaves behind a tree nobody
+    can delete, turning a recoverable error into a permanent one. That is the
+    opposite of this handler's purpose, and it bites on POSIX, where the
+    read-only case it exists for cannot even occur.
     """
-    os.chmod(path, stat.S_IWRITE)
+    try:
+        mode = os.stat(path).st_mode
+    except OSError:
+        mode = 0
+    os.chmod(path, mode | stat.S_IWRITE | (stat.S_IEXEC if os.path.isdir(path) else 0))
     func(path)
 
 

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -1,0 +1,141 @@
+"""The `temp_repo` teardown must survive git's read-only loose objects.
+
+Issue #1586: `git init` inside a `temp_repo` leaves `.git/objects/**` marked
+read-only. On Windows `os.unlink` refuses a read-only file outright, so
+`shutil.rmtree` raises and the teardown fails as an ERROR on a test that had
+already passed. POSIX only needs write permission on the CONTAINING directory,
+so the handler never fires there -- which is exactly why it needs a test that
+does not depend on running on Windows.
+
+The Windows condition is simulated rather than described: `os.unlink` is
+replaced with one that refuses a file lacking the write bit, and `shutil`'s
+fd-based fast path is disabled because it never calls the patched `os.unlink`.
+Both halves are required, and each is asserted to be in force before anything
+is concluded from a green result.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codebase_rag.tests.conftest import _clear_readonly
+
+
+def _windows_unlink(real_unlink: Any) -> Any:
+    """An `os.unlink` with Windows semantics: a read-only file cannot go."""
+
+    def unlink(path: Any, **kwargs: Any) -> None:
+        if kwargs.get("dir_fd") is None and not (os.stat(path).st_mode & stat.S_IWRITE):
+            raise PermissionError(13, "Access is denied", str(path))
+        real_unlink(path, **kwargs)
+
+    return unlink
+
+
+@pytest.fixture
+def windows_semantics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make this POSIX machine refuse to unlink read-only files."""
+    # The fd-based path never calls the patched `os.unlink`, so without this
+    # the simulation is vacuous: the tree would delete cleanly and the test
+    # would pass while proving nothing.
+    monkeypatch.setattr(shutil, "_use_fd_functions", False, raising=False)
+    monkeypatch.setattr(os, "unlink", _windows_unlink(os.unlink))
+
+
+def _readonly_tree(root: Path) -> Path:
+    nested = root / "objects" / "2f"
+    nested.mkdir(parents=True)
+    blob = nested / "f5a8deadbeef"
+    blob.write_text("contents", encoding="utf-8")
+    blob.chmod(stat.S_IREAD)
+    return blob
+
+
+def test_the_simulation_reproduces_the_windows_failure(
+    tmp_path: Path, windows_semantics: None
+) -> None:
+    """A bare rmtree must FAIL here, or the fix's green means nothing.
+
+    This is the positive control. If the simulated condition never occurs,
+    `test_clear_readonly_removes_a_tree_windows_cannot` passes whether or not
+    the handler works, and its green would be an artifact of the harness.
+    """
+    root = tmp_path / "bare"
+    root.mkdir()
+    _readonly_tree(root)
+    with pytest.raises(PermissionError):
+        shutil.rmtree(root)
+    assert root.exists(), "the tree must survive the failed removal"
+
+
+def test_clear_readonly_removes_a_tree_windows_cannot(
+    tmp_path: Path, windows_semantics: None
+) -> None:
+    """The handler clears the read-only bit and retries, so the tree goes."""
+    root = tmp_path / "handled"
+    root.mkdir()
+    _readonly_tree(root)
+    shutil.rmtree(root, onexc=_clear_readonly)
+    assert not root.exists()
+
+
+def test_clear_readonly_does_not_mask_a_genuine_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A removal that fails for another reason must still raise.
+
+    The handler retries once; it is not an `ignore_errors=True` in disguise.
+    """
+    root = tmp_path / "always-fails"
+    root.mkdir()
+    (root / "f").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(shutil, "_use_fd_functions", False, raising=False)
+
+    def always_denied(path: Any, **kwargs: Any) -> None:
+        raise PermissionError(13, "Access is denied", str(path))
+
+    monkeypatch.setattr(os, "unlink", always_denied)
+    with pytest.raises(PermissionError):
+        shutil.rmtree(root, onexc=_clear_readonly)
+
+
+def test_a_real_git_repo_is_removable_by_the_temp_repo_teardown(
+    tmp_path: Path, windows_semantics: None
+) -> None:
+    """End to end on a real `git init`, which is how #1586 actually arose.
+
+    Asserts git really did write read-only loose objects before drawing any
+    conclusion -- if it did not, the tree would be trivially removable and
+    this would be a test about nothing.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    (repo / "a.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "a.py"], cwd=repo, check=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "c"], cwd=repo, check=True, env=env)
+
+    objects = repo / ".git" / "objects"
+    readonly = [
+        p
+        for p in objects.rglob("*")
+        if p.is_file() and not (p.stat().st_mode & stat.S_IWRITE)
+    ]
+    assert readonly, "git wrote no read-only loose objects; nothing to test"
+
+    shutil.rmtree(repo, onexc=_clear_readonly)
+    assert not repo.exists()

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -20,6 +20,7 @@ import os
 import shutil
 import stat
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,32 @@ def windows_semantics(monkeypatch: pytest.MonkeyPatch) -> None:
     # would pass while proving nothing.
     monkeypatch.setattr(shutil, "_use_fd_functions", False, raising=False)
     monkeypatch.setattr(os, "unlink", _windows_unlink(os.unlink))
+
+    # Assert the simulation is IN FORCE, here in the fixture rather than in a
+    # separate test. With the check living elsewhere, removing either half
+    # above left the two behavioural tests green and meaningless -- the tree
+    # deletes cleanly on POSIX regardless of the handler, so they concluded
+    # from a green that proved nothing while only the positive control
+    # noticed. A precondition that every test depends on has to fail those
+    # tests, and setup is the only place that does.
+    probe = Path(tempfile.mkdtemp())
+    try:
+        victim = probe / "f"
+        victim.write_text("x", encoding="utf-8")
+        victim.chmod(stat.S_IREAD)
+        try:
+            shutil.rmtree(probe)
+        except PermissionError:
+            return
+        raise AssertionError(
+            "windows_semantics is not in force: a bare rmtree removed a "
+            "read-only file, so every test using this fixture would pass "
+            "without exercising the handler"
+        )
+    finally:
+        for p in sorted(probe.rglob("*"), reverse=True):
+            p.chmod(stat.S_IRWXU)
+        shutil.rmtree(probe, ignore_errors=True)
 
 
 def _readonly_tree(root: Path) -> Path:

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -139,3 +139,32 @@ def test_a_real_git_repo_is_removable_by_the_temp_repo_teardown(
 
     shutil.rmtree(repo, onexc=_clear_readonly)
     assert not repo.exists()
+
+
+def test_the_handler_leaves_a_directory_traversable(tmp_path: Path) -> None:
+    """Clearing read-only on a DIRECTORY must not strip its search bit.
+
+    `os.chmod(path, stat.S_IWRITE)` SETS the mode to exactly `0o200`, so a
+    directory becomes `d-w-------`: writable but not traversable. Nothing can
+    then list or delete its contents, and a removal that failed for some
+    other reason is converted from a recoverable error into a permanently
+    undeletable tree -- the opposite of what this handler exists to do, on
+    the platform where the read-only case cannot even arise.
+
+    Found in the wild: a peer's run reported `(rm_rf) ... [Errno 66] Directory
+    not empty` garbage-collecting a leftover from this very file, and the
+    stranded directory was mode `d-w-------`.
+    """
+    victim = tmp_path / "dir"
+    victim.mkdir()
+    victim.chmod(stat.S_IREAD | stat.S_IEXEC)
+
+    retried: list[object] = []
+    _clear_readonly(retried.append, victim, OSError())
+
+    assert retried == [victim], "the handler must retry the failed operation"
+    assert os.access(victim, os.X_OK), (
+        "the directory must stay traversable, or nothing can ever remove it"
+    )
+    assert os.access(victim, os.W_OK), "the directory must be made writable"
+    victim.chmod(stat.S_IRWXU)

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -186,12 +186,20 @@ def test_the_handler_leaves_a_directory_traversable(tmp_path: Path) -> None:
     victim.mkdir()
     victim.chmod(stat.S_IREAD | stat.S_IEXEC)
 
-    retried: list[object] = []
-    _clear_readonly(retried.append, victim, OSError())
+    # `finally`, not a trailing statement: when this test FAILS -- which is
+    # exactly what it does against the defective handler -- the directory is
+    # left at `d-w-------` and pytest's later `rm_rf` of the tmp root cannot
+    # remove it, reporting `[Errno 66] Directory not empty` on an unrelated
+    # run days later. A test for cleanup that only cleans up when it passes
+    # strands the very state it exists to prevent.
+    try:
+        retried: list[object] = []
+        _clear_readonly(retried.append, victim, OSError())
 
-    assert retried == [victim], "the handler must retry the failed operation"
-    assert os.access(victim, os.X_OK), (
-        "the directory must stay traversable, or nothing can ever remove it"
-    )
-    assert os.access(victim, os.W_OK), "the directory must be made writable"
-    victim.chmod(stat.S_IRWXU)
+        assert retried == [victim], "the handler must retry the failed operation"
+        assert os.access(victim, os.X_OK), (
+            "the directory must stay traversable, or nothing can ever remove it"
+        )
+        assert os.access(victim, os.W_OK), "the directory must be made writable"
+    finally:
+        victim.chmod(stat.S_IRWXU)


### PR DESCRIPTION
Closes #1586.

`git init` inside the `temp_repo` fixture leaves `.git/objects/**` read-only. On Windows `os.unlink` refuses a read-only file outright, so `shutil.rmtree` raises and the teardown fails as an **ERROR on a test that already PASSED**. POSIX only needs write permission on the containing *directory*, which is why this never reproduces locally and why every dev machine has been green.

Measured on a dispatched run at `ff858ffd` (run [33398631302](https://github.com/vitali87/code-graph-rag/actions/runs/33398631302)) — Windows only, both Python versions:

```
PermissionError: [WinError 5] Access is denied:
  ...\\Temp\\tmpxf7d896r\\delta_fixture\\.git\\objects\\04\\55b2f935...
ERROR test_structural_delta.py::test_check_reports_the_delta_since_a_git_ref
```

Independently reproduced by another session on a different branch at head `6cd0729b`: same fixture, same object path.

## The fix

An `onexc` handler on the `temp_repo` teardown that clears the read-only bit and retries. `onexc` landed in 3.12 and `requires-python` is `>=3.12`, so no supported interpreter takes the deprecated `onerror` path.

The mode is **OR-ed onto the existing bits**, not assigned:

```python
mode = os.stat(path).st_mode
os.chmod(path, mode | stat.S_IWRITE | (stat.S_IEXEC if os.path.isdir(path) else 0))
```

`os.chmod(path, stat.S_IWRITE)` **sets** the mode to exactly `0o200`, so a directory becomes `d-w-------` — writable but with no search bit, hence permanently untraversable. That converts a recoverable failure into an unrecoverable one, on the platform where the read-only case cannot even arise. It was not hypothetical: it stranded real undeletable directories on a dev machine, found when a peer's later pytest run hit `(rm_rf) ... [Errno 66] Directory not empty` garbage-collecting the leftovers.

The `isdir` gate is required rather than incidental — adding `S_IEXEC` unconditionally would mark read-only *data* files executable.

## Tests

Five tests. The Windows condition is **simulated** on POSIX (patched `os.unlink` refusing read-only files, plus `shutil._use_fd_functions = False` because the fd path never calls the patched unlink), so the module needs its own guards against passing vacuously:

- **The in-force check lives in the fixture, not a sibling test.** With it in a sibling, removing either half of the simulation left the behavioural tests green and meaningless — the tree deletes cleanly on POSIX regardless of the handler — and only the positive control noticed. Moving it into setup changes `1 failed, 3 passed` into `2 passed, 3 errors`: every dependent test now refuses to run rather than concluding from a vacuous green. Verified for **both** halves.
- **The traversability regression test restores the mode in a `finally`.** As a trailing statement it ran only when the test passed — and the failure path is the only path that ever stranded anything. Verified with a control: the old form against the defective handler leaves 1 stranded directory, the `finally` form leaves 0. A pass proves nothing here, since the trailing statement also ran on the pass.

Mutations, each caught by the test written for it: gut the chmod to a no-op (2 fail); make the handler swallow errors (1 fails); revert to the one-line chmod (traversability test fails on the `os.X_OK` assertion, for its stated reason); remove either simulation half (3 setup errors).

Full suite 8913 passed / 53 skipped / 1 xfailed; the 257 errors are environmental (no Docker daemon for the Memgraph integration marks).

## Scope

`temp_repo` is the only fixture pairing `mkdtemp` with a bare `rmtree`. `tmp_path`-based tests were never exposed, because pytest's own `rm_rf` already chmods and retries. On `main` the only files that git-init inside `temp_repo` are `conftest.py` and the new test; the failing `test_structural_delta.py` lives in the epic stack, so every layer above `feat/structural-delta` inherits the failure until this lands and is merged up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary repository cleanup on Windows by handling read-only files and directories created by Git.
  * Preserved directory access permissions during cleanup.
  * Ensured genuine cleanup failures continue to be reported.

* **Tests**
  * Added comprehensive coverage for read-only file and directory cleanup, including real Git repository scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->