### PR TITLE
chore: exclude constants from coverage, matching the sonar config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,30 @@ python-version = "3.12"
 [tool.ty.src]
 exclude = ["codebase_rag/tests/test_cypher_queries.py", "codebase_rag/tests/test_code_retrieval.py", "codebase_rag/tests/test_call_resolver.py", "benchmarks/", "optimize/"]
 
+[tool.coverage.run]
+# `codebase_rag/constants/` is excluded because coverage cannot say anything
+# useful about it, not because it is untested (issue #1599).
+#
+# Those 31 modules are almost entirely module-level assignments. A constant
+# definition executes exactly once, at import, and cannot fail to execute if
+# the module is imported at all -- so the measurement is 100% or 0% depending
+# on whether tracing had started by then, never on whether anything is tested.
+# Measured under pytest it is 0/2858 lines, because conftest imports
+# `graph_updater` (which alone pulls all 31) during collection, before
+# pytest-cov begins tracing. Importing the same package after starting
+# coverage manually records the lines normally.
+#
+# Keeping it in the denominator understated source coverage by ~2856 lines and
+# made `constants/` read as the largest gap in the tree while carrying no
+# signal in either direction. Excluding it makes the remaining figure mean
+# something; it does not hide dead code, since an unused constant executes at
+# import exactly like a used one and coverage could never have flagged it.
+#
+# This is not a new judgement: `sonar-project.properties` already carries
+# `sonar.coverage.exclusions=...,codebase_rag/constants/**`. The two tools
+# disagreed, and this makes Codecov match the call the project had made.
+omit = ["codebase_rag/constants/*"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 # loadgroup honors the xdist_group marker that pins the integration dir to


### PR DESCRIPTION
Closes #1599. One `omit` line in `pyproject.toml`, plus the reasoning beside it.

## Why fix #3 and not the other two

The issue offered three, and I ruled the first two out by measurement rather than preference.

**Fix #2 (move the constants import out of conftest module scope) cannot work.** Line 19 is not the binding import:

```
$ python -c "import codebase_rag.graph_updater; ..."
constants modules pulled by graph_updater alone: 31
```

`conftest.py` also imports `graph_updater`, `graph_audit`, `language_spec` and `parser_loader` at module level, and `graph_updater` alone pulls **all 31** constants modules. Moving line 19 changes nothing; the full version means removing every `codebase_rag` import from conftest module scope, which its fixtures need.

**Fix #1 (`COVERAGE_PROCESS_START`) lives in the CI invocation**, `.github/workflows/ci.yml`, which this token cannot modify (`workflow` scope). Flagging that as my constraint rather than an argument against it.

## The measurement, and it is worse than reported

The issue says ~4.52%. Measured under pytest:

```
codebase_rag/constants/cli.py       339   339    0%
codebase_rag/constants/graph.py     244   244    0%
codebase_rag/constants/security.py   41    41    0%
codebase_rag/constants/trace.py      96    96    0%
TOTAL                              2858  2858    0%
```

Zero, across all 2858 lines.

## This is not a new judgement

`sonar-project.properties` already carries:

```
sonar.coverage.exclusions=**/*.go,...,codebase_rag/constants/**
```

So the project had **already** decided that constants coverage carries no signal. Sonar and Codecov simply disagreed, and this makes them agree. That is what moved me off "this needs consensus", which is how the issue frames the choice.

## Why the metric is empty rather than merely inconvenient

A constant definition executes exactly once, at import, and cannot fail to execute if the module is imported at all. So the number is 100% or 0% depending on whether tracing had started by then, never on whether anything is tested. It also cannot flag an unused constant, because an unused one executes at import exactly like a used one.

That is the argument for excluding rather than for fixing the timing: even measured perfectly, the figure would carry no information about test quality, while occupying ~2856 lines of the denominator and reading as the largest gap in the tree.

## Verified by A/B on identical arguments

A config change that silently fails to apply looks exactly like one that works, so:

```
without the omit:  TOTAL 45512   31 constants rows   19%
with the omit:     TOTAL 42654    0 constants rows   20%
```

Delta 2858, exactly the constants line count. Same command both times; the second run bypassed the config with `--cov-config` pointing at an empty file, so the only variable is whether `[tool.coverage.run]` was read.

## One hypothesis I checked and discarded

`codebase_rag.trace.pytest_plugin` is registered as a `pytest11` entry point, so pytest imports it at startup, before conftest is read. That looked like an earlier and more fundamental cause than the one the issue names. It is not: importing it loads **zero** constants modules, because its imports sit under `TYPE_CHECKING`. The issue's conftest diagnosis is correct and I am not amending it.

## Scope

No test is added: this changes a reporting boundary, not behaviour, and a test asserting the omit is present would only restate the config file. The verification above is the evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage reporting to exclude constant-only modules from coverage metrics.
  * Aligned coverage results with existing project analysis settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->