### PR TITLE
fix: let a run finish when the mis-stamped cache cannot be removed either

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1277,12 +1277,15 @@ class GraphUpdater:
             self._pending_hash_cache = None
         if self._pending_dir_mtimes is not None:
             _save_dir_mtimes(*self._pending_dir_mtimes)
-            written.append(self._pending_dir_mtimes[0])
             self._pending_dir_mtimes = None
-        # Stamp both files with the instant captured before hashing, not with
-        # the time the write happened, so the deferral cannot swallow an edit
-        # made while the hashing loop and passes 3 and later were still
-        # running.
+        # Stamp the hash cache with the instant captured before hashing, not
+        # with the time the write happened, so the deferral cannot swallow an
+        # edit made while the hashing loop and passes 3 and later were still
+        # running. Only this file: `_is_already_in_sync` derives `cache_mtime`
+        # from the hash cache alone, and nothing anywhere stats the dir-mtimes
+        # file, whose entries are compared against the values stored INSIDE it.
+        # Backdating that one would be inert, and warning about it on failure
+        # would name a skipped file that cannot happen.
         if observed_at is not None:
             for path in written:
                 try:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1296,7 +1296,23 @@ class GraphUpdater:
                     # A missing cache only costs a rebuild, which is why every
                     # writer here already degrades to absent rather than wrong.
                     logger.warning(ls.CACHE_STAMP_FAILED, path=path, error=e)
-                    path.unlink(missing_ok=True)
+                    try:
+                        path.unlink(missing_ok=True)
+                    except OSError as unlink_error:
+                        # The canonical reason `utime` fails is a read-only
+                        # filesystem, and that same condition fails the unlink,
+                        # so this is the expected pairing rather than a remote
+                        # one. A run that cannot clean up must still finish:
+                        # every other filesystem writer on this path swallows
+                        # OSError, and crashing here would turn a degraded run
+                        # into no run at all. The cache is left mis-stamped and
+                        # the warning says so, because a silent pass would
+                        # leave the next run to discover it by skipping a file.
+                        logger.warning(
+                            ls.CACHE_STAMP_CLEANUP_FAILED,
+                            path=path,
+                            error=unlink_error,
+                        )
         self._pending_cache_observed_at = None
 
         if self._single_file is None:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -865,6 +865,11 @@ CACHE_STAMP_FAILED = (
     "Could not backdate {path} to the observed instant ({error}); removing it so "
     "the next run rebuilds rather than trusting a stamp that can hide edits"
 )
+CACHE_STAMP_CLEANUP_FAILED = (
+    "Could not remove {path} after its backdate failed ({error}); it keeps a write "
+    "time later than any edit made during this run, so the next run may skip that "
+    "file. Delete it by hand, or re-run once the path is writable"
+)
 PERIODIC_FLUSH = "Periodic flush after {count} files processed"
 INCREMENTAL_SKIPPED = "Skipped {count} unchanged files"
 INCREMENTAL_CHANGED = "Re-indexing {count} changed files"

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import os
 import time
@@ -599,6 +600,66 @@ class TestCrashBetweenCacheSaveAndFlush:
             "the cache survived a failed backdate: it now carries its own "
             "write time, which is later than an edit made during the run, so "
             "the successor skips that file and keeps stale graph content"
+        )
+
+    def test_run_survives_a_cache_that_can_be_neither_stamped_nor_removed(
+        self,
+        py_project: Path,
+        mock_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A read-only filesystem fails the stamp AND the cleanup.
+
+        `os.utime` failing with EROFS is the canonical reason to reach the
+        fail-closed path, and the same condition fails the `unlink` that path
+        performs, so the pairing is expected rather than remote. Every other
+        filesystem writer on this path swallows `OSError`; crashing here would
+        turn a run that merely could not tidy up into no run at all.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        (py_project / "module_c.py").write_text(
+            "def c():\n    return 1\n", encoding="utf-8"
+        )
+
+        real_utime = os.utime
+        real_unlink = Path.unlink
+        refused: list[str] = []
+
+        def _refuse_stamp(path, times=None, **kwargs):  # type: ignore[no-untyped-def]
+            if Path(path).name == cs.HASH_CACHE_FILENAME:
+                refused.append("utime")
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_utime(path, times, **kwargs)
+
+        def _refuse_unlink(self, missing_ok=False):  # type: ignore[no-untyped-def]
+            if self.name == cs.HASH_CACHE_FILENAME:
+                refused.append("unlink")
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(graph_updater_module.os, "utime", _refuse_stamp)
+        monkeypatch.setattr(Path, "unlink", _refuse_unlink)
+        # The run must COMPLETE. Before the unlink was guarded this raised
+        # OSError out of `run()` on exactly this pairing.
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        monkeypatch.setattr(Path, "unlink", real_unlink)
+        monkeypatch.setattr(graph_updater_module.os, "utime", real_utime)
+
+        assert refused == ["utime", "unlink"], (
+            "the run did not reach both refusals, so completing proves "
+            f"nothing about the pairing under test; saw {refused}"
         )
 
     def test_successor_run_still_deletes_the_module(


### PR DESCRIPTION
#1635 changed the hash-cache restamp to fail closed: if `os.utime` cannot backdate a written cache file, the file is removed so the next run rebuilds rather than trusting a stamp that can hide an edit. The `path.unlink(missing_ok=True)` that does the removal was placed **outside** the `try`, and the canonical reason `os.utime` fails is the one that also fails the unlink.

## The regression

A read-only filesystem raises `EROFS` from `os.utime`, which is what reaches the fail-closed handler at all. `Path.unlink` on that same file raises `EROFS` too, and nothing caught it, so an `OSError` propagates out of `GraphUpdater.run()`.

Reproduced on a real read-only APFS image:

```
utime raised:  OSError [Errno 30] Read-only file system
unlink RAISED: OSError [Errno 30] Read-only file system
```

This is a regression against the state before #1635's fail-closed commit: that version completed the run and degraded quietly. Every other filesystem writer on this path (`_touch_empty_json`, `_save_hash_cache`, `_save_dir_mtimes`, `_save_exclusion_state`) swallows `OSError`, so a read-only repo reaches the restamp normally and this unlink was the only unguarded mutation on the path.

## The fix

Wrap the unlink in its own `try/except OSError` and log a distinct string. The original message promises "removing it", which is false when the removal fails, so `CACHE_STAMP_CLEANUP_FAILED` says the file could not be removed and names the consequence: it keeps a write time later than any edit made during the run, so the next run may skip that file.

Finishing is the right degradation here. Crashing turns a run that merely could not tidy up into no run at all, and the mis-stamped cache is a warning-level problem the operator can resolve by deleting the file or re-running once the path is writable.

## Test

`test_run_survives_a_cache_that_can_be_neither_stamped_nor_removed` refuses both `os.utime` and `Path.unlink` with `EROFS` and asserts the run completes. A guard asserts both refusals were actually reached (`refused == ["utime", "unlink"]`), so a run that never attempted the stamp cannot pass it vacuously.

Reverting the guard turns it red with the uncaught `OSError [Errno 30]`, with a print confirming the mutated line executed.

## Scope

One hunk of production code plus a log string and a test. The rest of #1615's fix is unchanged and already on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incremental runs now continue when cache timestamp updates fail and the affected cache file cannot be removed.
  * Cache timestamps are applied only to the hash cache, using the pre-processing observation time.
  * Added separate logging for cache cleanup failures, including their potential impact on later incremental runs.

* **Tests**
  * Added coverage confirming runs complete successfully when the cache is on a read-only filesystem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->