### PR TITLE
fix: skip vendored minified bundles and make the ~ ignore entry live (#1636)

### DIFF
--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -445,9 +445,33 @@ IGNORE_PATTERNS = frozenset(
         "venv",
     }
 )
+# Machine-generated artefacts: never hand-edited, never first-party. Matched
+# against the whole FILENAME with `str.endswith`, not against `Path.suffix`,
+# because two entries here are not suffixes in pathlib's sense:
+# `Path("jquery.min.js").suffix` is ".js" and `Path("notes.py~").suffix` is
+# ".py~", so a `Path.suffix` test silently matched neither (issue #1636).
+# Use `path_utils.is_ignored_filename`; do not re-derive the rule.
 IGNORE_SUFFIXES = frozenset(
-    {".tmp", "~", ".pyc", ".pyo", ".o", ".a", ".so", ".dll", ".class"}
+    {
+        ".tmp",
+        "~",
+        ".pyc",
+        ".pyo",
+        ".o",
+        ".a",
+        ".so",
+        ".dll",
+        ".class",
+        # Vendored bundles that generated API docs (jazzy, YARD, JSDoc,
+        # Sphinx) ship alongside the source they document. Their symbols are
+        # whatever the minifier emitted, and they outnumber the real ones.
+        ".min.js",
+        ".min.css",
+    }
 )
+# `str.endswith` takes a tuple, and the repository walk tests every filename,
+# so build it once rather than per file. Derived, never edited separately.
+IGNORE_FILENAME_ENDINGS = tuple(sorted(IGNORE_SUFFIXES))
 
 # pathspec style for .cgrignore / --exclude patterns (#495).
 GITWILDMATCH_STYLE = "gitignore"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2189,12 +2189,9 @@ class GraphUpdater:
                 continue
             return f"{prefix}{name}", None
         for name in actual_files - expected_files:
-            dot = name.rfind(".")
-            suffix = name[dot:] if dot != -1 else ""
             if should_skip_rel_file(
                 f"{prefix}{name}",
                 dir_parts,
-                suffix,
                 exclude_paths=self.exclude_paths,
                 unignore_paths=self.unignore_paths,
             ):

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1645,13 +1645,9 @@ class ImportProcessor:
         """
         if not rel_parts:
             return False
-        filename = rel_parts[-1]
-        dot = filename.rfind(cs.SEPARATOR_DOT)
-        suffix = filename[dot:] if dot != -1 else ""
         return not should_skip_rel_file(
             cs.SEPARATOR_SLASH.join(rel_parts),
             tuple(rel_parts[:-1]),
-            suffix,
             exclude_paths=self.exclude_paths,
             unignore_paths=self.unignore_paths,
         )
@@ -2552,7 +2548,6 @@ class ImportProcessor:
             if should_skip_rel_file(
                 f"{dir_prefix}{filename}",
                 here,
-                cs.EXT_RS,
                 exclude_paths=self.exclude_paths,
                 unignore_paths=self.unignore_paths,
             ):

--- a/codebase_rag/tests/test_gitignore_ignore_semantics.py
+++ b/codebase_rag/tests/test_gitignore_ignore_semantics.py
@@ -19,7 +19,6 @@ def _skip(
     return should_skip_rel_file(
         rel_path,
         parts[:-1],
-        Path(rel_path).suffix,
         exclude_paths=exclude,
         unignore_paths=unignore,
     )

--- a/codebase_rag/tests/test_ignored_file_suffixes.py
+++ b/codebase_rag/tests/test_ignored_file_suffixes.py
@@ -1,0 +1,231 @@
+"""Vendored minified bundles must not enter the graph (#1636).
+
+Indexing a repository that ships generated API documentation pulled the
+documentation's vendored JavaScript in with it. On Alamofire, `jquery.min.js`
+alone contributed 1192 `Function` nodes against 1385 for the whole Swift
+library, and every `CALLS` edge in the project came from the docs tree. The
+node names are whatever the minifier left behind (`v`, `y`, `ce`, `fe`), so
+they are unsearchable and they outnumber the real symbols.
+
+`IGNORE_SUFFIXES` is the list that already exists for this category, but it was
+consumed under two different rules. `realtime_updater._is_relevant` tests
+`path.name.endswith(suffix)`, which honours a compound ending; both
+`path_utils` sites tested `path.suffix`, and `Path("jquery.min.js").suffix` is
+`".js"`, never `".min.js"`. Two consequences, both covered below:
+
+* Adding `".min.js"` to the frozenset alone would have matched NOTHING. A test
+  asserting `".min.js" in IGNORE_SUFFIXES` passes against exactly that broken
+  change, so every test here drives the production walk instead.
+* The `"~"` entry was already dead for the indexer while live for the watcher,
+  so the two disagreed about which files belong in the graph.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import codebase_rag.constants.languages as cs
+from codebase_rag.utils.path_utils import walk_eligible_files
+from realtime_updater import CodeChangeEventHandler
+
+# Kept out of the graph: machine-generated, never hand-edited.
+SKIPPED = (
+    "docs/js/jquery.min.js",
+    "docs/css/site.min.css",
+    "src/notes.py~",
+    "src/stale.pyc",
+)
+# Kept in. The last three are near-misses that share the letters "min" without
+# the compound ending, which is the axis that decides whether the new rule is
+# an `endswith` on the filename or a sloppy substring test.
+INDEXED = (
+    "src/app.js",
+    "src/site.css",
+    "Sources/Model.swift",
+    "src/min.js",
+    "src/admin.js",
+    "src/jquery.min.js.map",
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "Alamofire"
+    for rel in (*SKIPPED, *INDEXED):
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("function f() {}\n", encoding="utf-8")
+    return repo
+
+
+def _walked(repo: Path) -> set[str]:
+    return {rel for _dirpath, _fname, rel in walk_eligible_files(repo)}
+
+
+class TestMinifiedBundlesAreNotIndexed:
+    def test_fixture_directories_are_not_already_ignored(self, repo: Path) -> None:
+        # Without this, every assertion below could pass because `docs` or
+        # `src` happens to be a built-in ignore, and the suffix rule would
+        # never be exercised at all.
+        for part in ("docs", "js", "css", "src", "Sources"):
+            assert part not in cs.IGNORE_PATTERNS
+
+    def test_minified_bundles_are_skipped(self, repo: Path) -> None:
+        walked = _walked(repo)
+        for rel in SKIPPED:
+            assert rel not in walked, f"{rel} reached the graph"
+
+    def test_real_sources_beside_them_still_index(self, repo: Path) -> None:
+        # The over-broad direction: a rule that swallowed the whole docs tree,
+        # or every `.js`, would satisfy the test above and break the tool.
+        walked = _walked(repo)
+        for rel in INDEXED:
+            assert rel in walked, f"{rel} was wrongly skipped"
+
+    def test_walk_yields_exactly_the_indexed_set(self, repo: Path) -> None:
+        assert _walked(repo) == set(INDEXED)
+
+
+class TestWholeNameRuleEdges:
+    """Endings matched against a whole filename have edges a suffix test lacks.
+
+    Moving from `Path.suffix` to `str.endswith` widens what can match: a name
+    with no stem now matches, and a DIRECTORY name could match if the predicate
+    were reached for one. Both are asserted rather than reasoned about.
+    """
+
+    def test_a_name_that_is_only_the_ending_is_skipped(self, tmp_path: Path) -> None:
+        # `Path("~").suffix` and `Path(".min.js").suffix` are both "", so these
+        # are exactly the names the old rule could never see.
+        repo = tmp_path / "repo"
+        (repo / "src").mkdir(parents=True)
+        for name in ("~", ".min.js", ".min.css"):
+            (repo / "src" / name).write_text("x\n", encoding="utf-8")
+        (repo / "src" / "real.py").write_text("x = 1\n", encoding="utf-8")
+        assert {rel for _d, _f, rel in walk_eligible_files(repo)} == {"src/real.py"}
+
+    def test_a_directory_named_like_a_bundle_is_still_walked(
+        self, tmp_path: Path
+    ) -> None:
+        # The rule is about files. A directory called `assets.min.js` must not
+        # prune the real sources underneath it.
+        repo = tmp_path / "repo"
+        (repo / "assets.min.js").mkdir(parents=True)
+        (repo / "assets.min.js" / "app.js").write_text("x\n", encoding="utf-8")
+        (repo / "assets.min.js" / "vendor.min.js").write_text("x\n", encoding="utf-8")
+        assert {rel for _d, _f, rel in walk_eligible_files(repo)} == {
+            "assets.min.js/app.js"
+        }
+
+    def test_object_file_endings_do_not_catch_real_sources(
+        self, tmp_path: Path
+    ) -> None:
+        # `.a` and `.o` are short enough to worry about. `endswith` is exact,
+        # so `main.rs` and `Foo.java` are untouched while the artefacts go.
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        for name in ("main.rs", "Foo.java", "data.aa", "cargo.toml", "libx.a", "x.o"):
+            (repo / name).write_text("x\n", encoding="utf-8")
+        assert {rel for _d, _f, rel in walk_eligible_files(repo)} == {
+            "main.rs",
+            "Foo.java",
+            "data.aa",
+            "cargo.toml",
+        }
+
+
+class TestPrecedenceAgainstUnignore:
+    """The name-ending rule outranks `!`, and the two walk entry points agree.
+
+    `TestIgnoreSuffixesInteraction` in test_exclude_patterns.py already pins
+    this for `should_skip_path`: un-ignoring `build/` does not resurrect
+    `build/out.pyc`. Rescuing a DIRECTORY should not drag its generated
+    artefacts back in.
+
+    Adding `.min.js` puts a new kind of entry under that rule -- the first one
+    a user might plausibly want indexed -- so the precedence is asserted here
+    for the extension too, and for `should_skip_rel_file`, which had no such
+    test. The consequence is a real limit with no escape hatch, stated in
+    docs/advanced/ignore-patterns.md rather than left for a user to discover.
+    """
+
+    @staticmethod
+    def _repo(tmp_path: Path) -> Path:
+        # Parented under `build`, a BUILT-IN ignore, so `hand.js` reaches the
+        # graph only because a `!` line rescued it. Under a normal directory it
+        # would be walked whether or not `unignore_paths` were consulted, and
+        # the control could not tell "the ending rule outranked a live `!`"
+        # from "the unignore was never read at all".
+        repo = tmp_path / "repo"
+        (repo / "build" / "js").mkdir(parents=True)
+        (repo / "build" / "js" / "jquery.min.js").write_text("x\n", encoding="utf-8")
+        (repo / "build" / "js" / "hand.js").write_text("x\n", encoding="utf-8")
+        return repo
+
+    def test_the_control_file_needs_the_unignore_to_be_walked_at_all(
+        self, tmp_path: Path
+    ) -> None:
+        # Establishes that the control below is live: with no `!`, the built-in
+        # `build` ignore keeps everything out, so a later `hand.js` sighting
+        # can only mean the unignore was honoured.
+        assert not list(walk_eligible_files(self._repo(tmp_path)))
+
+    def test_an_unignored_directory_does_not_rescue_a_bundle_inside_it(
+        self, tmp_path: Path
+    ) -> None:
+        walked = {
+            rel
+            for _d, _f, rel in walk_eligible_files(
+                self._repo(tmp_path), unignore_paths=frozenset({"build"})
+            )
+        }
+        # Set equality does the work in both directions: `hand.js` present
+        # rules out a predicate that ignores everything, `jquery.min.js` absent
+        # rules out one that ignores nothing.
+        assert walked == {"build/js/hand.js"}
+
+    def test_an_exact_unignore_line_does_not_rescue_it_either(
+        self, tmp_path: Path
+    ) -> None:
+        # The exact-path case, which no pre-existing test settled in either
+        # direction. Pinning it restrictively here is a decision, not a
+        # discovery: implementing #1637 means inverting this test and the
+        # matching paragraph in docs/advanced/ignore-patterns.md.
+        walked = {
+            rel
+            for _d, _f, rel in walk_eligible_files(
+                self._repo(tmp_path),
+                unignore_paths=frozenset({"build", "build/js/jquery.min.js"}),
+            )
+        }
+        assert walked == {"build/js/hand.js"}
+
+
+class TestIndexerAndWatcherAgree:
+    """The divergence that let `~` be live in one consumer and dead in the other.
+
+    Both predicates answer "does this file belong in the graph". Nothing forced
+    them to agree, and this test was red on `src/notes.py~` before the fix.
+
+    Note what it does NOT do. Now that both consumers call
+    `is_ignored_filename`, a WRONG shared rule keeps them agreeing and this test
+    stays green -- verified by mutation: reverting the helper to the old
+    `Path.suffix` membership fails the walk tests above while every case here
+    still passes. So this guards against the two implementations drifting apart
+    again, and the walk tests above are what pin the rule itself.
+    """
+
+    @pytest.mark.parametrize("rel", [*SKIPPED, *INDEXED])
+    def test_same_verdict_for_every_fixture_file(self, repo: Path, rel: str) -> None:
+        handler = CodeChangeEventHandler(updater=MagicMock())
+        # The repo-relative path, NOT `repo / rel`: pytest's tmp_path sits under
+        # `/tmp`, and `tmp` is in IGNORE_PATTERNS, so an absolute path makes the
+        # watcher reject every file and the comparison passes for the wrong
+        # reason. The suffix rule is what is under test here.
+        watcher_indexes = handler._is_relevant(rel)
+        indexer_indexes = rel in _walked(repo)
+        assert watcher_indexes == indexer_indexes, (
+            f"watcher and indexer disagree on {rel}: "
+            f"watcher={watcher_indexes} indexer={indexer_indexes}"
+        )

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -124,6 +124,21 @@ def should_keep_dir(
     )
 
 
+def is_ignored_filename(name: str) -> bool:
+    """Whether a filename is a machine-generated artefact, by its ending.
+
+    The single definition of the `IGNORE_SUFFIXES` rule, shared by the
+    repository walk and the real-time watcher. It tests the whole filename
+    rather than `Path.suffix` because the list holds endings that are not
+    pathlib suffixes: `Path("jquery.min.js").suffix` is ".js" and
+    `Path("notes.py~").suffix` is ".py~", so a `Path.suffix` membership test
+    matched neither, and the two consumers disagreed about which files belong
+    in the graph -- `~` was live for the watcher and dead for the indexer
+    (issue #1636).
+    """
+    return name.endswith(cs.IGNORE_FILENAME_ENDINGS)
+
+
 def should_skip_path(
     path: Path,
     repo_path: Path,
@@ -132,7 +147,12 @@ def should_skip_path(
     is_file: bool | None = None,
 ) -> bool:
     _is_file = path.is_file() if is_file is None else is_file
-    if _is_file and path.suffix in cs.IGNORE_SUFFIXES:
+    # Ahead of every exclude/unignore check, and deliberately so: a generated
+    # artefact is not source in any configuration, so rescuing the DIRECTORY it
+    # sits in must not drag it back in. Pinned by
+    # TestIgnoreSuffixesInteraction in test_exclude_patterns.py; the docs state
+    # the precedence for the reader (#1636).
+    if _is_file and is_ignored_filename(path.name):
         return True
     # Containment below is lexical, so a symlink whose target escapes the root
     # would pass it and let a repo-scoped sweep read or overwrite outside files
@@ -180,11 +200,15 @@ def has_ignored_dir_part(dir_parts: tuple[str, ...]) -> bool:
 def should_skip_rel_file(
     rel_path_str: str,
     dir_parts: tuple[str, ...],
-    suffix: str,
     exclude_paths: frozenset[str] | None = None,
     unignore_paths: frozenset[str] | None = None,
 ) -> bool:
-    if suffix in cs.IGNORE_SUFFIXES:
+    # The filename comes from `rel_path_str` rather than a caller-supplied
+    # suffix: every caller derived that suffix with a last-dot split, which
+    # cannot see a compound ending like ".min.js" no matter what this function
+    # then does with it (issue #1636). First, matching `should_skip_path`; the
+    # two must agree on precedence as well as on the rule.
+    if is_ignored_filename(rel_path_str.rsplit(cs.SEPARATOR_SLASH, 1)[-1]):
         return True
     if exclude_paths and matches_ignore_patterns(rel_path_str, exclude_paths):
         return True
@@ -276,13 +300,10 @@ def walk_eligible_files(
         for fname in sorted(filenames):
             if fname in state_filenames:
                 continue
-            dot = fname.rfind(".")
-            suffix = fname[dot:] if dot != -1 else ""
             rel_path_str = f"{dir_prefix}{fname}"
             if not should_skip_rel_file(
                 rel_path_str,
                 dir_parts,
-                suffix,
                 exclude_paths=exclude_paths,
                 unignore_paths=unignore_paths,
             ):

--- a/docs/advanced/ignore-patterns.md
+++ b/docs/advanced/ignore-patterns.md
@@ -58,7 +58,9 @@ project's own source, under names the minifier chose (`v`, `y`, `ce`).
 Only the exact ending is matched, so `app.min.js` is skipped while `admin.js`
 and `min.js` are indexed normally. A non-minified vendored file (say
 `docs/js/typeahead.jquery.js`) is not covered by this rule; exclude it with a
-`.cgrignore` pattern such as `docs/**` if you do not want it in the graph.
+`.cgrignore` pattern naming the file, or `docs/**/js/**` for a whole vendored
+directory. Prefer either to a blanket `docs/**`, which also drops the
+first-party Markdown under `docs/` that the document tier indexes on purpose.
 
 Unlike the directory exclusions above, this rule takes precedence over `!`
 lines and **cannot be un-ignored**: a generated artefact is not source in any

--- a/docs/advanced/ignore-patterns.md
+++ b/docs/advanced/ignore-patterns.md
@@ -24,7 +24,7 @@ fixtures/**
 - A bare name (`vendor`) matches a file or directory with that name at any depth
 - A pattern containing a slash (`docs/*.md`, `/generated`) is anchored to the repository root
 - A trailing slash (`build/`) matches directories only
-- Lines starting with `!` un-ignore matching paths that a **default** exclusion would skip (explicit excludes always win)
+- Lines starting with `!` un-ignore matching paths that a **default** exclusion would skip (explicit excludes always win; the name-ending rule under [Default Exclusions](#default-exclusions) cannot be un-ignored)
 - Lines starting with `#` are comments; blank lines are ignored
 - Patterns from `.cgrignore` are merged with `--exclude` flags (which use the same syntax) and auto-detected directories
 
@@ -46,6 +46,25 @@ to establish it and logs why.
 ## Default Exclusions
 
 Code-Graph-RAG automatically excludes common non-source directories such as `.git`, `node_modules`, `__pycache__`, `dist`, `build`, and similar.
+
+Individual files are also skipped by how their **name ends**, covering build
+output and editor leftovers (`.pyc`, `.pyo`, `.o`, `.a`, `.so`, `.dll`,
+`.class`, `.tmp`, `~`) as well as minified bundles (`.min.js`, `.min.css`).
+Minified bundles matter more than their count suggests: a project that commits
+generated API documentation (jazzy, YARD, JSDoc, Sphinx) ships a vendored
+jQuery or Lunr with it, and those files can contribute more functions than the
+project's own source, under names the minifier chose (`v`, `y`, `ce`).
+
+Only the exact ending is matched, so `app.min.js` is skipped while `admin.js`
+and `min.js` are indexed normally. A non-minified vendored file (say
+`docs/js/typeahead.jquery.js`) is not covered by this rule; exclude it with a
+`.cgrignore` pattern such as `docs/**` if you do not want it in the graph.
+
+Unlike the directory exclusions above, this rule takes precedence over `!`
+lines and **cannot be un-ignored**: a generated artefact is not source in any
+configuration, so un-ignoring the directory it sits in does not bring it back.
+The trade-off is that there is currently no way to index a file whose name ends
+this way, even deliberately.
 
 ## Scope
 

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -21,7 +21,6 @@ from codebase_rag.constants import (
     DEFAULT_DEBOUNCE_SECONDS,
     DEFAULT_MAX_WAIT_SECONDS,
     IGNORE_PATTERNS,
-    IGNORE_SUFFIXES,
     KEY_PATH,
     KEY_PROJECT_NAME,
     KEY_PROJECT_PREFIX,
@@ -36,6 +35,7 @@ from codebase_rag.language_spec import get_language_spec
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.services import QueryProtocol
 from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.utils.path_utils import is_ignored_filename
 
 
 class PendingTimer(Protocol):
@@ -85,7 +85,6 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         # loaded runners (issue #1005). Production always uses threading.Timer.
         self._timer_factory = timer_factory
         self.ignore_patterns = IGNORE_PATTERNS
-        self.ignore_suffixes = IGNORE_SUFFIXES
 
         self.debounce_seconds = debounce_seconds
         self.max_wait_seconds = max_wait_seconds
@@ -114,7 +113,9 @@ class CodeChangeEventHandler(FileSystemEventHandler):
 
     def _is_relevant(self, path_str: str) -> bool:
         path = Path(path_str)
-        if any(path.name.endswith(suffix) for suffix in self.ignore_suffixes):
+        # Shared with the repository walk. These two predicates answer the same
+        # question and drifted apart once already (issue #1636).
+        if is_ignored_filename(path.name):
             return False
         return all(part not in self.ignore_patterns for part in path.parts)
 


### PR DESCRIPTION
Closes #1636.

Indexing a repository that ships generated API documentation pulled the documentation's vendored JavaScript into the graph. On Alamofire, `jquery.min.js` alone contributed 1192 `Function` nodes against 1385 for the entire Swift library, and every one of the project's 407 `CALLS` edges came from the docs tree rather than from any Swift source. The node names are whatever the minifier emitted (`v`, `y`, `ce`, `fe`), so they are unsearchable and they outnumber the real symbols.

## The one-line change in the issue does not work

`IGNORE_SUFFIXES` already exists for machine-generated artefacts, and the issue proposed adding `.min.js` to it. That would have matched nothing.

Both `path_utils` consumers tested `Path.suffix`, and `Path("jquery.min.js").suffix` is `.js`, never `.min.js`. Worse, a test asserting `".min.js" in IGNORE_SUFFIXES` passes against exactly that broken change, so the obvious test would not have caught it either.

## A second defect, fixed here: the `~` entry was dead for the indexer

The constant had three consumers under two different rules:

| Consumer | Rule | `.min.js` | `~` |
|---|---|---|---|
| `realtime_updater._is_relevant` | `path.name.endswith(suffix)` | works | works |
| `path_utils.should_skip_path` | `path.suffix in IGNORE_SUFFIXES` | no-op | no-op |
| `path_utils.should_skip_rel_file` | `suffix in IGNORE_SUFFIXES` | no-op | no-op |

So the `~` entry was **already dead for the indexer while live for the watcher**: `Path("notes.py~").suffix` is `.py~` and `Path("backup~").suffix` is `""`, neither of which is in the set. The real-time watcher and the repository walk disagreed about which files belong in the graph, and nothing in the test suite could see it.

That is a pre-existing defect the issue does not mention, and it is fixed here rather than separately, because it has the same cause and the same one-line cure. It is also why `should_skip_rel_file` changes signature — that is not gratuitous churn. `TestIndexerAndWatcherAgree::test_same_verdict_for_every_fixture_file[src/notes.py~]` is the test that pins it, and it was red against main.

## The fix

One predicate, `path_utils.is_ignored_filename`, matching `str.endswith` against the whole filename, with all three consumers routed through it. `.min.js` and `.min.css` join the list; the `~` entry starts working for the indexer.

`should_skip_rel_file` lost its `suffix` parameter and derives the filename from `rel_path_str` instead. Every caller computed that argument with a last-dot split, which cannot represent a compound ending no matter what the function does with it — leaving the parameter in place would have left the trap sitting there looking like the mechanism.

## Effect on the reported repository

Walking the real Alamofire clone, 4 files are newly excluded — both copies of `jquery.min.js` and `lunr.min.js` — removing roughly 1460 of the 2134 noise nodes.

The 6 remaining `.js` files (`typeahead.jquery.js`, `jazzy.js`, `jazzy.search.js`) are non-minified vendored files that a name-ending rule cannot catch, exactly as the issue said. The docset-directory question stays open and untouched; `docs/` is often first-party and the document tier indexes `.md` there deliberately.

## Tests

`codebase_rag/tests/test_ignored_file_suffixes.py` drives the production walk (`walk_eligible_files`), never set membership. Confirmed red on main first, failing on the minified files and on `src/notes.py~`.

**The walk tests are what pin the rule.** Near-miss controls in the indexed direction — `min.js`, `admin.js`, `jquery.min.js.map` — pin it to an ending rather than a substring, and a guard asserts none of the fixture directories are built-in ignores so the fixture cannot pass trivially.

Moving from `Path.suffix` to `str.endswith` widens what can match, so the new edges are asserted rather than reasoned about:

- a file whose whole name is the ending (`~`, `.min.js`, `.min.css` with no stem) is skipped — precisely the names the old rule could never see
- a **directory** named `assets.min.js` is still walked, and `assets.min.js/app.js` still indexes; the rule is about files
- the short entries do not over-match: `main.rs`, `Foo.java` and `data.aa` all index, while `libx.a` and `x.o` are skipped

Both mutations verified with a print proving the mutated line executed (140 executions each):

- revert `is_ignored_filename` to `Path.suffix` membership → the two walk tests fail
- substring instead of `endswith` → the near-miss control fails

The parity test is deliberately documented as *not* catching the original rule bug: now that both consumers share one predicate, a wrong shared rule keeps them agreeing. It guards against them drifting apart again, which is the defect it was red for on main.

## Precedence against `!`, and a limitation now documented

Local review flagged that the paragraph added to `docs/advanced/ignore-patterns.md` sat under "Default Exclusions" while the same document promises `!` can un-ignore a default exclusion — and this rule is tested before any unignore check, so no `!` line can reach it.

The contradiction was real, but the code is the side that is right. `TestIgnoreSuffixesInteraction` in `test_exclude_patterns.py` already pins the ordering deliberately: un-ignoring `build/` must not resurrect `build/out.pyc`. Rescuing a directory should not drag its generated artefacts back in. Reordering to satisfy the doc broke that test, so the docs are corrected instead and now state the precedence and the trade-off plainly.

Two tests added for the extension of that rule to `.min.js`, covering `should_skip_rel_file`, which had no precedence test at all — each carries a `hand.js` control so the bundle's absence is a verdict rather than a directory the walk never entered. Verified by mutation: moving the check after the unignore restores green on the old tests and turns both new ones red.

The consequence is that `IGNORE_SUFFIXES` is the one ignore mechanism with no user override, which mattered little for binaries and matters more now that the list contains text a parser can read. Filed separately as #1637 rather than resolved here, so the doc sentence does not quietly settle it.

## Suite

The full unit suite on the development host reports 9263 passed with 24 failures and 4 errors, all of them environment-dependent and **not** caused by this change: `test_ruby_structure_oracle` (Node 18 cannot `require()` the ESM-only `@ruby/prism`), the C# oracle tests (`dotnet build` exits 1), and `test_patcher::test_rust_rename_runs_the_rustfmt_check` (the installed rustfmt would reformat).

Attribution was checked rather than assumed: reverting this branch's five production files to `origin/main` and re-running the same subset produced byte-identical counts, 24 failed and 4 errors. Every test that touches the changed surface passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file filtering so minified JavaScript and CSS bundles, backup files, compiled artifacts, and other configured file endings are consistently excluded from indexing and live updates.
  - Ensured filtering correctly handles compound endings and files without conventional extensions.
  - Applied consistent ignore behavior across repository scans and file watching, while continuing to process directories with matching names.

- **Documentation**
  - Clarified default filename-ending exclusions and noted that these exclusions take precedence over un-ignore patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->