### PR TITLE
fix(fingerprint): treat capture selection as parser identity

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2257,7 +2257,7 @@ class GraphUpdater:
         # unknown (pre-fingerprint) parser: treat it as stale too, without
         # paying for a fingerprint computation that cannot match.
         if stored is None or stored != compute_parser_fingerprint(
-            repo_path=self.repo_path
+            repo_path=self.repo_path, capture=self.capture
         ):
             logger.warning(ls.PARSER_FINGERPRINT_MISMATCH)
 
@@ -2702,7 +2702,9 @@ class GraphUpdater:
         if is_full_build:
             _save_parser_fingerprint(
                 self.repo_path / cs.PARSER_FINGERPRINT_FILENAME,
-                compute_parser_fingerprint(repo_path=self.repo_path),
+                compute_parser_fingerprint(
+                    repo_path=self.repo_path, capture=self.capture
+                ),
             )
 
     def _pre_parse_changed_files(

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -876,11 +876,18 @@ HASH_CACHE_ORPHANED = (
 )
 PARSER_FINGERPRINT_SAVE_FAILED = "Failed to save parser fingerprint to {path}: {error}"
 PARSER_FINGERPRINT_MISMATCH = (
-    "Parser code changed since this graph was built. Incremental sync keeps "
-    "results from the old parser for files not touched since the last sync, so "
-    "the graph may be stale. Run 'cgr start --clean --update-graph' to rebuild "
-    "it from scratch. '--clean' on its own deletes the graph without rebuilding "
-    "it, and deletes every project in a shared database, not just this one."
+    "A parser input changed since this graph was built: parser code, a grammar "
+    "or toolchain version, a frontend mode, or the capture selection. "
+    "Incremental sync keeps results from the old inputs for files not touched "
+    "since the last sync, so the graph may be stale. To rebuild THIS repository "
+    "only, delete its '.cgr-hash-cache.json', '.cgr-dir-mtimes.json' and "
+    "'.cgr-parser-fingerprint' and index again with 'cgr start --update-graph': "
+    "every file is then treated as new, and other projects in a shared database "
+    "are untouched. That adds what the new inputs emit but does not remove nodes "
+    "the old ones left behind, so when names or node kinds changed rather than "
+    "edges being added, run 'cgr start --clean --update-graph' instead. "
+    "'--clean' on its own deletes the graph without rebuilding it, and deletes "
+    "every project in a shared database, not just this one."
 )
 
 REHYDRATE_QUERY_FAILED = (

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -10,11 +10,15 @@ import subprocess
 from collections.abc import Callable
 from importlib import metadata
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
 from . import constants as cs
 from . import logs as ls
+
+if TYPE_CHECKING:
+    from .capture import CaptureSelection
 
 _FILE_HASH_CHUNK_SIZE = 1024 * 1024
 
@@ -190,7 +194,9 @@ def _tool_versions(repo_path: Path | None = None) -> list[str]:
 
 
 def compute_parser_fingerprint(
-    package_root: Path | None = None, repo_path: Path | None = None
+    package_root: Path | None = None,
+    repo_path: Path | None = None,
+    capture: "CaptureSelection | None" = None,
 ) -> str:
     root = package_root if package_root is not None else Path(__file__).resolve().parent
     hasher = hashlib.md5(usedforsecurity=False)
@@ -213,7 +219,42 @@ def compute_parser_fingerprint(
     # (issue #1465).
     for entry in _tool_versions(repo_path):
         hasher.update(entry.encode())
+    # The capture selection decides which edges exist for unchanged sources,
+    # the same criterion the frontend mode above is hashed under: enabling a
+    # group must not leave an "already in sync" graph that predates it, and
+    # disabling one must not leave its edges behind (issue #1630).
+    for entry in _capture_entries(capture):
+        hasher.update(entry.encode())
     return hasher.hexdigest()
+
+
+def _capture_entries(capture: "CaptureSelection | None") -> list[str]:
+    """Stable identity of the resolved capture selection.
+
+    The RESOLVED selection is hashed rather than the raw `CGR_CAPTURE` spec,
+    so `io,io` and `io` are one identity and do not force a needless rebuild.
+    Sorted because the selection holds frozensets, whose iteration order is
+    not stable across processes and would otherwise make one selection hash
+    many ways.
+    """
+    from .capture import default_capture
+    from .config import settings
+
+    selection = capture if capture is not None else default_capture()
+    rels = sorted(rel.value for rel in selection.enabled_rels)
+    labels = sorted(label.value for label in selection.enabled_node_labels)
+    # Prefixed and counted so a relationship named like a node label cannot
+    # move between the two lists without changing the digest.
+    return [
+        f"capture-rel:{len(rels)}",
+        *rels,
+        f"capture-node:{len(labels)}",
+        *labels,
+        # Not part of CaptureSelection, but the same kind of input: it picks
+        # between two predicates for whether a nested definition becomes a
+        # method, so it changes which Method nodes unchanged sources produce.
+        f"capture-function-local-definitions:{settings.CAPTURE_FUNCTION_LOCAL_DEFINITIONS}",
+    ]
 
 
 def _repo_frontend_inputs(repo_path: Path | None) -> list[str]:

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from codebase_rag import constants as cs
 from codebase_rag import logs as ls
+from codebase_rag.capture import CaptureSelection, resolve_capture
 from codebase_rag.cli import _delete_hash_cache
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_fingerprint import compute_parser_fingerprint
@@ -38,13 +39,18 @@ def warnings_sink() -> Iterator[list[str]]:
     logger.remove(handler_id)
 
 
-def _make_updater(repo: Path, mock_ingestor: MagicMock) -> GraphUpdater:
+def _make_updater(
+    repo: Path,
+    mock_ingestor: MagicMock,
+    capture: "CaptureSelection | None" = None,
+) -> GraphUpdater:
     parsers, queries = load_parsers()
     return GraphUpdater(
         ingestor=mock_ingestor,
         repo_path=repo,
         parsers=parsers,
         queries=queries,
+        capture=capture,
     )
 
 
@@ -298,6 +304,33 @@ class TestStalenessWarning:
         updater.run()
 
         assert any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
+
+    def test_enabling_a_capture_group_warns(
+        self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]
+    ) -> None:
+        # The defect in #1630, end to end through the updater rather than
+        # against compute_parser_fingerprint directly: the stamp is written
+        # with the selection that built the graph and compared against the
+        # one running now, so dropping `capture=self.capture` at either call
+        # site brings the silent no-op back.
+        _make_updater(py_project, mock_ingestor).run()
+
+        _make_updater(py_project, mock_ingestor, resolve_capture(["io"])).run()
+
+        assert any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
+
+    def test_same_capture_group_twice_does_not_warn(
+        self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]
+    ) -> None:
+        # Control for the test above: it must warn because the selection
+        # CHANGED, not because a non-default selection warns unconditionally
+        # or because the entries hash differently each run. Without this, an
+        # unstable digest would look like a working fix.
+        _make_updater(py_project, mock_ingestor, resolve_capture(["io"])).run()
+
+        _make_updater(py_project, mock_ingestor, resolve_capture(["io"])).run()
+
+        assert not any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
 
     def test_missing_stamp_with_existing_cache_warns(
         self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -425,3 +425,62 @@ def test_changes_when_compile_database_content_changes(
     before = compute_parser_fingerprint(repo_path=repo)
     db.write_text('[{"arguments": ["c++", "-DFEATURE"]}]', encoding="utf-8")
     assert compute_parser_fingerprint(repo_path=repo) != before
+
+
+class TestCaptureSelectionIsParserIdentity:
+    # The capture selection decides which edges are produced for unchanged
+    # sources -- the same criterion the frontend selection is hashed under --
+    # so it belongs to the parser identity. Without it, enabling a capture
+    # group on an indexed project reports "already in sync" and emits
+    # nothing, and the only documented remedy wipes every project in the
+    # shared graph (issue #1630).
+
+    def test_changes_when_capture_env_changes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from codebase_rag.config import settings as cfg
+
+        monkeypatch.setattr(cfg, "CGR_CAPTURE", "")
+        before = compute_parser_fingerprint()
+        monkeypatch.setattr(cfg, "CGR_CAPTURE", "io")
+        assert compute_parser_fingerprint() != before
+
+    def test_changes_when_capture_passed_explicitly(self) -> None:
+        # The CLI resolves CGR_CAPTURE and --capture together and hands the
+        # GraphUpdater a CaptureSelection, so a fingerprint that consulted
+        # only the environment would stay blind to `--capture io`.
+        from codebase_rag.capture import resolve_capture
+
+        before = compute_parser_fingerprint(capture=resolve_capture([]))
+        after = compute_parser_fingerprint(capture=resolve_capture(["io"]))
+        assert after != before
+
+    def test_same_selection_same_fingerprint(self) -> None:
+        from codebase_rag.capture import resolve_capture
+
+        first = compute_parser_fingerprint(capture=resolve_capture(["io"]))
+        second = compute_parser_fingerprint(capture=resolve_capture(["io"]))
+        assert first == second
+
+    def test_repeated_token_is_the_same_identity(self) -> None:
+        # The RESOLVED selection is hashed, not the raw spec, so `io,io` and
+        # `io` are one identity and do not force a spurious rebuild.
+        from codebase_rag.capture import resolve_capture
+
+        once = compute_parser_fingerprint(capture=resolve_capture(["io"]))
+        twice = compute_parser_fingerprint(capture=resolve_capture(["io", "io"]))
+        assert once == twice
+
+    def test_changes_when_function_local_definitions_toggled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # CAPTURE_FUNCTION_LOCAL_DEFINITIONS picks between two predicates for
+        # whether a nested definition is ingested as a method, so flipping it
+        # changes which Method nodes exist for unchanged sources -- the same
+        # criterion as the frontend mode, and it was not hashed either.
+        from codebase_rag.config import settings as cfg
+
+        monkeypatch.setattr(cfg, "CAPTURE_FUNCTION_LOCAL_DEFINITIONS", True)
+        before = compute_parser_fingerprint()
+        monkeypatch.setattr(cfg, "CAPTURE_FUNCTION_LOCAL_DEFINITIONS", False)
+        assert compute_parser_fingerprint() != before

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -120,8 +120,9 @@ and because the wipe drops the hash cache, the re-index treats every file as
 new, which is what re-emits the documents under their suffixed names. Note
 that the wipe clears **every** project in the shared graph, so run it only
 when that graph holds just this repository.
+Requires the `treesitter-full` extra.
 
-The wipe is needed here because this case *renames* existing nodes: the old
+The wipe is needed there because that case *renames* existing nodes: the old
 unsuffixed document modules have to go, and re-parsing alone would not remove
 them. A change that only *adds* edges does not need it. Enabling a capture
 group is the common example -- `CGR_CAPTURE=io` on an indexed project reports
@@ -132,7 +133,6 @@ makes the next `--update-graph` treat every file as new and emit the newly
 enabled edges, leaving every other project in the shared graph untouched.
 The capture selection is part of the parser fingerprint, so a run that would
 skip in this way warns first rather than silently doing nothing (issue #1630).
-Requires the `treesitter-full` extra.
 
 ## Language-Agnostic Design
 

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -120,6 +120,18 @@ and because the wipe drops the hash cache, the re-index treats every file as
 new, which is what re-emits the documents under their suffixed names. Note
 that the wipe clears **every** project in the shared graph, so run it only
 when that graph holds just this repository.
+
+The wipe is needed here because this case *renames* existing nodes: the old
+unsuffixed document modules have to go, and re-parsing alone would not remove
+them. A change that only *adds* edges does not need it. Enabling a capture
+group is the common example -- `CGR_CAPTURE=io` on an indexed project reports
+"already in sync" and emits nothing, because the hash cache keys file
+contents and every file is unchanged. Deleting that one repository's
+`.cgr-hash-cache.json`, `.cgr-dir-mtimes.json` and `.cgr-parser-fingerprint`
+makes the next `--update-graph` treat every file as new and emit the newly
+enabled edges, leaving every other project in the shared graph untouched.
+The capture selection is part of the parser fingerprint, so a run that would
+skip in this way warns first rather than silently doing nothing (issue #1630).
 Requires the `treesitter-full` extra.
 
 ## Language-Agnostic Design


### PR DESCRIPTION
Closes #1630.

Enabling a capture group on an already-indexed project reported "Knowledge graph already in sync" and emitted nothing. The incremental hash cache keys file contents, so unchanged sources skip every pass, and the capture selection was not part of the parser fingerprint that exists to catch exactly this class of input.

`parser_fingerprint.py` already hashes the frontend mode under a criterion it states in its own comment:

> The active frontend selection changes which edges are produced for unchanged sources ... so it is part of the parser identity and must trip the staleness warning.

The capture selection meets that criterion and was not hashed. This adds it.

## What this does and does not do

It converts a **silent** no-op into a **warned** one. The run still reports "already in sync" and skips passes -- the fingerprint is a staleness *warning*, and #1630 asked for the existing path with no new machinery.

What actually makes a newly enabled group appear is deleting that one repository's `.cgr-hash-cache.json`, `.cgr-dir-mtimes.json` and `.cgr-parser-fingerprint`, then indexing again. Verified end to end:

```
before   requests__6601d2ee   14 relationship types, no io edges
after    requests__6601d2ee   same 14 + READS_FROM 93, WRITES_TO 40
         projects in shared graph: 9 before, 9 after
```

That remedy is now what both the warning and `docs/architecture/language-support.md` prescribe. Previously both pointed at `cgr start --clean --update-graph`, which wipes **every** project in a shared database -- disproportionate when the change only adds edges.

## Why the selection is threaded rather than read from settings

`cli.py:_capture_selection` merges `CGR_CAPTURE` with `--capture` tokens and hands `GraphUpdater` a resolved `CaptureSelection`:

```python
return resolve_capture([*split_spec(settings.CGR_CAPTURE), *(capture or [])])
```

A fingerprint consulting the environment alone would have stayed blind to `cgr start --capture io`, fixing the bug for one entry point and leaving it for the other. `compute_parser_fingerprint` takes the selection and both call sites in `graph_updater.py` pass `self.capture`, so what is stamped is what built the graph.

The RESOLVED selection is hashed rather than the raw spec, so `io,io` and `io` are one identity. Entries are sorted because the selection holds frozensets, whose iteration order is not stable across processes, and counted so a relationship named like a node label cannot move between the two lists unnoticed.

## Sibling sweep

Every `settings.*` read by `codebase_rag/parsers/` and `graph_updater.py`, classified:

| Input | Status |
|---|---|
| `CSHARP_FRONTEND`, `CPP_FRONTEND`, `GO_FRONTEND`, `PYTHON_FRONTEND`, `JAVA_FRONTEND` | hashed (`_frontend_settings`) |
| `LOMBOK_JAR` version | hashed (`LOMBOK=` in `_frontend_settings`) |
| go / javac / dotnet versions | hashed (`_tool_versions`) |
| `compile_commands.json` selection and contents | hashed (`_repo_frontend_inputs`) |
| parser sources, grammar wheel versions | hashed (`_fingerprint_sources`, `_grammar_versions`) |
| capture selection (`CGR_CAPTURE` + `--capture`) | **added here** |
| `CAPTURE_FUNCTION_LOCAL_DEFINITIONS` | **added here** |
| exclusions (`--exclude` / `--unignore`) | not a member: own `.cgr-exclusion-state.json` and `_exclusions_match_last_run` |
| delombok state | not a member: own `.cgr-delombok-state.json` |
| `SKIP_EMBEDDINGS`, `QDRANT_BATCH_SIZE`, `FILE_FLUSH_INTERVAL`, `EMBEDDING_PROGRESS_INTERVAL`, `CGR_HOME` | not a member: none changes which nodes or edges a source file produces |

`CAPTURE_FUNCTION_LOCAL_DEFINITIONS` is the one the sweep turned up. `parsers/class_ingest/mixin.py:126` uses it to pick between two predicates for whether a nested definition is ingested as a method, so flipping it changes which `Method` nodes unchanged sources produce. Same criterion, also unhashed, fixed here with its own test.

## Tests

Seven new tests. The behavioural red was real: before the fix, `CGR_CAPTURE=""` and `CGR_CAPTURE="io"` produced the identical digest `a3ea0db9dadd1bdba593c5835a6c0fab`.

Two of them exercise the updater rather than the hash function, and neither call site can be reverted silently. Verified with frame-scoped mutations that strip the kwarg at exactly one site, each asserting it was applied so a mutation that failed to take could not read as a pass:

- reverting only the stamp site (`graph_updater.py:2705`) fails `test_same_capture_group_twice_does_not_warn`, and that test alone
- reverting only the compare site (`graph_updater.py:2259`) fails **both** new tests

The stamp-site case is the one worth having: run 1 stamps the default digest while running io, run 2 compares the io digest, so the graph warns on **every** subsequent run. A "does not warn" control is the only thing that catches permanent false staleness -- an assertion that it *does* warn is satisfied by both the working and the broken code.

Mutating `_capture_entries` to `return []` fails four of the seven capture tests; `test_same_capture_group_twice_does_not_warn` survives, as a silence control must.

## Not covered

Disabling a group leaves its edges in the graph. The warning now says so and points at `--clean --update-graph` for the case where nodes must be removed rather than added.

## Verification

```
codebase_rag/tests/test_parser_fingerprint.py + test_clean_remedy_strings.py    60 passed
fingerprint + robustness + tool_versions + ast + flow_edges + local_definitions 168 passed
-k "capture or fingerprint or incremental or sync" -n 2                         716 passed, 1 env failure
ruff check .                                                                    All checks passed
```

The one failure is `test_csharp_retrieval_eval.py::test_oracle_captures_first_party_csharp_calls`, environmental and unrelated: `dotnet build` fails with `NETSDK1045` because the oracle targets .NET 10.0 and this box has SDK 8.0.130. Reproduced outside pytest and filed separately as #1632.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parser fingerprints now account for capture selections, helping detect stale indexes when capture settings change.
  * Improved mismatch warnings provide repository-scoped rebuild guidance and clarify when a clean graph update is required.

* **Documentation**
  * Clarified cache invalidation and graph rebuild behavior for capture changes, node renames, and newly generated relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->