### PR TITLE
fix: accept a missing space after the colon in both news extractors

### DIFF
--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -138,23 +138,61 @@ class TestExtractBullets:
         assert is_feature_theme("Improvements") is True
         assert is_feature_theme("CI automation") is False
 
-    def test_a_missing_space_after_the_colon_is_pinned_not_undefined(self) -> None:
-        """The two extractors disagree here, and did so before this change.
+    def test_both_extractors_accept_a_missing_space_after_the_colon(self) -> None:
+        """The unification issue #1609 asked for, in the permissive direction.
 
-        `BULLET_PATTERN` requires at least one space after the colon;
-        `HIGHLIGHT_BULLET` uses `\\s*` and so accepts none. The generator is
-        not under our control, so a bullet with no space is possible: pinning
-        the split makes it a known, testable behaviour rather than an
-        undefined one, and any future unification has to change this test
-        deliberately. Verified identical on origin/main (35bc841f).
-        Tracked as issue #1609, which measures the user-visible symptom: the
-        bullet is demoted into the Release Summary aggregate when it is the
-        only feature bullet, and vanishes entirely when it is not.
+        This test previously PINNED the disagreement: `BULLET_PATTERN`
+        required a space, `HIGHLIGHT_BULLET` accepted none, and it said any
+        future unification had to change it deliberately. This is that
+        deliberate change.
+
+        The direction was chosen by measuring both, not by symmetry. Making
+        both STRICT is worse than the bug: a lone no-space bullet currently
+        survives demoted into the Release Summary aggregate, and under a
+        strict rule `prepend_news` inserts NOTHING at all, so the feature is
+        lost completely rather than misfiled. Permissive is the only rule
+        that preserves the content in both arrangements, and the module's
+        own docstring notes the generator is not under our control, so
+        tolerating its whitespace is the fail-safe direction.
         """
         for line in ("- **Theme:**No space here.", "- **Theme**:No space here."):
-            assert extract_bullets(line) == [], line
+            assert extract_bullets(line) == ["- **Theme**: No space here."], line
         for line in ("* **Theme:**No space here.", "* **Theme**:No space here."):
             assert extract_all_highlights(line) == [("Theme", "No space here.")], line
+
+    def test_a_no_space_bullet_reaches_latest_news_as_its_own_entry(self) -> None:
+        """The user-visible half of #1609, in both arrangements it measured.
+
+        Before: alone it was demoted to `Release Summary`; beside a
+        well-formed sibling it vanished entirely, because `extract_bullets`
+        returned non-empty and the aggregate fallback never fired.
+        """
+        news = "# News\n\n## Latest News\n\n"
+
+        _alone, added_alone = prepend_news(
+            news, "## Highlights\n* **Voice Input**:Speak to the agent.\n"
+        )
+        _pair, added_pair = prepend_news(
+            news,
+            "## Highlights\n"
+            "* **Voice Input**:Speak to the agent.\n"
+            "* **Web Search**: Search the web.\n",
+        )
+
+        assert added_alone == ["- **Voice Input**: Speak to the agent."]
+        assert "- **Voice Input**: Speak to the agent." in added_pair, added_pair
+        assert "- **Web Search**: Search the web." in added_pair, added_pair
+
+    def test_a_space_after_the_colon_is_still_normalised_away(self) -> None:
+        """The control: loosening must not change the well-formed case.
+
+        Without this, a change that simply stopped normalising whitespace
+        would satisfy the assertions above while altering every existing
+        bullet.
+        """
+        assert extract_bullets("- **Theme**:   Lots of space.") == [
+            "- **Theme**: Lots of space."
+        ]
 
     def test_the_theme_key_never_keeps_a_trailing_colon(self) -> None:
         # existing_themes() dedupes NEW entries against NEWS.md using the

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -183,6 +183,26 @@ class TestExtractBullets:
         assert "- **Voice Input**: Speak to the agent." in added_pair, added_pair
         assert "- **Web Search**: Search the web." in added_pair, added_pair
 
+    def test_a_tab_after_the_colon_is_accepted_by_both_extractors(self) -> None:
+        """The same disagreement as #1609, on a different whitespace character.
+
+        The first fix unified the QUANTIFIER (` +` to ` *`) and left the
+        CHARACTER CLASS split: a literal space here, `\\s` in
+        `HIGHLIGHT_BULLET`. So `- **Theme**:\\tText` still parsed in one
+        extractor and not the other, with the same user-visible consequence
+        the issue measured. Fixing the named instance rather than the class
+        (CodeRabbit on PR #1627).
+
+        Both patterns now share one whitespace class, so a future divergence
+        has to be written deliberately in one place rather than drifting.
+        """
+        assert extract_bullets("- **Theme**:\tText here.") == [
+            "- **Theme**: Text here."
+        ]
+        assert extract_all_highlights("* **Theme**:\tText here.") == [
+            ("Theme", "Text here.")
+        ]
+
     def test_a_space_after_the_colon_is_still_normalised_away(self) -> None:
         """The control: loosening must not change the well-formed case.
 

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -62,9 +62,18 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 # not under our control, so tolerating its whitespace is the direction that
 # fails safe. Normalisation is unaffected: `text` still starts at the first
 # non-space, so the emitted bullet carries exactly one space either way.
-BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:) *(?P<text>\S.*)$")
+# The one separator both extractors use, so they cannot disagree about what
+# follows the colon. #1609 unified the QUANTIFIER, leaving this pattern with a
+# literal space and HIGHLIGHT_BULLET with `\s`; a tab then still parsed in one
+# and not the other, reproducing the same defect on a different character
+# (CodeRabbit, PR #1627). Sharing the fragment means a future divergence has
+# to be written deliberately in one place rather than drifting.
+_AFTER_COLON = r"\s*"
+BULLET_PATTERN = re.compile(
+    rf"^- \*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:){_AFTER_COLON}(?P<text>\S.*)$"
+)
 HIGHLIGHT_BULLET = re.compile(
-    r"^[-*]\s+\*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:)\s*(?P<text>\S.*)$"
+    rf"^[-*]\s+\*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:){_AFTER_COLON}(?P<text>\S.*)$"
 )
 
 # Any line a human would call a bullet, however malformed. Used only to tell

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -48,7 +48,21 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 # and leaves "CI automation" in the body, where is_feature_theme never
 # inspects it - a CI entry then reaches Latest News, which is the one thing
 # this module exists to prevent.
-BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:) +(?P<text>\S.*)$")
+# The separator is ` *`, not ` +`, so a bullet with no space after the colon
+# parses here exactly as it does in HIGHLIGHT_BULLET below. The two disagreed
+# until #1609: this pattern rejected it while HIGHLIGHT_BULLET accepted it, so
+# the same line got two answers and `prepend_news` silently demoted the bullet
+# into the Release Summary aggregate, or dropped it entirely when a
+# well-formed sibling kept `extract_bullets` non-empty.
+#
+# Unified toward the LOOSER rule after measuring both. Requiring the space in
+# both places is worse than the bug it fixes: a lone no-space bullet is
+# currently misfiled but survives, whereas under a strict rule `prepend_news`
+# inserts nothing at all and the feature is lost. This generator's input is
+# not under our control, so tolerating its whitespace is the direction that
+# fails safe. Normalisation is unaffected: `text` still starts at the first
+# non-space, so the emitted bullet carries exactly one space either way.
+BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:) *(?P<text>\S.*)$")
 HIGHLIGHT_BULLET = re.compile(
     r"^[-*]\s+\*\*(?P<theme>[^*]+?)(?::\*\*|\*\*:)\s*(?P<text>\S.*)$"
 )


### PR DESCRIPTION
Closes #1609.

`BULLET_PATTERN` required a space after the colon; `HIGHLIGHT_BULLET` used `\s*` and accepted none. Same line, same file, two answers, and the disagreement was user-visible: a feature bullet written without that space was demoted into the Release Summary aggregate, or dropped entirely when a well-formed sibling kept `extract_bullets` non-empty.

## The direction was measured, not chosen for symmetry

The issue asks for unification and leaves the direction open, calling it a behaviour decision. Both were measured before picking:

```
CURRENT (patterns disagree)
  A  lone no-space bullet     -> ['- **Release Summary**: Voice Input: Speak to the agent.']
  B  beside a well-formed one -> ['- **Web Search**: Search the web.']          (A vanishes)

IF UNIFIED ON STRICT (space required by both)
  A  lone no-space bullet     -> []                                             (nothing at all)
  B  beside a well-formed one -> ['- **Web Search**: Search the web.']          (A vanishes)
```

**Strict is worse than the bug it would fix.** Today a lone no-space bullet at least survives, misfiled into the Release Summary. Under a strict rule `prepend_news` inserts nothing and the feature is lost completely. Permissive is the only rule that preserves the content in both arrangements, and the module's own docstring notes the generator is not under our control, so tolerating its whitespace is the direction that fails safe.

So `BULLET_PATTERN`'s separator becomes ` *`, matching `HIGHLIGHT_BULLET`. The reasoning is in a comment above the pattern rather than only here.

## The pinning test was changed deliberately, as it required

`test_a_missing_space_after_the_colon_is_pinned_not_undefined` existed to make the split testable and said in its docstring that *"any future unification has to change this test deliberately"*. This is that change: it is now `test_both_extractors_accept_a_missing_space_after_the_colon`, and it records why the permissive direction was taken so the decision is not re-litigated from scratch.

## Tests

Verified RED first: the two new behaviour tests failed, the control passed.

- `test_both_extractors_accept_a_missing_space_after_the_colon` — the parser parity itself, both colon spellings, both extractors.
- `test_a_no_space_bullet_reaches_latest_news_as_its_own_entry` — the user-visible half, asserting **both** arrangements the issue measured, so a fix that repaired only the lone case would fail.
- `test_a_space_after_the_colon_is_still_normalised_away` — the control. Without it, a change that simply stopped normalising whitespace would satisfy the assertions above while altering every existing bullet. It passed before and after, which is what makes the other two transitions meaningful.

40 passed in `test_update_news.py`, including the 37 pre-existing ones that could have regressed from loosening the pattern.

## Generator output is unchanged

Per the review condition, `scripts/hooks/generate_readme.py` was run against main's current `NEWS.md` after the change: it produced **no** README or NEWS diff. The only working-tree changes are the two files in this PR, so nothing downstream of #1623 is disturbed.

No workflow files are touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * News bullets with no space or a tab after the theme colon are now recognized consistently.
  * Whitespace after the colon is normalized to a single space in Latest News.
  * Standalone bullets are retained as separate news entries instead of being dropped or grouped into the release summary.
  * Existing bullets with additional spacing continue to be normalized correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->