### PR TITLE
fix: do not paste a failed advisory API response into release notes

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -176,7 +176,7 @@ jobs:
           if [ -n "$GHSA" ]; then
             DETAIL=$(gh api "repos/${GITHUB_REPOSITORY}/security-advisories/${GHSA}" \
               --jq '"\(.summary) (\(.severity) severity, CVSS \(.cvss.score // "n/a")), advisory [\(.ghsa_id)](https://github.com/'"${GITHUB_REPOSITORY}"'/security/advisories/\(.ghsa_id))\(if .cve_id then " / " + .cve_id else "" end)."' \
-              2>/dev/null || true)
+              2>/dev/null) || DETAIL=""
           fi
           {
             echo "## 🔒 Security"

--- a/codebase_rag/tests/test_release_news_derivation.py
+++ b/codebase_rag/tests/test_release_news_derivation.py
@@ -11,8 +11,10 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 _WORKFLOW = (
@@ -61,6 +63,11 @@ def _security_notice_script() -> str:
     return step["run"]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="the step runs under the Ubuntu runner's bash; on the Windows runner "
+    "`bash` resolves to the WSL launcher, which has no distribution installed",
+)
 def test_security_notice_falls_back_when_the_advisory_fetch_fails(
     tmp_path: Path,
 ) -> None:

--- a/codebase_rag/tests/test_release_news_derivation.py
+++ b/codebase_rag/tests/test_release_news_derivation.py
@@ -52,3 +52,49 @@ def test_no_step_feeds_existing_news_entries_to_a_model() -> None:
         script = step.get("run", "")
         assert "known.md" not in script
         assert "newsbullets" not in script
+
+
+def _security_notice_script() -> str:
+    step = next(
+        step for step in _steps() if step.get("name") == "Prepend security notice"
+    )
+    return step["run"]
+
+
+def test_security_notice_falls_back_when_the_advisory_fetch_fails(
+    tmp_path: Path,
+) -> None:
+    # `gh api` prints its HTTP error body to STDOUT, so a draft advisory the
+    # token cannot read used to land as the advisory line of the release
+    # notes (v0.0.845). The step must fall back to the "see advisory" pointer.
+    import os
+    import subprocess
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        "#!/bin/sh\nprintf '%s' '{\"message\":\"Resource not accessible by "
+        'integration","status":"403"}\'\nexit 1\n',
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    out = tmp_path / "security.md"
+    script = (
+        _security_notice_script()
+        .replace("${{ steps.decide.outputs.ghsa }}", "GHSA-aaaa-bbbb-cccc")
+        .replace("/tmp/security.md", str(out))
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        "GITHUB_REPOSITORY": "vitali87/code-graph-rag",
+    }
+
+    subprocess.run(["bash", "-e", "-c", script], check=True, env=env)
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "## 🔒 Security"
+    assert lines[2].startswith("This release contains a security fix; see advisory")
+    assert "GHSA-aaaa-bbbb-cccc" in lines[2]
+    assert not any("403" in line for line in lines)


### PR DESCRIPTION
## Problem

The v0.0.845 release shipped with this as its entire Security section:

```
## 🔒 Security

{"message":"Resource not accessible by integration","documentation_url":"...","status":"403"}

**Upgrading is strongly recommended.**
```

`gh api` writes its HTTP error body to **stdout**, so `2>/dev/null || true` suppressed the stderr and the exit code but still captured the 403 JSON into `DETAIL`. The following `[ -n "$DETAIL" ]` test then passed, and the error blob was published as the advisory detail line. The intended fallback ("see advisory GHSA-…") was unreachable whenever the fetch failed.

This is not a rare edge case: `GITHUB_TOKEN` can never read a **draft** advisory, and an advisory is normally still a draft when the security release is cut, so the fetch fails on essentially every security release. v0.0.670 avoided it only because its Security section was replaced by hand.

## Fix

```diff
-              2>/dev/null || true)
+              2>/dev/null) || DETAIL=""
```

`gh api` exits non-zero on 403, so `|| DETAIL=""` clears the captured body and the existing GHSA-pointer fallback runs as designed.

## Verification

Reproduced with a stub `gh` that prints a 403 body to stdout and exits 1, run under Actions' real invocation (`bash --noprofile --norc -eo pipefail`):

- old form → raw 403 JSON in the Security section
- new form → `This release contains a security fix; see advisory [GHSA-…](…).`
- success path → detail line emitted verbatim, unchanged
- 404, jq filter error, and exit-0-with-empty-stdout all fall back correctly
- errexit unaffected: `V=$(...) || V=""` is a `||` list, suppressing `-e` exactly as `|| true` did
- `/tmp/security.md` stays non-empty in all branches, so the section is never dropped

v0.0.845's notes have already been corrected by hand; this prevents a recurrence.

## Known limitation

This fixes the symptom, not the ordering. The workflow reads advisory details at a moment when the advisory is usually still a draft and therefore unreadable, so the enriched section will rarely appear — you get the pointer line instead. Regenerating the notes on the advisory `published` event would be the real fix; out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security notice generation when security-advisory details cannot be retrieved, ensuring an appropriate fallback notice is used.
  * Added validation to confirm the fallback notice displays correctly when advisory details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->