### PR TITLE
fix: make the safe teardown the default for read-only trees under tmp_path (#1622)

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -5,6 +5,7 @@ import functools
 import os
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 from collections.abc import Generator
@@ -383,6 +384,104 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
         func(path)
     except FileNotFoundError:
         return
+
+
+def _make_tmp_path_removable(root: Path) -> None:
+    """Add the owner write bit to everything under `root`, bottom-up.
+
+    `_clear_readonly` rescues fixtures that tear themselves down through it.
+    Nothing rescues a test that runs `git init` under a bare `tmp_path` and
+    leaves the tree to pytest's own retention cleanup, which is what the
+    sweep on issue #1622 found in five places. Git writes loose objects
+    read-only, so on Windows that tree cannot be removed; pytest keeps the
+    last few basetemps and collects them in a LATER session with errors
+    ignored, so the failure never lands on the test that created it.
+
+    This runs for every test, so it must be cheap and total: it walks only
+    the test's own `tmp_path` (usually absent or tiny) and never raises.
+
+    Three constraints inherited from `_clear_readonly`, each load-bearing:
+
+    * The bit is ADDED to the existing mode, never assigned. `chmod(p, 0o200)`
+      sets a DIRECTORY untraversable for good, turning a recoverable state
+      into a permanent one.
+    * Symlinks are skipped. `os.chmod` follows links and `follow_symlinks`
+      is unsupported for chmod on Linux, one of the three matrix platforms.
+    * A path that vanishes mid-walk is already in the state teardown wanted;
+      git's background maintenance deletes its own lock asynchronously.
+    """
+    if not root.exists():
+        return
+
+    def widen(target: str) -> None:
+        if os.path.islink(target):
+            return
+        try:
+            mode = os.stat(target).st_mode
+            os.chmod(
+                target,
+                mode | stat.S_IWRITE | (stat.S_IEXEC if os.path.isdir(target) else 0),
+            )
+        except (FileNotFoundError, NotADirectoryError):
+            return
+        except OSError:
+            # A mode we cannot widen is not worth failing teardown over: the
+            # removal that follows reports the real problem.
+            return
+
+    # Bottom-up so a directory's own mode is widened only after its children
+    # have been visited through it.
+    for dirpath, dirnames, filenames in os.walk(root, topdown=False, followlinks=False):
+        for name in (*filenames, *dirnames):
+            widen(os.path.join(dirpath, name))
+    # The root last, and only after the walk: `os.walk` yields the entries
+    # UNDER a directory, never the directory it was given, so without this a
+    # restrictive mode on `tmp_path` itself would still block the removal.
+    widen(str(root))
+
+
+@pytest.fixture(autouse=True)
+def _tmp_path_stays_removable(request: pytest.FixtureRequest) -> Generator[None]:
+    """Leave no read-only object behind for pytest's cleanup to trip over.
+
+    Autouse and keyed on whether the test actually asked for `tmp_path`, so a
+    test that never used one does no work. This is the DEFAULT the issue asks
+    for: `git_repo` covers the fixtures that opt in, and this covers the ones
+    that build a repository by hand, including ones not yet written.
+    """
+    # Resolved BEFORE the yield: after the test, `tmp_path` may already be
+    # torn down and `getfixturevalue` then raises rather than returning it.
+    # Requesting it here does not create one for a test that never asked --
+    # the membership check gates that -- so an unrelated test still does no
+    # filesystem work.
+    root = (
+        request.getfixturevalue("tmp_path")
+        if "tmp_path" in request.fixturenames
+        else None
+    )
+    yield
+    if root is not None:
+        _make_tmp_path_removable(root)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Generator[Path, None, None]:
+    """A real git repository under `tmp_path`, torn down safely.
+
+    Prefer this over calling `git init` by hand: teardown goes through
+    `_clear_readonly`, so the read-only loose objects git writes cannot
+    strand the tree on Windows (issue #1622).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": str(tmp_path / "gitconfig-absent"),
+        "GIT_CONFIG_SYSTEM": str(tmp_path / "gitconfig-absent"),
+    }
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    yield repo
+    shutil.rmtree(repo, onexc=_clear_readonly, ignore_errors=False)
 
 
 @pytest.fixture

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -418,10 +418,11 @@ def _make_tmp_path_removable(root: Path) -> None:
             return
         try:
             mode = os.stat(target).st_mode
-            os.chmod(
-                target,
-                mode | stat.S_IWRITE | (stat.S_IEXEC if os.path.isdir(target) else 0),
-            )
+            # A directory needs READ to be listed as well as EXECUTE to be
+            # entered: at 0o300 it is traversable but `os.walk` still cannot
+            # enumerate it, so its children stay unreachable and unremovable.
+            extra = stat.S_IREAD | stat.S_IEXEC if os.path.isdir(target) else 0
+            os.chmod(target, mode | stat.S_IWRITE | extra)
         except (FileNotFoundError, NotADirectoryError):
             return
         except OSError:
@@ -429,8 +430,46 @@ def _make_tmp_path_removable(root: Path) -> None:
             # removal that follows reports the real problem.
             return
 
-    # Bottom-up so a directory's own mode is widened only after its children
-    # have been visited through it.
+    # Two passes, and the first is not optional. `os.walk` has to traverse
+    # INTO a directory to list it, so a directory missing the search bit
+    # yields no entries at all and everything beneath it is never visited --
+    # the same stranded-subtree defect this helper exists to prevent. Widening
+    # directories top-down on the way in restores that reachability; doing it
+    # bottom-up only fixes the ORDER of widening, never the reachability the
+    # listing itself needs.
+    # `widen(dirpath)` BEFORE reading `dirnames`, not the children afterwards:
+    # `os.walk` lists a directory when it yields it, so widening its children
+    # is already one level too late for a directory that cannot be listed at
+    # all (mode 0o000). Widening each directory as it arrives -- the root
+    # included, hence `widen(str(root))` also running here -- means the
+    # listing for the level below happens after the mode is fixed. `os.walk`
+    # swallows the listing error silently, so `onerror` is set to make a
+    # genuine failure visible rather than an empty subtree.
+    # Both `dirpath` and its `dirnames`: a directory at mode 0o000 is never
+    # YIELDED by `os.walk` at all (it raises while listing and is skipped
+    # silently), so widening only `dirpath` never reaches it. Its name is
+    # still visible in its PARENT's `dirnames`, which is the only handle on
+    # it, and widening it there means the walk can descend on the retry.
+    walk_errors: list[OSError] = []
+    for dirpath, dirnames, _filenames in os.walk(
+        root, topdown=True, followlinks=False, onerror=walk_errors.append
+    ):
+        widen(dirpath)
+        for name in dirnames:
+            widen(os.path.join(dirpath, name))
+    if walk_errors:
+        # A listing failed before its mode was fixed; the modes are fixed now,
+        # so a second walk reaches what the first could not. Bounded at one
+        # retry: anything still unlistable is a genuine failure, and the
+        # removal that follows reports it rather than this helper looping.
+        for dirpath, dirnames, _filenames in os.walk(
+            root, topdown=True, followlinks=False
+        ):
+            widen(dirpath)
+            for name in dirnames:
+                widen(os.path.join(dirpath, name))
+    # Then the full bottom-up pass for the files, now that every directory
+    # holding them can actually be listed.
     for dirpath, dirnames, filenames in os.walk(root, topdown=False, followlinks=False):
         for name in (*filenames, *dirnames):
             widen(os.path.join(dirpath, name))

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -378,10 +378,31 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     except OSError:
         mode = 0
     try:
-        os.chmod(
-            path, mode | stat.S_IWRITE | (stat.S_IEXEC if os.path.isdir(path) else 0)
-        )
-        func(path)
+        # S_IREAD as well as S_IEXEC on a directory: EXECUTE makes it
+        # traversable, READ makes it listable, and a removal needs both.
+        # Without READ a 0o000 directory becomes 0o300, which `rmtree` can
+        # enter but not enumerate, so the retry fails on the same directory
+        # this handler just "fixed" (#1622). Pytest's own `chmod_rw` adds
+        # S_IRUSR|S_IWUSR and no S_IXUSR, so it cannot repair that either.
+        extra = stat.S_IREAD | stat.S_IEXEC if os.path.isdir(path) else 0
+        os.chmod(path, mode | stat.S_IWRITE | extra)
+        # `func` is not always a one-argument removal, and the two cases need
+        # different handling (#1622).
+        #
+        # A REMOVAL that failed (`os.unlink`, `os.rmdir`) is retried directly:
+        # the mode is fixed now, so the same call succeeds.
+        #
+        # A LISTING that failed (`os.scandir`, `os.open`, `os.lstat`) is not.
+        # `os.open` requires `flags`, so a bare `func(path)` raises TypeError
+        # out of teardown; and `rmtree` does NOT retry the directory after
+        # this handler returns -- it abandons that subtree and moves on, so
+        # the parent's `rmdir` then fails with "Directory not empty" and
+        # nothing ever revisits the children. Recursing here is what removes
+        # them, and it is why widening the mode alone is not enough.
+        if func in (os.scandir, os.open, os.lstat):
+            shutil.rmtree(path, onexc=_clear_readonly)
+        else:
+            func(path)
     except FileNotFoundError:
         return
 
@@ -430,26 +451,22 @@ def _make_tmp_path_removable(root: Path) -> None:
             # removal that follows reports the real problem.
             return
 
-    # Two passes, and the first is not optional. `os.walk` has to traverse
-    # INTO a directory to list it, so a directory missing the search bit
-    # yields no entries at all and everything beneath it is never visited --
-    # the same stranded-subtree defect this helper exists to prevent. Widening
-    # directories top-down on the way in restores that reachability; doing it
-    # bottom-up only fixes the ORDER of widening, never the reachability the
-    # listing itself needs.
-    # `widen(dirpath)` BEFORE reading `dirnames`, not the children afterwards:
-    # `os.walk` lists a directory when it yields it, so widening its children
-    # is already one level too late for a directory that cannot be listed at
-    # all (mode 0o000). Widening each directory as it arrives -- the root
-    # included, hence `widen(str(root))` also running here -- means the
-    # listing for the level below happens after the mode is fixed. `os.walk`
-    # swallows the listing error silently, so `onerror` is set to make a
-    # genuine failure visible rather than an empty subtree.
-    # Both `dirpath` and its `dirnames`: a directory at mode 0o000 is never
-    # YIELDED by `os.walk` at all (it raises while listing and is skipped
-    # silently), so widening only `dirpath` never reaches it. Its name is
-    # still visible in its PARENT's `dirnames`, which is the only handle on
-    # it, and widening it there means the walk can descend on the retry.
+    # The root FIRST: every walk below has to list it, so a restrictive mode
+    # on `tmp_path` itself blocks all of them and the retry re-walks a root
+    # that is still unreadable. Fixing it last cannot help the passes that
+    # already failed.
+    widen(str(root))
+    # Then top-down, widening each directory as it ARRIVES rather than its
+    # children afterwards. `os.walk` is lazy and lists a directory when it
+    # yields it, so fixing a mode on arrival fixes it before the listing for
+    # the level below. Bottom-up would fix only the ORDER of widening, never
+    # the reachability the listing itself needs.
+    #
+    # `dirnames` as well as `dirpath`, because a directory at mode 0o000 is
+    # never YIELDED at all -- `os.walk` raises while listing it and skips it
+    # silently -- so its name in its PARENT's listing is the only handle on
+    # it. `onerror` collects what would otherwise be swallowed, turning a
+    # silently empty subtree into a signal.
     walk_errors: list[OSError] = []
     for dirpath, dirnames, _filenames in os.walk(
         root, topdown=True, followlinks=False, onerror=walk_errors.append
@@ -468,15 +485,11 @@ def _make_tmp_path_removable(root: Path) -> None:
             widen(dirpath)
             for name in dirnames:
                 widen(os.path.join(dirpath, name))
-    # Then the full bottom-up pass for the files, now that every directory
-    # holding them can actually be listed.
+    # Finally the files, bottom-up, now that every directory holding one can
+    # actually be listed.
     for dirpath, dirnames, filenames in os.walk(root, topdown=False, followlinks=False):
         for name in (*filenames, *dirnames):
             widen(os.path.join(dirpath, name))
-    # The root last, and only after the walk: `os.walk` yields the entries
-    # UNDER a directory, never the directory it was given, so without this a
-    # restrictive mode on `tmp_path` itself would still block the removal.
-    widen(str(root))
 
 
 @pytest.fixture(autouse=True)

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -572,7 +572,8 @@ def git_repo(tmp_path: Path) -> Generator[Path, None, None]:
         "GIT_CONFIG_SYSTEM": str(tmp_path / "gitconfig-absent"),
         # Pinned for the same reason the config files are neutralised: the
         # env is inherited, and an ambient GIT_DEFAULT_HASH=sha256 would give
-        # 62-hex object names instead of 40-hex, changing what callers see.
+        # 62-hex loose-object basenames instead of 38-hex, changing what
+        # callers see.
         "GIT_DEFAULT_HASH": "sha1",
     }
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -570,6 +570,10 @@ def git_repo(tmp_path: Path) -> Generator[Path, None, None]:
         **os.environ,
         "GIT_CONFIG_GLOBAL": str(tmp_path / "gitconfig-absent"),
         "GIT_CONFIG_SYSTEM": str(tmp_path / "gitconfig-absent"),
+        # Pinned for the same reason the config files are neutralised: the
+        # env is inherited, and an ambient GIT_DEFAULT_HASH=sha256 would give
+        # 62-hex object names instead of 40-hex, changing what callers see.
+        "GIT_DEFAULT_HASH": "sha1",
     }
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
     yield repo

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -292,7 +292,18 @@ def _isolate_cgr_home(
     yield home
 
 
-def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
+# What `shutil.rmtree` passes to `onexc` besides the removals. None of these
+# can be re-called with a single path argument: `os.open` needs `flags`,
+# `os.close` needs a descriptor, and `os.path.islink`/`os.scandir`/`os.lstat`
+# are queries that remove nothing (#1622).
+_NON_REMOVAL_FUNCS = frozenset(
+    {os.scandir, os.open, os.lstat, os.close, os.path.islink}
+)
+
+
+def _clear_readonly(
+    func: Any, path: Any, _exc: BaseException, _attempted: set[str] | None = None
+) -> None:
     """Retry a failed removal after clearing the read-only bit.
 
     On Windows `os.unlink` refuses a read-only file outright, so a tree
@@ -361,6 +372,14 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
     # not). Skipping the mode work is the portable answer.
     # On Windows `os.path.islink` is true for both symlink kinds, so this keeps
     # the handler platform-independent rather than trading one for another.
+    # Scoped to one top-level `rmtree`, not module-level: a module-level set
+    # would never be cleared and would suppress a legitimate second attempt on
+    # the same path in a later test. `functools.partial` carries it into the
+    # recursive call below.
+    if _attempted is None:
+        _attempted = set()
+    path_key = os.fspath(path)
+
     if os.path.islink(path):
         # Same vanished-path tolerance as the non-link path below: the link
         # can be gone by the time this retry runs, and that is the state the
@@ -386,23 +405,44 @@ def _clear_readonly(func: Any, path: Any, _exc: BaseException) -> None:
         # S_IRUSR|S_IWUSR and no S_IXUSR, so it cannot repair that either.
         extra = stat.S_IREAD | stat.S_IEXEC if os.path.isdir(path) else 0
         os.chmod(path, mode | stat.S_IWRITE | extra)
-        # `func` is not always a one-argument removal, and the two cases need
+        # `func` is not always a one-argument removal, and the cases need
         # different handling (#1622).
         #
-        # A REMOVAL that failed (`os.unlink`, `os.rmdir`) is retried directly:
-        # the mode is fixed now, so the same call succeeds.
+        # The discriminator names the callables that must NOT be re-called
+        # with a bare path, and retries everything else. `rmtree` passes
+        # `os.scandir`, `os.open`, `os.lstat`, `os.close` and
+        # `os.path.islink` besides the removals, and each is wrong to call
+        # differently: `os.open` wants `flags` and `os.close` wants a
+        # descriptor (both raise TypeError out of teardown), while
+        # `os.path.islink` is a pure query that removes nothing while looking
+        # like a successful retry.
         #
-        # A LISTING that failed (`os.scandir`, `os.open`, `os.lstat`) is not.
-        # `os.open` requires `flags`, so a bare `func(path)` raises TypeError
-        # out of teardown; and `rmtree` does NOT retry the directory after
-        # this handler returns -- it abandons that subtree and moves on, so
-        # the parent's `rmdir` then fails with "Directory not empty" and
-        # nothing ever revisits the children. Recursing here is what removes
-        # them, and it is why widening the mode alone is not enough.
-        if func in (os.scandir, os.open, os.lstat):
-            shutil.rmtree(path, onexc=_clear_readonly)
-        else:
+        # Named exclusions rather than an `(os.unlink, os.rmdir)` whitelist
+        # because callers legitimately pass their own removal callable -- the
+        # handler's own tests pass `retried.append` and bare lambdas, and a
+        # whitelist silently skips the retry for every one of them, which is
+        # the same "looks like a retry, removes nothing" failure this branch
+        # exists to stop.
+        if func not in _NON_REMOVAL_FUNCS:
             func(path)
+        elif os.path.isdir(path) and path_key not in _attempted:
+            # A LISTING failed. `rmtree` does NOT retry this directory after
+            # the handler returns -- it abandons the subtree, so the parent's
+            # `rmdir` then fails "Directory not empty" and nothing revisits
+            # the children. Recursing is what removes them.
+            #
+            # Guarded by `_attempted`: the recursive call re-enters this
+            # handler for the SAME path whenever a child cannot be removed
+            # (an immutable file, a read-only mount), and without the guard
+            # that is unbounded recursion ending in `RecursionError` raised
+            # from inside teardown -- strictly harder to attribute than the
+            # underlying `PermissionError`. Seen once, the path is left to
+            # report its own error.
+            _attempted.add(path_key)
+            shutil.rmtree(
+                path,
+                onexc=functools.partial(_clear_readonly, _attempted=_attempted),
+            )
     except FileNotFoundError:
         return
 

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -556,6 +556,26 @@ def _tmp_path_stays_removable(request: pytest.FixtureRequest) -> Generator[None]
         _make_tmp_path_removable(root)
 
 
+def git_env(**overrides: str) -> dict[str, str]:
+    """A Git environment with every inherited `GIT_*` routing variable gone.
+
+    `{**os.environ, ...}` is not enough. An inherited `GIT_DIR`,
+    `GIT_WORK_TREE`, `GIT_INDEX_FILE` or `GIT_OBJECT_DIRECTORY` redirects a
+    `git init` away from the directory it names, so the repo under test is
+    never built where the test looks for it -- and `git init` still exits 0,
+    so `check=True` does not catch it. The caller is then handed a path with
+    no `.git` at all, or object counts describing some other repository. A
+    test asserting an object is ABSENT passes vacuously that way, which is
+    why this is stripped rather than merely overridden.
+
+    Dropping the whole prefix rather than a listed few keeps that true for
+    routing variables not enumerated here (#1648 review).
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")} | dict(
+        overrides
+    )
+
+
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Generator[Path, None, None]:
     """A real git repository under `tmp_path`, torn down safely.
@@ -566,16 +586,15 @@ def git_repo(tmp_path: Path) -> Generator[Path, None, None]:
     """
     repo = tmp_path / "repo"
     repo.mkdir()
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": str(tmp_path / "gitconfig-absent"),
-        "GIT_CONFIG_SYSTEM": str(tmp_path / "gitconfig-absent"),
+    env = git_env(
+        GIT_CONFIG_GLOBAL=str(tmp_path / "gitconfig-absent"),
+        GIT_CONFIG_SYSTEM=str(tmp_path / "gitconfig-absent"),
         # Pinned for the same reason the config files are neutralised: the
         # env is inherited, and an ambient GIT_DEFAULT_HASH=sha256 would give
         # 62-hex loose-object basenames instead of 38-hex, changing what
         # callers see.
-        "GIT_DEFAULT_HASH": "sha1",
-    }
+        GIT_DEFAULT_HASH="sha1",
+    )
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
     yield repo
     shutil.rmtree(repo, onexc=_clear_readonly, ignore_errors=False)

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -530,9 +530,18 @@ def test_non_removal_funcs_lists_every_callable_rmtree_passes() -> None:
 
     The behavioural test above proves a listed callable is skipped; it cannot
     prove the list is COMPLETE, because a missing entry is only visible as a
-    silent no-op. Enumerated from CPython 3.12's `shutil`: `_rmtree_safe_fd`
-    binds `os.lstat`, `os.open`, `os.path.islink`, `os.scandir`, `os.rmdir`
-    and `os.close`, and `_rmtree_unsafe` adds nothing beyond those.
+    silent no-op.
+
+    Enumerated from `shutil` on BOTH matrix versions rather than one and
+    extrapolated -- `_rmtree_safe_fd` binds `func` indirectly, so a naive
+    scan for `onexc(<name>)` misses `os.open` and `os.scandir`. Resolving the
+    `func = ...` bindings too, the union across `_rmtree_safe_fd`,
+    `_rmtree_unsafe` and `rmtree` on 3.12 and 3.13 is exactly:
+
+        os.close, os.lstat, os.open, os.path.islink, os.scandir  (excluded)
+        os.rmdir, os.unlink                                      (retried)
+
+    Nothing else reaches the handler on either version.
     """
     from codebase_rag.tests.conftest import _NON_REMOVAL_FUNCS
 

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -449,24 +449,69 @@ def test_clear_readonly_survives_an_unremovable_entry(tmp_path: Path) -> None:
     ["close", "islink", "scandir", "open", "lstat"],
 )
 def test_clear_readonly_never_calls_a_non_removal_func(
-    tmp_path: Path, listing_func: str
+    tmp_path: Path, listing_func: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Only `os.unlink`/`os.rmdir` may be retried by calling `func(path)`.
+    """A non-removal callable must be SKIPPED, not called with a bare path.
 
-    `rmtree` passes several other callables, and each is wrong to call with a
-    single path: `os.open` wants `flags` and `os.close` wants a descriptor
-    (both raise TypeError out of teardown), while `os.path.islink` is a pure
-    query that removes nothing while looking like a successful retry. The
-    discriminator is a whitelist for that reason, so a callable nobody
-    anticipated is skipped rather than mis-called.
+    `rmtree` passes `os.scandir`, `os.open`, `os.lstat`, `os.close` and
+    `os.path.islink` besides the removals, and each is wrong to re-call
+    differently: `os.open` wants `flags` and `os.close` wants a descriptor
+    (both raise TypeError out of teardown), while `os.path.islink`,
+    `os.lstat` and `os.scandir` are pure queries that remove nothing while
+    looking like a successful retry. Unanticipated callables are retried --
+    callers legitimately pass their own removal function -- so only the five
+    named queries are excluded.
+
+    Asserts the callable was NOT INVOKED rather than that nothing raised.
+    Three of the five return silently, so an exception-only check passes
+    whether or not they are in the exclusion set: dropping islink, lstat and
+    scandir from `_NON_REMOVAL_FUNCS` left all five parametrisations green.
     """
-    from codebase_rag.tests.conftest import _clear_readonly
+    import codebase_rag.tests.conftest as conftest_module
 
     func = getattr(os, listing_func, None) or getattr(os.path, listing_func)
+    calls: list[object] = []
+
+    def spy(*args: object, **kwargs: object) -> object:
+        calls.append(args)
+        return func(*args, **kwargs)
+
+    # The spy stands in for the real callable on BOTH sides -- the exclusion
+    # set and the argument -- so membership is what decides, not identity of
+    # some other object.
+    monkeypatch.setattr(
+        conftest_module,
+        "_NON_REMOVAL_FUNCS",
+        frozenset(conftest_module._NON_REMOVAL_FUNCS - {func} | {spy}),
+    )
     target = tmp_path / "subject"
     target.mkdir()
 
-    _clear_readonly(func, str(target), OSError(13, "boom"))
+    conftest_module._clear_readonly(spy, str(target), OSError(13, "boom"))
+
+    assert not calls, (
+        f"os.{listing_func} was re-called with a bare path: it removes "
+        "nothing, so the handler abandons the subtree while appearing to "
+        "have retried"
+    )
+
+
+def test_non_removal_funcs_lists_every_callable_rmtree_passes() -> None:
+    """Pin the exclusion set's membership, which no behavioural test can.
+
+    The behavioural test above proves a listed callable is skipped; it cannot
+    prove the list is COMPLETE, because a missing entry is only visible as a
+    silent no-op. Enumerated from CPython 3.12's `shutil`: `_rmtree_safe_fd`
+    binds `os.lstat`, `os.open`, `os.path.islink`, `os.scandir`, `os.rmdir`
+    and `os.close`, and `_rmtree_unsafe` adds nothing beyond those.
+    """
+    from codebase_rag.tests.conftest import _NON_REMOVAL_FUNCS
+
+    assert _NON_REMOVAL_FUNCS == frozenset(
+        {os.scandir, os.open, os.lstat, os.close, os.path.islink}
+    )
+    assert os.unlink not in _NON_REMOVAL_FUNCS
+    assert os.rmdir not in _NON_REMOVAL_FUNCS
 
 
 def test_git_repo_fixture_tears_down_its_own_readonly_objects(

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -558,7 +558,10 @@ def test_non_removal_funcs_lists_every_callable_rmtree_passes() -> None:
 
 
 _FANOUT_DIR = re.compile(r"[0-9a-f]{2}")
-_LOOSE_OBJECT = re.compile(r"[0-9a-f]{38}")
+# 38 hex for sha1 object names, 62 for sha256; the leading two hex chars are
+# the fanout directory, so a basename is the remaining 38 or 62. Fixtures
+# here pin sha1, but the helper must not silently discard a sha256 repo.
+_LOOSE_OBJECT = re.compile(r"[0-9a-f]{38}|[0-9a-f]{62}")
 
 
 def _collect_loose_objects(repo: Path) -> tuple[list[str], list[int]]:
@@ -621,6 +624,7 @@ def test_git_repo_fixture_tears_down_its_own_readonly_objects(
         **os.environ,
         "GIT_CONFIG_GLOBAL": str(git_repo / "absent"),
         "GIT_CONFIG_SYSTEM": str(git_repo / "absent"),
+        "GIT_DEFAULT_HASH": "sha1",
     }
     subprocess.run(["git", "add", "a.py"], cwd=git_repo, check=True, env=env)
     subprocess.run(
@@ -670,6 +674,7 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
         **os.environ,
         "GIT_CONFIG_GLOBAL": str(tmp_path / "absent"),
         "GIT_CONFIG_SYSTEM": str(tmp_path / "absent"),
+        "GIT_DEFAULT_HASH": "sha1",
     }
     repo = tmp_path / "packed"
     repo.mkdir()

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -68,6 +68,61 @@ def test_plants_a_readonly_object(tmp_path):
 """
 
 
+def _git_env(**overrides: str) -> dict[str, str]:
+    """A Git environment with every inherited `GIT_*` routing variable gone.
+
+    `{**os.environ, ...}` is not enough. An inherited `GIT_DIR`,
+    `GIT_WORK_TREE`, `GIT_INDEX_FILE` or `GIT_OBJECT_DIRECTORY` redirects a
+    `git init` away from the directory it names, so the repo under test is
+    never built where the test looks for it. The object counts these tests
+    assert on would then describe some other repository, or an empty tree --
+    and a test asserting an object is ABSENT passes vacuously when it is
+    reading the wrong directory. Dropping the whole prefix rather than a
+    listed few keeps that true for routing variables not enumerated here
+    (#1648 review).
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")} | dict(
+        overrides
+    )
+
+
+def test_git_env_drops_inherited_routing_variables(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`_git_env` must strip inherited `GIT_*`, not merely add to it.
+
+    Pins the property directly rather than through a repo-building test: with
+    `GIT_DIR` set, `git init` builds the repo somewhere else entirely, so a
+    test that COUNTS objects would go red for a reason far from the cause,
+    and one asserting an object is absent would go GREEN vacuously. The
+    routing variables below are the ones that redirect a command away from
+    its `cwd`; `GIT_CONFIG_GLOBAL` is passed as an override to show the
+    filter drops inherited values without discarding the ones a caller asks
+    for.
+    """
+    monkeypatch.setenv("GIT_DIR", str(tmp_path / "elsewhere" / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path / "elsewhere"))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(tmp_path / "elsewhere" / "index"))
+    monkeypatch.setenv("GIT_OBJECT_DIRECTORY", str(tmp_path / "elsewhere" / "o"))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "inherited"))
+    monkeypatch.setenv("PATH", os.environ["PATH"])
+
+    env = _git_env(GIT_CONFIG_GLOBAL=str(tmp_path / "wanted"))
+
+    leaked = sorted(k for k in env if k.startswith("GIT_") and k != "GIT_CONFIG_GLOBAL")
+    assert leaked == [], (
+        f"inherited Git routing variables survived into the child env: {leaked}; "
+        "each one redirects git away from the directory the test built"
+    )
+    assert env["GIT_CONFIG_GLOBAL"] == str(tmp_path / "wanted"), (
+        "the caller's own override must win over the inherited value, or the "
+        "filter has thrown away the setting it was asked to apply"
+    )
+    assert "PATH" in env, (
+        "only GIT_* is dropped; stripping the rest would leave git unfindable"
+    )
+
+
 def _plant_readonly_object(root: Path) -> Path:
     """Write a file with git's loose-object mode: read-only for everyone."""
     objects = root / ".git" / "objects" / "ab"
@@ -631,12 +686,11 @@ def test_git_repo_fixture_tears_down_its_own_readonly_objects(
 
     assert (git_repo / ".git").is_dir()
     (git_repo / "a.py").write_text("x = 1\n", encoding="utf-8")
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": str(git_repo / "absent"),
-        "GIT_CONFIG_SYSTEM": str(git_repo / "absent"),
-        "GIT_DEFAULT_HASH": "sha1",
-    }
+    env = _git_env(
+        GIT_CONFIG_GLOBAL=str(git_repo / "absent"),
+        GIT_CONFIG_SYSTEM=str(git_repo / "absent"),
+        GIT_DEFAULT_HASH="sha1",
+    )
     subprocess.run(["git", "add", "a.py"], cwd=git_repo, check=True, env=env)
     subprocess.run(
         ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "c"],
@@ -694,12 +748,11 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
     already rejects packs, `*.idx`, `commit-graph` and the decoy by name.
     `_FANOUT_DIR` is a narrowing optimisation here, not independently pinned.
     """
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": str(tmp_path / "absent"),
-        "GIT_CONFIG_SYSTEM": str(tmp_path / "absent"),
-        "GIT_DEFAULT_HASH": "sha1",
-    }
+    env = _git_env(
+        GIT_CONFIG_GLOBAL=str(tmp_path / "absent"),
+        GIT_CONFIG_SYSTEM=str(tmp_path / "absent"),
+        GIT_DEFAULT_HASH="sha1",
+    )
     repo = tmp_path / "packed"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
@@ -763,12 +816,11 @@ def test_the_loose_object_filter_accepts_a_sha256_repo(
     the pins deliberately exclude, so the sha256 branch is pinned behaviour
     rather than uncovered code that can be dropped silently.
     """
-    env = {
-        **os.environ,
-        "GIT_CONFIG_GLOBAL": str(tmp_path / "absent"),
-        "GIT_CONFIG_SYSTEM": str(tmp_path / "absent"),
-        "GIT_DEFAULT_HASH": "sha256",
-    }
+    env = _git_env(
+        GIT_CONFIG_GLOBAL=str(tmp_path / "absent"),
+        GIT_CONFIG_SYSTEM=str(tmp_path / "absent"),
+        GIT_DEFAULT_HASH="sha256",
+    )
     repo = tmp_path / "sha256"
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -46,6 +46,8 @@ from pathlib import Path
 
 import pytest
 
+from codebase_rag import constants as cs
+
 # Planted by the inner session so the outer test can find the tree afterwards.
 _INNER_TEST = """
 import os
@@ -776,6 +778,10 @@ def test_the_loose_object_filter_accepts_a_sha256_repo(
         check=True,
         capture_output=True,
         text=True,
+        # Explicit, never the locale: `text=True` alone decodes with the
+        # locale encoding (cp1252 on the Windows runners), which #1454 made a
+        # suite-wide gate against. git writes UTF-8.
+        encoding=cs.ENCODING_UTF8,
         env=env,
     ).stdout.strip()
     if fmt != "sha256":

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -674,6 +674,18 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
     fixture never packs -- so without this test the filter can regress
     silently. `git gc` here creates the state the fixture cannot reach on its
     own: pack/commit-graph files present, mode 444, and zero loose objects.
+
+    The packed state alone does NOT exercise `_LOOSE_OBJECT`: packs live in
+    `objects/pack/` and `objects/info/`, which `_FANOUT_DIR` rejects on its
+    own, so the basename filter could be deleted with this test still green.
+    The planted `tmp_obj_*` decoy below closes that -- it sits INSIDE a fanout
+    directory, so only `_LOOSE_OBJECT` rejects it, and dropping the basename
+    filter turns this test red (measured).
+
+    The converse does not hold and is not claimed: dropping `_FANOUT_DIR`
+    alone leaves this green (measured, 27 passed), because the basename filter
+    already rejects packs, `*.idx`, `commit-graph` and the decoy by name.
+    `_FANOUT_DIR` is a narrowing optimisation here, not independently pinned.
     """
     env = {
         **os.environ,
@@ -711,10 +723,24 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
     ]
     assert packed, "gc produced no read-only artefacts: bad control"
 
+    # `_FANOUT_DIR` alone already rejects everything gc leaves behind, because
+    # packs live in `objects/pack/` and `objects/info/`. So the packed state
+    # tests only that half of the filter, and `_LOOSE_OBJECT` could be dropped
+    # entirely with this test still green. Plant a read-only NON-object file
+    # inside a real fanout directory -- `tmp_obj_*` is git's own name for a
+    # partially written object -- so the basename filter is the only thing
+    # standing between it and the assertions below.
+    fanout = repo / ".git" / "objects" / "00"
+    fanout.mkdir(parents=True, exist_ok=True)
+    decoy = fanout / "tmp_obj_A1b2C3"
+    decoy.write_bytes(b"not an object")
+    decoy.chmod(0o444)
+
     listed, readonly_modes = _collect_loose_objects(repo)
     assert listed == [], (
-        f"packed artefacts counted as loose objects: {listed} -- the filter "
-        "no longer discriminates and the fixture guard is satisfied by packs"
+        f"packed artefacts or temp files counted as loose objects: {listed} "
+        "-- the filter no longer discriminates and the fixture guard is "
+        "satisfied with zero loose objects present"
     )
     assert readonly_modes == []
 

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -38,7 +38,9 @@ reason above.
 from __future__ import annotations
 
 import os
+import re
 import stat
+import subprocess
 import sys
 from pathlib import Path
 
@@ -555,6 +557,53 @@ def test_non_removal_funcs_lists_every_callable_rmtree_passes() -> None:
     assert os.rmdir not in _NON_REMOVAL_FUNCS
 
 
+_FANOUT_DIR = re.compile(r"[0-9a-f]{2}")
+_LOOSE_OBJECT = re.compile(r"[0-9a-f]{38}")
+
+
+def _collect_loose_objects(repo: Path) -> tuple[list[str], list[int]]:
+    """Return the loose objects under `repo`, and which of them are read-only.
+
+    Counts ONLY `objects/<2 hex>/<38 hex>`. Everything else under `objects/`
+    is a different kind of file, and several are mode 444: `pack/*.pack`,
+    `*.idx`, `*.rev`, `commit-graph`. Walking all of `objects/` would let those
+    satisfy a "git wrote read-only loose objects" assertion with zero loose
+    objects present -- the exact state such an assertion exists to reject.
+    Git only packs at `gc.auto` (6700) loose objects, so the fixture cannot
+    reach that today, but the guard must not depend on that staying true.
+    `test_the_loose_object_filter_rejects_a_packed_repo` pins the difference.
+
+    Modes are read AT LISTING TIME, one `lstat` per entry, never a second
+    pass. `git commit` spawns `git maintenance run --auto --quiet --detach`,
+    which deletes its own `.git/objects/maintenance.lock` asynchronously, so a
+    list-then-stat pair races it: the entry is listed and gone by the time the
+    stat runs. That is the TOCTOU `_clear_readonly` documents, and it failed
+    exactly once, on macos/3.13 under xdist (#1622). A vanished entry is
+    skipped rather than tolerated after the fact: it cannot be the read-only
+    loose object callers assert on, because a loose object is permanent for
+    the life of the repo while the lock is transient.
+    """
+    listed: list[str] = []
+    readonly_modes: list[int] = []
+    for dirpath, _dirs, _files in os.walk(repo / ".git" / "objects"):
+        if not _FANOUT_DIR.fullmatch(os.path.basename(dirpath)):
+            continue
+        with os.scandir(dirpath) as entries:
+            for entry in entries:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if not _LOOSE_OBJECT.fullmatch(entry.name):
+                    continue
+                try:
+                    mode = entry.stat(follow_symlinks=False).st_mode
+                except FileNotFoundError:
+                    continue
+                listed.append(entry.name)
+                if not mode & stat.S_IWUSR:
+                    readonly_modes.append(mode)
+    return listed, readonly_modes
+
+
 def test_git_repo_fixture_tears_down_its_own_readonly_objects(
     git_repo: Path,
 ) -> None:
@@ -580,38 +629,81 @@ def test_git_repo_fixture_tears_down_its_own_readonly_objects(
         check=True,
         env=env,
     )
+    # Count ONLY loose objects: `objects/<2 hex>/<38 hex>`. Everything else
+    # under `objects/` is a different kind of file, and several of them are
+    # mode 444 -- `pack/*.pack`, `*.idx`, `*.rev`, `commit-graph`. Walking all
+    # of `objects/` would let those satisfy both guards below with zero loose
+    # objects present, which is the state the guards exist to reject. Git only
+    # packs at `gc.auto` (6700) loose objects so this fixture cannot reach it
+    # today, but the guards must not depend on that staying true.
+    #
     # Mode read AT LISTING TIME, one `lstat` per entry, never a second pass.
     # `git commit` spawns `git maintenance run --auto --quiet --detach`, which
     # deletes its own `.git/objects/maintenance.lock` asynchronously, so a
     # list-then-stat pair races it: the entry is listed and gone by the time
     # the stat runs. That is the TOCTOU `_clear_readonly` documents, and it
-    # failed exactly once, on macos/3.13 under xdist (#1622).
-    #
-    # A vanished entry is skipped rather than tolerated after the fact: it
-    # cannot be the read-only loose object this asserts on, because a loose
-    # object is permanent for the life of the repo while the lock is
-    # transient. `maintenance.lock` is excluded by name for the same reason --
-    # it is not an object at all, so counting it would let a run where git
-    # wrote NO objects satisfy the guard below.
-    readonly_modes: list[int] = []
-    listed: list[str] = []
-    for dirpath, _dirs, _files in os.walk(git_repo / ".git" / "objects"):
-        with os.scandir(dirpath) as entries:
-            for entry in entries:
-                if not entry.is_file(follow_symlinks=False):
-                    continue
-                if entry.name.endswith(".lock"):
-                    continue
-                try:
-                    mode = entry.stat(follow_symlinks=False).st_mode
-                except FileNotFoundError:
-                    continue
-                listed.append(entry.name)
-                if not mode & stat.S_IWUSR:
-                    readonly_modes.append(mode)
+    # failed exactly once, on macos/3.13 under xdist (#1622). A vanished entry
+    # is skipped rather than tolerated after the fact: it cannot be the
+    # read-only loose object this asserts on, because a loose object is
+    # permanent for the life of the repo while the lock is transient.
+    listed, readonly_modes = _collect_loose_objects(git_repo)
 
     assert listed, "git wrote no loose objects, so the fixture proves nothing"
     assert readonly_modes, (
         f"no loose object is read-only ({len(listed)} listed): the condition "
         "this fixture exists to survive was never created"
     )
+
+
+def test_the_loose_object_filter_rejects_a_packed_repo(
+    tmp_path: Path,
+) -> None:
+    """A repo with no loose objects must fail the guard, not pass it on packs.
+
+    This is the control for `_collect_loose_objects`. Widening it back to all
+    of `objects/` leaves every other test in this file green, because the
+    fixture never packs -- so without this test the filter can regress
+    silently. `git gc` here creates the state the fixture cannot reach on its
+    own: pack/commit-graph files present, mode 444, and zero loose objects.
+    """
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": str(tmp_path / "absent"),
+        "GIT_CONFIG_SYSTEM": str(tmp_path / "absent"),
+    }
+    repo = tmp_path / "packed"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    (repo / "a.py").write_text("x = 1\n")
+    subprocess.run(["git", "add", "a.py"], cwd=repo, check=True, env=env)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "c"],
+        cwd=repo,
+        check=True,
+        env=env,
+    )
+    assert _collect_loose_objects(repo)[0], "no loose objects before gc: bad control"
+
+    subprocess.run(
+        ["git", "gc", "-q", "--prune=now"],
+        cwd=repo,
+        check=True,
+        env=env,
+    )
+
+    # The packed artefacts really are present and really are read-only, so a
+    # filter that counted them would find plenty to satisfy both assertions.
+    packed = [
+        entry
+        for dirpath, _dirs, files in os.walk(repo / ".git" / "objects")
+        for entry in files
+        if not (os.stat(os.path.join(dirpath, entry)).st_mode & stat.S_IWUSR)
+    ]
+    assert packed, "gc produced no read-only artefacts: bad control"
+
+    listed, readonly_modes = _collect_loose_objects(repo)
+    assert listed == [], (
+        f"packed artefacts counted as loose objects: {listed} -- the filter "
+        "no longer discriminates and the fixture guard is satisfied by packs"
+    )
+    assert readonly_modes == []

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -469,7 +469,12 @@ def test_clear_readonly_survives_an_unremovable_entry(tmp_path: Path) -> None:
     subprocess.run(["chflags", "uchg", str(stuck)], check=True)
     inner.chmod(0o000)
     try:
-        with pytest.raises(OSError) as caught:
+        # Both are caught deliberately. `RecursionError` inherits
+        # `RuntimeError`, NOT `OSError`, so catching `OSError` alone would let
+        # an unbounded handler propagate as a test ERROR -- which reports as
+        # "something blew up" rather than naming the regression. Catching both
+        # and asserting on the type is what makes the failure say what broke.
+        with pytest.raises((OSError, RecursionError)) as caught:
             shutil.rmtree(root, onexc=_clear_readonly)
         assert not isinstance(caught.value, RecursionError), (
             "the handler recursed without bound instead of surfacing the "

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -68,28 +68,10 @@ def test_plants_a_readonly_object(tmp_path):
 """
 
 
-def _git_env(**overrides: str) -> dict[str, str]:
-    """A Git environment with every inherited `GIT_*` routing variable gone.
-
-    `{**os.environ, ...}` is not enough. An inherited `GIT_DIR`,
-    `GIT_WORK_TREE`, `GIT_INDEX_FILE` or `GIT_OBJECT_DIRECTORY` redirects a
-    `git init` away from the directory it names, so the repo under test is
-    never built where the test looks for it. The object counts these tests
-    assert on would then describe some other repository, or an empty tree --
-    and a test asserting an object is ABSENT passes vacuously when it is
-    reading the wrong directory. Dropping the whole prefix rather than a
-    listed few keeps that true for routing variables not enumerated here
-    (#1648 review).
-    """
-    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")} | dict(
-        overrides
-    )
-
-
 def test_git_env_drops_inherited_routing_variables(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """`_git_env` must strip inherited `GIT_*`, not merely add to it.
+    """`git_env` must strip inherited `GIT_*`, not merely add to it.
 
     Pins the property directly rather than through a repo-building test: with
     `GIT_DIR` set, `git init` builds the repo somewhere else entirely, so a
@@ -98,16 +80,19 @@ def test_git_env_drops_inherited_routing_variables(
     routing variables below are the ones that redirect a command away from
     its `cwd`; `GIT_CONFIG_GLOBAL` is passed as an override to show the
     filter drops inherited values without discarding the ones a caller asks
-    for.
+    for, and `DIGIT_SCALE` is planted so a substring match in place of a
+    prefix match is caught rather than passing as an equally green result.
     """
     monkeypatch.setenv("GIT_DIR", str(tmp_path / "elsewhere" / ".git"))
     monkeypatch.setenv("GIT_WORK_TREE", str(tmp_path / "elsewhere"))
     monkeypatch.setenv("GIT_INDEX_FILE", str(tmp_path / "elsewhere" / "index"))
     monkeypatch.setenv("GIT_OBJECT_DIRECTORY", str(tmp_path / "elsewhere" / "o"))
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "inherited"))
-    monkeypatch.setenv("PATH", os.environ["PATH"])
+    monkeypatch.setenv("DIGIT_SCALE", "sentinel")
 
-    env = _git_env(GIT_CONFIG_GLOBAL=str(tmp_path / "wanted"))
+    from codebase_rag.tests.conftest import git_env
+
+    env = git_env(GIT_CONFIG_GLOBAL=str(tmp_path / "wanted"))
 
     leaked = sorted(k for k in env if k.startswith("GIT_") and k != "GIT_CONFIG_GLOBAL")
     assert leaked == [], (
@@ -118,8 +103,10 @@ def test_git_env_drops_inherited_routing_variables(
         "the caller's own override must win over the inherited value, or the "
         "filter has thrown away the setting it was asked to apply"
     )
-    assert "PATH" in env, (
-        "only GIT_* is dropped; stripping the rest would leave git unfindable"
+    assert env.get("DIGIT_SCALE") == "sentinel", (
+        "only variables whose NAME BEGINS with `GIT_` may be dropped; a "
+        "substring test would also eat `DIGIT_SCALE` and anything else "
+        "merely containing the token, taking unrelated settings with it"
     )
 
 
@@ -673,6 +660,50 @@ def _collect_loose_objects(repo: Path) -> tuple[list[str], list[int]]:
     return listed, readonly_modes
 
 
+def test_git_repo_fixture_survives_an_inherited_git_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The fixture's own `git init` must ignore an ambient `GIT_DIR`.
+
+    Rebuilds the fixture's setup rather than consuming the fixture, because
+    `monkeypatch` cannot reach inside an already-running fixture's setup;
+    the env below is the same call the fixture makes.
+
+    The failure this pins is silent: `git init` under a redirecting `GIT_DIR`
+    still exits 0, so `check=True` raises nothing and the caller is handed a
+    directory with no `.git` in it at all. Both assertions are on the
+    filesystem for that reason -- a return code cannot tell the two apart.
+    """
+    import subprocess
+
+    from codebase_rag.tests.conftest import git_env
+
+    elsewhere = tmp_path / "elsewhere"
+    monkeypatch.setenv("GIT_DIR", str(elsewhere / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(elsewhere))
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q"],
+        cwd=repo,
+        check=True,
+        env=git_env(
+            GIT_CONFIG_GLOBAL=str(tmp_path / "absent"),
+            GIT_CONFIG_SYSTEM=str(tmp_path / "absent"),
+            GIT_DEFAULT_HASH="sha1",
+        ),
+    )
+
+    assert (repo / ".git").is_dir(), (
+        "git init did not build the repo where it was told to: the inherited "
+        "GIT_DIR redirected it, and exited 0 while doing so"
+    )
+    assert not elsewhere.exists(), (
+        "the repo was built at the inherited GIT_DIR location instead of cwd"
+    )
+
+
 def test_git_repo_fixture_tears_down_its_own_readonly_objects(
     git_repo: Path,
 ) -> None:
@@ -686,7 +717,9 @@ def test_git_repo_fixture_tears_down_its_own_readonly_objects(
 
     assert (git_repo / ".git").is_dir()
     (git_repo / "a.py").write_text("x = 1\n", encoding="utf-8")
-    env = _git_env(
+    from codebase_rag.tests.conftest import git_env
+
+    env = git_env(
         GIT_CONFIG_GLOBAL=str(git_repo / "absent"),
         GIT_CONFIG_SYSTEM=str(git_repo / "absent"),
         GIT_DEFAULT_HASH="sha1",
@@ -748,7 +781,9 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
     already rejects packs, `*.idx`, `commit-graph` and the decoy by name.
     `_FANOUT_DIR` is a narrowing optimisation here, not independently pinned.
     """
-    env = _git_env(
+    from codebase_rag.tests.conftest import git_env
+
+    env = git_env(
         GIT_CONFIG_GLOBAL=str(tmp_path / "absent"),
         GIT_CONFIG_SYSTEM=str(tmp_path / "absent"),
         GIT_DEFAULT_HASH="sha1",
@@ -816,7 +851,9 @@ def test_the_loose_object_filter_accepts_a_sha256_repo(
     the pins deliberately exclude, so the sha256 branch is pinned behaviour
     rather than uncovered code that can be dropped silently.
     """
-    env = _git_env(
+    from codebase_rag.tests.conftest import git_env
+
+    env = git_env(
         GIT_CONFIG_GLOBAL=str(tmp_path / "absent"),
         GIT_CONFIG_SYSTEM=str(tmp_path / "absent"),
         GIT_DEFAULT_HASH="sha256",

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -1,0 +1,298 @@
+"""A read-only object under `tmp_path` must not survive into pytest's cleanup.
+
+`_clear_readonly` (conftest) rescues the `temp_repo` fixture, but it only runs
+for fixtures that opt into it. The sweep on issue #1622 found five tests that
+call `git init` under a bare `tmp_path` and hand the result to pytest's own
+`tmp_path` retention cleanup instead:
+
+    codebase_rag/tests/test_indexing_bench.py:124  :146  :164  :180  :203
+
+Git writes every loose object mode `-r--r--r--`, so on Windows those trees
+cannot be removed. This is LATENT rather than a current red because pytest
+keeps the last few basetemps and garbage-collects them in a LATER session with
+errors ignored, so the failure never lands on the test that created the tree.
+
+WHY THE MAIN TESTS RUN A NESTED PYTEST SESSION
+----------------------------------------------
+The property under test belongs to the AUTOUSE FIXTURE, not to the helper it
+calls. A test that calls `_make_tmp_path_removable` directly passes whether or
+not any fixture ever invokes it -- measured, not hypothesised: with the
+fixture body disabled, five such tests all still passed. So the discriminating
+tests plant a read-only tree in an INNER test and then inspect that inner
+test's `tmp_path` from the outside, which is the only vantage point that can
+tell "the default ran" from "the default is gone".
+
+WHY THEY SIMULATE WINDOWS RATHER THAN CALLING `rmtree`
+-------------------------------------------------------
+POSIX `unlink` needs write permission on the containing DIRECTORY and ignores
+the file's own mode, so a real `rmtree` over a read-only file SUCCEEDS on
+macOS and Linux -- with or without the fix. The removal here is therefore
+driven through a stub that refuses a path lacking the owner write bit, which
+is what Windows does.
+
+The Windows CI job is a NON-REGRESSION check for this fix, not evidence for
+it: the defect it guards against is invisible there too, for the retention
+reason above.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+# Planted by the inner session so the outer test can find the tree afterwards.
+_INNER_TEST = """
+import os
+import stat
+from pathlib import Path
+
+
+def test_plants_a_readonly_object(tmp_path):
+    objects = tmp_path / "repo" / ".git" / "objects" / "ab"
+    objects.mkdir(parents=True)
+    loose = objects / "cdef0123456789"
+    loose.write_text("object", encoding="utf-8")
+    loose.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    assert not os.stat(loose).st_mode & stat.S_IWUSR
+    Path(os.environ["CGR_PLANTED_PATH_RECORD"]).write_text(
+        str(tmp_path), encoding="utf-8"
+    )
+"""
+
+
+def _plant_readonly_object(root: Path) -> Path:
+    """Write a file with git's loose-object mode: read-only for everyone."""
+    objects = root / ".git" / "objects" / "ab"
+    objects.mkdir(parents=True)
+    loose = objects / "cdef0123456789"
+    loose.write_text("object", encoding="utf-8")
+    loose.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    return loose
+
+
+class _WindowsRemovalSemantics:
+    """`os.unlink`/`os.rmdir` that refuse a path without the owner write bit.
+
+    This is the whole reason #1586 exists, and the only behaviour that
+    separates Windows from the platforms this suite is usually run on.
+    """
+
+    def __init__(self) -> None:
+        self._real_unlink = os.unlink
+        self._real_rmdir = os.rmdir
+
+    def _refuse_if_readonly(self, path: str | os.PathLike[str]) -> None:
+        mode = os.stat(path).st_mode
+        if not mode & stat.S_IWUSR:
+            raise PermissionError(13, "Access is denied", str(path))
+
+    def unlink(self, path: str | os.PathLike[str], **kwargs: object) -> None:
+        self._refuse_if_readonly(path)
+        self._real_unlink(path)
+
+    def rmdir(self, path: str | os.PathLike[str], **kwargs: object) -> None:
+        self._refuse_if_readonly(path)
+        self._real_rmdir(path)
+
+
+def _remove_tree_windows_style(root: Path, semantics: _WindowsRemovalSemantics) -> None:
+    """Depth-first removal using the refusing primitives.
+
+    Deliberately not `shutil.rmtree`: rmtree resolves `os.unlink` at call time
+    from the real module, so monkeypatching it is not reliably observed. Doing
+    the walk here makes the refusal explicit and the failure attributable.
+    """
+    for dirpath, dirnames, filenames in os.walk(root, topdown=False):
+        for name in filenames:
+            semantics.unlink(os.path.join(dirpath, name))
+        for name in dirnames:
+            semantics.rmdir(os.path.join(dirpath, name))
+    semantics.rmdir(root)
+
+
+def _run_inner_session_planting_a_readonly_repo(
+    pytester: pytest.Pytester,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Run a nested pytest whose test leaves a read-only repo in its tmp_path.
+
+    Returns that inner `tmp_path`, still on disk: pytest retains recent
+    basetemps rather than deleting them at session end, which is exactly the
+    behaviour that makes this defect latent and also what lets us inspect it.
+    """
+    record = tmp_path / "planted-path.txt"
+    pytester.makepyfile(test_plant=_INNER_TEST)
+    # `pytester` runs the inner session in an isolated directory, so it does
+    # NOT pick up this project's conftest. Re-export the real fixture into the
+    # inner session rather than copying its body: a copy would drift, and a
+    # test proving a copy works proves nothing about the fixture that ships.
+    pytester.makeconftest(
+        "from codebase_rag.tests.conftest import (  # noqa: F401\n"
+        "    _tmp_path_stays_removable,\n"
+        ")\n"
+    )
+    # The subprocess inherits the environment, so this is how the inner test
+    # is told where to report its tmp_path, and how it finds the package.
+    monkeypatch.setenv("CGR_PLANTED_PATH_RECORD", str(record))
+    monkeypatch.setenv("PYTHONPATH", str(Path(__file__).resolve().parents[2]))
+    result = pytester.runpytest_subprocess("-p", "no:cacheprovider", "-q")
+    result.assert_outcomes(passed=1)
+    assert record.is_file(), "inner test did not report its tmp_path"
+    planted = Path(record.read_text(encoding="utf-8").strip())
+    assert planted.is_dir(), f"inner tmp_path is gone: {planted}"
+    return planted
+
+
+def test_windows_semantics_stub_is_in_force(tmp_path: Path) -> None:
+    """Control: the stub must actually refuse, or every other test is vacuous.
+
+    Without this, a stub that silently permitted everything would make the
+    fix's green meaningless -- the same shape as asserting a real `rmtree`
+    succeeded on macOS.
+    """
+    root = tmp_path / "control"
+    root.mkdir()
+    _plant_readonly_object(root)
+
+    with pytest.raises(PermissionError):
+        _remove_tree_windows_style(root, _WindowsRemovalSemantics())
+
+
+def test_default_teardown_clears_readonly_left_by_another_test(
+    pytester: pytest.Pytester, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE discriminating test: the autouse default must have run by itself.
+
+    The inner test never asks for any helper -- it plants a read-only object
+    under a bare `tmp_path` exactly as the five swept call sites do. If the
+    autouse fixture is present, the object is writable by the time the inner
+    session ends; if it is removed, it is not. Nothing here calls
+    `_make_tmp_path_removable`, which is what makes the mutation detectable.
+    """
+    planted = _run_inner_session_planting_a_readonly_repo(
+        pytester, tmp_path, monkeypatch
+    )
+
+    loose = planted / "repo" / ".git" / "objects" / "ab" / "cdef0123456789"
+    assert loose.is_file(), f"planted object missing: {loose}"
+    assert os.stat(loose).st_mode & stat.S_IWUSR, (
+        "the autouse teardown did not clear the read-only bit a test left "
+        "under tmp_path, so pytest's later retention cleanup would fail to "
+        "remove it on Windows (issue #1622)"
+    )
+
+
+def test_tree_left_by_another_test_is_removable_under_windows_semantics(
+    pytester: pytest.Pytester, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End to end: the retained tree survives a Windows-style removal.
+
+    The bit-level assertion above says the mode changed; this says the change
+    is sufficient for the removal pytest will later attempt.
+    """
+    planted = _run_inner_session_planting_a_readonly_repo(
+        pytester, tmp_path, monkeypatch
+    )
+
+    _remove_tree_windows_style(planted / "repo", _WindowsRemovalSemantics())
+    assert not (planted / "repo").exists()
+
+
+def test_teardown_preserves_content_and_traversability(tmp_path: Path) -> None:
+    """Adding the write bit must not strip a directory's search bit.
+
+    `chmod(path, S_IWRITE)` SETS the mode to 0o200, making a directory
+    untraversable for good -- the exact hazard `_clear_readonly` documents.
+    A teardown that did that would turn a recoverable state into a permanent
+    one. Calls the helper directly on purpose: this pins the helper's own
+    contract, and is not the test that discriminates the fixture.
+    """
+    from codebase_rag.tests.conftest import _make_tmp_path_removable
+
+    root = tmp_path / "traversable"
+    nested = root / "a" / "b"
+    nested.mkdir(parents=True)
+    (nested / "leaf.txt").write_text("leaf", encoding="utf-8")
+    (root / "a").chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+    _make_tmp_path_removable(tmp_path)
+
+    assert (nested / "leaf.txt").read_text(encoding="utf-8") == "leaf"
+    assert os.stat(root / "a").st_mode & stat.S_IXUSR, (
+        "the write bit must be ADDED to the existing mode, never assigned: "
+        "assigning 0o200 to a directory makes it permanently untraversable"
+    )
+
+
+def test_teardown_tolerates_a_path_that_vanishes(tmp_path: Path) -> None:
+    """Git's background maintenance deletes its own lock asynchronously.
+
+    `_clear_readonly` documents this TOCTOU (it surfaced only under xdist on
+    CI). The default teardown walks the same trees and must not raise when an
+    entry disappears between the walk and the chmod.
+    """
+    from codebase_rag.tests.conftest import _make_tmp_path_removable
+
+    root = tmp_path / "vanishing"
+    root.mkdir()
+    doomed = root / "maintenance.lock"
+    doomed.write_text("lock", encoding="utf-8")
+
+    real_chmod = os.chmod
+
+    def chmod_after_vanishing(path: object, mode: int, **kwargs: object) -> None:
+        if Path(str(path)) == doomed:
+            real_chmod(doomed, stat.S_IWUSR | stat.S_IRUSR)
+            doomed.unlink()
+            raise FileNotFoundError(2, "No such file or directory", str(path))
+        real_chmod(path, mode, **kwargs)  # type: ignore[arg-type]
+
+    original = os.chmod
+    os.chmod = chmod_after_vanishing  # type: ignore[assignment]
+    try:
+        _make_tmp_path_removable(tmp_path)
+    finally:
+        os.chmod = original  # type: ignore[assignment]
+
+    assert not doomed.exists()
+
+
+def test_git_repo_fixture_tears_down_its_own_readonly_objects(
+    git_repo: Path,
+) -> None:
+    """The opt-in fixture must produce a real repo with real loose objects.
+
+    Teardown itself is exercised by the fixture running at all; what this
+    pins is that the repo is genuine, so the fixture is a true replacement
+    for a hand-rolled `git init` at the five swept call sites.
+    """
+    import subprocess
+
+    assert (git_repo / ".git").is_dir()
+    (git_repo / "a.py").write_text("x = 1\n", encoding="utf-8")
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": str(git_repo / "absent"),
+        "GIT_CONFIG_SYSTEM": str(git_repo / "absent"),
+    }
+    subprocess.run(["git", "add", "a.py"], cwd=git_repo, check=True, env=env)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "c"],
+        cwd=git_repo,
+        check=True,
+        env=env,
+    )
+    loose = [
+        Path(dirpath) / name
+        for dirpath, _dirs, files in os.walk(git_repo / ".git" / "objects")
+        for name in files
+    ]
+    assert loose, "git wrote no loose objects, so the fixture proves nothing"
+    assert any(not os.stat(p).st_mode & stat.S_IWUSR for p in loose), (
+        "no loose object is read-only: the condition this fixture exists to "
+        "survive was never created"
+    )

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -567,14 +567,18 @@ _LOOSE_OBJECT = re.compile(r"[0-9a-f]{38}|[0-9a-f]{62}")
 def _collect_loose_objects(repo: Path) -> tuple[list[str], list[int]]:
     """Return the loose objects under `repo`, and which of them are read-only.
 
-    Counts ONLY `objects/<2 hex>/<38 hex>`. Everything else under `objects/`
-    is a different kind of file, and several are mode 444: `pack/*.pack`,
-    `*.idx`, `*.rev`, `commit-graph`. Walking all of `objects/` would let those
-    satisfy a "git wrote read-only loose objects" assertion with zero loose
-    objects present -- the exact state such an assertion exists to reject.
-    Git only packs at `gc.auto` (6700) loose objects, so the fixture cannot
-    reach that today, but the guard must not depend on that staying true.
-    `test_the_loose_object_filter_rejects_a_packed_repo` pins the difference.
+    Counts ONLY `objects/<2 hex>/<38 or 62 hex>` (sha1 or sha256 basenames).
+    Everything else under `objects/` is a different kind of file, and several
+    are mode 444: `pack/*.pack`, `*.idx`, `*.rev`, `commit-graph`. Walking all
+    of `objects/` would let those satisfy a "git wrote read-only loose
+    objects" assertion with zero loose objects present -- the exact state such
+    an assertion exists to reject. Git only packs at `gc.auto` (6700) loose
+    objects, so the fixture cannot reach that today, but the guard must not
+    depend on that staying true.
+    `test_the_loose_object_filter_rejects_a_packed_repo` pins the packed
+    difference; `test_the_loose_object_filter_accepts_a_sha256_repo` pins the
+    62-hex branch, which the sha1 pins in every other fixture would otherwise
+    leave uncovered.
 
     Modes are read AT LISTING TIME, one `lstat` per entry, never a second
     pass. `git commit` spawns `git maintenance run --auto --quiet --detach`,
@@ -633,7 +637,8 @@ def test_git_repo_fixture_tears_down_its_own_readonly_objects(
         check=True,
         env=env,
     )
-    # Count ONLY loose objects: `objects/<2 hex>/<38 hex>`. Everything else
+    # Count ONLY loose objects: `objects/<2 hex>/<38 or 62 hex>` (sha1 or
+    # sha256 basenames). Everything else
     # under `objects/` is a different kind of file, and several of them are
     # mode 444 -- `pack/*.pack`, `*.idx`, `*.rev`, `commit-graph`. Walking all
     # of `objects/` would let those satisfy both guards below with zero loose
@@ -712,3 +717,60 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
         "no longer discriminates and the fixture guard is satisfied by packs"
     )
     assert readonly_modes == []
+
+
+def test_the_loose_object_filter_accepts_a_sha256_repo(
+    tmp_path: Path,
+) -> None:
+    """The 62-hex half of the predicate must be observable from the suite.
+
+    Every other test here pins `GIT_DEFAULT_HASH=sha1`, so nothing else can
+    tell `[0-9a-f]{38}` from `[0-9a-f]{38}|[0-9a-f]{62}`: reverting the regex
+    to sha1-only leaves the whole file green. This test builds the one repo
+    the pins deliberately exclude, so the sha256 branch is pinned behaviour
+    rather than uncovered code that can be dropped silently.
+    """
+    env = {
+        **os.environ,
+        "GIT_CONFIG_GLOBAL": str(tmp_path / "absent"),
+        "GIT_CONFIG_SYSTEM": str(tmp_path / "absent"),
+        "GIT_DEFAULT_HASH": "sha256",
+    }
+    repo = tmp_path / "sha256"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+
+    # Not every git builds with sha256. Assert the repo really is sha256
+    # rather than skipping on a falsy check: an empty `listed` below would
+    # otherwise read identically whether the branch is broken or the repo was
+    # never sha256 in the first place.
+    fmt = subprocess.run(
+        ["git", "rev-parse", "--show-object-format"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout.strip()
+    if fmt != "sha256":
+        pytest.skip(f"git does not support sha256 object format (got {fmt!r})")
+
+    (repo / "a.py").write_text("x = 1\n")
+    subprocess.run(["git", "add", "a.py"], cwd=repo, check=True, env=env)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "c"],
+        cwd=repo,
+        check=True,
+        env=env,
+    )
+
+    listed, _readonly_modes = _collect_loose_objects(repo)
+    assert listed, (
+        "a sha256 repo's loose objects were all discarded: the 62-hex half of "
+        "`_LOOSE_OBJECT` no longer matches, so the helper silently reports an "
+        "empty repo instead of the objects git wrote"
+    )
+    assert all(len(name) == 62 for name in listed), (
+        f"expected 62-hex sha256 basenames, got lengths "
+        f"{sorted({len(n) for n in listed})}"
+    )

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -265,6 +265,41 @@ def test_teardown_reaches_a_subtree_under_any_directory_mode(
     assert not root.exists()
 
 
+@pytest.mark.parametrize("root_mode", [0o000, 0o100, 0o200, 0o300, 0o400], ids=oct)
+def test_teardown_reaches_a_subtree_under_a_restrictive_root(
+    tmp_path: Path, root_mode: int
+) -> None:
+    """The mode of the ROOT the helper is handed, not of a directory inside it.
+
+    A separate axis from the one above: every walk has to list the root, so a
+    root missing `S_IREAD` blocks all of them and a retry re-walks a root that
+    is still unreadable. Widening it last cannot help the passes that already
+    failed, which is why the root is widened before the walks rather than
+    after them.
+
+    The root here is a subdirectory standing in for `tmp_path`, since chmod-ing
+    the real `tmp_path` would obstruct pytest's own cleanup of it.
+    """
+    from codebase_rag.tests.conftest import _make_tmp_path_removable
+
+    root = tmp_path / f"root-{root_mode:o}"
+    inner = root / "repo"
+    inner.mkdir(parents=True)
+    buried = inner / "loose-object"
+    buried.write_text("object", encoding="utf-8")
+    buried.chmod(stat.S_IRUSR)
+    root.chmod(root_mode)
+
+    _make_tmp_path_removable(root)
+
+    assert os.stat(buried).st_mode & stat.S_IWUSR, (
+        f"a file under a {root_mode:#o} ROOT was never reached: every walk "
+        "must list the root, so widening it after them is too late"
+    )
+    _remove_tree_windows_style(root, _WindowsRemovalSemantics())
+    assert not root.exists()
+
+
 def test_teardown_tolerates_a_path_that_vanishes(tmp_path: Path) -> None:
     """Git's background maintenance deletes its own lock asynchronously.
 
@@ -296,6 +331,75 @@ def test_teardown_tolerates_a_path_that_vanishes(tmp_path: Path) -> None:
         os.chmod = original  # type: ignore[assignment]
 
     assert not doomed.exists()
+
+
+def test_clear_readonly_makes_a_zero_mode_directory_listable(tmp_path: Path) -> None:
+    """`_clear_readonly` must leave a directory ENUMERABLE, not just enterable.
+
+    Drives the handler directly through `shutil.rmtree(onexc=...)` rather than
+    through `_make_tmp_path_removable`, so the two cannot cover for each
+    other: this is the #1586 handler's own contract, and every `git_repo`
+    teardown depends on it.
+
+    Without `S_IREAD` the handler turns a `0o000` directory into `0o300` --
+    traversable but not listable -- so `rmtree` fails again on the directory
+    the handler just claimed to fix, and pytest's own `chmod_rw` (which adds
+    `S_IRUSR|S_IWUSR` and no `S_IXUSR`) cannot repair it either. That residue
+    was found in the shared temp area during review of this change.
+    """
+    import shutil
+
+    from codebase_rag.tests.conftest import _clear_readonly
+
+    root = tmp_path / "sealed"
+    inner = root / "objects"
+    inner.mkdir(parents=True)
+    buried = inner / "loose-object"
+    buried.write_text("object", encoding="utf-8")
+    buried.chmod(stat.S_IRUSR)
+    inner.chmod(0o000)
+
+    shutil.rmtree(root, onexc=_clear_readonly)
+
+    assert not root.exists(), (
+        "rmtree could not remove a tree containing a 0o000 directory: the "
+        "handler made it traversable but not listable, so the retry failed "
+        "on the same directory"
+    )
+
+
+def test_clear_readonly_removes_nested_zero_mode_directories(tmp_path: Path) -> None:
+    """A `0o000` directory INSIDE another `0o000` directory.
+
+    Where "abandon and move on" bites twice: `rmtree` gives up on the outer
+    directory when its listing fails, so nothing revisits the inner one
+    either. A handler that recurses only one level deep, or that merely
+    widens modes, leaves the inner tree behind and the outer `rmdir` fails
+    with "Directory not empty".
+    """
+    import shutil
+
+    from codebase_rag.tests.conftest import _clear_readonly
+
+    root = tmp_path / "nested"
+    outer = root / "outer"
+    inner = outer / "inner"
+    inner.mkdir(parents=True)
+    for depth, directory in ((0, outer), (1, inner)):
+        buried = directory / f"loose-{depth}"
+        buried.write_text("object", encoding="utf-8")
+        buried.chmod(stat.S_IRUSR)
+    # Innermost first: chmod-ing the outer one first would block the inner.
+    inner.chmod(0o000)
+    outer.chmod(0o000)
+
+    shutil.rmtree(root, onexc=_clear_readonly)
+
+    assert not root.exists(), (
+        "a 0o000 directory nested inside another survived teardown: rmtree "
+        "abandons the outer subtree on a listing failure, so the handler has "
+        "to remove it rather than expecting a retry"
+    )
 
 
 def test_git_repo_fixture_tears_down_its_own_readonly_objects(

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -228,6 +228,43 @@ def test_teardown_preserves_content_and_traversability(tmp_path: Path) -> None:
     )
 
 
+# `ids` in octal: pytest's default renders these decimal, so a failing case
+# reads as `[256]` and a reader grepping the log for `0o400` finds nothing.
+@pytest.mark.parametrize("dir_mode", [0o000, 0o400, 0o444, 0o500, 0o600], ids=oct)
+def test_teardown_reaches_a_subtree_under_any_directory_mode(
+    tmp_path: Path, dir_mode: int
+) -> None:
+    """Every restrictive directory mode, not just the one that happens to work.
+
+    Parametrised because a single mode cannot cover this: `0o500` keeps the
+    search bit and descends normally, `0o400` blocks traversal, and `0o000`
+    is never YIELDED by `os.walk` at all -- it raises while listing and is
+    skipped silently, so it is only reachable through its parent's
+    `dirnames`. A directory also needs READ to be enumerated, not just
+    EXECUTE to be entered: widened to `0o300` it is traversable and still
+    unlistable. Each of those is a different way for the subtree to strand,
+    and picking any one mode hides the other two.
+    """
+    from codebase_rag.tests.conftest import _make_tmp_path_removable
+
+    root = tmp_path / f"mode-{dir_mode:o}"
+    inner = root / "inner"
+    inner.mkdir(parents=True)
+    buried = inner / "loose-object"
+    buried.write_text("object", encoding="utf-8")
+    buried.chmod(stat.S_IRUSR)
+    inner.chmod(dir_mode)
+
+    _make_tmp_path_removable(tmp_path)
+
+    assert os.stat(buried).st_mode & stat.S_IWUSR, (
+        f"a file under a {dir_mode:#o} directory was never reached, so the "
+        "subtree stays read-only and strands pytest's later cleanup"
+    )
+    _remove_tree_windows_style(root, _WindowsRemovalSemantics())
+    assert not root.exists()
+
+
 def test_teardown_tolerates_a_path_that_vanishes(tmp_path: Path) -> None:
     """Git's background maintenance deletes its own lock asynchronously.
 

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -159,8 +159,9 @@ def test_windows_semantics_stub_is_in_force(tmp_path: Path) -> None:
     root.mkdir()
     _plant_readonly_object(root)
 
+    semantics = _WindowsRemovalSemantics()
     with pytest.raises(PermissionError):
-        _remove_tree_windows_style(root, _WindowsRemovalSemantics())
+        _remove_tree_windows_style(root, semantics)
 
 
 def test_default_teardown_clears_readonly_left_by_another_test(
@@ -318,7 +319,9 @@ def test_teardown_reaches_a_subtree_under_a_restrictive_root(
             root.chmod(0o700)
 
 
-def test_teardown_tolerates_a_path_that_vanishes(tmp_path: Path) -> None:
+def test_teardown_tolerates_a_path_that_vanishes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Git's background maintenance deletes its own lock asynchronously.
 
     `_clear_readonly` documents this TOCTOU (it surfaced only under xdist on
@@ -341,12 +344,12 @@ def test_teardown_tolerates_a_path_that_vanishes(tmp_path: Path) -> None:
             raise FileNotFoundError(2, "No such file or directory", str(path))
         real_chmod(path, mode, **kwargs)  # type: ignore[arg-type]
 
-    original = os.chmod
-    os.chmod = chmod_after_vanishing  # type: ignore[assignment]
-    try:
-        _make_tmp_path_removable(tmp_path)
-    finally:
-        os.chmod = original  # type: ignore[assignment]
+    # `monkeypatch`, not a hand-rolled save/restore: it undoes the patch even
+    # if the call below raises, and it cannot leak a patched `os.chmod` into
+    # another test in the same worker.
+    monkeypatch.setattr(os, "chmod", chmod_after_vanishing)
+
+    _make_tmp_path_removable(tmp_path)
 
     assert not doomed.exists()
 
@@ -577,13 +580,38 @@ def test_git_repo_fixture_tears_down_its_own_readonly_objects(
         check=True,
         env=env,
     )
-    loose = [
-        Path(dirpath) / name
-        for dirpath, _dirs, files in os.walk(git_repo / ".git" / "objects")
-        for name in files
-    ]
-    assert loose, "git wrote no loose objects, so the fixture proves nothing"
-    assert any(not os.stat(p).st_mode & stat.S_IWUSR for p in loose), (
-        "no loose object is read-only: the condition this fixture exists to "
-        "survive was never created"
+    # Mode read AT LISTING TIME, one `lstat` per entry, never a second pass.
+    # `git commit` spawns `git maintenance run --auto --quiet --detach`, which
+    # deletes its own `.git/objects/maintenance.lock` asynchronously, so a
+    # list-then-stat pair races it: the entry is listed and gone by the time
+    # the stat runs. That is the TOCTOU `_clear_readonly` documents, and it
+    # failed exactly once, on macos/3.13 under xdist (#1622).
+    #
+    # A vanished entry is skipped rather than tolerated after the fact: it
+    # cannot be the read-only loose object this asserts on, because a loose
+    # object is permanent for the life of the repo while the lock is
+    # transient. `maintenance.lock` is excluded by name for the same reason --
+    # it is not an object at all, so counting it would let a run where git
+    # wrote NO objects satisfy the guard below.
+    readonly_modes: list[int] = []
+    listed: list[str] = []
+    for dirpath, _dirs, _files in os.walk(git_repo / ".git" / "objects"):
+        with os.scandir(dirpath) as entries:
+            for entry in entries:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if entry.name.endswith(".lock"):
+                    continue
+                try:
+                    mode = entry.stat(follow_symlinks=False).st_mode
+                except FileNotFoundError:
+                    continue
+                listed.append(entry.name)
+                if not mode & stat.S_IWUSR:
+                    readonly_modes.append(mode)
+
+    assert listed, "git wrote no loose objects, so the fixture proves nothing"
+    assert readonly_modes, (
+        f"no loose object is read-only ({len(listed)} listed): the condition "
+        "this fixture exists to survive was never created"
     )

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -400,6 +401,72 @@ def test_clear_readonly_removes_nested_zero_mode_directories(tmp_path: Path) -> 
         "abandons the outer subtree on a listing failure, so the handler has "
         "to remove it rather than expecting a retry"
     )
+
+
+def test_clear_readonly_survives_an_unremovable_entry(tmp_path: Path) -> None:
+    """An entry that can never be removed must report its error, not recurse.
+
+    The recursive branch re-enters the handler for the SAME directory when a
+    child cannot be removed, so without a progress guard this is unbounded
+    recursion ending in `RecursionError` raised from inside teardown -- which
+    is strictly harder to attribute than the underlying `OSError`, and worse
+    than the loud failure the handler had before recursing was introduced.
+
+    Uses `chflags uchg` (macOS) to make a file genuinely unremovable rather
+    than monkeypatching, so the shape is the real one: an immutable file
+    inside a `0o000` directory is exactly a `.git/objects` tree that some
+    other process has locked.
+    """
+    import shutil
+    import subprocess
+
+    if not sys.platform.startswith("darwin"):
+        pytest.skip("chflags is macOS-only; the guard itself is portable")
+
+    from codebase_rag.tests.conftest import _clear_readonly
+
+    root = tmp_path / "immovable"
+    inner = root / "inner"
+    inner.mkdir(parents=True)
+    stuck = inner / "loose-object"
+    stuck.write_text("object", encoding="utf-8")
+    subprocess.run(["chflags", "uchg", str(stuck)], check=True)
+    inner.chmod(0o000)
+    try:
+        with pytest.raises(OSError) as caught:
+            shutil.rmtree(root, onexc=_clear_readonly)
+        assert not isinstance(caught.value, RecursionError), (
+            "the handler recursed without bound instead of surfacing the "
+            "real error for a path it cannot remove"
+        )
+    finally:
+        subprocess.run(["chflags", "nouchg", str(stuck)], check=False)
+        inner.chmod(0o700)
+
+
+@pytest.mark.parametrize(
+    "listing_func",
+    ["close", "islink", "scandir", "open", "lstat"],
+)
+def test_clear_readonly_never_calls_a_non_removal_func(
+    tmp_path: Path, listing_func: str
+) -> None:
+    """Only `os.unlink`/`os.rmdir` may be retried by calling `func(path)`.
+
+    `rmtree` passes several other callables, and each is wrong to call with a
+    single path: `os.open` wants `flags` and `os.close` wants a descriptor
+    (both raise TypeError out of teardown), while `os.path.islink` is a pure
+    query that removes nothing while looking like a successful retry. The
+    discriminator is a whitelist for that reason, so a callable nobody
+    anticipated is skipped rather than mis-called.
+    """
+    from codebase_rag.tests.conftest import _clear_readonly
+
+    func = getattr(os, listing_func, None) or getattr(os.path, listing_func)
+    target = tmp_path / "subject"
+    target.mkdir()
+
+    _clear_readonly(func, str(target), OSError(13, "boom"))
 
 
 def test_git_repo_fixture_tears_down_its_own_readonly_objects(

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -256,14 +256,24 @@ def test_teardown_reaches_a_subtree_under_any_directory_mode(
     buried.chmod(stat.S_IRUSR)
     inner.chmod(dir_mode)
 
-    _make_tmp_path_removable(tmp_path)
+    # `finally`, not a trailing statement: when an assertion below FAILS the
+    # tree keeps its restrictive modes, and pytest's later `rm_rf` of the
+    # basetemp then cannot remove it -- reporting `[Errno 66] Directory not
+    # empty` on an unrelated run days later. A test for cleanup that only
+    # cleans up when it passes strands exactly the state it exists to
+    # prevent, which is the harm this whole change is about.
+    try:
+        _make_tmp_path_removable(tmp_path)
 
-    assert os.stat(buried).st_mode & stat.S_IWUSR, (
-        f"a file under a {dir_mode:#o} directory was never reached, so the "
-        "subtree stays read-only and strands pytest's later cleanup"
-    )
-    _remove_tree_windows_style(root, _WindowsRemovalSemantics())
-    assert not root.exists()
+        assert os.stat(buried).st_mode & stat.S_IWUSR, (
+            f"a file under a {dir_mode:#o} directory was never reached, so "
+            "the subtree stays read-only and strands pytest's later cleanup"
+        )
+        _remove_tree_windows_style(root, _WindowsRemovalSemantics())
+        assert not root.exists()
+    finally:
+        if inner.exists():
+            inner.chmod(0o700)
 
 
 @pytest.mark.parametrize("root_mode", [0o000, 0o100, 0o200, 0o300, 0o400], ids=oct)
@@ -291,14 +301,21 @@ def test_teardown_reaches_a_subtree_under_a_restrictive_root(
     buried.chmod(stat.S_IRUSR)
     root.chmod(root_mode)
 
-    _make_tmp_path_removable(root)
+    # See the `finally` on the directory-mode test above: a failing assertion
+    # here would otherwise leave `root` at its restrictive mode for pytest's
+    # cleanup to trip over.
+    try:
+        _make_tmp_path_removable(root)
 
-    assert os.stat(buried).st_mode & stat.S_IWUSR, (
-        f"a file under a {root_mode:#o} ROOT was never reached: every walk "
-        "must list the root, so widening it after them is too late"
-    )
-    _remove_tree_windows_style(root, _WindowsRemovalSemantics())
-    assert not root.exists()
+        assert os.stat(buried).st_mode & stat.S_IWUSR, (
+            f"a file under a {root_mode:#o} ROOT was never reached: every "
+            "walk must list the root, so widening it after them is too late"
+        )
+        _remove_tree_windows_style(root, _WindowsRemovalSemantics())
+        assert not root.exists()
+    finally:
+        if root.exists():
+            root.chmod(0o700)
 
 
 def test_teardown_tolerates_a_path_that_vanishes(tmp_path: Path) -> None:
@@ -360,13 +377,19 @@ def test_clear_readonly_makes_a_zero_mode_directory_listable(tmp_path: Path) -> 
     buried.chmod(stat.S_IRUSR)
     inner.chmod(0o000)
 
-    shutil.rmtree(root, onexc=_clear_readonly)
+    try:
+        shutil.rmtree(root, onexc=_clear_readonly)
 
-    assert not root.exists(), (
-        "rmtree could not remove a tree containing a 0o000 directory: the "
-        "handler made it traversable but not listable, so the retry failed "
-        "on the same directory"
-    )
+        assert not root.exists(), (
+            "rmtree could not remove a tree containing a 0o000 directory: "
+            "the handler made it traversable but not listable, so the retry "
+            "failed on the same directory"
+        )
+    finally:
+        # A failure here leaves a 0o000 directory for pytest's cleanup, which
+        # is the very state this change exists to prevent.
+        if inner.exists():
+            inner.chmod(0o700)
 
 
 def test_clear_readonly_removes_nested_zero_mode_directories(tmp_path: Path) -> None:
@@ -394,13 +417,19 @@ def test_clear_readonly_removes_nested_zero_mode_directories(tmp_path: Path) -> 
     inner.chmod(0o000)
     outer.chmod(0o000)
 
-    shutil.rmtree(root, onexc=_clear_readonly)
+    try:
+        shutil.rmtree(root, onexc=_clear_readonly)
 
-    assert not root.exists(), (
-        "a 0o000 directory nested inside another survived teardown: rmtree "
-        "abandons the outer subtree on a listing failure, so the handler has "
-        "to remove it rather than expecting a retry"
-    )
+        assert not root.exists(), (
+            "a 0o000 directory nested inside another survived teardown: "
+            "rmtree abandons the outer subtree on a listing failure, so the "
+            "handler has to remove it rather than expecting a retry"
+        )
+    finally:
+        # Outermost first: the inner chmod needs a traversable parent.
+        for directory in (outer, inner):
+            if directory.exists():
+                directory.chmod(0o700)
 
 
 def test_clear_readonly_survives_an_unremovable_entry(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1622.

## The sweep (part 1)

Enumerated every site creating a git repository under `tmp_path` and traced whether its teardown reaches `_clear_readonly`. Full table on the issue.

**5 unrouted instances across 4 test functions**, all in `codebase_rag/tests/test_indexing_bench.py` at `:124 :146 :164 :180 :203`, each via a file-local `_git(checkout, "init", "-q")` and each handing a bare `tmp_path` to pytest's own retention cleanup. A 6th at `integration/test_shell_command_integration.py:182` is unrouted but currently deselected by `-m "not integration"`, so it is one marker change from being live.

Correctly routed today: `conftest.py:397` (`temp_repo`, the #1586 fixture) and `test_temp_repo_readonly_cleanup.py:167` (the handler's own regression test).

Measured, not assumed:

1. `git init` + `add` + `commit` writes loose objects mode `-r--r--r--`.
2. `test_indexing_bench.py` carries no marker at all, and `testpaths` includes it.
3. The Windows job runs `pytest -n auto -m "not integration"`, which deselects the integration site but not these five.

## Why this is latent rather than a current red

`tmp_path` cleanup is not an unconditional `rmtree` at end of test. pytest keeps the last few basetemps (`_retention_count`) and garbage-collects them in a **later** session with errors ignored. So the failure never lands on the test that created the tree, which is why nobody has seen a red and why the sweep was needed to find them.

## The fix (part 2)

Two pieces, because a shared fixture alone is not a default:

* **`git_repo` fixture** for tests that want a repository, tearing down through `_clear_readonly`.
* **`_tmp_path_stays_removable`**, autouse, which after each test widens the owner write bit on everything under that test's `tmp_path`. This is what covers fixtures that never call the helper, **including ones not yet written** - the failure mode the sweep just demonstrated is easy to hit.

The five swept sites are left unedited on purpose: they need repositories at specific paths (`corpora/demo`, `src`) that `_ensure_corpus` requires, and the autouse default already covers them. Verified on the real shape rather than argued: a nested test built exactly like those call sites produced 3 loose objects, **0 still read-only** after teardown.

Three constraints inherited from `_clear_readonly`, each load-bearing:

* the bit is **added** to the existing mode, never assigned - `chmod(p, 0o200)` makes a directory permanently untraversable;
* symlinks are skipped, since `chmod` follows links and `follow_symlinks` is unsupported for chmod on Linux;
* a path that vanishes mid-walk is tolerated - git's background maintenance deletes its own lock asynchronously.

The root directory is widened after the walk, because `os.walk` yields the entries under a directory and never the directory it was given.

## Evidence

**Windows CI is a non-regression check here, not evidence for the fix.** The defect is invisible there for the same retention reason, so a green Windows job would be green with or without this change. The discriminating evidence is local and executed:

```
fix in place  -> 6 passed
fix disabled  -> 2 failed, 4 passed
```

with a production log line proving the mutation actually ran. The two that fail are the two that observe the fixture's effect from **outside**, via a nested `pytester` session that plants a read-only object in an inner test and inspects that inner `tmp_path` afterwards.

That shape was arrived at the hard way. The first version of these tests called `_make_tmp_path_removable` directly, and **all five passed with the fix disabled** - they tested the helper, not the fixture that must invoke it. Assertions satisfied by both the working and the broken code, invisible on re-reading and caught only by executing the mutation. The nested session is the only vantage point that separates "the default ran" from "the default is gone".

### The directory-mode axis

Review found a P1 in the first version of this fix: `os.walk` must traverse **into** a directory to enumerate it, so a directory missing the search bit yielded nothing and its entire subtree went un-widened - the same stranded-subtree defect this change exists to prevent, reintroduced inside the fix. Bottom-up ordering fixes the *order* of widening, never the *reachability* that listing requires.

Two further mechanisms sat underneath it, neither caught by the original report, both found by measuring every directory mode rather than one:

* a directory at `0o000` is never **yielded** by `os.walk` at all - it raises while listing and is skipped silently, so it is reachable only through its parent's `dirnames`;
* `widen` added write and execute but not **read**, and a directory at `0o300` is traversable while still not enumerable, so its children stayed stranded.

Neither of the two earlier mutations could have found this: both varied code in the fix, while the defect lives on the **directory mode** axis that the single `0o500` fixture held constant. `0o500` is the one read-only mode retaining the search bit, so it was the single value that stepped around the bug. Mutation covers only the axes you think to vary; the adversarial reader supplied this one.

Each mechanism now has its own executed kill, against the final file:

```
pre-pass removed  -> 4 failed (0o000, 0o400, 0o444, 0o600), 1 passed (0o500)
S_IREAD dropped   -> 1 failed (0o000), 4 passed
```

One failure is the correct kill for the second: `0o000` is the only mode where `S_IREAD` is load-bearing, since every other mode already carries the read bit. The count of failing cases measures how many parametrised cases exercise the mechanism, not the mutation's quality.

### The root's own mode, and the handler underneath

Re-review found two more, both fixed here:

* **The root was widened last.** Every walk has to list the root the helper is handed, so a root missing `S_IREAD` blocked all of them and the retry re-walked a root that was still unreadable. Fixing it after the walks cannot help passes that already failed. Measured before: roots at `0o000`/`0o100`/`0o200`/`0o300` all stranded, `0o400`+ succeeded. The root is now widened first.

* **`_clear_readonly` had the same `S_IREAD` bug.** The #1586 handler adds `S_IWRITE|S_IEXEC` and no read bit, so it turns a `0o000` directory into `0o300` - traversable but not enumerable - and `rmtree` fails again on the directory the handler just claimed to fix. Pytest's own `chmod_rw` adds `S_IRUSR|S_IWUSR` and no `S_IXUSR`, so it cannot repair it either. This is in scope rather than a follow-up: `_clear_readonly` *is* the safe teardown this issue names, and every `git_repo` teardown routes through it, so a default that still strands `0o000` through its own handler would close #1622 with the defect inside it.

  The evidence is a `0o300` directory found in the shared temp area during review, mtime `18:33:55`, predating this branch's commit at `18:36:14` - so it was the handler's output, not this change's. That artifact initially read as *this PR breaking pytest cleanup*; the mtime is what distinguished the two.

Each defect has its own executed kill, and each mutation printed a production log line proving it ran:

```
autouse fixture body disabled -> 2 failed, 4 passed
pre-pass + retry removed      -> 4 failed (0o000, 0o400, 0o444, 0o600), 1 passed (0o500)
S_IREAD dropped from helper   -> 1 failed (0o000), 4 passed
root widened last, not first  -> 4 failed (0o0, 0o100, 0o200, 0o300), 12 passed
S_IREAD dropped from handler  -> 1 failed (the handler test), 16 passed
```

The last one is the check that the two `S_IREAD` fixes are independent: the handler test drives `shutil.rmtree(onexc=_clear_readonly)` directly rather than going through the new helper, so neither covers for the other.

A real `rmtree` cannot discriminate either: POSIX `unlink` ignores a file's own mode, so it succeeds on macOS and Linux with or without the fix. Removal is therefore driven through a stub that refuses any path lacking the owner write bit, which is what Windows does. `test_windows_semantics_stub_is_in_force` is the control proving that stub actually refuses - without it, the other assertions would be vacuous.


## Two more, found after the fixes above

* **Unbounded recursion.** The recursive branch re-enters the handler for the *same* directory whenever a child cannot be removed (an immutable file, a read-only mount), turning a loud error into a `RecursionError` raised from inside teardown. Reproduced with no monkeypatching: `chflags uchg` on a file inside a `0o000` directory - a real `.git/objects` shape. An `_attempted` set, scoped per top-level `rmtree` and carried through the recursion, now lets the underlying error surface once. Module-level scoping would have been wrong: it would suppress a legitimate second attempt in a later test.

* **My own tests stranded directories.** The parametrised mode tests chmod to `0o000` and originally restored only on the success path, so a failing assertion would leave exactly the state this change exists to prevent. All four now restore in `finally`. The pre-existing `test_the_handler_leaves_a_directory_traversable` already carried this guard, with a comment saying so; I had read that file and not applied it.

## Evidence

**Windows CI is a non-regression check here, not evidence for the fix.** The defect is invisible there for the retention reason above, so a green Windows job would be green with or without this change. The discriminating evidence is local and executed.

Seven defects, each with its own kill, every mutation printing a production log line proving it ran and reverted through a trap so a killed run cannot strand the tree:

```
autouse fixture body disabled  -> 2 failed, 29 passed
pre-pass + retry removed       -> 4 failed (0o000,0o400,0o444,0o600), 1 passed (0o500)
S_IREAD dropped from helper    -> 5 failed, 26 passed
root widened last, not first   -> 4 failed (0o0,0o100,0o200,0o300), 27 passed
S_IREAD dropped from handler   -> 2 failed, 29 passed
recursive rmtree -> bare return-> 2 failed, 29 passed
_attempted guard removed       -> 1 failed, 30 passed  [36.5s vs ~4s: the runaway is visible in the timing]
exclusion set neutered         -> 5 failed, 26 passed
```

Against a true base (with `PYTHONPATH` forced to the base package, because a worktree otherwise resolves `codebase_rag` to the installed copy and every test passes vacuously): **23 failed, 1 passed** - the single passer being `test_windows_semantics_stub_is_in_force`, the deliberate control that tests no fixed code.

`_NON_REMOVAL_FUNCS` was derived by resolving `shutil`'s indirect `func = ...` bindings, not by scanning for `onexc(<name>)` - `_rmtree_safe_fd` binds `func` indirectly, so a naive scan misses `os.open` and `os.scandir`. The union is identical on 3.12, 3.13 and 3.14: five excluded, `os.rmdir`/`os.unlink` retried, nothing unaccounted for.

Full suite: **9030 passed, 0 failed**. The two touched files: 32 passed, zero unreadable directories left under a fresh `--basetemp`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cleanup of read-only temporary files and directories across nested, restricted-permission, and platform-specific scenarios.
  * Added regression coverage for disappearing paths, immutable entries, zero-permission directories, and non-removal callbacks.
  * Added consistent temporary Git repository setup and validation across supported object formats.
  * Expanded verification of generated files, directory accessibility, repository object discovery, and teardown reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->