### PR TITLE
fix: reset skipped_because_in_sync per run so a reused updater does not report a stale skip (#1620)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -954,6 +954,12 @@ class GraphUpdater:
         # Reset per-run parse tracking so a reused updater does not reprocess
         # a previous run's files in Pass 3.
         self._parsed_files.clear()
+        # Per-run for the same reason: set on the in-sync early return below
+        # and previously cleared only in `__init__`, so a reused instance kept
+        # reporting a previous run's skip. `cli.py` reads it to decide what to
+        # report, so a stale True describes a run that did real work as
+        # already in sync (#1620).
+        self.skipped_because_in_sync = False
         self._sink.ensure_node_batch(
             cs.NODE_PROJECT,
             {

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -968,6 +968,41 @@ class TestFastPathInSync:
             updater2.run(force=True)
             spy_calls.assert_called_once()
 
+    def test_skipped_flag_is_per_run_not_per_instance(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """A reused instance must not carry a previous run's skip into this one.
+
+        `skipped_because_in_sync` is set on the in-sync early return and was
+        only ever cleared in `__init__`, so once an instance skipped it kept
+        reporting True for every later `run()` however much work that run did.
+        `cli.py` reads the flag to decide what to tell the user, so a stale
+        True reports "already in sync" for a run that re-parsed the repo.
+
+        The order matters: the flag must be observed True first, or a run that
+        never set it would satisfy the second assertion on its own and the
+        test would pass against the unfixed code (#1620).
+        """
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+        updater.run()
+        assert updater.skipped_because_in_sync is True, (
+            "second run on an unchanged repo must take the in-sync fast path, "
+            "otherwise the reset below is never exercised"
+        )
+
+        updater.run(force=True)
+        assert updater.skipped_because_in_sync is False, (
+            "a forced run does real work, so the flag must reflect THIS run "
+            "rather than the skip recorded by the previous one"
+        )
+
 
 class TestSlots:
     def test_function_registry_trie_has_slots(self) -> None:


### PR DESCRIPTION
Closes #1620.

## Problem

`GraphUpdater.skipped_because_in_sync` is set to `True` on the in-sync early return in `run()` and was cleared only in `__init__`. On an instance reused for a second `run()` the flag stayed `True` even when that run did real work.

`cli.py:379` reads the flag to choose between "already in sync, no changes detected" and the normal completion message, so a stale `True` reports a run that re-parsed the repository as having done nothing.

No production caller reuses an instance today (`cli.py` and `mcp/tools.py` each construct one and call `run()` once), so this is latent. It matters because #1606 made instance reuse a supported shape: `run()` already resets its per-run state at the top, and this flag was the one piece that was not.

## Change

One assignment beside the existing per-run reset at the top of `run()`, above every branch point that can set or read the flag.

## Tests

`test_skipped_flag_is_per_run_not_per_instance` in the existing `TestFastPathInSync` class: one instance, two runs to reach the in-sync fast path, then a third forced run that does real work.

The order of assertions is load-bearing. The flag is asserted `True` first, because without that a run which never set it would satisfy the second assertion on its own and the test would pass against the unfixed code.

Verified red against the unfixed code, both before and after rebasing onto current `main`: it fails at the second assertion with `assert True is False`, which also proves the first assertion held and the fast path was genuinely taken rather than the test passing vacuously.

## Scope

Deliberately limited to the reset and its test, with nothing else in `run()` touched, so the pending #1615 work in the same function rebases cleanly. #1615 moves the hash-cache save to the post-flush commit point (~line 1220s); this inserts at ~957, a different region.

## Notes

Three staleness axes were checked beyond the reported one, all covered by a reset at the top of `run()` rather than needing a `finally`:

- **exception mid-run** — the flag reads `False` after a run that raises following a prior skip, because the reset happens before any code that can raise past it
- **single-file path** — `_is_already_in_sync` returns `False` unconditionally when `_single_file is not None`, so that path can never set the flag `True`, and the reset still clears a prior `True` on it
- **external setters** — none exist; the only three assignment sites are all in `graph_updater.py` (init, this reset, and the in-sync set), so the reset cannot clobber a caller-set value

Local: full suite 8965 passed, 0 failed (integration errors are Memgraph-connection setup failures with no local database, pre-existing). ruff, ruff format and `ty` clean; the one `ty` warning in this file is pre-existing on `main` and exits 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected status reporting when the graph updater is reused across multiple runs. Results now accurately indicate whether the current run was skipped because everything was already synchronized.

- **Tests**
  - Added regression coverage for status reset behavior across unchanged and forced update runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->