### PR TITLE
fix: tolerate a path that vanishes mid-teardown (#1586 follow-up)

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -323,10 +323,14 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     # the early return skips the retry, and `rmtree` then fails on a link it
     # could simply have unlinked ([Errno 66] Directory not empty). `os.lstat`
     # alone does not fix it -- `os.chmod` follows links too, and
-    # `follow_symlinks=False` is unsupported for chmod on macOS
-    # (`os.supports_follow_symlinks`), so the only portable answer is to skip
-    # the mode work entirely and retry the removal directly. On Windows
-    # `os.path.islink` is true for both symlink kinds, so this keeps the
+    # `follow_symlinks=False` is unsupported for chmod on LINUX, where CI runs:
+    # glibc has no `lchmod` and `fchmodat(AT_SYMLINK_NOFOLLOW)` returns ENOTSUP,
+    # so CPython raises NotImplementedError. It cannot be feature-detected --
+    # `os.chmod` is listed in `os.supports_follow_symlinks` on Linux anyway.
+    # (macOS DOES support it: measured succeeding on a dangling link, 3.12.7.)
+    # So the only portable answer is to skip the mode work entirely and retry
+    # the removal directly. On Windows `os.path.islink` is true for both
+    # symlink kinds, so this keeps the
     # handler platform-independent rather than trading one platform for another.
     if os.path.islink(path):
         # Same vanished-path tolerance as the non-link path below: the link

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -323,15 +323,25 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     # the early return skips the retry, and `rmtree` then fails on a link it
     # could simply have unlinked ([Errno 66] Directory not empty). `os.lstat`
     # alone does not fix it -- `os.chmod` follows links too, and
-    # `follow_symlinks=False` is unsupported for chmod on LINUX, where CI runs:
-    # glibc has no `lchmod` and `fchmodat(AT_SYMLINK_NOFOLLOW)` returns ENOTSUP,
-    # so CPython raises NotImplementedError. It cannot be feature-detected --
-    # `os.chmod` is listed in `os.supports_follow_symlinks` on Linux anyway.
-    # (macOS DOES support it: measured succeeding on a dangling link, 3.12.7.)
-    # So the only portable answer is to skip the mode work entirely and retry
-    # the removal directly. On Windows `os.path.islink` is true for both
-    # symlink kinds, so this keeps the
-    # handler platform-independent rather than trading one platform for another.
+    # `follow_symlinks=False` is unsupported for chmod on LINUX, where CI runs.
+    # CPython is built without `lchmod` there (configure forces it off because
+    # glibc's is a stub that fails on a link), and `os.py` gates chmod's entry
+    # into `os.supports_follow_symlinks` on HAVE_LCHMOD alone -- the
+    # HAVE_FCHMODAT line is deliberately commented out -- so the capability is
+    # simply absent. Measured on Linux/glibc 2.39, CPython 3.12.3 and 3.12.13:
+    # HAVE_LCHMOD 0, `os.chmod not in os.supports_follow_symlinks`, and the
+    # call raises NotImplementedError("chmod: follow_symlinks unavailable on
+    # this platform"). macOS ships HAVE_LCHMOD 1 and the same call SUCCEEDS.
+    #
+    # It IS detectable at runtime, so the skip is a deliberate choice rather
+    # than a workaround for an undetectable gap: branching on the support set
+    # would only trade a platform-specific chmod for a platform-specific skip.
+    # It also matters that NotImplementedError is a RuntimeError, NOT an
+    # OSError -- the `except FileNotFoundError` below would not catch it, so
+    # taking the chmod route would raise straight out of teardown on the one
+    # platform CI actually runs. Skipping the mode work is the portable answer.
+    # On Windows `os.path.islink` is true for both symlink kinds, so this keeps
+    # the handler platform-independent rather than trading one for another.
     if os.path.islink(path):
         # Same vanished-path tolerance as the non-link path below: the link
         # can be gone by the time this retry runs, and that is the state the

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -319,9 +319,14 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     only under `pytest-xdist` on a CI runner, never on a developer machine.
     """
     # A symlink has no mode of its own worth clearing, and every stat/chmod
-    # here FOLLOWS it: on a DANGLING link `os.stat` raises FileNotFoundError,
-    # the early return skips the retry, and `rmtree` then fails on a link it
-    # could simply have unlinked ([Errno 66] Directory not empty). `os.lstat`
+    # here FOLLOWS it: on a DANGLING link `os.stat` raises FileNotFoundError
+    # and the early return leaves the link in place, abandoning a removal the
+    # handler was asked to perform. On POSIX that costs nothing end-to-end
+    # (rmtree unlinks a dangling link unaided in a writable parent, and where
+    # it cannot the blocker is the parent's mode, not the link); the rescued
+    # platform is WINDOWS, where `os.unlink` refuses the link outright and the
+    # handler is the only removal path, so rmtree then fails on the parent.
+    # See the SCOPE block in test_temp_repo_readonly_cleanup.py. `os.lstat`
     # alone does not fix it -- `os.chmod` follows links too, and
     # `follow_symlinks=False` is unsupported for chmod on LINUX, one of the
     # three unit-matrix platforms and the one this handler must survive.

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -308,13 +308,27 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     can delete, turning a recoverable error into a permanent one. That is the
     opposite of this handler's purpose, and it bites on POSIX, where the
     read-only case it exists for cannot even occur.
+
+    A path that VANISHED between the walk and the removal has already reached
+    the state the teardown wanted, so it is not an error to recover from. Git
+    runs background maintenance after `git init` and deletes its own
+    `.git/objects/maintenance.lock` asynchronously, so `rmtree` can list the
+    entry and find it gone by the time it unlinks -- a TOCTOU that surfaced
+    only under `pytest-xdist` on a CI runner, never on a developer machine.
     """
     try:
         mode = os.stat(path).st_mode
+    except FileNotFoundError:
+        return
     except OSError:
         mode = 0
-    os.chmod(path, mode | stat.S_IWRITE | (stat.S_IEXEC if os.path.isdir(path) else 0))
-    func(path)
+    try:
+        os.chmod(
+            path, mode | stat.S_IWRITE | (stat.S_IEXEC if os.path.isdir(path) else 0)
+        )
+        func(path)
+    except FileNotFoundError:
+        return
 
 
 @pytest.fixture

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -311,7 +311,9 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
 
     A path that VANISHED between the walk and the removal has already reached
     the state the teardown wanted, so it is not an error to recover from. Git
-    runs background maintenance after `git init` and deletes its own
+    runs background maintenance after `git commit` -- `git commit` spawns
+    `git maintenance run --auto --quiet --detach`, `git init` spawns nothing
+    (verified under `GIT_TRACE=1`, git 2.47.1) -- and that deletes its own
     `.git/objects/maintenance.lock` asynchronously, so `rmtree` can list the
     entry and find it gone by the time it unlinks -- a TOCTOU that surfaced
     only under `pytest-xdist` on a CI runner, never on a developer machine.

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -316,6 +316,19 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     entry and find it gone by the time it unlinks -- a TOCTOU that surfaced
     only under `pytest-xdist` on a CI runner, never on a developer machine.
     """
+    # A symlink has no mode of its own worth clearing, and every stat/chmod
+    # here FOLLOWS it: on a DANGLING link `os.stat` raises FileNotFoundError,
+    # the early return skips the retry, and `rmtree` then fails on a link it
+    # could simply have unlinked ([Errno 66] Directory not empty). `os.lstat`
+    # alone does not fix it -- `os.chmod` follows links too, and
+    # `follow_symlinks=False` is unsupported for chmod on macOS
+    # (`os.supports_follow_symlinks`), so the only portable answer is to skip
+    # the mode work entirely and retry the removal directly. On Windows
+    # `os.path.islink` is true for both symlink kinds, so this keeps the
+    # handler platform-independent rather than trading one platform for another.
+    if os.path.islink(path):
+        func(path)
+        return
     try:
         mode = os.stat(path).st_mode
     except FileNotFoundError:

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -329,7 +329,14 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     # `os.path.islink` is true for both symlink kinds, so this keeps the
     # handler platform-independent rather than trading one platform for another.
     if os.path.islink(path):
-        func(path)
+        # Same vanished-path tolerance as the non-link path below: the link
+        # can be gone by the time this retry runs, and that is the state the
+        # teardown wanted. Without this the link branch would raise out of
+        # teardown for a case every other branch tolerates.
+        try:
+            func(path)
+        except FileNotFoundError:
+            pass
         return
     try:
         mode = os.stat(path).st_mode

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -323,23 +323,36 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     # the early return skips the retry, and `rmtree` then fails on a link it
     # could simply have unlinked ([Errno 66] Directory not empty). `os.lstat`
     # alone does not fix it -- `os.chmod` follows links too, and
-    # `follow_symlinks=False` is unsupported for chmod on LINUX, where CI runs.
-    # CPython is built without `lchmod` there (configure forces it off because
-    # glibc's is a stub that fails on a link), and `os.py` gates chmod's entry
-    # into `os.supports_follow_symlinks` on HAVE_LCHMOD alone -- the
-    # HAVE_FCHMODAT line is deliberately commented out -- so the capability is
-    # simply absent. Measured on Linux/glibc 2.39, CPython 3.12.3 and 3.12.13:
-    # HAVE_LCHMOD 0, `os.chmod not in os.supports_follow_symlinks`, and the
-    # call raises NotImplementedError("chmod: follow_symlinks unavailable on
-    # this platform"). macOS ships HAVE_LCHMOD 1 and the same call SUCCEEDS.
+    # `follow_symlinks=False` is unsupported for chmod on LINUX, one of the
+    # three unit-matrix platforms and the one this handler must survive.
+    # CPython is built without `lchmod` there (configure.ac forces it off for
+    # every Linux build: "Linux disallows changing the mode of symbolic links.
+    # Some libc implementations have a stub lchmod implementation that always
+    # returns an error." -- the kernel restriction is the reason; the stub is a
+    # secondary note and names no libc), and `os.py` gates chmod's entry into
+    # `os.supports_follow_symlinks` on HAVE_LCHMOD alone -- the HAVE_FCHMODAT
+    # line is deliberately commented out -- so the capability is absent from
+    # the support set -- advisory metadata about the build, not enforcement.
+    # Absent from the SET is not refused at the CALL: HAVE_FCHMODAT *is*
+    # defined on Linux, so posixmodule.c (v3.12.3) compiles out its early
+    # `follow_symlinks_specified` guard at :3348, the call reaches
+    # `fchmodat(AT_SYMLINK_NOFOLLOW)` at :3400, and NotImplementedError comes
+    # only from ENOTSUP/EOPNOTSUPP there (:3408) -- i.e. on a link. The refusal
+    # is FILE-TYPE dependent, not platform dependent. Measured on Ubuntu/glibc
+    # 2.39, x86_64, CPython 3.12.3 and 3.12.13 (musl not measured): HAVE_LCHMOD
+    # 0, `os.chmod not in os.supports_follow_symlinks`, `follow_symlinks=False`
+    # SUCCEEDS on a regular file and raises NotImplementedError("chmod:
+    # follow_symlinks unavailable on this platform") on a dangling link. macOS
+    # 3.12.7 is the mirror image: chmod IS in the set and both cases succeed.
     #
-    # It IS detectable at runtime, so the skip is a deliberate choice rather
-    # than a workaround for an undetectable gap: branching on the support set
-    # would only trade a platform-specific chmod for a platform-specific skip.
+    # The set IS readable at runtime, so the skip is a deliberate choice rather
+    # than a workaround for an undetectable gap -- but branching on it would be
+    # branching on the wrong thing, since it does not predict the call.
     # It also matters that NotImplementedError is a RuntimeError, NOT an
     # OSError -- the `except FileNotFoundError` below would not catch it, so
-    # taking the chmod route would raise straight out of teardown on the one
-    # platform CI actually runs. Skipping the mode work is the portable answer.
+    # taking the chmod route would raise straight out of teardown on the Linux
+    # CI runners (the unit matrix also runs Windows and macOS, where it would
+    # not). Skipping the mode work is the portable answer.
     # On Windows `os.path.islink` is true for both symlink kinds, so this keeps
     # the handler platform-independent rather than trading one for another.
     if os.path.islink(path):

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -266,8 +266,13 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
                                  rmtree still FAILS either way: the blocker is
                                  the PARENT's write bit and no chmod on the
                                  child can clear it. (The errno depends on the
-                                 removal path: 66 on the default fd-based one,
-                                 13 post-fix / 2 pre-fix without it.)
+                                 removal path: 66 on the default fd-based one
+                                 for every revision; without it, 13 post-fix
+                                 and 66 at 701c5036, whose early return leaves
+                                 the link so rmdir on the parent fails. The
+                                 merge-base handler 422d9916, which has no
+                                 vanished-path guard, gave 2 because its chmod
+                                 followed the dangling link.)
 
     So the rescued case is Windows, where `os.unlink` refuses outright and the
     handler is the only path to removal -- the same platform asymmetry as the
@@ -277,8 +282,14 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
     assertion satisfied by the broken code too.
 
     `os.lstat` alone does not fix the handler: `os.chmod` follows links too,
-    and `follow_symlinks=False` is unsupported for chmod on macOS. Skipping
-    the mode work for links is the only portable answer.
+    and `follow_symlinks=False` is unsupported for chmod on LINUX, where CI
+    runs -- glibc has no `lchmod` and `fchmodat(AT_SYMLINK_NOFOLLOW)` returns
+    ENOTSUP, so CPython raises NotImplementedError, and it cannot be
+    feature-detected because `os.chmod` is listed in
+    `os.supports_follow_symlinks` there regardless. macOS DOES support it
+    (measured on a dangling link, 3.12.7), so the conclusion holds for the
+    opposite reason to the obvious one. Skipping the mode work for links is
+    the only portable answer.
     """
     root = tmp_path / "tree"
     root.mkdir()

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -203,3 +203,33 @@ def test_the_handler_leaves_a_directory_traversable(tmp_path: Path) -> None:
         assert os.access(victim, os.W_OK), "the directory must be made writable"
     finally:
         victim.chmod(stat.S_IRWXU)
+
+
+def test_a_vanished_path_is_not_an_error(tmp_path: Path) -> None:
+    """A path removed by someone else between the walk and the unlink.
+
+    `git init` starts background maintenance, which deletes its own
+    `.git/objects/maintenance.lock` asynchronously. `shutil.rmtree` can list
+    that entry and find it gone by the time it unlinks, so the handler is
+    invoked for a path that no longer exists. The removal has already
+    achieved what it wanted, so this must not propagate.
+
+    Observed only under `pytest-xdist` on a CI runner (`popen-gw3`), never on
+    a developer machine -- the window is the few milliseconds git holds the
+    lock, so a serial run on a fast disk closes it before rmtree gets there.
+    """
+    ghost = tmp_path / "already-gone"
+
+    # No file is created: the handler must tolerate a path that is absent
+    # BEFORE it does anything, which is the state the race leaves behind.
+    _clear_readonly(lambda _p: None, ghost, FileNotFoundError(2, "No such file"))
+
+    # And when the path vanishes between the chmod and the retry, which is
+    # the same race one step later.
+    victim = tmp_path / "vanishes"
+    victim.write_text("x", encoding="utf-8")
+
+    def unlink_it(p: Path) -> None:
+        raise FileNotFoundError(2, "No such file or directory", str(p))
+
+    _clear_readonly(unlink_it, victim, FileNotFoundError(2, "No such file"))

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -236,6 +236,15 @@ def test_a_vanished_path_is_not_an_error(tmp_path: Path) -> None:
 
     _clear_readonly(unlink_it, victim, FileNotFoundError(2, "No such file"))
 
+    # And on the SYMLINK branch, which skips the mode work and so does not
+    # pass through the try/except that gives the two cases above their
+    # tolerance. A link is reached here only when the first unlink failed for
+    # some other reason and the link vanished before the retry -- narrow, but
+    # every other branch tolerates it and this one must not be the exception.
+    link = tmp_path / "link-that-vanishes"
+    link.symlink_to(tmp_path / "no-such-target")
+    _clear_readonly(unlink_it, link, OSError(13, "Permission denied"))
+
 
 def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> None:
     """A dangling link must be retried, not silently abandoned.
@@ -254,9 +263,11 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
                                  invoked ZERO times, so the tree comes down
                                  identically with and without this fix.
       link in a 0o500 dir     -- the handler IS reached and now retries, but
-                                 rmtree still fails `[Errno 66]` either way:
-                                 the blocker is the PARENT's write bit and no
-                                 chmod on the child can clear it.
+                                 rmtree still FAILS either way: the blocker is
+                                 the PARENT's write bit and no chmod on the
+                                 child can clear it. (The errno depends on the
+                                 removal path: 66 on the default fd-based one,
+                                 13 post-fix / 2 pre-fix without it.)
 
     So the rescued case is Windows, where `os.unlink` refuses outright and the
     handler is the only path to removal -- the same platform asymmetry as the

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -265,14 +265,18 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
       link in a 0o500 dir     -- the handler IS reached and now retries, but
                                  rmtree still FAILS either way: the blocker is
                                  the PARENT's write bit and no chmod on the
-                                 child can clear it. (The errno depends on the
-                                 removal path: 66 on the default fd-based one
-                                 for every revision; without it, 13 post-fix
-                                 and 66 at 701c5036, whose early return leaves
-                                 the link so rmdir on the parent fails. The
-                                 merge-base handler 422d9916, which has no
-                                 vanished-path guard, gave 2 because its chmod
-                                 followed the dangling link.)
+                                 child can clear it. (Errnos below are NAMES
+                                 because the numbers are platform-specific:
+                                 ENOTEMPTY is 66 on Darwin and 39 on Linux.
+                                 Measured on macOS 3.12.7. The errno depends on
+                                 the removal path: ENOTEMPTY on the default
+                                 fd-based one for every revision; without it,
+                                 EACCES post-fix and ENOTEMPTY at 701c5036,
+                                 whose early return leaves the link so rmdir on
+                                 the parent fails. The merge-base handler
+                                 422d9916, which has no vanished-path guard,
+                                 gave ENOENT because its chmod followed the
+                                 dangling link.)
 
     So the rescued case is Windows, where `os.unlink` refuses outright and the
     handler is the only path to removal -- the same platform asymmetry as the

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -283,13 +283,20 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
 
     `os.lstat` alone does not fix the handler: `os.chmod` follows links too,
     and `follow_symlinks=False` is unsupported for chmod on LINUX, where CI
-    runs -- glibc has no `lchmod` and `fchmodat(AT_SYMLINK_NOFOLLOW)` returns
-    ENOTSUP, so CPython raises NotImplementedError, and it cannot be
-    feature-detected because `os.chmod` is listed in
-    `os.supports_follow_symlinks` there regardless. macOS DOES support it
-    (measured on a dangling link, 3.12.7), so the conclusion holds for the
-    opposite reason to the obvious one. Skipping the mode work for links is
-    the only portable answer.
+    runs. CPython is built without `lchmod` there (configure forces it off
+    because glibc's is a stub that fails on a link), and `os.py` gates chmod's
+    entry into `os.supports_follow_symlinks` on HAVE_LCHMOD alone -- the
+    HAVE_FCHMODAT line is commented out -- so the capability is absent.
+    Measured on Linux/glibc 2.39, CPython 3.12.3 and 3.12.13: HAVE_LCHMOD 0,
+    `os.chmod not in os.supports_follow_symlinks`, and the call raises
+    NotImplementedError. macOS ships HAVE_LCHMOD 1 and the same call succeeds,
+    which is why a macOS-only reading gets this backwards.
+
+    The capability IS detectable at runtime, so the skip is a choice, not a
+    workaround for an undetectable gap. What makes it the right one is that
+    NotImplementedError is a RuntimeError, NOT an OSError: the handler's
+    `except FileNotFoundError` would not catch it, so the chmod route would
+    raise straight out of teardown on the very platform CI runs on.
     """
     root = tmp_path / "tree"
     root.mkdir()

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -208,7 +208,9 @@ def test_the_handler_leaves_a_directory_traversable(tmp_path: Path) -> None:
 def test_a_vanished_path_is_not_an_error(tmp_path: Path) -> None:
     """A path removed by someone else between the walk and the unlink.
 
-    `git init` starts background maintenance, which deletes its own
+    `git commit` starts background maintenance -- it spawns `git maintenance
+    run --auto --quiet --detach`, while `git init` spawns nothing (verified
+    under `GIT_TRACE=1`, git 2.47.1) -- which deletes its own
     `.git/objects/maintenance.lock` asynchronously. `shutil.rmtree` can list
     that entry and find it gone by the time it unlinks, so the handler is
     invoked for a path that no longer exists. The removal has already
@@ -240,14 +242,32 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
 
     Every stat/chmod in the handler FOLLOWS a symlink. On a dangling link
     `os.stat` raises FileNotFoundError, which the vanished-path guard treats
-    as "already gone" and returns -- but the LINK itself is still there, so
-    `rmtree` fails with `[Errno 66] Directory not empty` on an entry it could
-    have unlinked. The link is exactly the thing the handler was asked to
-    remove, and the target's absence says nothing about it.
+    as "already gone" and returns without calling `func` -- but the LINK
+    itself is still there. The link is exactly the thing the handler was
+    asked to remove, and the target's absence says nothing about it.
 
-    `os.lstat` alone does not fix this: `os.chmod` follows links too, and
-    `follow_symlinks=False` is unsupported for chmod on macOS. Skipping the
-    mode work for links is the only portable answer.
+    SCOPE, measured rather than assumed. This test asserts the HANDLER's
+    behaviour, not an end-to-end `rmtree` outcome, because end to end the fix
+    changes nothing on POSIX:
+
+      link in a writable dir  -- rmtree unlinks it unaided; the handler is
+                                 invoked ZERO times, so the tree comes down
+                                 identically with and without this fix.
+      link in a 0o500 dir     -- the handler IS reached and now retries, but
+                                 rmtree still fails `[Errno 66]` either way:
+                                 the blocker is the PARENT's write bit and no
+                                 chmod on the child can clear it.
+
+    So the rescued case is Windows, where `os.unlink` refuses outright and the
+    handler is the only path to removal -- the same platform asymmetry as the
+    read-only case above. On POSIX this is a correctness fix to the handler
+    (it no longer abandons a link it was asked to remove) with no reachable
+    end-to-end consequence. Asserting `rmtree` succeeded here would be an
+    assertion satisfied by the broken code too.
+
+    `os.lstat` alone does not fix the handler: `os.chmod` follows links too,
+    and `follow_symlinks=False` is unsupported for chmod on macOS. Skipping
+    the mode work for links is the only portable answer.
     """
     root = tmp_path / "tree"
     root.mkdir()
@@ -269,6 +289,7 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
         "early leaves it in place and rmtree fails on the parent"
     )
 
-    # And end to end: the tree comes down with the link inside it.
-    shutil.rmtree(root, onexc=_clear_readonly)
-    assert not root.exists()
+    # No end-to-end rmtree assertion here on purpose: see SCOPE above. In a
+    # writable dir rmtree removes the link without ever invoking the handler,
+    # so `assert not root.exists()` passes against the BROKEN handler too and
+    # would be evidence of nothing.

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -282,21 +282,40 @@ def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> No
     assertion satisfied by the broken code too.
 
     `os.lstat` alone does not fix the handler: `os.chmod` follows links too,
-    and `follow_symlinks=False` is unsupported for chmod on LINUX, where CI
-    runs. CPython is built without `lchmod` there (configure forces it off
-    because glibc's is a stub that fails on a link), and `os.py` gates chmod's
+    and `follow_symlinks=False` is unsupported for chmod on LINUX, one of the
+    three unit-matrix platforms. CPython is built without `lchmod` there
+    (configure.ac forces it off for every Linux build: "Linux disallows
+    changing the mode of symbolic links. Some libc implementations have a stub
+    lchmod implementation that always returns an error." -- the kernel
+    restriction is the reason, and no libc is named), and `os.py` gates chmod's
     entry into `os.supports_follow_symlinks` on HAVE_LCHMOD alone -- the
-    HAVE_FCHMODAT line is commented out -- so the capability is absent.
-    Measured on Linux/glibc 2.39, CPython 3.12.3 and 3.12.13: HAVE_LCHMOD 0,
-    `os.chmod not in os.supports_follow_symlinks`, and the call raises
-    NotImplementedError. macOS ships HAVE_LCHMOD 1 and the same call succeeds,
-    which is why a macOS-only reading gets this backwards.
+    HAVE_FCHMODAT line is commented out -- so the capability is absent from the
+    support set, which is advisory metadata about the build, not enforcement.
+    Absent from the SET is not refused at the CALL: HAVE_FCHMODAT *is* defined
+    on Linux, so posixmodule.c (v3.12.3) compiles out its early
+    `follow_symlinks_specified` guard at :3348 and the call reaches
+    `fchmodat(AT_SYMLINK_NOFOLLOW)` at :3400, which raises NotImplementedError
+    only when that returns ENOTSUP/EOPNOTSUPP (:3408) -- i.e. on a link.
 
-    The capability IS detectable at runtime, so the skip is a choice, not a
-    workaround for an undetectable gap. What makes it the right one is that
+    So the refusal is FILE-TYPE dependent, not platform dependent, and that is
+    what decides the handler's shape: the same Linux call succeeds on a regular
+    file and raises on a dangling link. Measured on Ubuntu/glibc 2.39, x86_64,
+    CPython 3.12.3 and 3.12.13 (musl not measured): HAVE_LCHMOD 0, `os.chmod
+    not in os.supports_follow_symlinks`, `follow_symlinks=False` SUCCEEDS on a
+    regular file and raises NotImplementedError on a dangling link. macOS 3.12.7
+    is the mirror image -- chmod IS in the set and both cases succeed -- which
+    is why a macOS-only reading gets this backwards. Set membership and
+    behaviour disagree on both platforms, in opposite directions, so neither
+    can be read off the other.
+
+    The support set IS readable at runtime, so the skip is a choice rather
+    than a workaround for an undetectable gap -- but branching on it would be
+    branching on the wrong thing, since it does not predict the call. What
+    makes skipping right is that
     NotImplementedError is a RuntimeError, NOT an OSError: the handler's
     `except FileNotFoundError` would not catch it, so the chmod route would
-    raise straight out of teardown on the very platform CI runs on.
+    raise straight out of teardown on the Linux CI runners (the unit matrix
+    also runs Windows and macOS, where it would not).
     """
     root = tmp_path / "tree"
     root.mkdir()

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -233,3 +233,42 @@ def test_a_vanished_path_is_not_an_error(tmp_path: Path) -> None:
         raise FileNotFoundError(2, "No such file or directory", str(p))
 
     _clear_readonly(unlink_it, victim, FileNotFoundError(2, "No such file"))
+
+
+def test_a_dangling_symlink_is_removed_rather_than_skipped(tmp_path: Path) -> None:
+    """A dangling link must be retried, not silently abandoned.
+
+    Every stat/chmod in the handler FOLLOWS a symlink. On a dangling link
+    `os.stat` raises FileNotFoundError, which the vanished-path guard treats
+    as "already gone" and returns -- but the LINK itself is still there, so
+    `rmtree` fails with `[Errno 66] Directory not empty` on an entry it could
+    have unlinked. The link is exactly the thing the handler was asked to
+    remove, and the target's absence says nothing about it.
+
+    `os.lstat` alone does not fix this: `os.chmod` follows links too, and
+    `follow_symlinks=False` is unsupported for chmod on macOS. Skipping the
+    mode work for links is the only portable answer.
+    """
+    root = tmp_path / "tree"
+    root.mkdir()
+    link = root / "dangling"
+    link.symlink_to(root / "nonexistent-target")
+
+    # Precondition: the link is present but its target is not, which is what
+    # makes os.stat raise. Without this the test could pass on a live link.
+    assert link.is_symlink(), "the fixture must create a real symlink"
+    assert not link.exists(), "the link must dangle, or os.stat would not raise"
+
+    # The handler must RETRY on the link, not return early. Asserting the
+    # retry directly, rather than only that the tree vanished, so a handler
+    # that got lucky through some other path cannot pass this.
+    retried: list[object] = []
+    _clear_readonly(retried.append, link, FileNotFoundError(2, "No such file"))
+    assert retried == [link], (
+        "the handler must invoke the removal on a dangling link; returning "
+        "early leaves it in place and rmtree fails on the parent"
+    )
+
+    # And end to end: the tree comes down with the link inside it.
+    shutil.rmtree(root, onexc=_clear_readonly)
+    assert not root.exists()


### PR DESCRIPTION
Follow-up to #1597, which fixed the Windows read-only teardown. A peer's CI run surfaced a **race in the same handler**, on base install under `pytest-xdist`:

```
FAILED test_temp_repo_readonly_cleanup.py::test_a_real_git_repo_is_removable_by_the_temp_repo_teardown
FileNotFoundError: [Errno 2] No such file or directory:
  '/tmp/pytest-of-runner/pytest-0/popen-gw3/.../repo/.git/objects/maintenance.lock'
```

`git commit` starts background maintenance (it spawns `git maintenance run --auto --quiet --detach`; `git init` spawns nothing -- verified under `GIT_TRACE=1`, git 2.47.1), which creates `.git/objects/maintenance.lock` and deletes it **asynchronously**. `shutil.rmtree` can list the entry and find it gone by the time it unlinks, so the `onexc` handler is invoked for a path that no longer exists. `_clear_readonly` then raised from its own `os.chmod`, because the existing `try` guarded only `os.stat`.

A path that vanished between the walk and the removal has already reached the state the teardown wanted, so it is not an error to recover from.

```python
except FileNotFoundError:
    return          # before the chmod: already gone
...
except FileNotFoundError:
    return          # between the chmod and the retry: the same race, one step later
```

Both windows are covered because they are genuinely different moments — the entry can disappear before the handler touches it, or between the chmod and the unlink.

### Verification

Red/green against the real suite, not a model:

```
with the fix:              6 passed
pre-race handler restored: 1 failed, 5 passed
                           FAILED test_a_vanished_path_is_not_an_error
```

Restore checksum-verified. The new test exercises both moments directly rather than trying to reproduce the timing, which is not reliably reproducible on a developer machine — the window is the few milliseconds git holds the lock, and a serial run on a fast disk closes it before `rmtree` arrives. It surfaced only under xdist on a CI runner (`popen-gw3`).

### Note on scope

This does not weaken the handler into `ignore_errors=True`: `test_clear_readonly_does_not_mask_a_genuine_failure` still passes, so a `PermissionError` that persists after the retry still propagates. Only a genuinely absent path is tolerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup handling for temporary files that disappear during processing.
  * Prevented transient missing-file conditions from causing cleanup failures, including during parallel test execution.
  * Improved removal of read-only and dangling symbolic links during cleanup.

* **Tests**
  * Added coverage for paths missing before cleanup, paths removed during a cleanup retry, and dangling symbolic links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Observed on CI, not only reasoned about

`main` went red with this exact race: [SonarCloud Analysis run 33566615803](https://github.com/vitali87/code-graph-rag/actions/runs/33566615803) at `2304c960`, on `ubuntu`, Python 3.12.14, under `pytest-xdist` (`gw1`):

```
FAILED codebase_rag/tests/test_temp_repo_readonly_cleanup.py::test_a_real_git_repo_is_removable_by_the_temp_repo_teardown
  FileNotFoundError: [Errno 2] No such file or directory: '.../repo/.git/objects/maintenance.lock'
1 failed, 8915 passed, 24 skipped, 1 xfailed
```

The run immediately before it was green, so the failure is intermittent, as a race should be.

**Read the chain, not the top frame.** The traceback points at `test_temp_repo_readonly_cleanup.py:36`, inside the test's own Windows-semantics shim, which invites the conclusion that the shim is at fault and this fix is unrelated. It is not what happens. The shim stats a read-only `maintenance.lock` and raises `PermissionError`; `rmtree` calls the `onexc` handler; the handler re-calls `func(path)`; git's detached `git maintenance` has deleted the lock in between; the shim's `os.stat` now raises `FileNotFoundError` **from inside the handler**, which propagates out of `rmtree`. The shim is where it surfaces; the handler is what does or does not absorb it.

Verified locally with a control across three revisions, driving the same chain:

| revision | result |
| --- | --- |
| `origin/main` | `FileNotFoundError` -- the CI error |
| `701c5036` | completed |
| branch HEAD | completed |

The commit that fixes it is `701c5036`, the vanished-path tolerance.

## Why the handler skips the mode work on a symlink

CodeRabbit suggested `os.lstat` to distinguish a dangling symlink from a missing entry, then chmod with `follow_symlinks=False`. That route is not viable on the platform CI runs on.

`os.chmod(..., follow_symlinks=False)` raises `NotImplementedError` on Linux -- measured on glibc 2.39, CPython 3.12.3 and 3.12.13: `HAVE_LCHMOD` 0 and `os.chmod not in os.supports_follow_symlinks`. (The 3.12.14 CI failure above is evidence about the race, not about this; it never exercises `lchmod`.) macOS ships `HAVE_LCHMOD` 1 and the same call succeeds, which is why a macOS-only reading gets this backwards.

The decisive part is the exception type: **`NotImplementedError` is a `RuntimeError`, not an `OSError`.** The handler's `except FileNotFoundError` would not catch it, so taking the chmod route would raise straight out of teardown on Linux. Skipping the mode work for links avoids that entirely.

