### PR TITLE
fix: preserve rejected highlights in release news

### DIFF
--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from scripts.update_news import (
     LATEST_RELEASE_MARKER,
+    create_aggregated_bullet,
     existing_themes,
+    extract_all_highlights,
     extract_bullets,
     is_feature_theme,
     prepend_news,
@@ -67,6 +69,32 @@ class TestExtractBullets:
         assert extract_bullets(fragment) == [
             "- **Web Search**: the agent can now search the web."
         ]
+
+
+class TestAggregateHighlights:
+    def test_extracts_both_highlight_markers_without_filtering(self) -> None:
+        fragment = (
+            "## Highlights\n"
+            "* **CI Speedups**: builds now finish faster.\n"
+            "- **Bug Fixes**: assorted crashes resolved.\n"
+            "* **Empty Body**: \n"
+        )
+        assert extract_all_highlights(fragment) == [
+            ("CI Speedups", "builds now finish faster."),
+            ("Bug Fixes", "assorted crashes resolved."),
+        ]
+
+    def test_combines_every_highlight_into_one_bullet(self) -> None:
+        highlights = [
+            ("CI Speedups", "builds now finish faster."),
+            ("Bug Fixes", "assorted crashes resolved."),
+            ("Documentation", "the deployment guide is clearer."),
+        ]
+        assert create_aggregated_bullet(highlights) == (
+            "- **Release Summary**: CI Speedups: builds now finish faster; "
+            "Bug Fixes: assorted crashes resolved; and Documentation: the "
+            "deployment guide is clearer."
+        )
 
 
 class TestIsFeatureTheme:
@@ -215,3 +243,27 @@ class TestPrependNews:
             "- **Static Binaries**: Intel macOS builds link OpenSSL statically.",
         ]
         assert "already covered" not in updated
+
+    def test_all_rejected_highlights_become_one_summary(self) -> None:
+        fragment = (
+            "* **CI Speedups**: builds now finish faster.\n"
+            "* **Bug Fixes**: assorted crashes resolved.\n"
+            "* **Documentation**: the deployment guide is clearer.\n"
+        )
+        updated, inserted = prepend_news(NEWS, fragment)
+        assert inserted == [
+            "- **Release Summary**: CI Speedups: builds now finish faster; "
+            "Bug Fixes: assorted crashes resolved; and Documentation: the "
+            "deployment guide is clearer."
+        ]
+        assert updated.count("- **Release Summary**:") == 1
+
+    def test_rejected_highlight_summary_is_idempotent(self) -> None:
+        fragment = (
+            "* **CI Speedups**: builds now finish faster.\n"
+            "* **Bug Fixes**: assorted crashes resolved.\n"
+        )
+        once, _ = prepend_news(NEWS, fragment)
+        twice, inserted = prepend_news(once, fragment)
+        assert inserted == []
+        assert twice == once

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -27,9 +27,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)\*\*: \S.*$")
-HIGHLIGHT_BULLET = re.compile(
-    r"^[-*]\s+\*\*(?P<theme>[^*]+?)\*\*:\s*(?P<text>\S.*)$"
-)
+HIGHLIGHT_BULLET = re.compile(r"^[-*]\s+\*\*(?P<theme>[^*]+?)\*\*:\s*(?P<text>\S.*)$")
 
 # Placed directly below the block of entries the latest release inserted, so
 # the README's "Latest News" can render that whole block instead of a fixed

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -27,7 +27,9 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)\*\*: \S.*$")
-HIGHLIGHT_BULLET = re.compile(r"^\*\s+\*\*(?P<theme>[^*]+?)\*\*:\s*(?P<text>.*)$")
+HIGHLIGHT_BULLET = re.compile(
+    r"^[-*]\s+\*\*(?P<theme>[^*]+?)\*\*:\s*(?P<text>\S.*)$"
+)
 
 # Placed directly below the block of entries the latest release inserted, so
 # the README's "Latest News" can render that whole block instead of a fixed
@@ -93,7 +95,7 @@ def extract_bullets(fragment: str) -> list[str]:
 
 
 def extract_all_highlights(fragment: str) -> list[tuple[str, str]]:
-    """Extract all highlights (theme, text) from the fragment, regardless of filtering.
+    """Extract every well-formed highlight, regardless of feature filtering.
 
     Used as fallback source for aggregation when no feature themes pass the filter.
     Returns list of (theme, text) tuples.
@@ -101,14 +103,9 @@ def extract_all_highlights(fragment: str) -> list[tuple[str, str]]:
     highlights: list[tuple[str, str]] = []
     for line in fragment.splitlines():
         stripped = _normalize_dashes(line.rstrip())
-        # Match both Highlights format (* **Theme**: text) and NEWS format (- **Theme**: text)
-        for pattern in [HIGHLIGHT_BULLET, BULLET_PATTERN]:
-            match = pattern.match(stripped)
-            if match:
-                theme = match.group("theme")
-                text = match.group("text") if "text" in match.groupdict() else ""
-                highlights.append((theme, text))
-                break
+        match = HIGHLIGHT_BULLET.match(stripped)
+        if match:
+            highlights.append((match.group("theme"), match.group("text")))
     return highlights
 
 
@@ -122,29 +119,22 @@ def existing_themes(news: str) -> set[str]:
 
 
 def create_aggregated_bullet(highlights: list[tuple[str, str]]) -> str:
-    """Create an aggregated feature bullet from all highlights.
+    """Combine all release highlights into one fallback news bullet.
 
-    Synthesizes a single summary bullet that captures the themes from all
-    highlights, suitable for insertion when no individual highlights pass
-    the feature filter.
+    This preserves the substance of every highlight instead of reducing the
+    release to a list of theme names. It is only used when every individual
+    highlight is rejected by the feature-theme filter.
     """
-    if not highlights:
+    summaries = [f"{theme}: {text.rstrip('.')}" for theme, text in highlights]
+    if not summaries:
         return ""
 
-    # Collect all themes
-    themes = [theme for theme, _ in highlights]
-
-    # Create a summary that mentions the key areas without repeating them
-    if len(themes) == 1:
-        summary = f"Comprehensive improvements in {themes[0].lower()}"
+    if len(summaries) == 1:
+        summary = summaries[0]
     else:
-        # Group similar themes
-        key_areas = ", ".join(themes[:-1])
-        if len(themes) > 1:
-            key_areas = f"{key_areas} and {themes[-1]}"
-        summary = f"Enhancements across {key_areas}"
+        summary = f"{'; '.join(summaries[:-1])}; and {summaries[-1]}"
 
-    return f"- **Release Improvements**: {summary} with stability and reliability refinements across the codebase."
+    return f"- **Release Summary**: {summary}."
 
 
 def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
@@ -163,7 +153,8 @@ def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
     """
     themes = existing_themes(news)
     fresh: list[str] = []
-    for bullet in extract_bullets(fragment):
+    feature_bullets = extract_bullets(fragment)
+    for bullet in feature_bullets:
         match = BULLET_PATTERN.match(bullet)
         if match is None:
             continue
@@ -173,13 +164,14 @@ def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
         fresh.append(bullet)
         themes.add(theme)
 
-    # If no feature bullets extracted, try to create an aggregated one from all highlights
-    if not fresh:
+    # Preserve at least one substantive entry when every highlight is filtered.
+    # Compare the whole fallback bullet rather than its generic theme so a
+    # workflow rerun is idempotent while a later release can add its own summary.
+    if not feature_bullets:
         all_highlights = extract_all_highlights(fragment)
-        if all_highlights:
-            aggregated = create_aggregated_bullet(all_highlights)
-            if aggregated:
-                fresh.append(aggregated)
+        aggregated = create_aggregated_bullet(all_highlights)
+        if aggregated and aggregated not in news.splitlines():
+            fresh.append(aggregated)
 
     if not fresh:
         return news, []


### PR DESCRIPTION
## Summary

- emit one `Release Summary` bullet when every generated highlight is rejected by the feature-theme filter
- preserve the theme and substance of every rejected highlight in that single bullet
- keep release-workflow reruns idempotent while allowing later releases to add distinct summaries
- parse both `*` and `-` highlight markers and ignore empty highlight bodies

## Red/green TDD

1. **Red** (`c2c251e`): added regression tests first; 7 tests failed against the existing implementation.
2. **Green** (`ddfaf34`): implemented the fallback summary and idempotence fix; the same suite passes.

## Verification

- `uv run pytest codebase_rag/tests/test_update_news.py codebase_rag/tests/test_release_news_derivation.py` — 26 passed
- `uv run ruff check scripts/update_news.py codebase_rag/tests/test_update_news.py` — passed
- `git diff --check` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release highlight detection for both dash- and asterisk-style bullets.
  * Excluded empty highlight entries from generated news.
  * Added a consolidated **Release Summary** when no feature highlights are available.
  * Prevented duplicate summaries when news updates are repeated.
* **Tests**
  * Added coverage for highlight extraction, aggregation, filtering, and repeated updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->