### PR TITLE
feat: verify a PR is actually gated before merging (#1582)

### DIFF
--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -108,6 +108,29 @@ class TestContextName:
         assert "name" not in REAL_STATUS_CONTEXT
         assert context_name(REAL_STATUS_CONTEXT) == "CodeRabbit"
 
+    def test_the_entry_a_name_only_scan_drops_is_the_review_bot(self) -> None:
+        """The drop is not random: it lands on the review evidence.
+
+        Verified independently on PR #1624, whose rollup is 28 `CheckRun`
+        entries and exactly one `StatusContext` -- and that one is
+        CodeRabbit. So a scan keyed on `name` reports the review bot ABSENT
+        on a PR where it reviewed cleanly and anchored to the head, which
+        fails in the safe-looking direction.
+
+        The control is the naive scan itself, so the assertion below means
+        something rather than restating the implementation.
+        """
+        rollup = [
+            {"__typename": "CheckRun", "name": "Unit Tests (ubuntu-latest, py3.12)"},
+            REAL_STATUS_CONTEXT,
+        ]
+
+        naive = [e.get("name") for e in rollup if e.get("name")]
+        resolved = [context_name(e) for e in rollup]
+
+        assert "CodeRabbit" not in naive, "fixture no longer shows the drop"
+        assert "CodeRabbit" in resolved
+
     def test_an_unknown_shape_yields_empty_rather_than_raising(self) -> None:
         """A silent skip is wrong, but so is dying mid-scan.
 

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -1,0 +1,243 @@
+"""The PR-readiness checker's own traps, each taken from real GitHub JSON.
+
+Every fixture below was captured from a live PR in this repository rather
+than written by hand, because the whole point of the checker is that the
+naive reading of these payloads is wrong in a way that reads as success
+(issues #1581, #1582).
+
+The four that bite, and which a naive implementation gets wrong:
+
+* `statusCheckRollup` mixes two shapes. A `CheckRun` carries `name`; a
+  `StatusContext` carries `context` and has no `name` key at all, so
+  `select(.name | test(...))` raises mid-pipeline and the error reads as
+  "no matching contexts" if stderr scrolls past.
+* A queued check reports `conclusion: ""` -- an empty STRING, not null --
+  so a `.conclusion // "pending"` default never fires and the check looks
+  concluded.
+* `Integration Tests` and `Binary Smoke Test` match a loose `/test/i` but
+  are not unit coverage, so a loose pattern over-counts.
+* A CodeRabbit skip notice is a comment with a non-empty body. Counting
+  comments therefore cannot distinguish "reviewed" from "declined to
+  review", and the skip wording is not a closed set -- three variants are
+  in the wild.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.check_pr_gated import (
+    AGGREGATED_JOBS,
+    context_name,
+    is_concluded,
+    is_real_review,
+    missing_aggregated_jobs,
+    required_contexts_present,
+    unit_test_contexts,
+)
+
+# Captured from PR #1611's statusCheckRollup. The CodeRabbit entry is a
+# StatusContext with NO `name` key; every other entry is a CheckRun.
+REAL_STATUS_CONTEXT = {
+    "__typename": "StatusContext",
+    "context": "CodeRabbit",
+    "startedAt": "2026-09-01T22:37:05Z",
+    "state": "SUCCESS",
+    "targetUrl": "",
+}
+
+REAL_CHECK_RUN = {
+    "__typename": "CheckRun",
+    "completedAt": "2026-09-01T22:33:32Z",
+    "conclusion": "SKIPPED",
+    "detailsUrl": "https://github.com/vitali87/code-graph-rag/actions/runs/33566887159/job/100052009082",
+    "name": "scan-scheduled",
+    "startedAt": "2026-09-01T22:33:32Z",
+    "status": "COMPLETED",
+    "workflowName": "OSV-Scanner",
+}
+
+# A queued CheckRun: conclusion is the empty string, not null.
+REAL_QUEUED_CHECK_RUN = {
+    "__typename": "CheckRun",
+    "completedAt": "",
+    "conclusion": "",
+    "name": "Unit Tests (ubuntu-latest, py3.12)",
+    "startedAt": "2026-09-01T22:33:32Z",
+    "status": "QUEUED",
+    "workflowName": "CI",
+}
+
+# Captured from PR #1576, live at the time of writing. A THIRD skip shape,
+# beyond the two named in the issue: neither "auto reviews are disabled"
+# nor "already reviewed".
+REAL_RATE_LIMIT_NOTICE = (
+    "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n"
+    "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n"
+    "\n> [!WARNING]\n> ## Review limit reached\n> \n"
+    "> **Next included review available in 31 minutes.**\n"
+)
+
+REAL_AUTO_REVIEW_DISABLED_NOTICE = (
+    "> [!IMPORTANT]\n> ## Review skipped\n>\n"
+    "> Auto reviews are disabled on base/target branches other than the "
+    "default branch.\n>\n> Please check the settings in the CodeRabbit UI "
+    "or the `.coderabbit.yaml` file in this repository. To trigger a single "
+    "review, invoke the `@coderabbitai review` command.\n>\n"
+    "> Configuration used: **defaults**\n"
+)
+
+# Captured from PR #1596: a completed review that found nothing. This is a
+# REAL review and must count, which is what makes "empty means skipped"
+# wrong.
+REAL_EMPTY_BUT_COMPLETED_REVIEW = (
+    "**Actionable comments posted: 0**\n\n"
+    "<details>\n<summary>♻️ Duplicate comments (1)</summary>\n"
+    "</details>\n\n"
+    "No actionable comments were generated in the recent review."
+)
+
+
+class TestContextName:
+    """Both rollup shapes must yield a name, and neither may raise."""
+
+    def test_a_check_run_uses_its_name(self) -> None:
+        assert context_name(REAL_CHECK_RUN) == "scan-scheduled"
+
+    def test_a_status_context_has_no_name_key_and_must_not_raise(self) -> None:
+        assert "name" not in REAL_STATUS_CONTEXT
+        assert context_name(REAL_STATUS_CONTEXT) == "CodeRabbit"
+
+    def test_an_unknown_shape_yields_empty_rather_than_raising(self) -> None:
+        """A silent skip is wrong, but so is dying mid-scan.
+
+        Returning "" lets the caller report the entry as unnamed instead of
+        aborting the whole check, which is how the jq form failed.
+        """
+        assert context_name({"__typename": "Mystery"}) == ""
+
+
+class TestIsConcluded:
+    def test_a_queued_check_is_not_concluded(self) -> None:
+        """`conclusion` is "" here, not null: a `or "pending"` default lies."""
+        assert REAL_QUEUED_CHECK_RUN["conclusion"] == ""
+        assert is_concluded(REAL_QUEUED_CHECK_RUN) is False
+
+    def test_a_completed_check_is_concluded(self) -> None:
+        assert is_concluded(REAL_CHECK_RUN) is True
+
+    def test_the_naive_none_default_would_have_passed_this(self) -> None:
+        """Pins why the guard is written against "" and not against None."""
+        assert (REAL_QUEUED_CHECK_RUN["conclusion"] or "pending") == "pending"
+        assert REAL_QUEUED_CHECK_RUN.get("conclusion", "pending") == ""
+
+
+class TestUnitTestContexts:
+    def test_integration_and_smoke_are_not_unit_tests(self) -> None:
+        rollup = [
+            {"__typename": "CheckRun", "name": "Unit Tests (ubuntu-latest, py3.12)"},
+            {"__typename": "CheckRun", "name": "Integration Tests (ubuntu-latest)"},
+            {"__typename": "CheckRun", "name": "Binary Smoke Test"},
+        ]
+
+        names = unit_test_contexts(rollup)
+
+        assert names == ["Unit Tests (ubuntu-latest, py3.12)"]
+
+    def test_a_loose_match_would_have_counted_three(self) -> None:
+        """The control that makes the assertion above mean something."""
+        rollup = [
+            {"__typename": "CheckRun", "name": "Unit Tests (ubuntu-latest, py3.12)"},
+            {"__typename": "CheckRun", "name": "Integration Tests (ubuntu-latest)"},
+            {"__typename": "CheckRun", "name": "Binary Smoke Test"},
+        ]
+
+        loose = [e for e in rollup if "test" in context_name(e).lower()]
+
+        assert len(loose) == 3, "fixture no longer demonstrates the over-count"
+
+
+class TestRequiredContextsPresent:
+    def test_a_missing_context_is_reported_not_ignored(self) -> None:
+        rollup = [{"__typename": "CheckRun", "name": "All Checks Pass"}]
+
+        missing = required_contexts_present(rollup, ["All Checks Pass", "CodeRabbit"])
+
+        assert missing == ["CodeRabbit"]
+
+    def test_presence_is_not_inferred_from_absence_of_failure(self) -> None:
+        """An empty rollup must report every required context missing.
+
+        This is the #1582 shape: zero failures out of a set containing no
+        tests reads as clean.
+        """
+        missing = required_contexts_present([], ["All Checks Pass"])
+
+        assert missing == ["All Checks Pass"]
+
+
+class TestMissingAggregatedJobs:
+    def test_matrix_job_names_are_matched_by_prefix(self) -> None:
+        """Exact comparison finds none of them and reports everything missing."""
+        rollup = [
+            {"__typename": "CheckRun", "name": f"{job} (ubuntu-latest, py3.12)"}
+            for job in AGGREGATED_JOBS
+        ]
+
+        assert missing_aggregated_jobs(rollup) == []
+
+    def test_the_codeql_only_set_reports_every_job_missing(self) -> None:
+        """The #1582 shape: a green aggregate over a set containing no tests.
+
+        Seven CodeQL contexts and nothing else is what a stacked branch is
+        left with after a rebase cancels its runs, and `0 FAILURE` over that
+        set reads as clean.
+        """
+        rollup = [
+            {"__typename": "CheckRun", "name": "Analyze (actions)"},
+            {"__typename": "CheckRun", "name": "Analyze (python)"},
+            {"__typename": "StatusContext", "context": "CodeRabbit"},
+        ]
+
+        assert missing_aggregated_jobs(rollup) == list(AGGREGATED_JOBS)
+
+
+class TestIsRealReview:
+    @pytest.mark.parametrize(
+        ("label", "body"),
+        [
+            ("rate limited", REAL_RATE_LIMIT_NOTICE),
+            ("auto review disabled", REAL_AUTO_REVIEW_DISABLED_NOTICE),
+        ],
+    )
+    def test_a_skip_notice_is_not_a_review(self, label: str, body: str) -> None:
+        assert body.strip(), f"{label}: fixture is empty, so it proves nothing"
+        assert is_real_review(body) is False, label
+
+    def test_a_completed_review_that_found_nothing_still_counts(self) -> None:
+        """The case that makes "non-empty body" and "no findings" both wrong.
+
+        A review reporting zero actionable comments DID run. Treating it as
+        skipped would refuse a properly reviewed PR.
+        """
+        assert is_real_review(REAL_EMPTY_BUT_COMPLETED_REVIEW) is True
+
+    def test_an_empty_body_is_not_a_review(self) -> None:
+        assert is_real_review("") is False
+        assert is_real_review("   \n  ") is False
+
+    def test_an_unrecognised_notice_shape_is_refused_not_admitted(self) -> None:
+        """Fails closed on wording nobody has seen yet.
+
+        The skip wording is not a closed set -- three variants are already
+        in the wild, and #1581 was filed knowing only two. So the test is
+        "does this positively carry a review verdict", not "is this absent
+        from a blocklist of known skips"; a blocklist admits every future
+        variant by default, which is the wrong direction to fail in.
+        """
+        invented_future_notice = (
+            "> [!WARNING]\n> ## Review postponed\n> Some new reason nobody "
+            "has written down yet.\n"
+        )
+
+        assert is_real_review(invented_future_notice) is False

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -332,6 +332,52 @@ class TestUnresolvedInPage:
         with pytest.raises(KeyError):
             unresolved_in_page(no_page_info)
 
+    def test_a_pageinfo_without_hasnextpage_is_unverified_not_final(self) -> None:
+        """The same defect one level down, which the first fix missed.
+
+        `bool(info.get("hasNextPage"))` is False for a `pageInfo` that exists
+        but omits the field, so pagination ended as if complete. Fixing the
+        missing-`pageInfo` case without this one repaired the named instance
+        rather than the class (CodeRabbit on PR #1625).
+        """
+        missing_flag = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [{"isResolved": False}],
+                            "pageInfo": {"endCursor": "Y3Vyc29y"},
+                        }
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(KeyError):
+            unresolved_in_page(missing_flag)
+
+    def test_a_string_hasnextpage_is_refused_rather_than_trusted(self) -> None:
+        """A wrong type must not be read as an answer.
+
+        `"false"` is a truthy string, so a shape change turning the flag into
+        a string would invert this check while looking like it worked.
+        """
+        wrong_type = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": "false", "endCursor": ""},
+                        }
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(TypeError):
+            unresolved_in_page(wrong_type)
+
 
 class TestIsRealReview:
     @pytest.mark.parametrize(

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -307,6 +307,31 @@ class TestUnresolvedInPage:
         with pytest.raises((KeyError, TypeError)):
             unresolved_in_page({"data": {}})
 
+    def test_a_page_with_nodes_but_no_pageinfo_is_unverified_not_final(self) -> None:
+        """The one shape that used to answer "complete" instead of "unverified".
+
+        `info = threads.get("pageInfo", {})` defaulted `hasNextPage` to
+        False, so a page carrying `nodes` and no `pageInfo` key read as the
+        FINAL page and returned its count with no error -- while every other
+        unreadable shape here routes to unverified. A missing key answered
+        as a clean result is the class this script exists to close, so the
+        inconsistency mattered more than its likelihood (CodeRabbit on
+        PR #1625).
+
+        The two-page fixtures above are the control: they must stay green,
+        or this would have been "fixed" by making every page unverified.
+        """
+        no_page_info = {
+            "data": {
+                "repository": {
+                    "pullRequest": {"reviewThreads": {"nodes": [{"isResolved": False}]}}
+                }
+            }
+        }
+
+        with pytest.raises(KeyError):
+            unresolved_in_page(no_page_info)
+
 
 class TestIsRealReview:
     @pytest.mark.parametrize(

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -34,6 +34,7 @@ from scripts.check_pr_gated import (
     missing_aggregated_jobs,
     required_contexts_present,
     unit_test_contexts,
+    unresolved_in_page,
 )
 
 # Captured from PR #1611's statusCheckRollup. The CodeRabbit entry is a
@@ -225,6 +226,88 @@ class TestMissingAggregatedJobs:
         assert missing_aggregated_jobs(rollup) == list(AGGREGATED_JOBS)
 
 
+class TestReviewEvidenceIsNotForgeable:
+    """A verdict marker written by anyone must not satisfy the gate.
+
+    Greptile's P1 on PR #1625: bodies were pooled without author, so the
+    PR author could write "confidence score" in an ordinary comment and
+    the gate would report the PR reviewed. The check then asserted
+    something the author controls (CWE-345).
+    """
+
+    def test_the_pr_author_cannot_forge_a_verdict(self) -> None:
+        forged = "Looks good. confidence score is fine here."
+
+        assert is_real_review(forged, "vitali87") is False
+
+    def test_the_same_body_from_the_bot_does_count(self) -> None:
+        """The control: it is the AUTHOR that makes the difference, not the text.
+
+        Without this the test above would also pass if `is_real_review`
+        rejected the body for some unrelated reason.
+        """
+        forged = "Looks good. confidence score is fine here."
+
+        assert is_real_review(forged, "coderabbitai") is True
+
+    def test_a_trusted_author_alone_is_not_enough(self) -> None:
+        """The bot posts the skip notices too, so author alone cannot decide."""
+        assert is_real_review(REAL_RATE_LIMIT_NOTICE, "coderabbitai") is False
+
+    def test_the_bot_suffix_spelling_is_accepted(self) -> None:
+        """`author.login` and `user.login` differ on the `[bot]` suffix."""
+        assert is_real_review(REAL_EMPTY_BUT_COMPLETED_REVIEW, "coderabbitai[bot]")
+
+    def test_an_unknown_author_fails_closed(self) -> None:
+        assert is_real_review(REAL_EMPTY_BUT_COMPLETED_REVIEW, "") is False
+
+
+class TestUnresolvedInPage:
+    """An unresolved thread on page two must not be invisible.
+
+    `reviewThreads(first: 100)` without `pageInfo` silently truncates, and
+    PR #1503 carried 53 threads, so the ceiling is reachable rather than
+    theoretical (Greptile P1 on PR #1625).
+    """
+
+    @staticmethod
+    def _page(unresolved: int, has_next: bool, cursor: str) -> dict[str, object]:
+        nodes = [{"isResolved": False}] * unresolved
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": nodes,
+                            "pageInfo": {
+                                "hasNextPage": has_next,
+                                "endCursor": cursor,
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_page_one_reports_that_another_page_exists(self) -> None:
+        count, has_next, cursor = unresolved_in_page(self._page(0, True, "Y3Vyc29y"))
+
+        assert count == 0
+        assert has_next is True, "a single-page read would stop here and report clean"
+        assert cursor == "Y3Vyc29y"
+
+    def test_the_blocker_on_page_two_is_counted(self) -> None:
+        count, has_next, _ = unresolved_in_page(self._page(1, False, ""))
+
+        assert count == 1
+        assert has_next is False
+
+    def test_a_malformed_page_raises_rather_than_reporting_zero(self) -> None:
+        """The caller turns this into "unverified", never into a clean count."""
+        with pytest.raises((KeyError, TypeError)):
+            unresolved_in_page({"data": {}})
+
+
 class TestIsRealReview:
     @pytest.mark.parametrize(
         ("label", "body"),
@@ -235,7 +318,7 @@ class TestIsRealReview:
     )
     def test_a_skip_notice_is_not_a_review(self, label: str, body: str) -> None:
         assert body.strip(), f"{label}: fixture is empty, so it proves nothing"
-        assert is_real_review(body) is False, label
+        assert is_real_review(body, "coderabbitai") is False, label
 
     def test_a_completed_review_that_found_nothing_still_counts(self) -> None:
         """The case that makes "non-empty body" and "no findings" both wrong.
@@ -243,11 +326,11 @@ class TestIsRealReview:
         A review reporting zero actionable comments DID run. Treating it as
         skipped would refuse a properly reviewed PR.
         """
-        assert is_real_review(REAL_EMPTY_BUT_COMPLETED_REVIEW) is True
+        assert is_real_review(REAL_EMPTY_BUT_COMPLETED_REVIEW, "coderabbitai") is True
 
     def test_an_empty_body_is_not_a_review(self) -> None:
-        assert is_real_review("") is False
-        assert is_real_review("   \n  ") is False
+        assert is_real_review("", "coderabbitai") is False
+        assert is_real_review("   \n  ", "coderabbitai") is False
 
     def test_an_unrecognised_notice_shape_is_refused_not_admitted(self) -> None:
         """Fails closed on wording nobody has seen yet.
@@ -263,4 +346,4 @@ class TestIsRealReview:
             "has written down yet.\n"
         )
 
-        assert is_real_review(invented_future_notice) is False
+        assert is_real_review(invented_future_notice, "coderabbitai") is False

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -107,6 +107,8 @@ the workflow run rather than assuming the cadence explains it.
 
 This project uses automated code review bots (**Greptile** and **Gemini Code Assist**). Before requesting a human review, address all bot comments by either implementing suggestions or replying with a clear justification for why a suggestion doesn't apply.
 
+A green check list does not by itself mean a PR was verified: a review bot's *skip* notice is a comment with a non-empty body, and a PR based on a branch other than the default is covered by no ruleset, so nothing is required of it. Run `uv run python scripts/check_pr_gated.py <pr-number>` before merging; it reports every reason a PR is not verifiably gated rather than only the first.
+
 ## Technical Requirements
 
 - **PydanticAI for now**: The current framework choice, open to a well-argued change. Do not add a second one (LangChain, CrewAI, AutoGen) in a feature PR; open an issue first

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -241,7 +241,14 @@ def unresolved_in_page(page: dict[str, Any]) -> tuple[int, bool, str]:
     threads = page["data"]["repository"]["pullRequest"]["reviewThreads"]
     nodes = threads["nodes"]
     unresolved = sum(1 for n in nodes if n.get("isResolved") is False)
-    info = threads.get("pageInfo", {})
+    # Subscripted, not `.get(..., {})`. A page carrying `nodes` but no
+    # `pageInfo` key would default to `hasNextPage: False` and be read as the
+    # FINAL page, so the count came back complete with no error -- while every
+    # other unreadable shape here routes to "unverified". That inconsistency
+    # is the class this script exists to close: a missing key answered as a
+    # clean result (CodeRabbit on PR #1625). The KeyError now takes the same
+    # branch as the rest.
+    info = threads["pageInfo"]
     return unresolved, bool(info.get("hasNextPage")), str(info.get("endCursor") or "")
 
 

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -1,0 +1,320 @@
+"""Report whether a pull request is actually gated, not merely green.
+
+`mergeStateStatus=CLEAN` plus a green check list is the combination that
+normally reads as ready, and on this repository it can be fully satisfied
+by a PR that nothing verified (issues #1581, #1582). Three independent
+reasons, any one sufficient:
+
+* The active ruleset's conditions are `ref_name.include = ["~DEFAULT_BRANCH"]`,
+  so a PR based on a sibling branch is required to satisfy NOTHING. Its
+  CLEAN status means "nothing is required", not "everything passed", and
+  the two are indistinguishable from the checks list alone.
+* A check that never ran is not failing. A rebase arriving mid-run cancels
+  it, so a rapidly-moving branch can leave its head with only the fast
+  unfiltered jobs and report zero failures out of a set containing no tests.
+* CodeRabbit's auto-review is skipped on non-default bases, and the skip is
+  a comment with a non-empty body, so a comment COUNT cannot see it.
+
+This script asks the positive question in each case -- is a run present at
+this head, is each required context present, did a review actually happen,
+is this base covered by a rule -- because every corresponding negative is
+satisfied by absence.
+
+It is ADVISORY. It reads GitHub through the ambient `gh` auth and writes
+nothing. Closing the gap for real means widening the ruleset's
+`ref_name.include`, which is repository settings and the owner's decision.
+
+Usage:  uv run python scripts/check_pr_gated.py <pr-number>
+Exit 0 when every check passes, 1 otherwise, printing EVERY reason found.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+REPO = "vitali87/code-graph-rag"
+
+# The one context the active ruleset requires on the default branch. It
+# aggregates the jobs below and asserts each result == "success", so a
+# skipped or cancelled job fails it rather than passing silently.
+REQUIRED_CONTEXT = "All Checks Pass"
+
+AGGREGATED_JOBS = (
+    "Lint & Format",
+    "Type Check",
+    "Unit Tests",
+    "Integration Tests",
+    "Binary Smoke Test",
+)
+
+# A review artifact must POSITIVELY carry a verdict. The alternative --
+# rejecting a list of known skip notices -- fails in the wrong direction:
+# the wording is not a closed set (three variants are already in the wild,
+# and #1581 was filed knowing two), so a blocklist admits every future
+# variant by default.
+REVIEW_VERDICT_MARKERS = (
+    "actionable comments posted",
+    "no actionable comments were generated",
+    "last reviewed commit",
+    "confidence score",
+)
+
+
+def _gh(*args: str) -> str:
+    """`gh` stdout, or "" when the call fails.
+
+    Failures are returned as empty rather than raised so one unavailable
+    endpoint reports as its own named reason instead of aborting the run
+    and leaving the other checks unreported.
+    """
+    try:
+        done = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=False, timeout=60
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return done.stdout if done.returncode == 0 else ""
+
+
+def context_name(entry: dict[str, object]) -> str:
+    """The display name of a `statusCheckRollup` entry, whichever shape it is.
+
+    A `CheckRun` carries `name`; a `StatusContext` carries `context` and has
+    no `name` key at all. The jq form `select(.name | test(...))` raises on
+    the second, and that error reads as "no matching contexts" if stderr
+    scrolls past -- an instrument failure that looks like a measurement.
+    """
+    for key in ("name", "context"):
+        value = entry.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def is_concluded(entry: dict[str, object]) -> bool:
+    """Whether a check has finished.
+
+    A queued check reports `conclusion: ""` -- an empty STRING, not null --
+    so `.conclusion // "pending"` in jq and `entry.get("conclusion", ...)`
+    in Python both fail to default, and the entry reads as concluded.
+    """
+    conclusion = entry.get("conclusion")
+    return isinstance(conclusion, str) and conclusion != ""
+
+
+def unit_test_contexts(rollup: list[dict[str, object]]) -> list[str]:
+    """Names of the unit-test contexts only.
+
+    `startswith` rather than a loose `test` match: `Integration Tests` and
+    `Binary Smoke Test` are real checks and not unit coverage, and a loose
+    pattern reports them as such.
+    """
+    return [
+        name
+        for entry in rollup
+        if (name := context_name(entry)).startswith("Unit Tests")
+    ]
+
+
+def missing_aggregated_jobs(rollup: list[dict[str, object]]) -> list[str]:
+    """Jobs `All Checks Pass` aggregates that have no context at this head.
+
+    Matched by PREFIX because the matrix jobs carry their platform in the
+    name (`Unit Tests (ubuntu-latest, py3.12)`), so an exact comparison
+    finds none of them and would report every job missing.
+
+    Checking these as well as the aggregate is the difference between
+    trusting the gate and verifying it: `All Checks Pass` is a job like any
+    other, and if it never ran then its own absence is what to catch.
+    """
+    names = [context_name(entry) for entry in rollup]
+    return [job for job in AGGREGATED_JOBS if not any(n.startswith(job) for n in names)]
+
+
+def required_contexts_present(
+    rollup: list[dict[str, object]], required: list[str]
+) -> list[str]:
+    """Required names that are ABSENT from `rollup`.
+
+    Presence, not success: a context that never ran is not failing, so
+    asking "did anything fail" returns clean for a PR that ran nothing.
+    """
+    present = {context_name(entry) for entry in rollup}
+    return [name for name in required if name not in present]
+
+
+def is_real_review(body: str) -> bool:
+    """Whether a comment body is a review rather than a notice about one.
+
+    Positive detection, so an unrecognised notice fails closed. A review
+    that found nothing still counts -- it ran -- which is why emptiness of
+    findings cannot be the test either.
+    """
+    lowered = body.strip().lower()
+    if not lowered:
+        return False
+    return any(marker in lowered for marker in REVIEW_VERDICT_MARKERS)
+
+
+def _json_dict(text: str) -> dict[str, Any]:
+    """Parsed object, or `{}` when the call failed or returned something else.
+
+    Split from the list form rather than returning a bare `object`, so the
+    call sites keep their types instead of every `.get` needing a cast.
+    """
+    try:
+        parsed = json.loads(text) if text.strip() else None
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _json_list(text: str) -> list[Any]:
+    """Parsed array, or `[]` when the call failed or returned something else."""
+    try:
+        parsed = json.loads(text) if text.strip() else None
+    except json.JSONDecodeError:
+        return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def check(pr: str) -> list[str]:
+    """Every reason `pr` is not verifiably gated, in order. Empty means gated."""
+    reasons: list[str] = []
+
+    view = _json_dict(
+        _gh(
+            "pr",
+            "view",
+            pr,
+            "--repo",
+            REPO,
+            "--json",
+            "headRefOid,baseRefName,statusCheckRollup,comments,reviews",
+        )
+    )
+    if not view:
+        return [f"could not read PR #{pr} (is `gh` authenticated?)"]
+
+    head = str(view.get("headRefOid", ""))
+    base = str(view.get("baseRefName", ""))
+    rollup = [e for e in view.get("statusCheckRollup", []) if isinstance(e, dict)]
+
+    rules = _json_list(_gh("api", f"repos/{REPO}/rules/branches/{base}"))
+    rule_types = {r.get("type") for r in rules if isinstance(r, dict)}
+    if "required_status_checks" not in rule_types:
+        reasons.append(
+            f"base '{base}' is covered by no ruleset requiring status checks, "
+            "so nothing is enforced on this PR regardless of its check list"
+        )
+
+    runs = _json_list(
+        _gh(
+            "run",
+            "list",
+            "--repo",
+            REPO,
+            "--workflow",
+            "CI",
+            "--limit",
+            "40",
+            "--json",
+            "headSha,databaseId",
+        )
+    )
+    at_head = [
+        r for r in runs if isinstance(r, dict) and str(r.get("headSha", "")) == head
+    ]
+    if not at_head:
+        reasons.append(f"no CI run exists at the head SHA {head[:8]}")
+    else:
+        owners: set[str] = set()
+        for run in at_head:
+            detail = _json_dict(
+                _gh("api", f"repos/{REPO}/actions/runs/{run.get('databaseId')}")
+            )
+            owners.update(
+                str(p.get("number"))
+                for p in detail.get("pull_requests", [])
+                if isinstance(p, dict)
+            )
+        if owners and pr not in owners:
+            reasons.append(
+                f"the CI run at {head[:8]} belongs to PR(s) {sorted(owners)}, not #{pr}; "
+                "branches sharing a head SHA after a rebase report each other's runs"
+            )
+
+    missing = required_contexts_present(rollup, [REQUIRED_CONTEXT])
+    if missing:
+        reasons.append(f"required context absent at the head: {missing}")
+    else:
+        for entry in rollup:
+            if context_name(entry) != REQUIRED_CONTEXT:
+                continue
+            if not is_concluded(entry):
+                reasons.append(f"'{REQUIRED_CONTEXT}' has not concluded")
+            elif str(entry.get("conclusion", "")).upper() != "SUCCESS":
+                reasons.append(
+                    f"'{REQUIRED_CONTEXT}' concluded {entry.get('conclusion')}"
+                )
+
+    absent_jobs = missing_aggregated_jobs(rollup)
+    if absent_jobs:
+        reasons.append(
+            f"jobs aggregated by '{REQUIRED_CONTEXT}' have no context at the head: "
+            f"{absent_jobs}; a green aggregate over a set containing none of these "
+            "reports on nothing"
+        )
+
+    bodies = [
+        str(c.get("body", "")) for c in view.get("comments", []) if isinstance(c, dict)
+    ] + [str(r.get("body", "")) for r in view.get("reviews", []) if isinstance(r, dict)]
+    if not any(is_real_review(b) for b in bodies):
+        reasons.append(
+            f"no review artifact carries a verdict ({len(bodies)} comment(s)/review(s) "
+            "present, none of which is a review)"
+        )
+
+    threads = _json_dict(
+        _gh(
+            "api",
+            "graphql",
+            "-f",
+            "query="
+            '{repository(owner:"vitali87",name:"code-graph-rag")'
+            f"{{pullRequest(number:{pr})"
+            "{reviewThreads(first:100){nodes{isResolved}}}}}",
+        )
+    )
+    try:
+        nodes = threads["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        unresolved = sum(1 for n in nodes if n.get("isResolved") is False)
+    except (KeyError, TypeError, AttributeError):
+        unresolved = 0
+        reasons.append("could not read review threads, so resolution is unverified")
+    if unresolved:
+        reasons.append(f"{unresolved} unresolved review thread(s)")
+
+    return reasons
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or not argv[1].isdigit():
+        sys.stderr.write(f"usage: {argv[0]} <pr-number>\n")
+        return 2
+    pr = argv[1]
+    reasons = check(pr)
+    if not reasons:
+        sys.stdout.write(f"PR #{pr}: gated (every check present and satisfied)\n")
+        return 0
+    sys.stdout.write(f"PR #{pr}: NOT verifiably gated -- {len(reasons)} reason(s)\n")
+    for reason in reasons:
+        sys.stdout.write(f"  - {reason}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -24,6 +24,13 @@ It is ADVISORY. It reads GitHub through the ambient `gh` auth and writes
 nothing. Closing the gap for real means widening the ruleset's
 `ref_name.include`, which is repository settings and the owner's decision.
 
+Intended for an OPEN pull request, immediately before merging. Run against
+an already-merged one it will usually report the CI run as unresolvable:
+GitHub leaves `pull_requests: []` on runs belonging to closed PRs, and this
+script treats an unanswerable ownership question as unverified rather than
+clean. That is the deliberate direction -- an empty answer is not a pass --
+but it makes the tool noisy after the fact, which is not what it is for.
+
 Usage:  uv run python scripts/check_pr_gated.py <pr-number>
 Exit 0 when every check passes, 1 otherwise, printing EVERY reason found.
 """
@@ -62,8 +69,26 @@ REVIEW_VERDICT_MARKERS = (
     "confidence score",
 )
 
+# A verdict is only evidence if the account that wrote it is the one whose
+# review the gate is asking about. Without this the check is spoofable by
+# the author it is meant to constrain: writing "confidence score" in an
+# ordinary comment satisfies a marker-only test (CWE-345, Greptile on
+# PR #1625). Bot logins carry the `[bot]` suffix on some payloads and not
+# others, so both spellings are accepted.
+TRUSTED_REVIEWERS = frozenset(
+    {
+        "coderabbitai",
+        "coderabbitai[bot]",
+        "greptile-apps",
+        "greptile-apps[bot]",
+        "greptileai",
+        "gemini-code-assist",
+        "gemini-code-assist[bot]",
+    }
+)
 
-def _gh(*args: str) -> str:
+
+def _gh_stdout_or_empty(*args: str) -> str:
     """`gh` stdout, or "" when the call fails.
 
     Failures are returned as empty rather than raised so one unavailable
@@ -146,17 +171,42 @@ def required_contexts_present(
     return [name for name in required if name not in present]
 
 
-def is_real_review(body: str) -> bool:
-    """Whether a comment body is a review rather than a notice about one.
+def is_real_review(body: str, author: str) -> bool:
+    """Whether this is a review artifact from an account that reviews.
 
-    Positive detection, so an unrecognised notice fails closed. A review
-    that found nothing still counts -- it ran -- which is why emptiness of
-    findings cannot be the test either.
+    Both halves are required. A marker alone is forgeable: the PR author
+    can write "confidence score" in an ordinary comment and satisfy a
+    marker-only test, which makes the gate assert something the author
+    controls (CWE-345, Greptile on PR #1625). An author alone is not
+    enough either, because a skip notice is posted by the same bot.
+
+    Positive on both axes, so an unrecognised notice or an unexpected
+    account fails closed. A review that found nothing still counts -- it
+    ran -- which is why emptiness of findings cannot be the test.
     """
+    if author.strip().lower() not in TRUSTED_REVIEWERS:
+        return False
     lowered = body.strip().lower()
     if not lowered:
         return False
     return any(marker in lowered for marker in REVIEW_VERDICT_MARKERS)
+
+
+def _author_login(artifact: dict[str, Any]) -> str:
+    """The login that wrote a comment or review, across both payload shapes.
+
+    `gh pr view --json comments` nests it as `author.login`; the REST
+    comment payload uses `user.login`. Returning "" for an unrecognised
+    shape makes the artifact fail the trusted-author test rather than
+    silently pass it.
+    """
+    for key in ("author", "user"):
+        holder = artifact.get(key)
+        if isinstance(holder, dict):
+            login = holder.get("login")
+            if isinstance(login, str):
+                return login
+    return ""
 
 
 def _json_dict(text: str) -> dict[str, Any]:
@@ -181,12 +231,66 @@ def _json_list(text: str) -> list[Any]:
     return parsed if isinstance(parsed, list) else []
 
 
+def unresolved_in_page(page: dict[str, Any]) -> tuple[int, bool, str]:
+    """`(unresolved on this page, has another page, end cursor)`.
+
+    Split out so the pagination arithmetic is testable without the network,
+    which is what makes the two-page fixture below a real test rather than
+    a mock of the code under test.
+    """
+    threads = page["data"]["repository"]["pullRequest"]["reviewThreads"]
+    nodes = threads["nodes"]
+    unresolved = sum(1 for n in nodes if n.get("isResolved") is False)
+    info = threads.get("pageInfo", {})
+    return unresolved, bool(info.get("hasNextPage")), str(info.get("endCursor") or "")
+
+
+def _unresolved_thread_count(pr: str) -> tuple[int, str]:
+    """`(count, error)`. A non-empty error means the count is unverified.
+
+    Paginated because `first: 100` silently truncates: an unresolved 101st
+    thread is invisible, and PR #1503 carried 53, so the ceiling is within
+    reach rather than theoretical. A page that cannot be read is reported
+    rather than counted as zero.
+    """
+    total = 0
+    cursor = ""
+    for _ in range(20):
+        after = f', after: "{cursor}"' if cursor else ""
+        page = _json_dict(
+            _gh_stdout_or_empty(
+                "api",
+                "graphql",
+                "-f",
+                "query="
+                '{repository(owner:"vitali87",name:"code-graph-rag")'
+                f"{{pullRequest(number:{pr})"
+                f"{{reviewThreads(first: 100{after})"
+                "{nodes{isResolved} pageInfo{hasNextPage endCursor}}}}}",
+            )
+        )
+        try:
+            unresolved, has_next, cursor = unresolved_in_page(page)
+        except (KeyError, TypeError, AttributeError):
+            return (
+                0,
+                "could not read a page of review threads, so resolution is unverified",
+            )
+        total += unresolved
+        if not has_next:
+            return total, ""
+    return (
+        total,
+        "review threads did not terminate after 20 pages; treating as unverified",
+    )
+
+
 def check(pr: str) -> list[str]:
     """Every reason `pr` is not verifiably gated, in order. Empty means gated."""
     reasons: list[str] = []
 
     view = _json_dict(
-        _gh(
+        _gh_stdout_or_empty(
             "pr",
             "view",
             pr,
@@ -203,7 +307,9 @@ def check(pr: str) -> list[str]:
     base = str(view.get("baseRefName", ""))
     rollup = [e for e in view.get("statusCheckRollup", []) if isinstance(e, dict)]
 
-    rules = _json_list(_gh("api", f"repos/{REPO}/rules/branches/{base}"))
+    rules = _json_list(
+        _gh_stdout_or_empty("api", f"repos/{REPO}/rules/branches/{base}")
+    )
     rule_types = {r.get("type") for r in rules if isinstance(r, dict)}
     if "required_status_checks" not in rule_types:
         reasons.append(
@@ -212,7 +318,7 @@ def check(pr: str) -> list[str]:
         )
 
     runs = _json_list(
-        _gh(
+        _gh_stdout_or_empty(
             "run",
             "list",
             "--repo",
@@ -234,17 +340,25 @@ def check(pr: str) -> list[str]:
         owners: set[str] = set()
         for run in at_head:
             detail = _json_dict(
-                _gh("api", f"repos/{REPO}/actions/runs/{run.get('databaseId')}")
+                _gh_stdout_or_empty(
+                    "api", f"repos/{REPO}/actions/runs/{run.get('databaseId')}"
+                )
             )
             owners.update(
                 str(p.get("number"))
                 for p in detail.get("pull_requests", [])
                 if isinstance(p, dict)
             )
-        if owners and pr not in owners:
+        if pr not in owners:
+            # Empty is UNVERIFIED, not clean. A run whose detail fetch failed,
+            # or one reporting `pull_requests: []`, leaves `owners` empty; the
+            # earlier `if owners and ...` guard then never fired and scored the
+            # absence of an answer as a pass (Greptile on PR #1625) -- the same
+            # fail-open shape this checker exists to catch.
+            found = sorted(owners) if owners else "none (could not be determined)"
             reasons.append(
-                f"the CI run at {head[:8]} belongs to PR(s) {sorted(owners)}, not #{pr}; "
-                "branches sharing a head SHA after a rebase report each other's runs"
+                f"the CI run at {head[:8]} does not resolve to #{pr}; owners: {found}. "
+                "Branches sharing a head SHA after a rebase report each other's runs"
             )
 
     missing = required_contexts_present(rollup, [REQUIRED_CONTEXT])
@@ -269,33 +383,24 @@ def check(pr: str) -> list[str]:
             "reports on nothing"
         )
 
-    bodies = [
-        str(c.get("body", "")) for c in view.get("comments", []) if isinstance(c, dict)
-    ] + [str(r.get("body", "")) for r in view.get("reviews", []) if isinstance(r, dict)]
-    if not any(is_real_review(b) for b in bodies):
+    artifacts = [
+        (str(a.get("body", "")), _author_login(a))
+        for key in ("comments", "reviews")
+        for a in view.get(key, [])
+        if isinstance(a, dict)
+    ]
+    if not any(is_real_review(body, author) for body, author in artifacts):
         reasons.append(
-            f"no review artifact carries a verdict ({len(bodies)} comment(s)/review(s) "
-            "present, none of which is a review)"
+            f"no review artifact carries a verdict from a reviewing account "
+            f"({len(artifacts)} comment(s)/review(s) present, none of which is a "
+            "review by one of "
+            f"{sorted(a for a in TRUSTED_REVIEWERS if not a.endswith('[bot]'))})"
         )
 
-    threads = _json_dict(
-        _gh(
-            "api",
-            "graphql",
-            "-f",
-            "query="
-            '{repository(owner:"vitali87",name:"code-graph-rag")'
-            f"{{pullRequest(number:{pr})"
-            "{reviewThreads(first:100){nodes{isResolved}}}}}",
-        )
-    )
-    try:
-        nodes = threads["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
-        unresolved = sum(1 for n in nodes if n.get("isResolved") is False)
-    except (KeyError, TypeError, AttributeError):
-        unresolved = 0
-        reasons.append("could not read review threads, so resolution is unverified")
-    if unresolved:
+    unresolved, thread_error = _unresolved_thread_count(pr)
+    if thread_error:
+        reasons.append(thread_error)
+    elif unresolved:
         reasons.append(f"{unresolved} unresolved review thread(s)")
 
     return reasons

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -249,7 +249,18 @@ def unresolved_in_page(page: dict[str, Any]) -> tuple[int, bool, str]:
     # clean result (CodeRabbit on PR #1625). The KeyError now takes the same
     # branch as the rest.
     info = threads["pageInfo"]
-    return unresolved, bool(info.get("hasNextPage")), str(info.get("endCursor") or "")
+    # Required keys with type checks, not `.get`. `bool(info.get("hasNextPage"))`
+    # is False for a `pageInfo` that exists but omits the field, so pagination
+    # ended as if complete -- the same defect as the missing `pageInfo` above,
+    # one level down, and I fixed the outer one without fixing the class
+    # (CodeRabbit on PR #1625). A wrong TYPE is refused too: a string
+    # "false" is truthy, so a shape change that turned the flag into a string
+    # would silently invert this.
+    has_next = info["hasNextPage"]
+    cursor = info["endCursor"]
+    if not isinstance(has_next, bool) or not isinstance(cursor, str | None):
+        raise TypeError(f"unexpected pageInfo types: {type(has_next)}, {type(cursor)}")
+    return unresolved, has_next, cursor or ""
 
 
 def _unresolved_thread_count(pr: str) -> tuple[int, str]:


### PR DESCRIPTION
Related to #1581, #1582. Not "Fixes": the fix for both is a repository-settings change, which is the owner's, and this does not attempt it.

An advisory checker that answers **"is this PR actually gated"** rather than "does it look green". Reads GitHub through the ambient `gh` auth, writes nothing, and prints **every** reason it found rather than the first.

```
uv run python scripts/check_pr_gated.py <pr-number>
```

## What it establishes, and why the mechanism differs from both issues

Investigating turned up a third mechanism that neither issue had, and it is checkable in one query rather than inferred.

The legacy branch-protection API returns **404**, which reads as "main is unprotected". It is not: this repository uses a **ruleset**, which does not appear on that endpoint.

```
GET /branches/main/protection  -> 404 "Branch not protected"
GET /rulesets                  -> "main branch protection", enforcement: active
  conditions  ref_name.include = ["~DEFAULT_BRANCH"]     <- main ONLY
  required    exactly one context: "All Checks Pass"
  strict      false
```

So PRs into `main` **are** gated, on one aggregate context, and that job is well built: `ci.yml:548` asserts each aggregated job's result `== "success"`, not the absence of failure, so a skipped or cancelled job fails it.

The gap is **coverage**: a PR based on a sibling branch is matched by no ruleset, so its `mergeStateStatus=CLEAN` means *nothing is required*, not *everything passed*. That is base-scoped, and it is neither #1582's original branch-filter theory (falsified: a rebase produced a full matrix with the base unchanged) nor "no branch protection" (falsified above).

Verified live, and the endpoint discriminates:

```
/rules/branches/main                    -> ["deletion","non_fast_forward","pull_request","required_status_checks"]
/rules/branches/feat/ts-inheritance-eval -> []
```

## The five checks

1. the base is covered by a ruleset requiring status checks
2. a CI run exists **at the head SHA** and resolves to **this** PR, since branches sharing a SHA after a rebase report each other's runs
3. `All Checks Pass` is present and concluded success
4. every job it aggregates has a context present, matched by prefix because matrix jobs carry their platform in the name
5. a review artifact carries a **verdict**, and zero review threads are unresolved

Each is the positive question. Every corresponding negative is satisfied by absence, which is the whole defect.

## Verified to discriminate, not merely to run

A checker that fires on everything is as useless as one that never fires, so both directions were measured against live PRs:

```
#1576 (base = fix/incremental-stem-siblings)   NOT gated -- 4 reasons:
  - base covered by no ruleset requiring status checks
  - no CI run exists at the head SHA 3385d8c0
  - 'All Checks Pass' concluded FAILURE
  - no review artifact carries a verdict (4 comments present, none is a review)

#1611 (base = main, merged normally)           gated
```

The fourth reason on #1576 is #1581 exactly: four non-empty comments, zero reviews.

## Tests: 17, every fixture captured from real GitHub JSON

Master's condition, and it earned itself — one fixture is sharper than the issue described and another is a shape neither issue knew about.

- **`statusCheckRollup` mixes two types.** A `CheckRun` carries `name`; a `StatusContext` carries `context` and **has no `name` key at all**. `select(.name | test(...))` raises on the second, and that error reads as "no matching contexts" if stderr scrolls past. Captured from #1611.
- **A queued check reports `conclusion: ""`** — an empty string, not null — so `.conclusion // "pending"` never fires. Pinned with a test asserting the naive default *would* have passed, so the guard cannot be "simplified" back.
- **`Integration Tests` and `Binary Smoke Test` match a loose `/test/i`.** The control asserts a loose match counts three where the unit count is one, so the strict assertion means something.
- **A third skip notice exists.** #1581 names two ("auto reviews are disabled", "already reviewed"). Live on #1576 right now is a third: **"Review limit reached"**. So the skip wording is not a closed set, and a blocklist admits every future variant by default. `is_real_review` therefore tests for a **verdict marker** positively and fails closed, with a test using an invented future notice to pin that direction.
- **A review that found nothing still counts.** Captured from #1596: "No actionable comments were generated" is a completed review. Treating emptiness as skipped would refuse a properly reviewed PR.

## Scope

Advisory only. Closing the gap means widening the ruleset's `ref_name.include` (#1582) or adding `.coderabbit.yaml` with `reviews.auto_review.base_branches` (#1581). Both are repository settings, both are the owner's, and neither is attempted here.

One line added to `docs/contributing.md` under Automated Code Review pointing at the script. It went there rather than `CLAUDE.md` because `CLAUDE.md` is untracked in this repository, so a PR cannot carry a change to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull request gate checks now fail closed when ownership details are missing or unavailable.
  - Review verdicts are accepted only from trusted reviewers.
  - Unresolved review threads are checked across all result pages, with malformed pagination treated as unverified.
  - The command reports all detected gating issues rather than stopping at the first one.

- **Documentation**
  - Updated contributor guidance with instructions for running the gate check and clarifications about review-bot notices and branch coverage.

- **Tests**
  - Added regression coverage for status formats, review outcomes, pagination, missing contexts, skip notices, and unknown formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->