### PR TITLE
fix: record the exclusion set so a changed --exclude re-runs instead of skipping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ evals/oracles/scala_oracle/.bsp/
 .cgr-hash-cache.json
 .cgr-dir-mtimes.json
 .cgr-parser-fingerprint
+.cgr-exclusion-state.json
 .cgr-delombok-state.json
 .cgr-edit-history.json
 .cgr-edit-lock
@@ -62,3 +63,4 @@ evals/results/corpora/
 evals/results/**/agentic_qa*records*.jsonl
 evals/results/logs/
 .cgr-parser-fingerprint
+.cgr-exclusion-state.json

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -406,6 +406,7 @@ def _delete_hash_cache(repo_path: Path) -> None:
         cache_path.unlink(missing_ok=True)
     (repo_path / cs.DIR_MTIMES_FILENAME).unlink(missing_ok=True)
     (repo_path / cs.PARSER_FINGERPRINT_FILENAME).unlink(missing_ok=True)
+    (repo_path / cs.EXCLUSION_STATE_FILENAME).unlink(missing_ok=True)
 
 
 def _resolve_and_validate_repo(repo_path: str | None) -> Path:

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -129,9 +129,11 @@ HASH_CACHE_FILENAME = ".cgr-hash-cache.json"
 DIR_MTIMES_FILENAME = ".cgr-dir-mtimes.json"
 PARSER_FINGERPRINT_FILENAME = ".cgr-parser-fingerprint"
 DELOMBOK_STATE_FILENAME = ".cgr-delombok-state.json"
-# The exclusion set the last run indexed under. Nothing on disk changes when
-# only the CLI --exclude/--unignore flags do, so without this the sync check
-# cannot tell that the eligible set moved (issue #1606).
+# The exclusion set the last run indexed under, covering both the excludes and
+# the unignores (which come from `!` lines in .cgrignore/.gitignore and from
+# interactive setup; there is no --unignore flag). Nothing on disk changes when
+# only the CLI --exclude flags do, so without this the sync check cannot tell
+# that the eligible set moved (issue #1606).
 EXCLUSION_STATE_FILENAME = ".cgr-exclusion-state.json"
 # Recorded edit transactions for `cgr edits show|undo` (issue #1528).
 EDIT_HISTORY_FILENAME = ".cgr-edit-history.json"

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -129,6 +129,10 @@ HASH_CACHE_FILENAME = ".cgr-hash-cache.json"
 DIR_MTIMES_FILENAME = ".cgr-dir-mtimes.json"
 PARSER_FINGERPRINT_FILENAME = ".cgr-parser-fingerprint"
 DELOMBOK_STATE_FILENAME = ".cgr-delombok-state.json"
+# The exclusion set the last run indexed under. Nothing on disk changes when
+# only the CLI --exclude/--unignore flags do, so without this the sync check
+# cannot tell that the eligible set moved (issue #1606).
+EXCLUSION_STATE_FILENAME = ".cgr-exclusion-state.json"
 # Recorded edit transactions for `cgr edits show|undo` (issue #1528).
 EDIT_HISTORY_FILENAME = ".cgr-edit-history.json"
 EDIT_LOCK_FILENAME = ".cgr-edit-lock"
@@ -144,6 +148,7 @@ CGR_STATE_FILENAMES: frozenset[str] = frozenset(
         DIR_MTIMES_FILENAME,
         PARSER_FINGERPRINT_FILENAME,
         DELOMBOK_STATE_FILENAME,
+        EXCLUSION_STATE_FILENAME,
         EDIT_HISTORY_FILENAME,
         EDIT_LOCK_FILENAME,
     }

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -402,6 +402,10 @@ class GraphUpdater:
         # definition spans exist for hybrid macro-call attribution.
         self._reparsed_file_keys: set[str] = set()
         self._exclusion_match: bool | None = None
+        # Set when a run that needed the graph's module paths could not read
+        # them: the reconciliation it was meant to do may not have happened,
+        # so that run must not stamp its exclusion set as reconciled.
+        self._graph_state_unknown: bool = False
         # Package paths read from the graph before Pass 1 of an incremental
         # run; None on a full build or when the graph could not be read.
         self._packages_before_run: set[str] | None = None
@@ -974,6 +978,7 @@ class GraphUpdater:
         # run replaced. Reset after _register_generated_sources so the answer
         # is always computed against the effective unignore set.
         self._exclusion_match = None
+        self._graph_state_unknown = False
         if not force and self._is_already_in_sync():
             logger.info(ls.GRAPH_ALREADY_IN_SYNC)
             self.skipped_because_in_sync = True
@@ -1229,10 +1234,13 @@ class GraphUpdater:
         # reads that run's own result as a change. A single-file run walks one
         # file and cannot speak for the project's exclusion set.
         if self._single_file is None:
-            _save_exclusion_state(
-                self.repo_path / cs.EXCLUSION_STATE_FILENAME,
-                _exclusion_state(self.exclude_paths, self.unignore_paths),
-            )
+            if self._graph_state_unknown:
+                logger.warning(ls.EXCLUSION_STATE_NOT_RECORDED)
+            else:
+                _save_exclusion_state(
+                    self.repo_path / cs.EXCLUSION_STATE_FILENAME,
+                    _exclusion_state(self.exclude_paths, self.unignore_paths),
+                )
 
     def _emit_pending_endpoints(self) -> None:
         if not self.capture.rel_enabled(cs.RelationshipType.EXPOSES):
@@ -2462,6 +2470,13 @@ class GraphUpdater:
             if is_full_build or not self._exclusions_match_last_run()
             else frozenset()
         )
+        # None is "the sink claims readability and the query failed", not
+        # "nothing there": below it falls back to the hash cache alone, which
+        # after a pre-flush crash no longer names the excluded file. That run
+        # completes and would stamp, and every later run would fast-path over
+        # the surviving subtree. Remembering the failure keeps the stamp back.
+        if preexisting_paths is None:
+            self._graph_state_unknown = True
         new_hashes: FileHashCache = {}
         skipped_count = 0
         changed_count = 0

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -401,6 +401,7 @@ class GraphUpdater:
         # Files (re)parsed by Pass 2 this run: the only files whose
         # definition spans exist for hybrid macro-call attribution.
         self._reparsed_file_keys: set[str] = set()
+        self._exclusion_match: bool | None = None
         # Package paths read from the graph before Pass 1 of an incremental
         # run; None on a full build or when the graph could not be read.
         self._packages_before_run: set[str] | None = None
@@ -966,6 +967,13 @@ class GraphUpdater:
         # since the cached run changes the eligible set, and the check walks
         # with the same unignore patterns the indexing pass will use.
         self._register_generated_sources()
+        # Per-run, and reset here rather than in __init__: the memo answers
+        # "did the set move since the last COMPLETED run", and this run writes
+        # a new stamp at the end, so an instance used for a second run must
+        # re-read rather than reuse an answer about the stamp its own previous
+        # run replaced. Reset after _register_generated_sources so the answer
+        # is always computed against the effective unignore set.
+        self._exclusion_match = None
         if not force and self._is_already_in_sync():
             logger.info(ls.GRAPH_ALREADY_IN_SYNC)
             self.skipped_because_in_sync = True
@@ -1209,12 +1217,17 @@ class GraphUpdater:
         # excluded file triggers are execute_write calls that only become
         # durable at the flush above; stamping back in _process_files would let
         # a run that died in between tell its successor the exclusion was
-        # already reconciled, and the successor would then fast-path over a
-        # subtree still in the graph -- a leak that outlasts the one #1606
-        # describes. Recorded on EVERY completed project run, not full builds
-        # only: an incremental run that narrowed the set must record it, or the
-        # next run reads that run's own result as a change. A single-file run
-        # walks one file and cannot speak for the project's exclusion set.
+        # already reconciled, and the successor would fast-path over a subtree
+        # still in the graph. Deferring the stamp buys only that: the successor
+        # RUNS. It does not on its own make the successor delete anything,
+        # because the hash cache was already saved inside _process_files before
+        # this flush and no longer names the excluded file. What closes the
+        # gap is the graph-backed reconciliation in _process_files, which the
+        # changed exclusion set turns on; the two are needed together.
+        # Recorded on EVERY completed project run, not full builds only: an
+        # incremental run that narrowed the set must record it, or the next run
+        # reads that run's own result as a change. A single-file run walks one
+        # file and cannot speak for the project's exclusion set.
         if self._single_file is None:
             _save_exclusion_state(
                 self.repo_path / cs.EXCLUSION_STATE_FILENAME,
@@ -2241,9 +2254,15 @@ class GraphUpdater:
             logger.warning(ls.PARSER_FINGERPRINT_MISMATCH)
 
     def _exclusions_match_last_run(self) -> bool:
+        # Memoised: `_process_files` asks again to decide whether the graph's
+        # own module paths must join reconciliation, and the answer must be
+        # the same one the sync check acted on, logged once.
+        if self._exclusion_match is not None:
+            return self._exclusion_match
         stored = _load_exclusion_state(self.repo_path / cs.EXCLUSION_STATE_FILENAME)
         current = _exclusion_state(self.exclude_paths, self.unignore_paths)
         if stored == current:
+            self._exclusion_match = True
             return True
         # A missing stamp means an index built before it existed, whose
         # exclusion set is unknown rather than known-equal -- the posture
@@ -2256,6 +2275,7 @@ class GraphUpdater:
             logger.info(
                 ls.EXCLUSION_SET_CHANGED.format(previous=stored, current=current)
             )
+        self._exclusion_match = False
         return False
 
     def _is_already_in_sync(self) -> bool:
@@ -2427,8 +2447,20 @@ class GraphUpdater:
         # there. A file whose Module already exists must take the
         # delete-before-reingest path or renamed-away symbols and their
         # CALLS/REFERENCES edges accumulate alongside the fresh parse.
+        # A changed exclusion set has to reconcile against the GRAPH, not just
+        # against the hash cache. The cache is saved inside this method, before
+        # the final flush, so a run that died in that window already committed
+        # a cache with the newly excluded file removed; its successor would
+        # compute an empty `deleted_keys` and leave the subtree behind for
+        # good, since the stamp it then writes matches. Asking the graph for
+        # its module paths is what closes that, and it costs a query only on
+        # the runs where the set actually moved. The general case, where an
+        # ordinary deletion is lost the same way, is #1615 and is not closed
+        # here.
         preexisting_paths = (
-            self._existing_module_paths() if is_full_build else frozenset()
+            self._existing_module_paths()
+            if is_full_build or not self._exclusions_match_last_run()
+            else frozenset()
         )
         new_hashes: FileHashCache = {}
         skipped_count = 0

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -214,6 +214,47 @@ def _save_delombok_state(state_path: Path, state: dict) -> None:
         return None
 
 
+def _exclusion_state(
+    exclude_paths: frozenset[str] | None,
+    unignore_paths: frozenset[str] | None,
+) -> dict[str, list[str]]:
+    return {
+        "exclude": sorted(exclude_paths or ()),
+        "unignore": sorted(unignore_paths or ()),
+    }
+
+
+def _load_exclusion_state(state_path: Path) -> dict[str, list[str]] | None:
+    """The exclusion set the last completed run indexed under, or None.
+
+    None means "cannot be established" and must be read as changed by the
+    caller: an index written before this stamp existed carries an unknown
+    exclusion set, exactly like a missing parser fingerprint.
+    """
+    try:
+        loaded = json.loads(state_path.read_text(encoding=cs.ENCODING_UTF8))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(loaded, dict):
+        return None
+    result: dict[str, list[str]] = {}
+    for key in ("exclude", "unignore"):
+        values = loaded.get(key)
+        if not isinstance(values, list):
+            return None
+        result[key] = sorted(v for v in values if isinstance(v, str))
+    return result
+
+
+def _save_exclusion_state(state_path: Path, state: dict[str, list[str]]) -> None:
+    try:
+        state_path.write_text(
+            json.dumps(state, sort_keys=True), encoding=cs.ENCODING_UTF8
+        )
+    except OSError:
+        return None
+
+
 def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1162,6 +1203,22 @@ class GraphUpdater:
             _save_delombok_state(
                 self.repo_path / cs.DELOMBOK_STATE_FILENAME,
                 self._delombok_state_candidate,
+            )
+
+        # Same commit point, for the same reason. The module deletions a newly
+        # excluded file triggers are execute_write calls that only become
+        # durable at the flush above; stamping back in _process_files would let
+        # a run that died in between tell its successor the exclusion was
+        # already reconciled, and the successor would then fast-path over a
+        # subtree still in the graph -- a leak that outlasts the one #1606
+        # describes. Recorded on EVERY completed project run, not full builds
+        # only: an incremental run that narrowed the set must record it, or the
+        # next run reads that run's own result as a change. A single-file run
+        # walks one file and cannot speak for the project's exclusion set.
+        if self._single_file is None:
+            _save_exclusion_state(
+                self.repo_path / cs.EXCLUSION_STATE_FILENAME,
+                _exclusion_state(self.exclude_paths, self.unignore_paths),
             )
 
     def _emit_pending_endpoints(self) -> None:
@@ -2183,6 +2240,24 @@ class GraphUpdater:
         ):
             logger.warning(ls.PARSER_FINGERPRINT_MISMATCH)
 
+    def _exclusions_match_last_run(self) -> bool:
+        stored = _load_exclusion_state(self.repo_path / cs.EXCLUSION_STATE_FILENAME)
+        current = _exclusion_state(self.exclude_paths, self.unignore_paths)
+        if stored == current:
+            return True
+        # A missing stamp means an index built before it existed, whose
+        # exclusion set is unknown rather than known-equal -- the posture
+        # `_warn_if_parser_changed` takes for a missing fingerprint. Reported
+        # apart from a real change so a user seeing an unexpected full pass
+        # can tell which of the two they are looking at.
+        if stored is None:
+            logger.info(ls.EXCLUSION_STATE_MISSING)
+        else:
+            logger.info(
+                ls.EXCLUSION_SET_CHANGED.format(previous=stored, current=current)
+            )
+        return False
+
     def _is_already_in_sync(self) -> bool:
         if self._delombok_state_changed:
             # The overlay's effect changed while the checked-in bytes did
@@ -2192,6 +2267,13 @@ class GraphUpdater:
             return False
         cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
         if not cache_path.is_file():
+            return False
+        # Nothing on disk changes when only the exclusion set does, so no
+        # hash or directory mtime below can see it: a file excluded by a CLI
+        # flag alone would keep the Module, Class and Method nodes the last
+        # run gave it (issue #1606). `.cgrignore` was covered only
+        # incidentally, by being an indexed and hashed file itself.
+        if not self._exclusions_match_last_run():
             return False
         cache_mtime = cache_path.stat().st_mtime
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -101,6 +101,16 @@ GO_FRONTEND_NO_FACTS = (
 GRAPH_ALREADY_IN_SYNC = (
     "Knowledge graph already in sync (hash cache matches every file). Skipping passes."
 )
+EXCLUSION_SET_CHANGED = (
+    "Exclusion set changed since the last sync ({previous} -> {current}); "
+    "re-running so newly excluded files leave the graph and newly included "
+    "ones enter it."
+)
+EXCLUSION_STATE_MISSING = (
+    "No recorded exclusion set for this graph, so it cannot be shown "
+    "unchanged; re-running once to establish it. Expect this exactly once "
+    "per existing index."
+)
 
 # Analysis logs
 FOUND_FUNCTIONS = "\n--- Found {count} functions/methods in codebase ---"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -111,6 +111,11 @@ EXCLUSION_STATE_MISSING = (
     "unchanged; re-running once to establish it. Expect this exactly once "
     "per existing index."
 )
+EXCLUSION_STATE_NOT_RECORDED = (
+    "The graph could not be asked for its module paths, so newly excluded "
+    "files may still be indexed; the exclusion set is not recorded and the "
+    "next run will reconcile again."
+)
 
 # Analysis logs
 FOUND_FUNCTIONS = "\n--- Found {count} functions/methods in codebase ---"

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -750,6 +750,115 @@ class TestFastPathInSync:
             "later run matches the stamp and never looks again"
         )
 
+    def test_failed_module_query_leaves_no_exclusion_stamp(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """A run whose graph query failed must not claim the exclusion is done.
+
+        When the module-path query raises, the reconciliation falls back to
+        the hash cache alone, and after a pre-flush crash that cache no longer
+        names the excluded file. The run completes with the subtree still in
+        the graph; stamping would make every later run fast-path over it.
+        Withholding the stamp is what makes the next run look again.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        stamp = excludable_project / cs.EXCLUSION_STATE_FILENAME
+        before = stamp.read_text()
+
+        exclusions = frozenset({"module_a.py"})
+        mock_ingestor.flush_all.side_effect = RuntimeError("died before the flush")
+        with pytest.raises(RuntimeError):
+            GraphUpdater(
+                ingestor=mock_ingestor,
+                repo_path=excludable_project,
+                parsers=parsers,
+                queries=queries,
+                exclude_paths=exclusions,
+            ).run()
+        mock_ingestor.flush_all.side_effect = None
+
+        def _graph_unreachable(query: str, _params: object = None) -> list[object]:
+            if query == cs.CYPHER_PROJECT_MODULE_PATHS:
+                raise RuntimeError("graph unreachable")
+            return []
+
+        mock_ingestor.reset_mock()
+        mock_ingestor.fetch_all.side_effect = _graph_unreachable
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
+        updater.run()
+        assert _module_path_queries(mock_ingestor) == 1
+        assert "module_a.py" not in _deleted_module_paths(mock_ingestor), (
+            "the fake raised on the module-path query, so nothing could have "
+            "named module_a.py for deletion; the fixture is not exercising the "
+            "failure it claims to"
+        )
+        assert stamp.read_text() == before, (
+            "the run stamped the new exclusion set although it never learned "
+            "what the graph holds, so the surviving subtree is now permanent"
+        )
+
+        mock_ingestor.fetch_all.side_effect = lambda query, _params=None: (
+            [{cs.KEY_PATH: "module_a.py"}, {cs.KEY_PATH: "module_b.py"}]
+            if query == cs.CYPHER_PROJECT_MODULE_PATHS
+            else []
+        )
+        mock_ingestor.reset_mock()
+        updater3 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
+        assert updater3._is_already_in_sync() is False
+        updater3.run()
+        assert "module_a.py" in _deleted_module_paths(mock_ingestor)
+        assert stamp.read_text() != before
+
+    def test_empty_module_query_still_records_the_exclusion_set(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """A query that answers "no modules" is an answer, and the run stamps.
+
+        The withheld stamp above is for a query that RAISED. A readable sink
+        that returns no rows has told the run what the graph holds, so the
+        reconciliation is complete and the stamp must be written; otherwise
+        every run on an empty graph would re-query and warn forever.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        stamp = excludable_project / cs.EXCLUSION_STATE_FILENAME
+        before = stamp.read_text()
+
+        mock_ingestor.reset_mock()
+        mock_ingestor.fetch_all.side_effect = lambda _query, _params=None: []
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=frozenset({"module_a.py"}),
+        ).run()
+        assert _module_path_queries(mock_ingestor) == 1
+        assert stamp.read_text() != before
+
     def test_memo_is_per_run_not_per_instance(
         self, excludable_project: Path, mock_ingestor: MagicMock
     ) -> None:

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -717,14 +717,15 @@ class TestFastPathInSync:
 
         exclusions = frozenset({"module_a.py"})
         mock_ingestor.flush_all.side_effect = RuntimeError("died before the flush")
+        crashing = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
         with pytest.raises(RuntimeError):
-            GraphUpdater(
-                ingestor=mock_ingestor,
-                repo_path=excludable_project,
-                parsers=parsers,
-                queries=queries,
-                exclude_paths=exclusions,
-            ).run()
+            crashing.run()
         mock_ingestor.flush_all.side_effect = None
 
         # After the crash the graph is the ONLY place `module_a.py` still
@@ -773,14 +774,15 @@ class TestFastPathInSync:
 
         exclusions = frozenset({"module_a.py"})
         mock_ingestor.flush_all.side_effect = RuntimeError("died before the flush")
+        crashing = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
         with pytest.raises(RuntimeError):
-            GraphUpdater(
-                ingestor=mock_ingestor,
-                repo_path=excludable_project,
-                parsers=parsers,
-                queries=queries,
-                exclude_paths=exclusions,
-            ).run()
+            crashing.run()
         mock_ingestor.flush_all.side_effect = None
 
         def _graph_unreachable(query: str, _params: object = None) -> list[object]:

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -28,6 +28,48 @@ def updater(temp_repo: Path, mock_ingestor: MagicMock) -> GraphUpdater:
     )
 
 
+_EXCLUDED_QNS = frozenset(
+    {
+        "excludable.module_a",
+        "excludable.module_a.Alpha",
+        "excludable.module_a.Alpha.greet",
+    }
+)
+
+
+def _emitted_qns(mock_ingestor: MagicMock) -> set[str]:
+    return {
+        call.args[1]["qualified_name"]
+        for call in mock_ingestor.ensure_node_batch.call_args_list
+        if len(call.args) > 1 and "qualified_name" in call.args[1]
+    }
+
+
+def _deleted_module_paths(mock_ingestor: MagicMock) -> set[str]:
+    return {
+        call.args[1][cs.KEY_PATH]
+        for call in mock_ingestor.execute_write.call_args_list
+        if call.args and call.args[0] == cs.CYPHER_DELETE_MODULE
+    }
+
+
+@pytest.fixture
+def excludable_project(tmp_path: Path) -> Path:
+    """A project whose module_a carries a Module, a Class and a Method.
+
+    Named apart from `temp_repo` so the project name (and therefore every
+    qualified name asserted above) is stable.
+    """
+    repo = tmp_path / "excludable"
+    repo.mkdir()
+    (repo / "__init__.py").touch()
+    (repo / "module_a.py").write_text(
+        "class Alpha:\n    def greet(self):\n        return 1\n"
+    )
+    (repo / "module_b.py").write_text("def func_b():\n    pass\n")
+    return repo
+
+
 @pytest.fixture
 def py_project(temp_repo: Path) -> Path:
     (temp_repo / "__init__.py").touch()
@@ -419,6 +461,227 @@ class TestFastPathInSync:
             queries=queries,
         )
         assert updater._is_already_in_sync() is False
+
+    def test_changed_cli_exclusion_disables_fast_path(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=frozenset({"module_a.py"}),
+        )
+        assert updater2._is_already_in_sync() is False
+
+    def test_changed_unignore_disables_fast_path(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+            unignore_paths=frozenset({"vendor/**"}),
+        )
+        assert updater2._is_already_in_sync() is False
+
+    def test_unchanged_exclusion_keeps_fast_path(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        exclusions = frozenset({"module_a.py"})
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
+        updater.run()
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
+        assert updater2._is_already_in_sync() is True
+
+    def test_newly_excluded_file_leaves_the_index(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        assert _EXCLUDED_QNS <= _emitted_qns(mock_ingestor)
+
+        mock_ingestor.reset_mock()
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=frozenset({"module_a.py"}),
+        )
+        with patch.object(
+            updater2, "_process_files", wraps=updater2._process_files
+        ) as spy_files:
+            updater2.run()
+
+        assert spy_files.call_count == 1
+        assert "module_a.py" in _deleted_module_paths(mock_ingestor)
+        # Deleting is not enough: a run that deleted and then re-parsed the
+        # file would put every node straight back.
+        assert not (_EXCLUDED_QNS & _emitted_qns(mock_ingestor))
+        with (excludable_project / cs.HASH_CACHE_FILENAME).open() as f:
+            assert "module_a.py" not in json.load(f)
+
+    def test_cgrignore_exclusion_leaves_the_index(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """Control for #1606: the path that already worked must keep working.
+
+        A `.cgrignore` edit is caught even without an exclusion stamp,
+        because that file is itself indexed and hashed, so its own hash
+        turns the sync check over. The CLI merges both sources before
+        constructing the updater, so the exclusion set is passed either way
+        and only the on-disk change distinguishes them.
+        """
+        parsers, queries = load_parsers()
+        ignore_file = excludable_project / ".cgrignore"
+        ignore_file.write_text("\n")
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        assert _EXCLUDED_QNS <= _emitted_qns(mock_ingestor)
+
+        ignore_file.write_text("module_a.py\n")
+        mock_ingestor.reset_mock()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=frozenset({"module_a.py"}),
+        ).run()
+
+        assert "module_a.py" in _deleted_module_paths(mock_ingestor)
+        assert not (_EXCLUDED_QNS & _emitted_qns(mock_ingestor))
+
+    def test_exclusion_state_file_is_never_indexed(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The stamp must not be a file the hash loop watches.
+
+        A state file that indexed itself would be written by every run and so
+        differ from its own cached hash on the next one, leaving the fast path
+        permanently dead. That is what its CGR_STATE_FILENAMES entry prevents.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        assert (py_project / cs.EXCLUSION_STATE_FILENAME).is_file()
+        with (py_project / cs.HASH_CACHE_FILENAME).open() as f:
+            assert cs.EXCLUSION_STATE_FILENAME not in json.load(f)
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        assert updater2._is_already_in_sync() is True
+
+    def test_crash_before_flush_leaves_no_exclusion_stamp(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """A run that dies after Pass 2 must not claim the exclusion is done.
+
+        The module deletions a newly excluded file triggers are only durable
+        once the ingestor flushes. Stamping earlier would tell the next run
+        the exclusion was already reconciled, and it would fast-path over a
+        subtree still in the graph.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        stamp = excludable_project / cs.EXCLUSION_STATE_FILENAME
+        before = stamp.read_text()
+
+        exclusions = frozenset({"module_a.py"})
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
+        processed = False
+
+        def _fail_after_pass_2(*_args: object, **_kwargs: object) -> None:
+            if processed:
+                raise RuntimeError("ingestor died before the deletions landed")
+
+        real_process_files = updater2._process_files
+
+        def _tracked(*args: object, **kwargs: object) -> None:
+            nonlocal processed
+            real_process_files(*args, **kwargs)  # type: ignore[arg-type]
+            processed = True
+
+        mock_ingestor.flush_all.side_effect = _fail_after_pass_2
+        with patch.object(updater2, "_process_files", side_effect=_tracked):
+            with pytest.raises(RuntimeError):
+                updater2.run()
+
+        mock_ingestor.flush_all.side_effect = None
+        assert stamp.read_text() == before
+
+        updater3 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        )
+        assert updater3._is_already_in_sync() is False
 
     def test_force_bypasses_fast_path(
         self, py_project: Path, mock_ingestor: MagicMock

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -683,6 +683,64 @@ class TestFastPathInSync:
         )
         assert updater3._is_already_in_sync() is False
 
+    def test_crash_before_flush_still_removes_the_excluded_subtree(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The re-run a lost stamp forces must also DELETE, not just re-parse.
+
+        Declining to stamp only buys the next run a chance to reconcile; it
+        cannot take that chance on its own. The hash cache is saved inside
+        `_process_files`, before the flush, so the crashed run already
+        committed a cache with no `module_a.py` in it, and on the successor
+        `deleted_keys` is computed from that cache and comes out empty. The
+        graph's own module paths have to join the reconciliation, or the
+        subtree survives, the successor stamps a matching exclusion set, and
+        every run after that fast-paths over it. The general case, an ordinary
+        deletion lost in the same window, is #1615 and is not closed here.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        exclusions = frozenset({"module_a.py"})
+        mock_ingestor.flush_all.side_effect = RuntimeError("died before the flush")
+        with pytest.raises(RuntimeError):
+            GraphUpdater(
+                ingestor=mock_ingestor,
+                repo_path=excludable_project,
+                parsers=parsers,
+                queries=queries,
+                exclude_paths=exclusions,
+            ).run()
+        mock_ingestor.flush_all.side_effect = None
+
+        # After the crash the graph is the ONLY place `module_a.py` still
+        # exists: the hash cache the crashed run committed has already dropped
+        # it. So the sink has to be able to answer for it, or the test would
+        # pass or fail on the fake's silence rather than on the reconciliation.
+        mock_ingestor.reset_mock()
+        mock_ingestor.fetch_all.side_effect = lambda query, _params=None: (
+            [{cs.KEY_PATH: "module_a.py"}, {cs.KEY_PATH: "module_b.py"}]
+            if query == cs.CYPHER_PROJECT_MODULE_PATHS
+            else []
+        )
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclusions,
+        ).run()
+        assert "module_a.py" in _deleted_module_paths(mock_ingestor), (
+            "the excluded module survived the crash and the run after it, so "
+            "its Module, Class and Method nodes are now permanent: every "
+            "later run matches the stamp and never looks again"
+        )
+
     def test_force_bypasses_fast_path(
         self, py_project: Path, mock_ingestor: MagicMock
     ) -> None:

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -45,6 +45,15 @@ def _emitted_qns(mock_ingestor: MagicMock) -> set[str]:
     }
 
 
+def _module_path_queries(mock_ingestor: MagicMock) -> int:
+    """How many times this run asked the graph for its project module paths."""
+    return sum(
+        1
+        for call in mock_ingestor.fetch_all.call_args_list
+        if call.args and call.args[0] == cs.CYPHER_PROJECT_MODULE_PATHS
+    )
+
+
 def _deleted_module_paths(mock_ingestor: MagicMock) -> set[str]:
     return {
         call.args[1][cs.KEY_PATH]
@@ -740,6 +749,91 @@ class TestFastPathInSync:
             "its Module, Class and Method nodes are now permanent: every "
             "later run matches the stamp and never looks again"
         )
+
+    def test_memo_is_per_run_not_per_instance(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """One instance run twice must re-read the stamp its own run wrote.
+
+        The memo answers "did the set move since the last COMPLETED run", and
+        a run invalidates that answer by stamping at the end. Held across
+        `run()` calls it would keep reporting the pre-stamp answer, so the
+        instance would never fast-path again and would re-query the graph
+        every time. No production caller reuses an instance, which is exactly
+        why nothing else would catch this.
+
+        The stamp is removed after the build so the reused instance starts
+        from a MISSING one: a full build short-circuits the `or` and leaves
+        the memo unset, and an unset memo is recomputed with or without the
+        reset, so it could not tell the two apart.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        (excludable_project / cs.EXCLUSION_STATE_FILENAME).unlink()
+
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        mock_ingestor.reset_mock()
+        updater.run()
+        assert updater._exclusion_match is False, (
+            "an index with no stamp carries an unknown set, not a matching one"
+        )
+        assert updater.skipped_because_in_sync is False
+        assert _module_path_queries(mock_ingestor) == 1, (
+            "an unknown set must reconcile against the graph exactly once"
+        )
+
+        mock_ingestor.reset_mock()
+        updater.run()
+        assert updater._exclusion_match is True, (
+            "the stamp this instance wrote at the end of its own previous run "
+            "must be re-read, not answered from the memo it invalidated"
+        )
+        assert updater.skipped_because_in_sync is True
+        assert _module_path_queries(mock_ingestor) == 0, (
+            "a matching set costs no graph round-trip"
+        )
+
+    def test_memo_reconciles_again_when_the_stamp_changes_underneath(
+        self, excludable_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The reset has to work in the other direction too.
+
+        Re-reading is only correct if it can turn a match back into a
+        mismatch; a memo that refreshed to True once and stuck would pass the
+        test above and still be wrong.
+        """
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=excludable_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+        mock_ingestor.reset_mock()
+        updater.run()
+        assert updater._exclusion_match is True
+
+        (excludable_project / cs.EXCLUSION_STATE_FILENAME).write_text(
+            json.dumps({"exclude": ["module_a.py"], "unignore": []})
+        )
+        mock_ingestor.reset_mock()
+        updater.run()
+        assert updater._exclusion_match is False, (
+            "the stamp on disk no longer matches this run's set, so the "
+            "instance must reconcile rather than reuse its own True"
+        )
+        assert _module_path_queries(mock_ingestor) == 1
 
     def test_force_bypasses_fast_path(
         self, py_project: Path, mock_ingestor: MagicMock

--- a/docs/advanced/ignore-patterns.md
+++ b/docs/advanced/ignore-patterns.md
@@ -31,10 +31,12 @@ fixtures/**
 ## Changing the Exclusion Set
 
 The exclusion set is part of what an index is built against, so changing it is
-treated as a change to the repository. Editing `.cgrignore` or passing a
-different set of `--exclude` / `--unignore` flags re-runs the sync even when no
-file on disk has changed: newly excluded files have their `Module`, `Class` and
-`Method` nodes removed from the graph, and newly included ones are indexed.
+treated as a change to the repository. Passing a different set of `--exclude`
+flags, editing the patterns in `.cgrignore` or `.gitignore` (including `!`
+negations), or changing the unignore choices made in interactive setup all
+re-run the sync even when no file on disk has changed: newly excluded files
+have their `Module`, `Class` and `Method` nodes removed from the graph, and
+newly included ones are indexed.
 
 The set each index was built under is recorded in `.cgr-exclusion-state.json`
 in the repository root, alongside the hash cache. An index built before that

--- a/docs/advanced/ignore-patterns.md
+++ b/docs/advanced/ignore-patterns.md
@@ -28,6 +28,19 @@ fixtures/**
 - Lines starting with `#` are comments; blank lines are ignored
 - Patterns from `.cgrignore` are merged with `--exclude` flags (which use the same syntax) and auto-detected directories
 
+## Changing the Exclusion Set
+
+The exclusion set is part of what an index is built against, so changing it is
+treated as a change to the repository. Editing `.cgrignore` or passing a
+different set of `--exclude` / `--unignore` flags re-runs the sync even when no
+file on disk has changed: newly excluded files have their `Module`, `Class` and
+`Method` nodes removed from the graph, and newly included ones are indexed.
+
+The set each index was built under is recorded in `.cgr-exclusion-state.json`
+in the repository root, alongside the hash cache. An index built before that
+file existed has no recorded set, so the first run after upgrading re-runs once
+to establish it and logs why.
+
 ## Default Exclusions
 
 Code-Graph-RAG automatically excludes common non-source directories such as `.git`, `node_modules`, `__pycache__`, `dist`, `build`, and similar.


### PR DESCRIPTION
## Summary

- Record the exclusion set (excludes plus unignores) each completed run indexed under, in `.cgr-exclusion-state.json`, written after the final flush and listed in `CGR_STATE_FILENAMES` so it is never indexed itself.
- When the recorded set differs from the current one, or no readable record exists, the fast path is disabled and the run reconciles against the graph, so a newly excluded file leaves the index instead of surviving a skipped run.
- Docs name the real ways the exclusion set changes (CLI `--exclude`, `!` lines in `.cgrignore`/`.gitignore`, interactive setup); there is no `--unignore` flag.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Fixes #1606
Related to #1615 (hash cache saved before flush forgets deletions; left open, this PR does not change that ordering), #1619, #1620

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto --ignore=codebase_rag/tests/integration`): 8906 passed, 34 skipped, 1 xfailed on macOS
- [x] New tests added (`TestFastPathInSync` in `test_graph_updater_incremental.py`: changed CLI exclusion, changed unignore, newly excluded file leaves the index, state file never indexed, crash before flush leaves no stamp, crash before flush still removes the excluded subtree, per-run memo reset on a reused instance)
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

Mutation check, each mutant run against the new test file:

| Mutant | Result |
|---|---|
| Revert the fix | 8 failed |
| `preexisting_paths` always uses `is_full_build` only | 3 failed |
| `preexisting_paths` always empty | 3 failed |
| Stamp write omitted | 1 failed |
| Stamp written empty | 1 failed |
| Memo not reset at the top of `run()` | 2 failed |
| Test mutant: deletion assertion removed | 1 failed |
| Test mutant: stamp rewrite assertion removed | 1 failed |

Failure posture: with no readable record (first run after upgrade, or a corrupt file) and a run that adds files, every existing file re-parses once and the stamp is written; subsequent runs take the fast path again.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings: the constant, the state-reading helper and the per-run memo reset each carry a short note explaining why the set is compared against the last completed run rather than the last invocation, because the ordering is the whole bug and was mis-read twice during review

## Background

Storage: a separate stamp file rather than a field in the hash cache, because the hash cache is saved before the final flush (#1615), so a stamp inside it would claim a set the graph had not yet been reconciled to. Rejected alternatives: hashing the exclusion set into the sync fingerprint (invisible on disk, so a crash between fingerprint and flush leaves a false in-sync state), and always disabling the fast path when any `--exclude` is passed (re-parses every file on every run for users who always pass excludes).

The change was authored in a peer session that went offline before pushing; this branch was rebased onto `main` and reviewed to 5/5 from this session before the push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Index synchronization now detects changes to exclusion and unignore rules, even when source files are unchanged.
  * Newly excluded files and their related code elements are removed from the index; newly included files are reconciled correctly.
  * Missing or outdated exclusion metadata is handled safely during synchronization and recovery.
  * Failed state checks no longer record incomplete exclusion updates, allowing reconciliation to retry safely.

* **Documentation**
  * Added guidance on how exclusion-set changes affect indexing and synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->