### PR TITLE
fix: MCP index and update honour .cgrignore and .gitignore like the CLI (#1616)

### DIFF
--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from codebase_rag import constants as cs
 from codebase_rag import logs as lg
 from codebase_rag import tool_errors as te
+from codebase_rag.config import load_ignore_patterns
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.models import ToolMetadata
 from codebase_rag.parser_loader import load_parsers
@@ -707,6 +708,22 @@ class MCPToolsRegistry:
             logger.error(lg.MCP_ERROR_WIPE.format(error=e))
             return cs.MCP_WIPE_ERROR.format(error=e)
 
+    def _ignore_sets(self) -> tuple[frozenset[str] | None, frozenset[str] | None]:
+        # The CLI resolves `.cgrignore` and the root `.gitignore` through
+        # `load_ignore_patterns` before every ingest; MCP omitted it entirely,
+        # so an MCP-driven run parsed what the ignore files exclude and built a
+        # different graph from the CLI for the same repo (#1616). MCP has no
+        # `--exclude` flag and no interactive setup, so that loader is the whole
+        # contract here -- the CLI's extra `cli_excludes` union and
+        # `prompt_for_unignored_directories` branch have no MCP counterpart.
+        # `or None` mirrors the CLI's own `... or None` idiom and the
+        # parameters' default. It is call-shape parity, not behaviour: every
+        # consumer gates on truthiness (`if exclude_paths and ...` in
+        # should_skip_path/should_skip_rel_file/should_keep_dir), so an empty
+        # frozenset and None are indistinguishable downstream.
+        patterns = load_ignore_patterns(Path(self.project_root))
+        return patterns.exclude or None, patterns.unignore or None
+
     def _index_repository_sync(self) -> str:
         # Same collision-resistant derivation as the CLI: a bare directory
         # name would let two repos named alike delete each other's graphs.
@@ -718,11 +735,14 @@ class MCPToolsRegistry:
         self.ingestor.ensure_constraints()
         self.ingestor.flush_all()
 
+        exclude_paths, unignore_paths = self._ignore_sets()
         updater = GraphUpdater(
             ingestor=self.ingestor,
             repo_path=Path(self.project_root),
             parsers=self.parsers,
             queries=self.queries,
+            unignore_paths=unignore_paths,
+            exclude_paths=exclude_paths,
             project_name=project_name,
         )
         updater.run()
@@ -763,11 +783,14 @@ class MCPToolsRegistry:
         self.ingestor.ensure_constraints()
         self.ingestor.flush_all()
 
+        exclude_paths, unignore_paths = self._ignore_sets()
         updater = GraphUpdater(
             ingestor=self.ingestor,
             repo_path=Path(self.project_root),
             parsers=self.parsers,
             queries=self.queries,
+            unignore_paths=unignore_paths,
+            exclude_paths=exclude_paths,
             project_name=project_name,
         )
         updater.run()

--- a/codebase_rag/tests/test_mcp_ignore_parity.py
+++ b/codebase_rag/tests/test_mcp_ignore_parity.py
@@ -1,0 +1,100 @@
+"""MCP index/update must honour the same ignore files the CLI honours (#1616).
+
+`GraphUpdater`'s `exclude_paths`/`unignore_paths` both default to `None`, so a
+call site that omits them parses everything `.cgrignore` and `.gitignore` were
+meant to skip. The defect was an OMISSION at the two MCP call sites, which is
+why these tests assert on the kwargs `GraphUpdater` is CALLED with rather than
+on the resulting graph: a missing argument leaves the graph well-formed but
+wrong, and an end-to-end assertion would pass against the broken code.
+
+The CLI resolves the merged set with `load_ignore_patterns`, which unions
+`.cgrignore` with the root `.gitignore` minus negations. MCP has no `--exclude`
+flag and no interactive setup, so that loader alone is the whole contract here.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag.config import load_ignore_patterns
+from codebase_rag.mcp.tools import MCPToolsRegistry
+
+_SYNC_METHODS = ("_index_repository_sync", "_update_repository_sync")
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "backend"
+    repo.mkdir()
+    (repo / "app.py").write_text("def main(): pass\n", encoding="utf-8")
+    (repo / ".cgrignore").write_text("vendor/\ngenerated/\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("dist/\nbuild/\n", encoding="utf-8")
+    return repo
+
+
+@pytest.fixture
+def registry(repo: Path) -> MCPToolsRegistry:
+    return MCPToolsRegistry(
+        project_root=str(repo),
+        ingestor=MagicMock(),
+        cypher_gen=MagicMock(),
+    )
+
+
+@pytest.mark.parametrize("sync_method", _SYNC_METHODS)
+def test_mcp_passes_the_cli_exclude_set(
+    registry: MCPToolsRegistry, repo: Path, sync_method: str
+) -> None:
+    expected = load_ignore_patterns(repo).exclude
+    # Guard the fixture: an empty expectation would make the assertion below
+    # true of the broken code too, since `exclude_paths` would be None-vs-empty
+    # rather than a real difference.
+    assert {"vendor/", "generated/", "dist/", "build/"} <= expected
+
+    with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+        getattr(registry, sync_method)()
+
+    assert updater_cls.call_args.kwargs["exclude_paths"] == expected
+
+
+@pytest.mark.parametrize("sync_method", _SYNC_METHODS)
+def test_mcp_passes_the_cli_unignore_set(
+    registry: MCPToolsRegistry, repo: Path, sync_method: str
+) -> None:
+    # A .gitignore exclude cancelled by a negation must reach the updater as an
+    # unignore, not silently vanish: dropping it would re-exclude `generated/`.
+    (repo / ".cgrignore").write_text("vendor/\n!generated/\n", encoding="utf-8")
+    (repo / ".gitignore").write_text("generated/\ndist/\n", encoding="utf-8")
+
+    patterns = load_ignore_patterns(repo)
+    assert "generated/" in patterns.unignore
+    assert "generated/" not in patterns.exclude
+
+    with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+        getattr(registry, sync_method)()
+
+    assert updater_cls.call_args.kwargs["unignore_paths"] == patterns.unignore
+
+
+@pytest.mark.parametrize("sync_method", _SYNC_METHODS)
+def test_mcp_passes_none_when_the_repo_has_no_ignore_files(
+    tmp_path: Path, sync_method: str
+) -> None:
+    # The CLI's `... or None` idiom yields None for an empty set. Consumers
+    # gate on truthiness, so this pins the CALL SHAPE rather than behaviour:
+    # it keeps the two entry points passing identical arguments, so a future
+    # consumer that does distinguish them cannot diverge by entry point.
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    (bare / "app.py").write_text("def main(): pass\n", encoding="utf-8")
+    registry = MCPToolsRegistry(
+        project_root=str(bare), ingestor=MagicMock(), cypher_gen=MagicMock()
+    )
+    assert not load_ignore_patterns(bare).exclude
+
+    with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+        getattr(registry, sync_method)()
+
+    assert updater_cls.call_args.kwargs["exclude_paths"] is None
+    assert updater_cls.call_args.kwargs["unignore_paths"] is None


### PR DESCRIPTION
Closes #1616.

## Problem

`_index_repository_sync` and `_update_repository_sync` constructed `GraphUpdater` without `exclude_paths` or `unignore_paths`. Both parameters default to `None`, so an MCP-driven index or update parsed everything `.cgrignore` and `.gitignore` were meant to skip, while the CLI honoured both files at each of its two call sites.

Two consequences, per the issue: an MCP index produces a different graph from the CLI for the same repository, and alternating CLI and MCP runs flip the eligible file set on every switch, so each run after a switch is a full re-parse rather than a fast-path no-op.

## Change

A `_ignore_sets()` helper on `MCPToolsRegistry` resolves the sets through `load_ignore_patterns`, the same loader both CLI sites use, and both sync methods now pass them.

`load_ignore_patterns` is the correct loader rather than `load_cgrignore_patterns`: it unions `.cgrignore` with the root `.gitignore` minus negations, whereas the latter would drop the `.gitignore` half that the issue explicitly names.

MCP has no `--exclude` flag and no interactive setup (both tool schemas are `properties={}, required=[]`), so that loader is the whole contract here. The CLI's additional `cli_excludes` union is a no-op when the flag is absent, and its `prompt_for_unignored_directories` branch has no MCP counterpart.

## Tests

`codebase_rag/tests/test_mcp_ignore_parity.py`, six cases parametrised over both sync methods.

They assert on the kwargs `GraphUpdater` is **called with**, not on the resulting graph. The defect is an omission at the call site: a missing argument leaves the graph well-formed but wrong, so an end-to-end assertion would pass against the broken code. The exclude test also guards its own fixture (`{"vendor/", "generated/", "dist/", "build/"} <= expected`) so an empty expectation cannot produce a vacuous pass.

Confirmed red first against the unfixed code (`KeyError: 'exclude_paths'`), then green. Three mutants, each caught by the test written for it, with apply-and-restore verified both ways:

- drop `exclude_paths` at the update site only -> only the `_update_repository_sync` cases fail, so the parametrisation discriminates per call site
- drop the `or None` idiom -> the empty-repo cases fail
- swap to `load_cgrignore_patterns` -> the exclude cases fail, catching the lost `.gitignore` half

## Notes

`or None` mirrors the CLI's own idiom and the parameters' defaults. It is call-shape parity rather than behaviour: every consumer gates on truthiness (`if exclude_paths and ...` in `should_skip_path`, `should_skip_rel_file`, `should_keep_dir`), so an empty frozenset and `None` are indistinguishable downstream. The comments say so explicitly, because an earlier draft claimed a behavioural distinction that does not exist.

No interaction with #1606's exclusion-state stamp: `.cgrignore` and `.gitignore` are themselves eligible hashed files and are not in `CGR_STATE_FILENAMES`, so editing either already defeats the in-sync skip. MCP has no flag channel, so the only exclusion source on this path is covered.

Local: 8903 passed excluding `tests/integration/` (the 257 integration errors are Memgraph-connection setup failures with no local DB, pre-existing and unrelated). ruff, ruff format and `ty` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository indexing and updates through MCP now respect `.cgrignore` and root `.gitignore` rules.
  * Excluded files are no longer processed during MCP-driven ingestion, matching CLI behavior.
  * Ignore rules with negation patterns are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->