### PR TITLE
fix: report highlight parse failures instead of exiting 0 silently

### DIFF
--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -440,9 +440,16 @@ class TestParseFailureIsReported:
             "- **Graph Export**  the graph exports to GraphML.\n"
         )
         exit_code, news = self._run(tmp_path, monkeypatch, fragment)
+        captured = capsys.readouterr()
         assert exit_code != 0
         assert "Web Search" not in news
-        assert "parsed 0" in capsys.readouterr().out
+        assert "parsed 0" in captured.out
+        # The diagnostic must name the regex an operator has to inspect, and the
+        # file to inspect it against. An earlier review found this message naming
+        # BULLET_PATTERN after the guard had moved to HIGHLIGHT_BULLET, which would
+        # send someone to the wrong regex mid-incident; nothing asserted it then.
+        assert "HIGHLIGHT_BULLET" in captured.err
+        assert str(tmp_path / "highlights.md") in captured.err
 
     def test_an_empty_highlights_file_stays_a_clean_noop(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -14,6 +14,7 @@ from scripts.update_news import (
     existing_themes,
     extract_all_highlights,
     extract_bullets,
+    has_unparsable_bullets,
     is_feature_theme,
     prepend_news,
 )
@@ -519,3 +520,49 @@ class TestParseFailureIsReported:
         assert "- **Release Summary**:" in news
         out = capsys.readouterr().out
         assert "parsed 0, deduped 0, inserted 1 (aggregated fallback)" in out
+
+    def test_a_rerun_of_an_all_nonfeature_release_is_not_a_parse_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Filtered out is not the same as failed to parse.
+
+        When every theme is non-feature, extract_bullets is empty because
+        is_feature_theme dropped them, not because the patterns failed. The
+        first run is masked: the aggregation fallback inserts a summary, so the
+        guard is never reached. On a rerun that summary is already in NEWS.md,
+        nothing is inserted, and a guard keyed on extract_bullets fires with
+        "the format has diverged" about bullets that parsed perfectly. The
+        parse-success question is what extract_all_highlights answers.
+        """
+        fragment = (
+            "* **CI Automation**: pipelines are faster.\n"
+            "* **Docs**: the readme was rewritten.\n"
+        )
+        first_code, after_first = self._run(tmp_path, monkeypatch, fragment)
+        assert first_code == 0
+        assert "- **Release Summary**:" in after_first
+
+        # Rerun against the NEWS.md the first run produced.
+        (tmp_path / "NEWS.md").write_text(after_first, encoding="utf-8")
+        fragment_path = tmp_path / "highlights.md"
+        fragment_path.write_text(fragment, encoding="utf-8")
+        monkeypatch.setattr(update_news, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(sys, "argv", ["update_news.py", str(fragment_path)])
+        assert update_news.main() == 0
+
+    def test_unparsable_and_merely_filtered_are_distinguished(self) -> None:
+        """The guard must separate the two ways extract_bullets returns [].
+
+        A direct unit check on the discrimination itself, so a future change
+        that reintroduces the conflation fails here rather than only in the
+        end-to-end rerun above.
+        """
+        parses_but_filtered = (
+            "* **CI Automation**: pipelines are faster.\n* **Docs**: rewritten.\n"
+        )
+        does_not_parse = "- **Web Search**  no colon at all.\n"
+
+        assert extract_bullets(parses_but_filtered) == []
+        assert extract_bullets(does_not_parse) == []
+        assert has_unparsable_bullets(parses_but_filtered) is False
+        assert has_unparsable_bullets(does_not_parse) is True

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import update_news
 from scripts.update_news import (
     BULLET_PATTERN,
     HIGHLIGHT_BULLET,
@@ -395,3 +401,121 @@ class TestPrependNews:
         twice, inserted = prepend_news(once, fragment)
         assert inserted == []
         assert twice == once
+
+
+class TestParseFailureIsReported:
+    """`main` must distinguish "nothing to say" from "could not parse it".
+
+    The v0.0.820 outage was silent precisely because these two collapsed into
+    one exit-0 path: every highlight used a colon spelling the parser rejected,
+    zero bullets were inserted, and the release step reported success. An empty
+    highlights file is a legitimate no-op and must stay exit 0, so the failure
+    signal keys on bullet-shaped input that parsed to nothing.
+    """
+
+    @staticmethod
+    def _run(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fragment: str
+    ) -> tuple[int, str]:
+        """Drive main() end to end against a throwaway NEWS.md."""
+        news_path = tmp_path / "NEWS.md"
+        news_path.write_text(NEWS, encoding="utf-8")
+        fragment_path = tmp_path / "highlights.md"
+        fragment_path.write_text(fragment, encoding="utf-8")
+        monkeypatch.setattr(update_news, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(sys, "argv", ["update_news.py", str(fragment_path)])
+        return update_news.main(), news_path.read_text(encoding="utf-8")
+
+    def test_bullet_shaped_input_that_parses_to_nothing_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The v0.0.820 shape itself: bullets present, none parseable."""
+        fragment = (
+            "## Highlights\n"
+            "- **Web Search**  the agent can now search the web.\n"
+            "- **Graph Export**  the graph exports to GraphML.\n"
+        )
+        exit_code, news = self._run(tmp_path, monkeypatch, fragment)
+        assert exit_code != 0
+        assert "Web Search" not in news
+        assert "parsed 0" in capsys.readouterr().out
+
+    def test_an_empty_highlights_file_stays_a_clean_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A release with intentionally empty highlights must still bump."""
+        exit_code, news = self._run(tmp_path, monkeypatch, "")
+        assert exit_code == 0
+        assert news == NEWS
+
+    def test_prose_without_bullets_stays_a_clean_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No bullet-shaped line means there was nothing to parse, not a failure."""
+        fragment = "## Highlights\n\nThis release contains internal changes only.\n"
+        exit_code, news = self._run(tmp_path, monkeypatch, fragment)
+        assert exit_code == 0
+        assert news == NEWS
+
+    def test_a_fully_deduped_release_is_not_a_parse_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Bullets parsed but every theme is already present: success, not failure.
+
+        This is the case a naive "inserted == 0 means failure" check would call
+        a failure, which would turn every workflow rerun red.
+        """
+        fragment = "- **Ruby Support**: Ruby joins the graph through ast-grep.\n"
+        exit_code, news = self._run(tmp_path, monkeypatch, fragment)
+        assert exit_code == 0
+        assert news == NEWS
+        out = capsys.readouterr().out
+        assert "parsed 1" in out
+        assert "inserted 0" in out
+
+    def test_counts_are_reported_separately(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """parsed/deduped/inserted are distinct numbers, not one collapsed total."""
+        fragment = (
+            "- **Ruby Support**: already in NEWS, so this one dedupes away.\n"
+            "- **Graph Export**: the graph exports to GraphML.\n"
+        )
+        exit_code, _ = self._run(tmp_path, monkeypatch, fragment)
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        assert "parsed 2" in out
+        assert "deduped 1" in out
+        assert "inserted 1" in out
+
+    def test_the_aggregation_fallback_is_labelled_not_counted_as_dedup(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """An aggregated summary is inserted without ever being "parsed".
+
+        prepend_news falls back to one "Release Summary" bullet when every
+        theme is filtered out, and extract_bullets never produced it, so
+        inserted exceeds parsed. Reporting that as negative dedup - or
+        clamping it to zero and printing "parsed 0, deduped 0, inserted 1" -
+        describes a state that cannot happen; the line must say which path ran.
+        """
+        fragment = (
+            "* **CI Speedups**: builds are faster.\n* **Docs**: readme rewritten.\n"
+        )
+        exit_code, news = self._run(tmp_path, monkeypatch, fragment)
+        assert exit_code == 0
+        assert "- **Release Summary**:" in news
+        out = capsys.readouterr().out
+        assert "parsed 0, deduped 0, inserted 1 (aggregated fallback)" in out

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -12,11 +12,15 @@ anchor on. Bullets may use either `- ` or the Highlights' `* ` marker, and the c
 may sit inside or outside the bold theme (`**Theme:**` or `**Theme**:`,
 both of which satisfy the generator's prompt); all are normalised to the
 NEWS.md entry format `- **Theme**: sentence`. Anything else
-in the fragment is ignored, so a malformed or empty AI response degrades
-to a no-op instead of corrupting the file. Exit code 0 always signals NEWS.md
-is in a valid state; the caller decides whether a no-op warrants skipping the
-follow-up README regeneration. Standard library only, so the release workflow
-can run it before the project environment is synced (issue #1146).
+in the fragment is ignored, so a malformed or empty AI response never corrupts
+the file. Exit code 0 signals NEWS.md is in a valid state, which includes a
+no-op: an empty or prose-only fragment offered nothing, so nothing is missing.
+Exit code 1 is reserved for the one case that used to be silent: the fragment
+carries bullet-shaped lines and none of them parsed, meaning the generator's
+format and the patterns here have diverged (issue #1605). The caller decides
+whether a no-op warrants skipping the follow-up README regeneration. Standard
+library only, so the release workflow can run it before the project environment
+is synced (issue #1146).
 """
 
 # ruff: noqa: T201
@@ -48,6 +52,12 @@ BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:) +(?P<text>
 HIGHLIGHT_BULLET = re.compile(
     r"^[-*]\s+\*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:)\s*(?P<text>\S.*)$"
 )
+
+# Any line a human would call a bullet, however malformed. Used only to tell
+# "nothing was offered" apart from "what was offered did not parse"; it must
+# stay looser than BULLET_PATTERN or it would reject the broken input it is
+# meant to catch.
+BULLET_SHAPED = re.compile(r"^[-*]\s+\S")
 
 # Placed directly below the block of entries the latest release inserted, so
 # the README's "Latest News" can render that whole block instead of a fixed
@@ -113,6 +123,27 @@ def extract_bullets(fragment: str) -> list[str]:
             theme = match.group("theme").strip()
             bullets.append(f"- **{theme}**: {match.group('text')}")
     return bullets
+
+
+def has_unparsable_bullets(fragment: str) -> bool:
+    """True when the fragment offers bullets but none of them parse.
+
+    Distinguishes the two ways a release inserts no news. An empty or
+    prose-only highlights section is a legitimate no-op: nothing was offered,
+    so nothing is missing. A section full of bullets that yields no entries
+    means the generator's format and this module's patterns have diverged,
+    which is a failure that must be loud - it is the exact shape of the
+    v0.0.820 outage, where every bullet used ``**Theme:**`` and the parser
+    accepted only ``**Theme**:``.
+
+    Deliberately looser than BULLET_PATTERN: it asks whether a line was MEANT
+    to be a bullet, so a shape the real patterns reject still counts as one.
+    A stricter test here would return False on precisely the malformed input
+    this exists to detect.
+    """
+    return any(
+        BULLET_SHAPED.match(line.strip()) for line in fragment.splitlines()
+    ) and not extract_bullets(fragment)
 
 
 def extract_all_highlights(fragment: str) -> list[tuple[str, str]]:
@@ -227,8 +258,34 @@ def main() -> int:
 
     news_path = PROJECT_ROOT / "NEWS.md"
     news = news_path.read_text(encoding="utf-8")
-    updated, inserted = prepend_news(news, fragment_path.read_text(encoding="utf-8"))
+    fragment = fragment_path.read_text(encoding="utf-8")
+    updated, inserted = prepend_news(news, fragment)
+
+    # Reported separately because they fail for different reasons and only the
+    # first distinguishes a broken parser from a quiet release: parsed counts
+    # what the patterns understood, deduped what was already in NEWS.md, and
+    # inserted what actually reached the file. Collapsing them into "nothing
+    # added" is what hid issue #1605 for roughly fifty releases.
+    feature_bullets = extract_bullets(fragment)
+    inserted_count = len(inserted)
+    # When every theme is filtered out, prepend_news falls back to a single
+    # aggregated "Release Summary" (added by #1600) that extract_bullets never
+    # produced, so inserted can exceed parsed. Counting that as a negative
+    # dedup would be nonsense; report the aggregate for what it is instead.
+    aggregated = inserted_count and not feature_bullets
+    parsed = len(feature_bullets)
+    deduped = 0 if aggregated else parsed - inserted_count
+    summary = f"parsed {parsed}, deduped {deduped}, inserted {inserted_count}"
+    print(f"{summary} (aggregated fallback)" if aggregated else summary)
+
     if not inserted:
+        if has_unparsable_bullets(fragment):
+            print(
+                f"{fragment_path} contains bullet-shaped lines but none parsed; "
+                "the highlights format and BULLET_PATTERN have diverged",
+                file=sys.stderr,
+            )
+            return 1
         print("no new themes to add, NEWS.md unchanged")
         return 0
 

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -125,6 +125,21 @@ def extract_bullets(fragment: str) -> list[str]:
     return bullets
 
 
+def extract_all_highlights(fragment: str) -> list[tuple[str, str]]:
+    """Extract every well-formed highlight, regardless of feature filtering.
+
+    Used as fallback source for aggregation when no feature themes pass the filter.
+    Returns list of (theme, text) tuples.
+    """
+    highlights: list[tuple[str, str]] = []
+    for line in fragment.splitlines():
+        stripped = _normalize_dashes(line.rstrip())
+        match = HIGHLIGHT_BULLET.match(stripped)
+        if match:
+            highlights.append((match.group("theme"), match.group("text")))
+    return highlights
+
+
 def has_unparsable_bullets(fragment: str) -> bool:
     """True when the fragment offers bullets but none of them parse.
 
@@ -140,25 +155,17 @@ def has_unparsable_bullets(fragment: str) -> bool:
     to be a bullet, so a shape the real patterns reject still counts as one.
     A stricter test here would return False on precisely the malformed input
     this exists to detect.
+
+    Parse success is measured with extract_all_highlights, never with
+    extract_bullets. extract_bullets both parses AND drops non-feature themes,
+    so it returns [] for two unrelated reasons, and using it here reported a
+    parse failure for an all-CI release whose bullets parsed perfectly. That
+    misfires only on a RERUN: the first run inserts the aggregated summary, so
+    the guard is never reached.
     """
     return any(
         BULLET_SHAPED.match(line.strip()) for line in fragment.splitlines()
-    ) and not extract_bullets(fragment)
-
-
-def extract_all_highlights(fragment: str) -> list[tuple[str, str]]:
-    """Extract every well-formed highlight, regardless of feature filtering.
-
-    Used as fallback source for aggregation when no feature themes pass the filter.
-    Returns list of (theme, text) tuples.
-    """
-    highlights: list[tuple[str, str]] = []
-    for line in fragment.splitlines():
-        stripped = _normalize_dashes(line.rstrip())
-        match = HIGHLIGHT_BULLET.match(stripped)
-        if match:
-            highlights.append((match.group("theme"), match.group("text")))
-    return highlights
+    ) and not extract_all_highlights(fragment)
 
 
 def existing_themes(news: str) -> set[str]:
@@ -282,7 +289,7 @@ def main() -> int:
         if has_unparsable_bullets(fragment):
             print(
                 f"{fragment_path} contains bullet-shaped lines but none parsed; "
-                "the highlights format and BULLET_PATTERN have diverged",
+                "the highlights format and HIGHLIGHT_BULLET have diverged",
                 file=sys.stderr,
             )
             return 1


### PR DESCRIPTION
## Summary

- `scripts/update_news.py` exited 0 whenever nothing was inserted, so a highlights format change that made every bullet unparsable looked exactly like "no new themes to add". That is what let the v0.0.820 outage run silently for ~50 releases.
- Bullet-shaped lines that none of the patterns parse now exit 1 with a diagnostic naming `HIGHLIGHT_BULLET` and the fragment path. Genuinely empty input, prose-only input and fully-deduped releases still exit 0.
- The parsed/deduped/inserted counts are reported separately, and the aggregation fallback added by #1600 is labelled rather than counted as a negative dedup.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Part 1 of #1605. The workflow half (dropping `continue-on-error` on the two news steps) is deliberately a separate PR because it touches release CI.

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto -m "not integration"`)
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker) - Docker unavailable on this host; integration tests untouched by this PR
- [x] Manual testing (described below)

- 8 new tests. 3 were confirmed red against the current script before
  implementing; 2 of the 4 state tests passed beforehand by design, pinning
  behaviour this change must not break; and the 2 covering the regression above
  were confirmed red before its fix, both failing with
  `assert True is False` on `has_unparsable_bullets`.
- All four states verified by driving `main()` end to end at the head commit:
  non-feature run 1 rc=0 / run 2 rc=0, broken shape rc=1, empty rc=0,
  prose-only rc=0.
- The stderr message named `BULLET_PATTERN` after the guard moved to
  `HIGHLIGHT_BULLET`, so an operator debugging a real failure would have
  inspected the wrong regex. Corrected, after confirming no test asserts on
  that string.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings (code should be self-documenting) - this PR adds one helper with a docstring and explanatory comments, deliberately: they record why the guard keys on parse success rather than feature filtering, which is the exact regression this branch already went through once

## Background

### What was silent

`scripts/update_news.py` exited 0 whether it inserted news or understood
nothing at all. When every v0.0.820 highlight used a colon spelling the parser
rejected, zero bullets parsed, no news was inserted, and the release step
reported success. That is how the outage ran for roughly fifty releases without
anyone seeing it.

### What this changes

**Counts are reported separately** on every run: `parsed N, deduped N,
inserted N`. They fail for different reasons, and only the first distinguishes
a broken parser from a quiet release. Collapsing them into "nothing added" is
what hid the outage.

**Exit 1 is reserved for one case**: the fragment contains bullet-shaped lines
AND none of them parsed. That is the format-divergence signature. Everything
else stays exit 0.

Four states, all pinned by tests:

| fragment | exit | why |
|---|---|---|
| bullet-shaped, none parse | **1** | parser and generator have diverged |
| empty | 0 | nothing offered, so nothing missing; a release with intentionally empty highlights must still bump |
| prose only, no bullets | 0 | same reason |
| bullets parse, all themes already in NEWS.md | 0 | a normal rerun, not a failure |

That last state is why the condition is an AND. A naive `inserted == 0 means
failure` check turns every workflow rerun red.

### `BULLET_SHAPED` is deliberately looser than `BULLET_PATTERN`

`has_unparsable_bullets` asks whether a line was *meant* to be a bullet, so a
shape the real patterns reject still counts as one. A stricter matcher here
would return `False` on precisely the malformed input this exists to detect.
The docstring says so, because the natural review instinct is to tighten it.

### Aggregation-fallback counts

`prepend_news` falls back to a single `Release Summary` bullet (added by #1600)
that `extract_bullets` never produced, so `inserted` can exceed `parsed`. The
first draft computed `deduped = max(parsed - inserted, 0)`, which clamped -1 to
0 and printed the self-contradictory `parsed 0, deduped 0, inserted 1`. That
path is now labelled `(aggregated fallback)` and pinned by a test.

### The regression this went through, and the evidence it is closed

The first version of the guard keyed on `extract_bullets`, which both parses
**and** applies `is_feature_theme`. So it returned `[]` for two unrelated
reasons, and a release whose highlights are all non-feature themes (CI, docs)
was reported as a parse failure even though every bullet parsed perfectly.

It misfires only on a **rerun**. The first run is masked because the #1600
aggregation fallback makes `inserted` non-empty, so the guard is never reached.
On the rerun the summary is already in NEWS.md, nothing is inserted, and the
guard fires.

Measured on both revisions, same fragment, two consecutive runs:

| revision | run 1 | run 2 |
|---|---|---|
| base `900fe04a` | rc=0 | rc=0 |
| this branch, first attempt | rc=0 | **rc=1** (regression) |
| this branch, fixed | rc=0 | rc=0 |

The guard now keys on `extract_all_highlights`, which uses `HIGHLIGHT_BULLET`
with no feature filter and is the actual "did the patterns understand this"
question. The two return values separate the cases that `extract_bullets`
cannot:

| fragment | `extract_bullets` | `extract_all_highlights` |
|---|---|---|
| non-feature, parses fine | 0 | 2 |
| v0.0.820 broken shape | 0 | 0 |

Detection is preserved: the broken shape still exits 1. Two tests pin this - an
end-to-end rerun, and a unit test asserting the discrimination directly so a
future change that reconflates them fails at the unit level rather than only in
the rerun path. Both were confirmed red before the fix.

Worth noting the CI consequence, since it was not cosmetic: Actions `run:` blocks
execute under `bash -e`, so that exit 1 aborted the step before the README
regeneration, skipping the re-render on an otherwise healthy release.

### This is not yet fatal in CI

The non-zero exit is **recorded on the step and swallowed** by
`continue-on-error: true` at `.github/workflows/version-bump.yml:230`, which
covers the call at line 241. So part 1 makes the failure **visible in the log**;
part 2 (a separate PR, owned by the user because it touches the release
workflow) removes `continue-on-error` and makes it **fatal**. Stating this
explicitly because a PR that reads as "this stops the silent failure", while the
failure is still swallowed one layer up, would be the same class of bug it fixes.

### Stale docstring

The module docstring claimed "a malformed or empty AI response degrades to a
no-op" and "Exit code 0 always signals NEWS.md is in a valid state". This change
falsifies both. Found by grepping the *concept* (`exit code`, `no-op`, `always`)
rather than the symbol edited, because the claim sits at lines the diff never
displays. Rewritten to state both exit codes and what each means.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear update summaries showing parsed, deduplicated, and inserted release counts.
  * Added an “aggregated fallback” indicator when that fallback is used.
  * Update processing now reports a failure when bullet-formatted content cannot be parsed.

* **Bug Fixes**
  * Distinguished legitimate no-op updates from malformed release content.
  * Correctly handles reruns, fully deduplicated releases, and releases containing only non-feature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->