### PR TITLE
docs: backfill the v0.0.820 feature news the parse outage skipped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ inserted; hand edits remain welcome between releases and render too.
 
 - **Transactional Multi-File Edits**: Multi-file edits now run as a transaction with staged verification and undo, alongside concrete-syntax-preserving patchers per language and import rewriting for renames and moves.
 - **Scala Inheritance and Markdown Front-Matter**: Scala `INHERITS` edges are read from `extends`/`with` clauses, and declared Markdown front-matter is read onto the `Module` node.
-- **Graph Retrieval**: A graph-proximity reranking prototype was added, MCP and CLI graph retrieval is scoped to one project, and call-site and import-site locations are now stored on graph edges.
+- **Graph Retrieval**: MCP and CLI graph retrieval is scoped to one project, and call-site and import-site locations are now stored on graph edges.
 - **Direct MCP Tools**: `find_duplicate_code` and `get_function_source` are exposed as direct MCP tools, and PHP `use function` imports resolve through declared namespaces.
 - **Graph Indexing**: The name property is now indexed for improved graph read-path lookups. SQL routines are also indexed to resolve calls that name their target in a string.
 - **Duplicate Code Detection**: An AST-based duplicate code detection system has been introduced, alongside fixes for duplicate detection across multiple repositories.

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,10 @@ the README. The release workflow prepends feature entries via
 (dropping non-feature themes), and moves the marker below the block it
 inserted; hand edits remain welcome between releases and render too.
 
+- **Transactional Multi-File Edits**: Multi-file edits now run as a transaction with staged verification and undo, alongside concrete-syntax-preserving patchers per language and import rewriting for renames and moves.
+- **Scala Inheritance and Markdown Front-Matter**: Scala `INHERITS` edges are read from `extends`/`with` clauses, and declared Markdown front-matter is read onto the `Module` node.
+- **Graph Retrieval**: A graph-proximity reranking prototype was added, MCP and CLI graph retrieval is scoped to one project, and call-site and import-site locations are now stored on graph edges.
+- **Direct MCP Tools**: `find_duplicate_code` and `get_function_source` are exposed as direct MCP tools, and PHP `use function` imports resolve through declared namespaces.
 - **Graph Indexing**: The name property is now indexed for improved graph read-path lookups. SQL routines are also indexed to resolve calls that name their target in a string.
 - **Duplicate Code Detection**: An AST-based duplicate code detection system has been introduced, alongside fixes for duplicate detection across multiple repositories.
 - **Agentic QA**: A new agentic QA benchmark harness and indexing-time benchmark have been added.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 ## Latest News 🔥
 
 <!-- SECTION:latest_news -->
+- **Transactional Multi-File Edits**: Multi-file edits now run as a transaction with staged verification and undo, alongside concrete-syntax-preserving patchers per language and import rewriting for renames and moves.
+- **Scala Inheritance and Markdown Front-Matter**: Scala `INHERITS` edges are read from `extends`/`with` clauses, and declared Markdown front-matter is read onto the `Module` node.
+- **Graph Retrieval**: A graph-proximity reranking prototype was added, MCP and CLI graph retrieval is scoped to one project, and call-site and import-site locations are now stored on graph edges.
+- **Direct MCP Tools**: `find_duplicate_code` and `get_function_source` are exposed as direct MCP tools, and PHP `use function` imports resolve through declared namespaces.
 - **Graph Indexing**: The name property is now indexed for improved graph read-path lookups. SQL routines are also indexed to resolve calls that name their target in a string.
 - **Duplicate Code Detection**: An AST-based duplicate code detection system has been introduced, alongside fixes for duplicate detection across multiple repositories.
 - **Agentic QA**: A new agentic QA benchmark harness and indexing-time benchmark have been added.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 <!-- SECTION:latest_news -->
 - **Transactional Multi-File Edits**: Multi-file edits now run as a transaction with staged verification and undo, alongside concrete-syntax-preserving patchers per language and import rewriting for renames and moves.
 - **Scala Inheritance and Markdown Front-Matter**: Scala `INHERITS` edges are read from `extends`/`with` clauses, and declared Markdown front-matter is read onto the `Module` node.
-- **Graph Retrieval**: A graph-proximity reranking prototype was added, MCP and CLI graph retrieval is scoped to one project, and call-site and import-site locations are now stored on graph edges.
+- **Graph Retrieval**: MCP and CLI graph retrieval is scoped to one project, and call-site and import-site locations are now stored on graph edges.
 - **Direct MCP Tools**: `find_duplicate_code` and `get_function_source` are exposed as direct MCP tools, and PHP `use function` imports resolve through declared namespaces.
 - **Graph Indexing**: The name property is now indexed for improved graph read-path lookups. SQL routines are also indexed to resolve calls that name their target in a string.
 - **Duplicate Code Detection**: An AST-based duplicate code detection system has been introduced, alongside fixes for duplicate detection across multiple repositories.


### PR DESCRIPTION
## Summary

- Backfills the four feature entries that v0.0.820 should have added to `NEWS.md`. That release parsed zero highlights (colon inside the bold, fixed in #1614) and the step reported success anyway (fixed in #1618), so it inserted nothing.
- Entries are hand-picked, not a mechanical replay. `is_feature_theme` returns `True` for all five of v0.0.820's original themes, including `Stability & Reliability`, whose body is a Rust test-flake fix and a startup validation fix. `NEWS.md`'s header excludes tests and bug fixes, so that theme is deliberately omitted.
- `README.md` is the regenerated rendering of the `NEWS.md` change, nothing else.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Follow-up to #1614 and #1618. Demonstrates #1608 (the feature filter inspects only the theme, so a mechanical replay would have inserted the bug-fix theme).

## Test Plan

- [ ] Unit tests pass (`uv run pytest -n auto -m "not integration"`) - not run; Markdown-only change
- [ ] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (described below)

Verified on the branch head:

- All four entries match `BULLET_PATTERN`, return `is_feature_theme=True`, and register in `existing_themes` (casefolded), so a later release cannot re-insert them.
- The `latest-release-end` marker moved 16 to 20, exactly the four new entries. Everything below it is byte-identical to `main`.
- `README.md` is the generator's exact output: re-running `scripts/generate_readme.py` produces zero working-tree change, confirmed with a positive control (corrupt the line, regenerate, generator restores it byte-for-byte).
- Every claim traces to a real `feat:` PR whose merge commit is an ancestor of `v0.0.820` and not of `v0.0.770`, and every claim was separately checked for a live user entry point.
- No em-dashes or en-dashes in any added line.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting) - no code changed

## Background

### Why the second commit exists

The first draft's `Graph Retrieval` entry opened by advertising a graph-proximity reranking prototype (PR #1467). Local review caught that `codebase_rag/tools/graph_rerank.py` has zero production callers and its own docstring reads `DELIBERATELY NOT INTEGRATED`, because integration is conditional on a retrieval-quality measurement that has not been taken. Backing a claim with a real `feat:` PR is not the same as the claim being reachable by a user, and only the first was checked. The clause is removed; the entry keeps its two user-reachable halves.

### Coverage

Six `feat:` PRs from v0.0.820 are intentionally uncovered: #1470 and #1513 are developer tooling and evals, #1468 is an internal enabler, #1483 and #1485 refine an existing feature rather than adding a headline one, and #1506 states in its own body that it is a mechanism with no caller.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added transactional multi-file editing with staged verification and undo support.
  - Added language-aware patching that preserves syntax, including import updates for renamed or moved code.
  - Added Scala inheritance relationships and Markdown front matter to project graphs.
  - Added project-scoped MCP and CLI graph retrieval with call-site and import-site locations.
  - Added direct tools for finding duplicate code and retrieving function source, including PHP namespace-aware function imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->