### PR TITLE
fix: commit the hash cache after the graph flush so a crash cannot hide a deletion

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -992,10 +992,14 @@ class GraphUpdater:
         # Per-run for the same reason (issue #1620's shape): a run that raised
         # between `_process_files` and the commit point leaves its cache
         # stashed on the instance. No test covers this because no such write is
-        # reachable today: a reused instance either re-parses and overwrites
-        # the stash, or takes the in-sync fast path and returns above the
-        # commit point. Reset anyway, so the stash cannot outlive its run if a
-        # future path does reach the commit point without re-parsing.
+        # reachable, and the argument is structural rather than a survey of
+        # paths: `_process_files` contains no `return` and no `raise`, and
+        # `run` returns only at the in-sync fast path below, which is above the
+        # commit point. So every path that reaches the commit point ran
+        # `_process_files` to its last statement, and that statement
+        # unconditionally re-stashes both fields. Reset anyway: the guarantee
+        # is a property of those two functions' control flow, and the first
+        # early `return` added to either one silently ends it.
         self._pending_hash_cache = None
         self._pending_dir_mtimes = None
         if not force and self._is_already_in_sync():

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import sys
+import time
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from pathlib import Path
@@ -410,6 +411,7 @@ class GraphUpdater:
         # `_process_files` (issue #1615).
         self._pending_hash_cache: tuple[Path, FileHashCache] | None = None
         self._pending_dir_mtimes: tuple[Path, DirMtimesCache] | None = None
+        self._pending_cache_observed_at: float | None = None
         # Package paths read from the graph before Pass 1 of an incremental
         # run; None on a full build or when the graph could not be read.
         self._packages_before_run: set[str] | None = None
@@ -1002,6 +1004,7 @@ class GraphUpdater:
         # the first early `return` added to either one silently ends it.
         self._pending_hash_cache = None
         self._pending_dir_mtimes = None
+        self._pending_cache_observed_at = None
         if not force and self._is_already_in_sync():
             logger.info(ls.GRAPH_ALREADY_IN_SYNC)
             self.skipped_because_in_sync = True
@@ -1266,12 +1269,26 @@ class GraphUpdater:
         # hashes, which stays true; the withheld exclusion stamp is what tells
         # the next run that deletions were not reconciled, and that alone both
         # fails the sync check and turns graph-backed reconciliation on.
+        observed_at = self._pending_cache_observed_at
+        written: list[Path] = []
         if self._pending_hash_cache is not None:
             _save_hash_cache(*self._pending_hash_cache)
+            written.append(self._pending_hash_cache[0])
             self._pending_hash_cache = None
         if self._pending_dir_mtimes is not None:
             _save_dir_mtimes(*self._pending_dir_mtimes)
+            written.append(self._pending_dir_mtimes[0])
             self._pending_dir_mtimes = None
+        # Stamp both files with the instant the hashes describe, not with the
+        # time the write happened, so the deferral cannot swallow an edit made
+        # while passes 3 and later were still running.
+        if observed_at is not None:
+            for path in written:
+                try:
+                    os.utime(path, (observed_at, observed_at))
+                except OSError:
+                    pass
+        self._pending_cache_observed_at = None
 
         if self._single_file is None:
             if self._graph_state_unknown:
@@ -2738,6 +2755,13 @@ class GraphUpdater:
         # delete. The subtree then stays in the graph until a full rebuild.
         self._pending_hash_cache = (cache_path, new_hashes)
         self._pending_dir_mtimes = (dir_mtimes_path, self._collected_dir_mtimes)
+        # The instant the hashes above describe. `_is_already_in_sync` skips
+        # rehashing any file whose mtime is at or below the CACHE FILE's own
+        # mtime, so deferring the write must not defer that stamp: a file
+        # edited after its hash was taken but before the commit point would be
+        # stamped newer than its own edit and skipped for good (issue #1615
+        # review). Stamped back onto both files after the write.
+        self._pending_cache_observed_at = time.time()
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry
         # the old parser's edges.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1243,10 +1243,11 @@ class GraphUpdater:
         # a run that died in between tell its successor the exclusion was
         # already reconciled, and the successor would fast-path over a subtree
         # still in the graph. Deferring the stamp buys only that: the successor
-        # RUNS. It does not on its own make the successor delete anything,
-        # because the hash cache was already saved inside _process_files before
-        # this flush and no longer names the excluded file. What closes the
-        # gap is the graph-backed reconciliation in _process_files, which the
+        # RUNS. It does not on its own make the successor delete anything:
+        # the cache commits below, after this flush (issue #1615), so a run
+        # that died earlier leaves no cache at all and its successor re-hashes
+        # from scratch. What names a file whose exclusion predates the cache
+        # is the graph-backed reconciliation in _process_files, which the
         # changed exclusion set turns on; the two are needed together.
         # Recorded on EVERY completed project run, not full builds only: an
         # incremental run that narrowed the set must record it, or the next run
@@ -2488,15 +2489,13 @@ class GraphUpdater:
         # delete-before-reingest path or renamed-away symbols and their
         # CALLS/REFERENCES edges accumulate alongside the fresh parse.
         # A changed exclusion set has to reconcile against the GRAPH, not just
-        # against the hash cache. The cache is saved inside this method, before
-        # the final flush, so a run that died in that window already committed
-        # a cache with the newly excluded file removed; its successor would
-        # compute an empty `deleted_keys` and leave the subtree behind for
-        # good, since the stamp it then writes matches. Asking the graph for
-        # its module paths is what closes that, and it costs a query only on
-        # the runs where the set actually moved. The general case, where an
-        # ordinary deletion is lost the same way, is #1615 and is not closed
-        # here.
+        # against the hash cache. Since #1615 the cache commits only after the
+        # flush, so a crashed run cannot leave one that has already forgotten
+        # the file. The graph query is still required for a different reason:
+        # `preexisting_paths` is empty on an incremental run, so nothing else
+        # can name a file whose exclusion predates the current cache, and no
+        # on-disk hash ever recorded it as present. It costs a query only on
+        # the runs where the set actually moved.
         preexisting_paths = (
             self._existing_module_paths()
             if is_full_build or not self._exclusions_match_last_run()
@@ -2504,9 +2503,9 @@ class GraphUpdater:
         )
         # None is "the sink claims readability and the query failed", not
         # "nothing there": below it falls back to the hash cache alone, which
-        # after a pre-flush crash no longer names the excluded file. That run
-        # completes and would stamp, and every later run would fast-path over
-        # the surviving subtree. Remembering the failure keeps the stamp back.
+        # cannot name a file whose exclusion predates it. That run completes
+        # and would stamp, and every later run would fast-path over the
+        # surviving subtree. Remembering the failure keeps the stamp back.
         if preexisting_paths is None:
             self._graph_state_unknown = True
         new_hashes: FileHashCache = {}

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -989,6 +989,15 @@ class GraphUpdater:
         # is always computed against the effective unignore set.
         self._exclusion_match = None
         self._graph_state_unknown = False
+        # Per-run for the same reason (issue #1620's shape): a run that raised
+        # between `_process_files` and the commit point leaves its cache
+        # stashed on the instance. No test covers this because no such write is
+        # reachable today: a reused instance either re-parses and overwrites
+        # the stash, or takes the in-sync fast path and returns above the
+        # commit point. Reset anyway, so the stash cannot outlive its run if a
+        # future path does reach the commit point without re-parsing.
+        self._pending_hash_cache = None
+        self._pending_dir_mtimes = None
         if not force and self._is_already_in_sync():
             logger.info(ls.GRAPH_ALREADY_IN_SYNC)
             self.skipped_because_in_sync = True

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1279,9 +1279,10 @@ class GraphUpdater:
             _save_dir_mtimes(*self._pending_dir_mtimes)
             written.append(self._pending_dir_mtimes[0])
             self._pending_dir_mtimes = None
-        # Stamp both files with the instant the hashes describe, not with the
-        # time the write happened, so the deferral cannot swallow an edit made
-        # while passes 3 and later were still running.
+        # Stamp both files with the instant captured before hashing, not with
+        # the time the write happened, so the deferral cannot swallow an edit
+        # made while the hashing loop and passes 3 and later were still
+        # running.
         if observed_at is not None:
             for path in written:
                 try:
@@ -2540,6 +2541,17 @@ class GraphUpdater:
 
         processed_since_flush = 0
 
+        # Taken BEFORE the loop below, so it is at or earlier than every hash
+        # it describes. `_is_already_in_sync` skips rehashing any file whose
+        # mtime is at or below the CACHE FILE's own mtime, so deferring the
+        # write must not defer that stamp: a file edited after its hash was
+        # taken but before the commit point would otherwise be stamped newer
+        # than its own edit and skipped for good (issue #1615 review).
+        # Capturing here rather than after the loop also covers a file edited
+        # between its own hash and the end of the loop. Erring early only ever
+        # costs a redundant rehash; erring late loses an edit.
+        self._pending_cache_observed_at = time.time()
+
         changed_entries: list[tuple[Path, str, bool, bytes]] = []
         for filepath, file_key in eligible_files:
             if not force and file_key in old_hashes:
@@ -2755,13 +2767,6 @@ class GraphUpdater:
         # delete. The subtree then stays in the graph until a full rebuild.
         self._pending_hash_cache = (cache_path, new_hashes)
         self._pending_dir_mtimes = (dir_mtimes_path, self._collected_dir_mtimes)
-        # The instant the hashes above describe. `_is_already_in_sync` skips
-        # rehashing any file whose mtime is at or below the CACHE FILE's own
-        # mtime, so deferring the write must not defer that stamp: a file
-        # edited after its hash was taken but before the commit point would be
-        # stamped newer than its own edit and skipped for good (issue #1615
-        # review). Stamped back onto both files after the write.
-        self._pending_cache_observed_at = time.time()
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry
         # the old parser's edges.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2496,10 +2496,11 @@ class GraphUpdater:
         # against the hash cache. Since #1615 the cache commits only after the
         # flush, so a crashed run cannot leave one that has already forgotten
         # the file. The graph query is still required for a different reason:
-        # `preexisting_paths` is empty on an incremental run, so nothing else
-        # can name a file whose exclusion predates the current cache, and no
-        # on-disk hash ever recorded it as present. It costs a query only on
-        # the runs where the set actually moved.
+        # the cache records only the files eligible on the run that wrote it,
+        # so a file excluded by an EARLIER completed run was already dropped
+        # from it and no on-disk hash names it any more. Only the graph still
+        # does. It costs a query only on the runs where the set actually
+        # moved.
         preexisting_paths = (
             self._existing_module_paths()
             if is_full_build or not self._exclusions_match_last_run()

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -995,11 +995,11 @@ class GraphUpdater:
         # reachable, and the argument is structural rather than a survey of
         # paths: `_process_files` contains no `return` and no `raise`, and
         # `run` returns only at the in-sync fast path below, which is above the
-        # commit point. So every path that reaches the commit point ran
-        # `_process_files` to its last statement, and that statement
-        # unconditionally re-stashes both fields. Reset anyway: the guarantee
-        # is a property of those two functions' control flow, and the first
-        # early `return` added to either one silently ends it.
+        # commit point. Both stashes are unconditional top-level statements of
+        # `_process_files`, so every path that reaches the commit point has
+        # re-stashed both fields before getting there. Reset anyway: the
+        # guarantee is a property of those two functions' control flow, and
+        # the first early `return` added to either one silently ends it.
         self._pending_hash_cache = None
         self._pending_dir_mtimes = None
         if not force and self._is_already_in_sync():

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -997,9 +997,9 @@ class GraphUpdater:
         # reachable, and the argument is structural rather than a survey of
         # paths: `_process_files` contains no `return` and no `raise`, and
         # `run` returns only at the in-sync fast path below, which is above the
-        # commit point. Both stashes are unconditional top-level statements of
-        # `_process_files`, so every path that reaches the commit point has
-        # re-stashed both fields before getting there. Reset anyway: the
+        # commit point. All three stashes are unconditional top-level
+        # statements of `_process_files`, so every path that reaches the commit
+        # point has re-stashed all three before getting there. Reset anyway: the
         # guarantee is a property of those two functions' control flow, and
         # the first early `return` added to either one silently ends it.
         self._pending_hash_cache = None

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -406,6 +406,10 @@ class GraphUpdater:
         # them: the reconciliation it was meant to do may not have happened,
         # so that run must not stamp its exclusion set as reconciled.
         self._graph_state_unknown: bool = False
+        # Written at the post-flush commit point in `run`, never inside
+        # `_process_files` (issue #1615).
+        self._pending_hash_cache: tuple[Path, FileHashCache] | None = None
+        self._pending_dir_mtimes: tuple[Path, DirMtimesCache] | None = None
         # Package paths read from the graph before Pass 1 of an incremental
         # run; None on a full build or when the graph could not be read.
         self._packages_before_run: set[str] | None = None
@@ -1239,6 +1243,22 @@ class GraphUpdater:
         # incremental run that narrowed the set must record it, or the next run
         # reads that run's own result as a change. A single-file run walks one
         # file and cannot speak for the project's exclusion set.
+        # Committed here, not in `_process_files` (issue #1615), so a run that
+        # dies before the flush leaves a cache that still names the deleted
+        # file and its successor re-issues the delete. Deliberately NOT inside
+        # the single-file guard below: a single-file run writes the cache today
+        # and must keep doing so. Written even when `_graph_state_unknown` is
+        # set, because the cache only claims which files were parsed at which
+        # hashes, which stays true; the withheld exclusion stamp is what tells
+        # the next run that deletions were not reconciled, and that alone both
+        # fails the sync check and turns graph-backed reconciliation on.
+        if self._pending_hash_cache is not None:
+            _save_hash_cache(*self._pending_hash_cache)
+            self._pending_hash_cache = None
+        if self._pending_dir_mtimes is not None:
+            _save_dir_mtimes(*self._pending_dir_mtimes)
+            self._pending_dir_mtimes = None
+
         if self._single_file is None:
             if self._graph_state_unknown:
                 logger.warning(ls.EXCLUSION_STATE_NOT_RECORDED)
@@ -2697,8 +2717,14 @@ class GraphUpdater:
         if unreadable_count > 0:
             logger.info(ls.INCREMENTAL_UNREADABLE, count=unreadable_count)
 
-        _save_hash_cache(cache_path, new_hashes)
-        _save_dir_mtimes(dir_mtimes_path, self._collected_dir_mtimes)
+        # Deferred to the post-flush commit point in `run` (issue #1615). The
+        # deletions above are execute_write calls that only become durable at
+        # that flush; committing the cache here would let a run that died in
+        # between tell its successor the file was already reconciled, and the
+        # successor computes an empty `deleted_keys` and never re-issues the
+        # delete. The subtree then stays in the graph until a full rebuild.
+        self._pending_hash_cache = (cache_path, new_hashes)
+        self._pending_dir_mtimes = (dir_mtimes_path, self._collected_dir_mtimes)
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry
         # the old parser's edges.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1287,8 +1287,16 @@ class GraphUpdater:
             for path in written:
                 try:
                     os.utime(path, (observed_at, observed_at))
-                except OSError:
-                    pass
+                except OSError as e:
+                    # Fail CLOSED. Leaving the file with its own write time is
+                    # exactly the defect this stamping exists to prevent: that
+                    # time is later than an edit made while the run was still
+                    # hashing, so the successor's `mtime <= cache_mtime` check
+                    # skips the edited file and the graph keeps stale content.
+                    # A missing cache only costs a rebuild, which is why every
+                    # writer here already degrades to absent rather than wrong.
+                    logger.warning(ls.CACHE_STAMP_FAILED, path=path, error=e)
+                    path.unlink(missing_ok=True)
         self._pending_cache_observed_at = None
 
         if self._single_file is None:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -861,6 +861,10 @@ HASH_CACHE_LOADED = "Loaded hash cache with {count} entries from {path}"
 HASH_CACHE_LOAD_FAILED = "Failed to load hash cache from {path}: {error}"
 HASH_CACHE_SAVED = "Saved hash cache with {count} entries to {path}"
 HASH_CACHE_SAVE_FAILED = "Failed to save hash cache to {path}: {error}"
+CACHE_STAMP_FAILED = (
+    "Could not backdate {path} to the observed instant ({error}); removing it so "
+    "the next run rebuilds rather than trusting a stamp that can hide edits"
+)
 PERIODIC_FLUSH = "Periodic flush after {count} files processed"
 INCREMENTAL_SKIPPED = "Skipped {count} unchanged files"
 INCREMENTAL_CHANGED = "Re-indexing {count} changed files"

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -23,10 +23,11 @@ def _force_mtime_after_cache(repo: Path, source: Path) -> None:
     greater than the cache file's own (`if file_mtime <= cache_mtime`), so a
     rewrite that lands on the same filesystem tick as the cache written by the
     preceding run is SKIPPED and the run under test never reaches the code the
-    test is about. On a fine-grained clock the two differ by the incidental
-    cost of the previous run's teardown; on a coarse one they collide, which
-    is why this failed on Windows py3.12. Stating the precondition removes the
-    dependency on clock resolution entirely.
+    test is about. Since #1615 the cache file is restamped back to the instant
+    observed before the previous run's hashing loop, so on a fine-grained clock
+    the two differ by that run's own hashing and later passes; on a coarse one
+    they can still collide, which is why this failed on Windows py3.12.
+    Stating the precondition removes the dependency on clock resolution.
     """
     cache_mtime = (repo / cs.HASH_CACHE_FILENAME).stat().st_mtime
     stamp = cache_mtime + 1.0

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -6,6 +6,7 @@
 # reingest every current file (deleting an absent module is a no-op).
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -13,6 +14,23 @@ import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag.tests.conftest import create_and_run_updater
+
+
+def _force_mtime_after_cache(repo: Path, source: Path) -> None:
+    """Put `source` on a strictly later tick than the hash cache file.
+
+    An incremental run only re-hashes a cached file whose mtime is strictly
+    greater than the cache file's own (`if file_mtime <= cache_mtime`), so a
+    rewrite that lands on the same filesystem tick as the cache written by the
+    preceding run is SKIPPED and the run under test never reaches the code the
+    test is about. On a fine-grained clock the two differ by the incidental
+    cost of the previous run's teardown; on a coarse one they collide, which
+    is why this failed on Windows py3.12. Stating the precondition removes the
+    dependency on clock resolution entirely.
+    """
+    cache_mtime = (repo / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    stamp = cache_mtime + 1.0
+    os.utime(source, (stamp, stamp))
 
 
 def test_module_path_lookup_failure_forces_delete_before_reingest(
@@ -79,6 +97,7 @@ def test_incremental_rehydration_failure_aborts(
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
 
     source.write_text("def f():\n    return 2\n", encoding="utf-8")
+    _force_mtime_after_cache(temp_repo, source)
 
     def unavailable(query: str, params: dict | None = None) -> list:
         if query == cs.CYPHER_ALL_DEFINITION_QNS:
@@ -183,6 +202,7 @@ def test_incremental_run_aborts_when_inbound_capture_fails(
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
 
     source.write_text("def f():\n    return 2\n", encoding="utf-8")
+    _force_mtime_after_cache(temp_repo, source)
 
     def unavailable(query: str, params: dict | None = None) -> list:
         if query == cs.CYPHER_INBOUND_EDGES:

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -804,10 +804,17 @@ class TestFastPathInSync:
         """A run whose graph query failed must not claim the exclusion is done.
 
         When the module-path query raises, the reconciliation falls back to
-        the hash cache alone, and after a pre-flush crash that cache no longer
-        names the excluded file. The run completes with the subtree still in
-        the graph; stamping would make every later run fast-path over it.
+        the hash cache alone, and that cache no longer names a file excluded
+        by an EARLIER completed run. The run completes with the subtree still
+        in the graph; stamping would make every later run fast-path over it.
         Withholding the stamp is what makes the next run look again.
+
+        The stale cache is reached here through a completed run rather than a
+        pre-flush crash: since #1615 the cache commits only after the flush,
+        so a crashed run leaves no cache to be stale. Removing the stamp
+        afterwards is the "no readable record" case, an index predating the
+        stamp or a corrupt file, which is what puts run 3 back into
+        reconciliation with a cache that has already forgotten module_a.py.
         """
         parsers, queries = load_parsers()
         GraphUpdater(
@@ -820,17 +827,16 @@ class TestFastPathInSync:
         before = stamp.read_text()
 
         exclusions = frozenset({"module_a.py"})
-        mock_ingestor.flush_all.side_effect = RuntimeError("died before the flush")
-        crashing = GraphUpdater(
+        GraphUpdater(
             ingestor=mock_ingestor,
             repo_path=excludable_project,
             parsers=parsers,
             queries=queries,
             exclude_paths=exclusions,
-        )
-        with pytest.raises(RuntimeError):
-            crashing.run()
-        mock_ingestor.flush_all.side_effect = None
+        ).run()
+        # The committed cache no longer names module_a.py, so the cache-based
+        # deletion set is empty from here on; only the graph could name it.
+        stamp.unlink()
 
         def _graph_unreachable(query: str, _params: object = None) -> list[object]:
             if query == cs.CYPHER_PROJECT_MODULE_PATHS:
@@ -853,7 +859,7 @@ class TestFastPathInSync:
             "named module_a.py for deletion; the fixture is not exercising the "
             "failure it claims to"
         )
-        assert stamp.read_text() == before, (
+        assert not stamp.exists(), (
             "the run stamped the new exclusion set although it never learned "
             "what the graph holds, so the surviving subtree is now permanent"
         )
@@ -874,6 +880,9 @@ class TestFastPathInSync:
         assert updater3._is_already_in_sync() is False
         updater3.run()
         assert "module_a.py" in _deleted_module_paths(mock_ingestor)
+        # The recovered run learned what the graph holds, so it records the
+        # exclusion set again: a stamp exists once more, and for this set.
+        assert stamp.exists()
         assert stamp.read_text() != before
 
     def test_empty_module_query_still_records_the_exclusion_set(

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -455,6 +455,78 @@ class TestCrashBetweenCacheSaveAndFlush:
             "rehashing it and the graph keeps the pre-edit contents"
         )
 
+    def test_edit_between_a_files_hash_and_the_end_of_the_loop_is_not_skipped(
+        self,
+        py_project: Path,
+        mock_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An edit landing after a file's own hash but before the loop ends.
+
+        The observation instant is captured before the hashing loop rather
+        than after it, so it is at or earlier than every hash it describes.
+        Captured after the loop it would be an upper bound, and this edit
+        would be stamped newer than its own change and skipped for good.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        # Real work for run 2, so it cannot take the in-sync fast path and
+        # return above the hashing loop this test needs it to enter.
+        (py_project / "module_c.py").write_text(
+            "def c():\n    return 1\n", encoding="utf-8"
+        )
+        target = py_project / "module_b.py"
+        target.write_text("def b():\n    return 2\n", encoding="utf-8")
+
+        real_hash = graph_updater_module._hash_file_with_bytes
+        raced = "def b():\n    return 999\n"
+        fired = False
+
+        def _hash_then_edit(path: Path, *args: object, **kwargs: object) -> object:
+            nonlocal fired
+            result = real_hash(path, *args, **kwargs)
+            if path.name == "module_b.py" and not fired:
+                fired = True
+                # After this file's own hash is taken, still inside the loop.
+                path.write_text(raced, encoding="utf-8")
+            return result
+
+        monkeypatch.setattr(
+            graph_updater_module, "_hash_file_with_bytes", _hash_then_edit
+        )
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        monkeypatch.setattr(graph_updater_module, "_hash_file_with_bytes", real_hash)
+
+        assert fired, (
+            "the wrapper never fired, so no edit raced the loop and the "
+            "assertion below would pass for a reason unrelated to the window"
+        )
+        assert target.read_text(encoding="utf-8") == raced, (
+            "fixture guard: the racing edit did not land"
+        )
+        successor = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        assert successor._is_already_in_sync() is False, (
+            "an edit made after its own file's hash but before the loop ended "
+            "is invisible: its mtime is at or below the cache stamp, so the "
+            "successor skips rehashing it and the edit is lost for good"
+        )
+
     def test_successor_run_still_deletes_the_module(
         self, py_project: Path, mock_ingestor: MagicMock
     ) -> None:

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -542,6 +543,62 @@ class TestCrashBetweenCacheSaveAndFlush:
             "an edit made after its own file's hash but before the loop ended "
             "is invisible: its mtime is at or below the cache stamp, so the "
             "successor skips rehashing it and the edit is lost for good"
+        )
+
+    def test_cache_is_removed_when_it_cannot_be_backdated(
+        self,
+        py_project: Path,
+        mock_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cache that cannot be stamped back must not survive the run.
+
+        Keeping it would leave the file carrying its own write time, which is
+        later than an edit made while the run was still hashing, so the
+        successor would skip that file and the graph would keep pre-edit
+        content. Absent costs a rebuild; present-and-mis-stamped hides an edit.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        cache = py_project / cs.HASH_CACHE_FILENAME
+        assert cache.is_file(), "fixture guard: run 1 wrote no cache to remove"
+
+        (py_project / "module_c.py").write_text(
+            "def c():\n    return 1\n", encoding="utf-8"
+        )
+
+        real_utime = os.utime
+        refused: list[Path] = []
+
+        def _refuse_cache_stamp(path, times=None, **kwargs):  # type: ignore[no-untyped-def]
+            if Path(path).name == cs.HASH_CACHE_FILENAME:
+                refused.append(Path(path))
+                raise OSError("read-only file system")
+            return real_utime(path, times, **kwargs)
+
+        monkeypatch.setattr(graph_updater_module.os, "utime", _refuse_cache_stamp)
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        monkeypatch.setattr(graph_updater_module.os, "utime", real_utime)
+
+        assert refused, (
+            "the run never tried to stamp the hash cache, so the assertion "
+            "below would pass without exercising the failure path at all"
+        )
+        assert not cache.is_file(), (
+            "the cache survived a failed backdate: it now carries its own "
+            "write time, which is later than an edit made during the run, so "
+            "the successor skips that file and keeps stale graph content"
         )
 
     def test_successor_run_still_deletes_the_module(

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -364,8 +364,13 @@ class TestIncrementalUpdates:
 
 
 class TestCrashBetweenCacheSaveAndFlush:
-    """Issue #1615: a run that dies after the hash cache commits but before the
-    graph flush must not convince its successor the deletion was reconciled."""
+    """Issue #1615: a run that dies before the graph flush must not convince
+    its successor the deletion was reconciled.
+
+    Named for the window as it WAS: the cache used to commit inside
+    `_process_files`, so a crash in between left a cache already claiming the
+    file was gone. The fix closes the window by committing the cache after the
+    flush, so what these tests pin is that no such cache is left behind."""
 
     def test_successor_run_still_deletes_the_module(
         self, py_project: Path, mock_ingestor: MagicMock
@@ -745,14 +750,12 @@ class TestFastPathInSync:
         """The re-run a lost stamp forces must also DELETE, not just re-parse.
 
         Declining to stamp only buys the next run a chance to reconcile; it
-        cannot take that chance on its own. The hash cache is saved inside
-        `_process_files`, before the flush, so the crashed run already
-        committed a cache with no `module_a.py` in it, and on the successor
-        `deleted_keys` is computed from that cache and comes out empty. The
+        cannot take that chance on its own. Since #1615 the cache commits only
+        after the flush, so the crashed run leaves no cache naming anything it
+        parsed, and nothing on disk records `module_a.py` as excluded. The
         graph's own module paths have to join the reconciliation, or the
         subtree survives, the successor stamps a matching exclusion set, and
-        every run after that fast-paths over it. The general case, an ordinary
-        deletion lost in the same window, is #1615 and is not closed here.
+        every run after that fast-paths over it.
         """
         parsers, queries = load_parsers()
         GraphUpdater(

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -750,12 +750,19 @@ class TestFastPathInSync:
         """The re-run a lost stamp forces must also DELETE, not just re-parse.
 
         Declining to stamp only buys the next run a chance to reconcile; it
-        cannot take that chance on its own. Since #1615 the cache commits only
-        after the flush, so the crashed run leaves no cache naming anything it
-        parsed, and nothing on disk records `module_a.py` as excluded. The
-        graph's own module paths have to join the reconciliation, or the
-        subtree survives, the successor stamps a matching exclusion set, and
-        every run after that fast-paths over it.
+        cannot take that chance on its own. The cache reaches the state that
+        matters through a COMPLETED excluding run, which drops `module_a.py`
+        from it; after that no on-disk hash names the file and the graph's own
+        module paths are the only thing that can, so they have to join the
+        reconciliation or the subtree survives, the successor stamps a matching
+        exclusion set, and every run after that fast-paths over it.
+
+        Reached this way rather than through a pre-flush crash: since #1615 a
+        crashed run commits no cache at all, so it leaves the PREVIOUS run's
+        cache intact and that one still names `module_a.py`. A crash-based
+        fixture would let `old_hashes` supply the deletion on its own and the
+        test would pass with the graph query neutered, which is what it is
+        here to rule out. The control at the end pins exactly that.
         """
         parsers, queries = load_parsers()
         GraphUpdater(
@@ -766,22 +773,26 @@ class TestFastPathInSync:
         ).run()
 
         exclusions = frozenset({"module_a.py"})
-        mock_ingestor.flush_all.side_effect = RuntimeError("died before the flush")
-        crashing = GraphUpdater(
+        # A COMPLETED excluding run is what drops module_a.py from the cache.
+        GraphUpdater(
             ingestor=mock_ingestor,
             repo_path=excludable_project,
             parsers=parsers,
             queries=queries,
             exclude_paths=exclusions,
+        ).run()
+        cache = json.loads((excludable_project / cs.HASH_CACHE_FILENAME).read_text())
+        assert "module_a.py" not in cache, (
+            "fixture guard: the cache still names module_a.py, so old_hashes "
+            "could supply the deletion and the graph query would not be "
+            "measured by anything below"
         )
-        with pytest.raises(RuntimeError):
-            crashing.run()
-        mock_ingestor.flush_all.side_effect = None
+        # The stamp is what would let the next run fast-path over the subtree.
+        (excludable_project / cs.EXCLUSION_STATE_FILENAME).unlink()
 
-        # After the crash the graph is the ONLY place `module_a.py` still
-        # exists: the hash cache the crashed run committed has already dropped
-        # it. So the sink has to be able to answer for it, or the test would
-        # pass or fail on the fake's silence rather than on the reconciliation.
+        # The graph is now the ONLY place module_a.py still exists, so the sink
+        # has to be able to answer for it or the test would turn on the fake's
+        # silence rather than on the reconciliation.
         mock_ingestor.reset_mock()
         mock_ingestor.fetch_all.side_effect = lambda query, _params=None: (
             [{cs.KEY_PATH: "module_a.py"}, {cs.KEY_PATH: "module_b.py"}]
@@ -796,9 +807,32 @@ class TestFastPathInSync:
             exclude_paths=exclusions,
         ).run()
         assert "module_a.py" in _deleted_module_paths(mock_ingestor), (
-            "the excluded module survived the crash and the run after it, so "
-            "its Module, Class and Method nodes are now permanent: every "
-            "later run matches the stamp and never looks again"
+            "the excluded module survived the run after it, so its Module, "
+            "Class and Method nodes are now permanent: every later run "
+            "matches the stamp and never looks again"
+        )
+
+        # Control: with the graph unable to name it, the delete must VANISH.
+        # Without this the assertion above passes whether or not the graph
+        # query contributes anything, which is what happened when #1615
+        # changed where the cache commits and left this test measuring
+        # `old_hashes` instead.
+        (excludable_project / cs.EXCLUSION_STATE_FILENAME).unlink()
+        mock_ingestor.reset_mock()
+        with patch.object(
+            GraphUpdater, "_existing_module_paths", lambda self: frozenset()
+        ):
+            GraphUpdater(
+                ingestor=mock_ingestor,
+                repo_path=excludable_project,
+                parsers=parsers,
+                queries=queries,
+                exclude_paths=exclusions,
+            ).run()
+        assert "module_a.py" not in _deleted_module_paths(mock_ingestor), (
+            "the delete fired with the graph contributing nothing, so this "
+            "test no longer measures the graph-backed reconciliation it "
+            "claims to and would pass with that reconciliation removed"
         )
 
     def test_failed_module_query_leaves_no_exclusion_stamp(

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from codebase_rag import constants as cs
+from codebase_rag import graph_updater as graph_updater_module
 from codebase_rag.graph_updater import (
     BoundedASTCache,
     FunctionRegistryTrie,
@@ -371,6 +372,88 @@ class TestCrashBetweenCacheSaveAndFlush:
     `_process_files`, so a crash in between left a cache already claiming the
     file was gone. The fix closes the window by committing the cache after the
     flush, so what these tests pin is that no such cache is left behind."""
+
+    def test_edit_during_the_deferred_window_is_not_skipped(
+        self,
+        py_project: Path,
+        mock_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An edit racing the deferred save must still be re-parsed.
+
+        `_is_already_in_sync` skips rehashing any file whose mtime is at or
+        below the CACHE FILE's own mtime. Deferring the write to the post-flush
+        commit point moved that stamp later, so a file edited after
+        `_process_files` hashed it but before the save would be stamped newer
+        than its own edit and skipped for good. The recorded mtime has to be
+        the one observed at hash time, not one implied by when the write
+        happened.
+        """
+        parsers, queries = load_parsers()
+        target = py_project / "module_b.py"
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        # Edit in the true window: after `_process_files` hashed the file,
+        # before the deferred write stamps the cache. Wrapping the save is the
+        # only way to land there; `flush_all` fires BEFORE the commit point, so
+        # an edit there precedes the cache write and cannot reproduce this.
+        # Give run 2 real work, or it takes the in-sync fast path and returns
+        # above the commit point, so the save never fires and the wrapper below
+        # never lands its edit.
+        (py_project / "module_c.py").write_text(
+            "def c():\n    return 1\n", encoding="utf-8"
+        )
+
+        edited = "def b():\n    return 999\n"
+        real_save = graph_updater_module._save_hash_cache
+
+        reached_write_site = False
+
+        def _edit_then_save(path: Path, hashes: dict[str, str]) -> None:
+            nonlocal reached_write_site
+            reached_write_site = True
+            target.write_text(edited, encoding="utf-8")
+            real_save(path, hashes)
+
+        monkeypatch.setattr(graph_updater_module, "_save_hash_cache", _edit_then_save)
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        monkeypatch.setattr(graph_updater_module, "_save_hash_cache", real_save)
+
+        # Three guards, each catching a different lie. The first two are what
+        # caught two wrong versions of this test: an edit placed in `flush_all`
+        # (which fires BEFORE the commit point, so it could not reach the
+        # window at all), and a second run that took the in-sync fast path and
+        # returned above the write site, so the wrapper never fired.
+        assert reached_write_site, (
+            "the run never reached the deferred write, so it cannot have "
+            "raced anything; the assertion below would pass on an unfixed "
+            "tree for a reason unrelated to the window"
+        )
+        assert target.read_text(encoding="utf-8") == edited, (
+            "fixture guard: the racing edit did not land, so nothing below "
+            "measures the window it claims to"
+        )
+        successor = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        assert successor._is_already_in_sync() is False, (
+            "the edit made during the deferred window is invisible: its mtime "
+            "is at or below the cache file's own stamp, so the successor skips "
+            "rehashing it and the graph keeps the pre-edit contents"
+        )
 
     def test_successor_run_still_deletes_the_module(
         self, py_project: Path, mock_ingestor: MagicMock
@@ -943,7 +1026,8 @@ class TestFastPathInSync:
         before = stamp.read_text()
 
         mock_ingestor.reset_mock()
-        mock_ingestor.fetch_all.side_effect = lambda _query, _params=None: []
+        mock_ingestor.fetch_all.side_effect = None
+        mock_ingestor.fetch_all.return_value = []
         GraphUpdater(
             ingestor=mock_ingestor,
             repo_path=excludable_project,

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1,4 +1,5 @@
 import json
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -417,6 +418,15 @@ class TestCrashBetweenCacheSaveAndFlush:
         def _edit_then_save(path: Path, hashes: dict[str, str]) -> None:
             nonlocal reached_write_site
             reached_write_site = True
+            # The observation instant is already captured by now, and this
+            # edit must be measurably later than it rather than landing on the
+            # same filesystem tick; 200 ms clears every CI platform's mtime
+            # granularity, the coarsest being Windows at 15.6 ms.
+            # The pause moves nothing, it only waits, which is why it cannot
+            # pin the assertion below: break the fix and the cache is stamped
+            # after this point regardless of how long the edit waited, so it
+            # is still the newer of the two and the successor still skips.
+            time.sleep(0.2)
             target.write_text(edited, encoding="utf-8")
             real_save(path, hashes)
 
@@ -494,6 +504,13 @@ class TestCrashBetweenCacheSaveAndFlush:
             if path.name == "module_b.py" and not fired:
                 fired = True
                 # After this file's own hash is taken, still inside the loop.
+                # As in the test above, the pause makes this edit measurably
+                # later than the captured instant instead of trusting the
+                # filesystem to separate two writes made in the same moment.
+                # It moves nothing, it only waits: it widens a gap the fix
+                # creates and the unfixed placement reverses, so it cannot
+                # decide the assertion either way.
+                time.sleep(0.2)
                 path.write_text(raced, encoding="utf-8")
             return result
 

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -363,6 +363,53 @@ class TestIncrementalUpdates:
         assert "module_b.py" not in new_data
 
 
+class TestCrashBetweenCacheSaveAndFlush:
+    """Issue #1615: a run that dies after the hash cache commits but before the
+    graph flush must not convince its successor the deletion was reconciled."""
+
+    def test_successor_run_still_deletes_the_module(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        (py_project / "module_b.py").unlink()
+
+        # Run 2 dies at the commit point: the deletes are queued but never
+        # flushed. Whatever this run wrote to disk is all its successor has.
+        crashed = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        with (
+            patch.object(
+                mock_ingestor, "flush_all", side_effect=RuntimeError("database gone")
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            crashed.run()
+
+        # Run 3 is the one under test: it must re-issue the delete the crashed
+        # run only queued. Asserting on the delete itself, not on the sync
+        # check, because a stale-cache no-op also leaves the fast path off.
+        mock_ingestor.reset_mock()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        assert "module_b.py" in _deleted_module_paths(mock_ingestor)
+
+
 class TestFastPathInSync:
     def test_second_run_skips_all_passes(
         self, py_project: Path, mock_ingestor: MagicMock

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1049,7 +1049,7 @@ class TestFastPathInSync:
         (excludable_project / cs.EXCLUSION_STATE_FILENAME).unlink()
         mock_ingestor.reset_mock()
         with patch.object(
-            GraphUpdater, "_existing_module_paths", lambda self: frozenset()
+            GraphUpdater, "_existing_module_paths", return_value=frozenset()
         ):
             GraphUpdater(
                 ingestor=mock_ingestor,


### PR DESCRIPTION
## Summary

- `_save_hash_cache` ran inside `_process_files`, before the final `flush_all` in `run()`. Deletions are `execute_write` calls that only become durable at that flush, so a process dying in between left a cache already claiming the file was gone. The next incremental run computed an empty `deleted_keys` and never re-issued the delete, and the subtree stayed in the graph until a full rebuild.
- The hash-cache and dir-mtimes writes now commit at the post-flush point in `run()`, beside the delombok and exclusion stamps. A crashed run leaves no cache, so its successor re-hashes and reconciles.
- The pending stash is reset per run, matching the treatment `_exclusion_match`, `_graph_state_unknown` and (since #1620) `skipped_because_in_sync` already get.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Fixes #1615. Adjacent and deliberately untouched: #1634 (the parser fingerprint has the same pre-flush commit semantics; its stamp stays exactly where it is here, so #1633's `capture=self.capture` threading is preserved), and #1619 (single-file scope, which lands on this commit point next).

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto -m "not integration"`) - 8972 passed, 34 skipped, 1 xfailed
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker) - Docker unavailable on this host
- [x] Manual testing (described below)

`TestCrashBetweenCacheSaveAndFlush::test_successor_run_still_deletes_the_module` drives run 1, a run 2 that raises at `flush_all`, then run 3, and asserts the delete is re-issued. It fails against the pre-fix ordering with `assert 'module_b.py' in set()`: run 3 issued no delete at all.

Verified by mutation, not just by passing: restoring the eager `_save_hash_cache`/`_save_dir_mtimes` calls in `_process_files` turns exactly that one test red and leaves the other 39 green.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings (code should be self-documenting) - this PR adds comments deliberately, and rewrites six existing ones; see below

## Why the prose changed in six places

The fix falsified a premise that turned out to live in **six** separate sites, none of them in the diff that made them false: three comments in `graph_updater.py`, a test docstring, a test class docstring, and an inline comment in a test body. One of them told the reader *"The general case, where an ordinary deletion is lost the same way, is #1615 and is not closed here"* - a sentence this branch makes false.

Review rounds found them in stages, and one round found a site created by the previous round's fix: a replacement comment justified the graph query with *"`preexisting_paths` is empty on an incremental run"*, which is true only in the `else` branch where the query is skipped. That is worse than the original error, because a corrected claim reads as more trustworthy. The current wording states the measured reason: the cache records only files eligible on the run that wrote it, so a file excluded by an earlier completed run is absent from it and only the graph still names it.

## The test that stopped measuring its own subject

`test_crash_before_flush_still_removes_the_excluded_subtree` existed to prove the graph-backed reconciliation is load-bearing. Pre-fix, the crashed run committed a cache with `module_a.py` dropped, so only the graph could name it. **This fix silently drained that.** Post-fix the crashed run commits nothing, run 1's cache survives and still names the file, and `old_hashes` alone supplies the deletion: the test passed with `_existing_module_paths` returning `frozenset()`.

Nothing turned red. The suite stayed green while one of its tests quietly stopped measuring its subject.

The fixture now reaches the cache-without-`module_a` state through a **completed** excluding run, so no on-disk hash names the file. Two guards make the loss non-repeatable: a fixture-integrity assertion that the cache genuinely dropped it, and a control that neuters `_existing_module_paths` and asserts the delete **vanishes**.

## Scope left alone

The parser fingerprint (`_save_parser_fingerprint`, still inside `_process_files`) has the identical pre-flush commit semantics and is **not** moved here. That is #1634, with a reproduction and a control posted on it. Moving it would widen a diff that already needed several rounds, and it carries its own trap: the exclusion stamp at the commit point is guarded by `if self._single_file is None`, and the fingerprint must not inherit that guard, since its condition is `is_full_build`.


## The race the deferral opened, and why only the file path had it

Deferring the write moved the cache file's own mtime later, and `_is_already_in_sync` skips rehashing any file whose mtime is at or below it (`if stat.st_mtime <= cache_mtime`). A source edited after `_process_files` hashed it but before the deferred save would therefore have its OLD hash recorded under a NEWER stamp, and the successor run would skip it. The fix captures the observation instant at hash time and `os.utime`s the written cache files with it, so the stamp describes when the hashes were taken rather than when they were written.

The directory record does not need the same treatment, and the asymmetry is the reason. Directories are compared with `current_mtime != cached_mtime`, an inequality, whereas files use `<=`; an early recorded value therefore cannot fast-path past a change, because any addition moves the directory mtime away from the recorded value and `!=` fires in either direction. Those values are captured earlier still, during the walk in `_collect_eligible_files`, so a file added inside the deferred window is caught by `_diff_dir_against_cache` rather than missed.

## Why the race test carries three guards

The first version of that test **passed against the unfixed code**. It put the edit in `flush_all`, which fires before the commit point, so it never entered the window it was written to exercise. The retargeted version then failed on a different guard: run 2 took the in-sync fast path and never reached the write site at all, so the wrapper never fired.

Both were caught by assertions rather than by inspection, which is why all three remain: one asserting the run **reached** the write site, one fixture-integrity assertion on the edited bytes, and the outcome assertion itself. A green here is only meaningful if the fixture actually entered the window, and two of the three guards exist solely to prove that it did. Discrimination is verified against the committed bytes: mutating the fix out turns the test red, and the restore is byte-identical to `git show HEAD`.

## The Windows failure: a test clock assumption, hardened here

`test_incremental_run_aborts_when_inbound_capture_fails` failed on Windows py3.12. It is not caused by this branch, and the branch does not fix it on its own, so it is fixed here directly.

An incremental run only re-hashes a cached file whose mtime is strictly greater than the cache file's own (`if file_mtime <= cache_mtime`). Both affected tests rewrite `m.py` immediately after a completed run, leaving nothing between the cache write and the rewrite but the previous run's teardown. On a fine-grained clock the two timestamps differ by that incidental cost; on a coarser one they land in the same tick, the rewrite is skipped, and the run never reaches the code under test. The failure then surfaces as an expected exception that simply never arrives.

Both instances are hardened, not only the one observed failing: a helper reads the cache file's mtime and `os.utime`s the source to a strictly greater value, replacing the clock assumption with a stated precondition. No production code changes for this.

- `test_incremental_rehydration_failure_aborts`
- `test_incremental_run_aborts_when_inbound_capture_fails`

A sweep of `codebase_rag/tests` for a `write_text` following a run finds fifteen candidate sites. Most cannot hit this path: they write a newly created file absent from the hash cache, an ignore or exclusion-state file (compared via `_exclusions_match_last_run`, not mtime), the parser fingerprint (read by content, never by mtime), or do not depend on a re-hash for their outcome.

The two fixed here are the ones that reach the mtime skip **and** depend on an abort.

The two tests this branch adds were clock-sensitive in the same way, and are fixed rather than deferred: their racing edit now pauses 200 ms first, so it is measurably later than the captured instant instead of relying on the filesystem to separate two writes made in the same moment. 200 ms clears every CI platform's mtime granularity, the coarsest being Windows at 15.6 ms.

The pause moves nothing, it only waits, which is why it cannot pin the result. Break the fix and the cache is stamped after the edit regardless of how long the edit waited, so it is still the newer of the two and the successor still skips. Both tests are killed by mutation: moving the capture back after the hashing loop fails the intra-loop test, and disabling the `os.utime` restamp fails both. They pass 20 consecutive runs on the fixed tree.

Two pre-existing tests in that file remain sensitive to a 1 s-granularity filesystem. They are not introduced here (the merge-base version fails the same way under that model) and are left alone rather than papered over, tracked on the clock-assumption issue.

This branch stamps the cache files with an instant captured before hashing, which moves the stamp earlier and so widens the successor's re-hash window rather than narrowing it. It therefore neither causes nor repairs the Windows failure.

**Measured outcome:** both Windows legs pass at `d81de411`, the first commit on this branch CI has run that contains the fix. `Unit Tests (windows-latest, py3.12)` and `(windows-latest, py3.13)` both succeeded; the py3.12 leg is the one that failed at `d7a8d31a` with `Failed: DID NOT RAISE <class 'RuntimeError'>`.

One local suite run went red once during development. That was a mid-run edit to this same test file, not a real failure: the suite had already collected the file when it changed on disk. The clean run below is on a tree unmodified for its full duration.

Verification: full suite, no deselect, output captured to a file, collected 9324, `9028 passed, 38 skipped, 1 xfailed, 257 errors` with zero `FAILED` lines. The 257 errors are all `@memgraph-integration`, i.e. no local database, and are unrelated to this change.

## The restamp fails closed

If `os.utime` cannot backdate a written cache file, the file is removed rather than left carrying its own write time. Keeping it would reintroduce exactly the defect this branch fixes: that write time is later than an edit made while the run was still hashing, so the successor's `mtime <= cache_mtime` check skips the edited file and the graph keeps stale content.

Removing it only costs a rebuild, which is the degradation every writer here already chooses (`_save_hash_cache` logs and returns on a write failure, leaving the cache absent). Measured on the state the unlink leaves, with the dir-mtimes file still present: the successor's in-sync fast path does not fire, `_is_full_build` is `True`, and both files are rebuilt.

`test_cache_is_removed_when_it_cannot_be_backdated` pins it, and fails if the error path swallows the failure instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after interrupted updates so changes are not marked complete until fully applied.
  * Ensured subsequent runs retry necessary deletions when an earlier update stops unexpectedly.
  * Prevented stale cache data from leaving excluded or outdated content in the graph.
  * Improved handling of edits made during incremental updates so they are not skipped.
  * Removed invalid cache data when update tracking cannot be recorded reliably, ensuring the next run rebuilds affected content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




