### PR TITLE
fix: publish the hash cache atomically with its stamp (#1646)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ evals/results/**/agentic_qa*records*.jsonl
 evals/results/logs/
 .cgr-parser-fingerprint
 .cgr-exclusion-state.json
+.cgr-*.tmp

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -268,8 +268,13 @@ def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
 
 def _publish_hash_cache(
     cache_path: Path, hashes: FileHashCache, observed_at: float | None
-) -> None:
+) -> bool:
     """Write the hash cache and its timestamp as one visible step.
+
+    Returns True when the cache is published, False when it is not. The
+    caller needs that answer: the directory-mtime map must not advance past
+    a hash cache that failed to publish, or the pair on disk becomes the
+    fresh-map/stale-cache combination that hides an addition entirely.
 
     `_is_already_in_sync` skips any file whose mtime is at or below this
     file's, so a cache carrying its own write time hides every edit made
@@ -293,6 +298,7 @@ def _publish_hash_cache(
             os.utime(tmp_path, (observed_at, observed_at))
         os.replace(tmp_path, cache_path)
         logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
+        return True
     except OSError as e:
         logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
         try:
@@ -307,6 +313,7 @@ def _publish_hash_cache(
             logger.warning(
                 ls.CACHE_STAMP_CLEANUP_FAILED, path=tmp_path, error=cleanup_error
             )
+        return False
 
 
 def _load_parser_fingerprint(stamp_path: Path) -> str | None:
@@ -1332,13 +1339,21 @@ class GraphUpdater:
         # compared, and the file loop only walks keys the hash cache already
         # names, so a file added in the gap is never indexed. Publishing the
         # hash cache first leaves the harmless window.
+        # A failed publish leaves the PREVIOUS hash cache on disk, so advancing
+        # the map anyway would build exactly the fresh-map/stale-cache pair the
+        # ordering above exists to avoid: nothing would be compared, and a file
+        # added during the run would never be indexed. Withholding the map
+        # keeps both artefacts one run behind, which only costs a rescan.
+        hash_cache_published = True
         if self._pending_hash_cache is not None:
             cache_path, new_hashes = self._pending_hash_cache
-            _publish_hash_cache(cache_path, new_hashes, observed_at)
+            hash_cache_published = _publish_hash_cache(
+                cache_path, new_hashes, observed_at
+            )
             self._pending_hash_cache = None
-        if self._pending_dir_mtimes is not None:
+        if self._pending_dir_mtimes is not None and hash_cache_published:
             _save_dir_mtimes(*self._pending_dir_mtimes)
-            self._pending_dir_mtimes = None
+        self._pending_dir_mtimes = None
         self._pending_cache_observed_at = None
 
         if self._single_file is None:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1309,18 +1309,20 @@ class GraphUpdater:
         # the next run that deletions were not reconciled, and that alone both
         # fails the sync check and turns graph-backed reconciliation on.
         observed_at = self._pending_cache_observed_at
-        # Hash cache FIRST, directory mtimes LAST. The pair is trusted in
-        # only one direction, and it is the reverse of what the reading
-        # suggests, so it was measured rather than reasoned: a stop leaving a
-        # FRESH dir-mtimes map beside a STALE hash cache is trusted, and the
-        # file added in the gap is never indexed. `_is_already_in_sync` walks
-        # the directories the dir-mtimes map records, so a fresh map lists the
-        # new directory as current and the scan finds nothing to look at,
-        # while the file loop only walks keys the hash cache already names.
-        # The opposite pairing is caught: a stale map has no entry for the new
-        # directory, so the walk reaches it and the mismatch surfaces. The
-        # dir-mtimes file is therefore the one whose arrival must mean "both
-        # are current".
+        # Hash cache FIRST, directory mtimes LAST, because a stop between the
+        # two leaves a mismatched pair that is only detected in one direction.
+        # `_is_already_in_sync` iterates the entries the map RECORDS, so it
+        # never reaches a directory the map has no entry for; what catches an
+        # addition is the recorded PARENT whose stored mtime no longer matches
+        # the directory on disk, which sends `_diff_dir_against_cache` into
+        # that parent to find the new child. A stale map still holds the
+        # parent's old mtime, so the addition surfaces. A FRESH map records
+        # the parent as current, nothing is compared, and the file loop only
+        # walks keys the hash cache already names, so a file added in the gap
+        # is never indexed. Publishing the hash cache first leaves the
+        # harmless window. Measured both directions, and the mechanism was
+        # confirmed by refreshing only the root entry: the addition then goes
+        # undetected even though its own directory is still absent.
         if self._pending_hash_cache is not None:
             cache_path, new_hashes = self._pending_hash_cache
             _publish_hash_cache(cache_path, new_hashes, observed_at)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -297,12 +297,16 @@ def _publish_hash_cache(
         logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
         try:
             tmp_path.unlink(missing_ok=True)
-        except OSError:
+        except OSError as cleanup_error:
+            # Bound separately: `e` is why the PUBLISH failed, and reporting
+            # that here would name a reason unrelated to the removal.
             # A filesystem too read-only to write the cache is too read-only
             # to have created the temporary, so there is normally nothing to
             # remove; if there is and it cannot go, the stale temporary is
             # inert (no reader looks for `.tmp`) and must not end the run.
-            logger.warning(ls.CACHE_STAMP_CLEANUP_FAILED, path=tmp_path, error=e)
+            logger.warning(
+                ls.CACHE_STAMP_CLEANUP_FAILED, path=tmp_path, error=cleanup_error
+            )
 
 
 def _load_parser_fingerprint(stamp_path: Path) -> str | None:
@@ -1312,17 +1316,20 @@ class GraphUpdater:
         # Hash cache FIRST, directory mtimes LAST, because a stop between the
         # two leaves a mismatched pair that is only detected in one direction.
         # `_is_already_in_sync` iterates the entries the map RECORDS, so it
-        # never reaches a directory the map has no entry for; what catches an
-        # addition is the recorded PARENT whose stored mtime no longer matches
-        # the directory on disk, which sends `_diff_dir_against_cache` into
-        # that parent to find the new child. A stale map still holds the
-        # parent's old mtime, so the addition surfaces. A FRESH map records
-        # the parent as current, nothing is compared, and the file loop only
-        # walks keys the hash cache already names, so a file added in the gap
-        # is never indexed. Publishing the hash cache first leaves the
-        # harmless window. Measured both directions, and the mechanism was
-        # confirmed by refreshing only the root entry: the addition then goes
-        # undetected even though its own directory is still absent.
+        # never reaches a directory the map has no entry for. What catches an
+        # addition is the recorded entry for the directory that DIRECTLY
+        # CONTAINS it, whose stored mtime no longer matches disk: that sends
+        # `_diff_dir_against_cache` into it to find the new child. For a new
+        # subdirectory that containing entry is the parent; for a file added
+        # to a directory already in the map it is that directory's own entry,
+        # and the parent contributes nothing. Measured both shapes by
+        # refreshing one entry at a time: refreshing the containing entry
+        # alone hides the addition, refreshing any other leaves it visible.
+        # A stale map holds every entry's old mtime, so the addition surfaces
+        # either way. A FRESH map records them all as current, nothing is
+        # compared, and the file loop only walks keys the hash cache already
+        # names, so a file added in the gap is never indexed. Publishing the
+        # hash cache first leaves the harmless window.
         if self._pending_hash_cache is not None:
             cache_path, new_hashes = self._pending_hash_cache
             _publish_hash_cache(cache_path, new_hashes, observed_at)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -266,6 +266,45 @@ def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
         logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
 
 
+def _publish_hash_cache(
+    cache_path: Path, hashes: FileHashCache, observed_at: float | None
+) -> None:
+    """Write the hash cache and its timestamp as one visible step.
+
+    `_is_already_in_sync` skips any file whose mtime is at or below this
+    file's, so a cache carrying its own write time hides every edit made
+    while the run was hashing. Writing then stamping leaves that exact state
+    on disk between the two calls, and a run that stops there hands it to its
+    successor. Building the whole thing on a temporary path and renaming it
+    into place closes that window: `os.replace` is atomic within a
+    filesystem, so a successor sees either the previous cache or a fully
+    stamped new one, never an unstamped new one.
+
+    On any failure the temporary file is removed and the PREVIOUS cache is
+    left untouched, which is the safe direction: a cache that is one run out
+    of date costs a rescan, while a mis-stamped one loses an edit.
+    """
+    tmp_path = cache_path.with_name(f"{cache_path.name}.{os.getpid()}.tmp")
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with tmp_path.open("w", encoding="utf-8") as f:
+            json.dump(hashes, f, indent=2)
+        if observed_at is not None:
+            os.utime(tmp_path, (observed_at, observed_at))
+        os.replace(tmp_path, cache_path)
+        logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
+    except OSError as e:
+        logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            # A filesystem too read-only to write the cache is too read-only
+            # to have created the temporary, so there is normally nothing to
+            # remove; if there is and it cannot go, the stale temporary is
+            # inert (no reader looks for `.tmp`) and must not end the run.
+            logger.warning(ls.CACHE_STAMP_CLEANUP_FAILED, path=tmp_path, error=e)
+
+
 def _load_parser_fingerprint(stamp_path: Path) -> str | None:
     try:
         return stamp_path.read_text(encoding="utf-8").strip() or None
@@ -1270,52 +1309,25 @@ class GraphUpdater:
         # the next run that deletions were not reconciled, and that alone both
         # fails the sync check and turns graph-backed reconciliation on.
         observed_at = self._pending_cache_observed_at
-        written: list[Path] = []
+        # Hash cache FIRST, directory mtimes LAST. The pair is trusted in
+        # only one direction, and it is the reverse of what the reading
+        # suggests, so it was measured rather than reasoned: a stop leaving a
+        # FRESH dir-mtimes map beside a STALE hash cache is trusted, and the
+        # file added in the gap is never indexed. `_is_already_in_sync` walks
+        # the directories the dir-mtimes map records, so a fresh map lists the
+        # new directory as current and the scan finds nothing to look at,
+        # while the file loop only walks keys the hash cache already names.
+        # The opposite pairing is caught: a stale map has no entry for the new
+        # directory, so the walk reaches it and the mismatch surfaces. The
+        # dir-mtimes file is therefore the one whose arrival must mean "both
+        # are current".
         if self._pending_hash_cache is not None:
-            _save_hash_cache(*self._pending_hash_cache)
-            written.append(self._pending_hash_cache[0])
+            cache_path, new_hashes = self._pending_hash_cache
+            _publish_hash_cache(cache_path, new_hashes, observed_at)
             self._pending_hash_cache = None
         if self._pending_dir_mtimes is not None:
             _save_dir_mtimes(*self._pending_dir_mtimes)
             self._pending_dir_mtimes = None
-        # Stamp the hash cache with the instant captured before hashing, not
-        # with the time the write happened, so the deferral cannot swallow an
-        # edit made while the hashing loop and passes 3 and later were still
-        # running. Only this file: `_is_already_in_sync` derives `cache_mtime`
-        # from the hash cache alone, and nothing anywhere stats the dir-mtimes
-        # file, whose entries are compared against the values stored INSIDE it.
-        # Backdating that one would be inert, and warning about it on failure
-        # would name a skipped file that cannot happen.
-        if observed_at is not None:
-            for path in written:
-                try:
-                    os.utime(path, (observed_at, observed_at))
-                except OSError as e:
-                    # Fail CLOSED. Leaving the file with its own write time is
-                    # exactly the defect this stamping exists to prevent: that
-                    # time is later than an edit made while the run was still
-                    # hashing, so the successor's `mtime <= cache_mtime` check
-                    # skips the edited file and the graph keeps stale content.
-                    # A missing cache only costs a rebuild, which is why every
-                    # writer here already degrades to absent rather than wrong.
-                    logger.warning(ls.CACHE_STAMP_FAILED, path=path, error=e)
-                    try:
-                        path.unlink(missing_ok=True)
-                    except OSError as unlink_error:
-                        # The canonical reason `utime` fails is a read-only
-                        # filesystem, and that same condition fails the unlink,
-                        # so this is the expected pairing rather than a remote
-                        # one. A run that cannot clean up must still finish:
-                        # every other filesystem writer on this path swallows
-                        # OSError, and crashing here would turn a degraded run
-                        # into no run at all. The cache is left mis-stamped and
-                        # the warning says so, because a silent pass would
-                        # leave the next run to discover it by skipping a file.
-                        logger.warning(
-                            ls.CACHE_STAMP_CLEANUP_FAILED,
-                            path=path,
-                            error=unlink_error,
-                        )
         self._pending_cache_observed_at = None
 
         if self._single_file is None:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1325,6 +1325,8 @@ class GraphUpdater:
         # and the parent contributes nothing. Measured both shapes by
         # refreshing one entry at a time: refreshing the containing entry
         # alone hides the addition, refreshing any other leaves it visible.
+        # Checked on all three shapes: a new subdirectory, a file added to a
+        # directory already recorded, and a file added at the repo root.
         # A stale map holds every entry's old mtime, so the addition surfaces
         # either way. A FRESH map records them all as current, nothing is
         # compared, and the file loop only walks keys the hash cache already

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -861,14 +861,9 @@ HASH_CACHE_LOADED = "Loaded hash cache with {count} entries from {path}"
 HASH_CACHE_LOAD_FAILED = "Failed to load hash cache from {path}: {error}"
 HASH_CACHE_SAVED = "Saved hash cache with {count} entries to {path}"
 HASH_CACHE_SAVE_FAILED = "Failed to save hash cache to {path}: {error}"
-CACHE_STAMP_FAILED = (
-    "Could not backdate {path} to the observed instant ({error}); removing it so "
-    "the next run rebuilds rather than trusting a stamp that can hide edits"
-)
 CACHE_STAMP_CLEANUP_FAILED = (
-    "Could not remove {path} after its backdate failed ({error}); it keeps a write "
-    "time later than any edit made during this run, so the next run may skip that "
-    "file. Delete it by hand, or re-run once the path is writable"
+    "Could not remove the temporary cache file {path} ({error}); it is inert, since "
+    "nothing reads a .tmp path, but it can be deleted by hand"
 )
 PERIODIC_FLUSH = "Periodic flush after {count} files processed"
 INCREMENTAL_SKIPPED = "Skipped {count} unchanged files"

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -562,9 +562,14 @@ class TestCrashBetweenCacheSaveAndFlush:
         (a live cache stamped in place, removed when the stamp failed). That
         code path is gone: the cache is built on a temporary path and renamed,
         so the live file is never mutated and never needs removing. The OUTER
-        contract those tests existed for survives and is what this asserts -
+        contract those tests existed for survives and is what this asserts:
         indexing work must not be forfeited because a cache could not be
-        written - so all three steps that can now refuse are refused at once.
+        written. All three publish steps are refused, but the write is the one
+        that fires - it short-circuits `_publish_hash_cache` before the stamp
+        or the rename is reached - so the `utime` and `replace` refusals stand
+        as guards against a future reordering rather than as live assertions.
+        The cleanup branch they leave unexercised is covered by the test
+        below.
         """
         parsers, queries = load_parsers()
         GraphUpdater(
@@ -638,6 +643,74 @@ class TestCrashBetweenCacheSaveAndFlush:
         leftovers = sorted(q.name for q in py_project.glob("*.tmp"))
         assert not leftovers, f"temporary cache files were left behind: {leftovers}"
 
+    def test_a_temp_that_cannot_be_cleaned_up_does_not_end_the_run(
+        self,
+        py_project: Path,
+        mock_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The publish fails after the temp exists, and the temp cannot go.
+
+        Restores the pairing the #1644 tests pinned before the publish became
+        atomic: one failure the handler expects, plus a second failure in the
+        handler's own cleanup. The test above cannot reach this, because its
+        write refusal short-circuits before any temp file exists. A leftover
+        temp is inert, since nothing reads a `.tmp` path, so the run must
+        finish and the previous cache must survive untouched.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        cache = py_project / cs.HASH_CACHE_FILENAME
+        before = cache.read_text(encoding="utf-8")
+        assert "module_b.py" in before, (
+            "fixture guard: run 1 wrote no usable cache to preserve"
+        )
+
+        (py_project / "module_c.py").write_text(
+            "def c():\n    return 1\n", encoding="utf-8"
+        )
+
+        real_replace = os.replace
+        real_unlink = Path.unlink
+        reached: set[str] = set()
+
+        def _refuse_replace(src, dst, **kwargs):  # type: ignore[no-untyped-def]
+            if Path(dst).name == cs.HASH_CACHE_FILENAME:
+                reached.add("replace")
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_replace(src, dst, **kwargs)
+
+        def _refuse_unlink(self, missing_ok=False):  # type: ignore[no-untyped-def]
+            if self.name.endswith(".tmp"):
+                reached.add("cleanup")
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(graph_updater_module.os, "replace", _refuse_replace)
+        monkeypatch.setattr(Path, "unlink", _refuse_unlink)
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        monkeypatch.setattr(Path, "unlink", real_unlink)
+        monkeypatch.setattr(graph_updater_module.os, "replace", real_replace)
+
+        assert reached == {"replace", "cleanup"}, (
+            "the run did not reach both the failed rename and the failed "
+            f"cleanup, so finishing proves nothing about the pairing; {reached}"
+        )
+        assert cache.read_text(encoding="utf-8") == before, (
+            "the failed publish damaged the previous cache"
+        )
+
     def test_a_stop_between_the_two_cache_publishes_is_still_detected(
         self,
         py_project: Path,
@@ -647,13 +720,16 @@ class TestCrashBetweenCacheSaveAndFlush:
         """The two caches are published in the only safe order.
 
         They are separate files, so a run stopping between them leaves a
-        mismatched pair, and the pair is trusted in only ONE direction. A
-        FRESH dir-mtimes map beside a STALE hash cache is trusted: the sync
-        check walks the directories that map records, finds the new one listed
-        as current, and the file loop only walks keys the hash cache already
-        names, so a file added in the gap is never indexed. Publishing the
-        hash cache first makes the surviving window the harmless one, where a
-        stale map has no entry for the new directory and the mismatch shows.
+        mismatched pair, and the pair is trusted in only ONE direction. The
+        sync check iterates the entries the map RECORDS and so never reaches a
+        directory the map omits; what catches an addition is the recorded
+        PARENT whose stored mtime no longer matches disk, which sends
+        `_diff_dir_against_cache` into that parent to find the new child. A
+        FRESH map records the parent as current, nothing is compared, and the
+        file loop only walks keys the hash cache already names, so a file
+        added in the gap is never indexed. Publishing the hash cache first
+        leaves the harmless window, where a stale map still holds the parent's
+        old mtime and the addition surfaces.
 
         The stop is keyed on whichever publish happens SECOND rather than on
         either by name, so reversing the two calls still constructs a real

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -689,9 +689,11 @@ class TestCrashBetweenCacheSaveAndFlush:
         def _refuse_unlink(self, missing_ok=False):  # type: ignore[no-untyped-def]
             if self.name.endswith(".tmp"):
                 reached.add("cleanup")
-                raise OSError(errno.EROFS, "Read-only file system")
+                raise OSError(errno.EACCES, "Permission denied")
             return real_unlink(self, missing_ok=missing_ok)
 
+        messages: list[str] = []
+        sink_id = graph_updater_module.logger.add(messages.append, level="WARNING")
         monkeypatch.setattr(graph_updater_module.os, "replace", _refuse_replace)
         monkeypatch.setattr(Path, "unlink", _refuse_unlink)
         GraphUpdater(
@@ -702,7 +704,21 @@ class TestCrashBetweenCacheSaveAndFlush:
         ).run()
         monkeypatch.setattr(Path, "unlink", real_unlink)
         monkeypatch.setattr(graph_updater_module.os, "replace", real_replace)
+        # Removed here rather than left to the session: a sink that outlives
+        # this test appends to `messages` for every later test that warns.
+        graph_updater_module.logger.remove(sink_id)
 
+        cleanup_warnings = [m for m in messages if "temporary cache file" in m]
+        assert cleanup_warnings, (
+            "the cleanup failure was never logged, so its reported reason "
+            "cannot be checked"
+        )
+        # The publish failed EROFS and the removal EACCES; reporting the
+        # publish reason here would name a cause unrelated to the removal.
+        assert "Permission denied" in cleanup_warnings[0], (
+            "the cleanup warning reports the publish failure rather than why "
+            f"the removal failed: {cleanup_warnings[0]}"
+        )
         assert reached == {"replace", "cleanup"}, (
             "the run did not reach both the failed rename and the failed "
             f"cleanup, so finishing proves nothing about the pairing; {reached}"
@@ -723,13 +739,14 @@ class TestCrashBetweenCacheSaveAndFlush:
         mismatched pair, and the pair is trusted in only ONE direction. The
         sync check iterates the entries the map RECORDS and so never reaches a
         directory the map omits; what catches an addition is the recorded
-        PARENT whose stored mtime no longer matches disk, which sends
-        `_diff_dir_against_cache` into that parent to find the new child. A
-        FRESH map records the parent as current, nothing is compared, and the
-        file loop only walks keys the hash cache already names, so a file
-        added in the gap is never indexed. Publishing the hash cache first
-        leaves the harmless window, where a stale map still holds the parent's
-        old mtime and the addition surfaces.
+        entry for the directory that DIRECTLY CONTAINS it, whose stored mtime
+        no longer matches disk. For a new subdirectory that is the parent; for
+        a file added to a directory already in the map it is that directory's
+        own entry. A FRESH map records them all as current, nothing is
+        compared, and the file loop only walks keys the hash cache already
+        names, so a file added in the gap is never indexed. Publishing the
+        hash cache first leaves the harmless window, where a stale map still
+        holds the old mtimes and the addition surfaces.
 
         The stop is keyed on whichever publish happens SECOND rather than on
         either by name, so reversing the two calls still constructs a real

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -419,7 +419,7 @@ class TestCrashBetweenCacheSaveAndFlush:
 
         def _edit_then_save(
             path: Path, hashes: dict[str, str], observed_at: float | None
-        ) -> None:
+        ) -> bool:
             nonlocal reached_write_site
             reached_write_site = True
             # The observation instant is already captured by now, and this
@@ -432,7 +432,10 @@ class TestCrashBetweenCacheSaveAndFlush:
             # is still the newer of the two and the successor still skips.
             time.sleep(0.2)
             target.write_text(edited, encoding="utf-8")
-            real_save(path, hashes, observed_at)
+            # Pass the real verdict through: swallowing it would report a
+            # failed publish as a success and let the directory-mtime map
+            # advance past a cache that never landed.
+            return bool(real_save(path, hashes, observed_at))
 
         monkeypatch.setattr(
             graph_updater_module, "_publish_hash_cache", _edit_then_save
@@ -643,6 +646,87 @@ class TestCrashBetweenCacheSaveAndFlush:
         leftovers = sorted(q.name for q in py_project.glob("*.tmp"))
         assert not leftovers, f"temporary cache files were left behind: {leftovers}"
 
+    def test_a_failed_publish_does_not_advance_the_directory_mtimes(
+        self,
+        py_project: Path,
+        mock_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A hash cache that did not publish must not advance the map.
+
+        The two artefacts are only safe as a PAIR. A failed publish leaves the
+        previous hash cache on disk, so advancing the directory-mtime map
+        builds the fresh-map/stale-cache combination the publish order exists
+        to avoid: `_is_already_in_sync` compares every recorded directory
+        against a map that already calls it current, finds nothing changed,
+        and the file loop walks only the keys the OLD cache names. A file
+        added during the failed run is then never indexed at all.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        mtimes_path = py_project / cs.DIR_MTIMES_FILENAME
+        before = mtimes_path.read_text(encoding="utf-8")
+        assert before.strip() not in ("", "{}"), (
+            "fixture guard: run 1 recorded no directory mtimes, so an "
+            "unchanged map below would prove nothing"
+        )
+
+        # An addition is what the pair has to keep visible, and it also moves
+        # the containing directory's mtime so run 2 has something new to
+        # record. Without it the map could be byte-identical for the trivial
+        # reason that nothing changed.
+        (py_project / "module_c.py").write_text(
+            "def c():\n    return 1\n", encoding="utf-8"
+        )
+
+        real_replace = os.replace
+        reached = False
+
+        def _refuse_replace(src: object, dst: object) -> None:
+            nonlocal reached
+            if str(src).endswith(".tmp"):
+                reached = True
+                raise OSError(errno.EROFS, "Read-only file system")
+            real_replace(src, dst)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(os, "replace", _refuse_replace)
+
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        monkeypatch.undo()
+
+        assert reached, (
+            "the run never attempted the atomic rename, so the assertion "
+            "below would hold for a run that simply had nothing to publish"
+        )
+        assert mtimes_path.read_text(encoding="utf-8") == before, (
+            "the directory-mtime map advanced past a hash cache that failed "
+            "to publish, leaving the pair that hides an addition"
+        )
+
+        # The pair is still consistent, which is the point of withholding it:
+        # the next run must NOT take the fast path, so module_c is indexed.
+        assert not GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )._is_already_in_sync(), (
+            "the successor took the in-sync fast path, so the file added "
+            "during the failed run is never indexed"
+        )
+
     def test_a_temp_that_cannot_be_cleaned_up_does_not_end_the_run(
         self,
         py_project: Path,
@@ -772,10 +856,15 @@ class TestCrashBetweenCacheSaveAndFlush:
 
         def _publish_unless_second(
             path: Path, hashes: dict[str, str], observed_at: float | None
-        ) -> None:
+        ) -> bool:
             order.append("hash_cache")
             if len(order) == 1:
-                real_publish(path, hashes, observed_at)
+                return bool(real_publish(path, hashes, observed_at))
+            # The STOP this test models is the process dying between the two
+            # publishes, not a publish that failed. Reporting success is what
+            # keeps the caller reaching `_save_dir_mtimes`, which is the call
+            # whose ordering is under test.
+            return True
 
         def _dir_mtimes_unless_second(path: Path, mtimes: dict[str, float]) -> None:
             order.append("dir_mtimes")

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -413,11 +413,13 @@ class TestCrashBetweenCacheSaveAndFlush:
         )
 
         edited = "def b():\n    return 999\n"
-        real_save = graph_updater_module._save_hash_cache
+        real_save = graph_updater_module._publish_hash_cache
 
         reached_write_site = False
 
-        def _edit_then_save(path: Path, hashes: dict[str, str]) -> None:
+        def _edit_then_save(
+            path: Path, hashes: dict[str, str], observed_at: float | None
+        ) -> None:
             nonlocal reached_write_site
             reached_write_site = True
             # The observation instant is already captured by now, and this
@@ -430,16 +432,18 @@ class TestCrashBetweenCacheSaveAndFlush:
             # is still the newer of the two and the successor still skips.
             time.sleep(0.2)
             target.write_text(edited, encoding="utf-8")
-            real_save(path, hashes)
+            real_save(path, hashes, observed_at)
 
-        monkeypatch.setattr(graph_updater_module, "_save_hash_cache", _edit_then_save)
+        monkeypatch.setattr(
+            graph_updater_module, "_publish_hash_cache", _edit_then_save
+        )
         GraphUpdater(
             ingestor=mock_ingestor,
             repo_path=py_project,
             parsers=parsers,
             queries=queries,
         ).run()
-        monkeypatch.setattr(graph_updater_module, "_save_hash_cache", real_save)
+        monkeypatch.setattr(graph_updater_module, "_publish_hash_cache", real_save)
 
         # Three guards, each catching a different lie. The first two are what
         # caught two wrong versions of this test: an edit placed in `flush_all`
@@ -546,18 +550,21 @@ class TestCrashBetweenCacheSaveAndFlush:
             "successor skips rehashing it and the edit is lost for good"
         )
 
-    def test_cache_is_removed_when_it_cannot_be_backdated(
+    def test_a_read_only_tree_still_completes_the_run(
         self,
         py_project: Path,
         mock_ingestor: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A cache that cannot be stamped back must not survive the run.
+        """A filesystem that refuses every publish step must not end the run.
 
-        Keeping it would leave the file carrying its own write time, which is
-        later than an edit made while the run was still hashing, so the
-        successor would skip that file and the graph would keep pre-edit
-        content. Absent costs a rebuild; present-and-mis-stamped hides an edit.
+        Replaces the two tests that pinned the previous fail-closed handler
+        (a live cache stamped in place, removed when the stamp failed). That
+        code path is gone: the cache is built on a temporary path and renamed,
+        so the live file is never mutated and never needs removing. The OUTER
+        contract those tests existed for survives and is what this asserts -
+        indexing work must not be forfeited because a cache could not be
+        written - so all three steps that can now refuse are refused at once.
         """
         parsers, queries = load_parsers()
         GraphUpdater(
@@ -568,53 +575,89 @@ class TestCrashBetweenCacheSaveAndFlush:
         ).run()
 
         cache = py_project / cs.HASH_CACHE_FILENAME
-        assert cache.is_file(), "fixture guard: run 1 wrote no cache to remove"
+        before = cache.read_text(encoding="utf-8")
+        assert "module_b.py" in before, (
+            "fixture guard: run 1 wrote no usable cache, so leaving it intact "
+            "below would prove nothing"
+        )
 
         (py_project / "module_c.py").write_text(
             "def c():\n    return 1\n", encoding="utf-8"
         )
 
+        real_open = Path.open
         real_utime = os.utime
-        refused: list[Path] = []
+        real_replace = os.replace
+        refused: set[str] = set()
 
-        def _refuse_cache_stamp(path, times=None, **kwargs):  # type: ignore[no-untyped-def]
-            if Path(path).name == cs.HASH_CACHE_FILENAME:
-                refused.append(Path(path))
-                raise OSError("read-only file system")
+        def _is_cache_temp(path: Path) -> bool:
+            return path.name.startswith(cs.HASH_CACHE_FILENAME) and path.name.endswith(
+                ".tmp"
+            )
+
+        def _refuse_open(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if _is_cache_temp(self):
+                refused.add("write")
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_open(self, *args, **kwargs)
+
+        def _refuse_utime(path, times=None, **kwargs):  # type: ignore[no-untyped-def]
+            if _is_cache_temp(Path(path)):
+                refused.add("utime")
+                raise OSError(errno.EROFS, "Read-only file system")
             return real_utime(path, times, **kwargs)
 
-        monkeypatch.setattr(graph_updater_module.os, "utime", _refuse_cache_stamp)
+        def _refuse_replace(src, dst, **kwargs):  # type: ignore[no-untyped-def]
+            if Path(dst).name == cs.HASH_CACHE_FILENAME:
+                refused.add("replace")
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_replace(src, dst, **kwargs)
+
+        monkeypatch.setattr(Path, "open", _refuse_open)
+        monkeypatch.setattr(graph_updater_module.os, "utime", _refuse_utime)
+        monkeypatch.setattr(graph_updater_module.os, "replace", _refuse_replace)
+        # Must COMPLETE: a cache that cannot be written is not a failed run.
         GraphUpdater(
             ingestor=mock_ingestor,
             repo_path=py_project,
             parsers=parsers,
             queries=queries,
         ).run()
+        monkeypatch.setattr(graph_updater_module.os, "replace", real_replace)
         monkeypatch.setattr(graph_updater_module.os, "utime", real_utime)
+        monkeypatch.setattr(Path, "open", real_open)
 
-        assert refused, (
-            "the run never tried to stamp the hash cache, so the assertion "
-            "below would pass without exercising the failure path at all"
+        assert "write" in refused, (
+            "the run never attempted the temporary cache write, so completing "
+            f"says nothing about a read-only tree; refused={sorted(refused)}"
         )
-        assert not cache.is_file(), (
-            "the cache survived a failed backdate: it now carries its own "
-            "write time, which is later than an edit made during the run, so "
-            "the successor skips that file and keeps stale graph content"
+        assert cache.read_text(encoding="utf-8") == before, (
+            "the refused publish damaged the previous cache; it must be left "
+            "exactly as the last successful run wrote it"
         )
+        leftovers = sorted(q.name for q in py_project.glob("*.tmp"))
+        assert not leftovers, f"temporary cache files were left behind: {leftovers}"
 
-    def test_run_survives_a_cache_that_can_be_neither_stamped_nor_removed(
+    def test_a_stop_between_the_two_cache_publishes_is_still_detected(
         self,
         py_project: Path,
         mock_ingestor: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A read-only filesystem fails the stamp AND the cleanup.
+        """The two caches are published in the only safe order.
 
-        `os.utime` failing with EROFS is the canonical reason to reach the
-        fail-closed path, and the same condition fails the `unlink` that path
-        performs, so the pairing is expected rather than remote. Every other
-        filesystem writer on this path swallows `OSError`; crashing here would
-        turn a run that merely could not tidy up into no run at all.
+        They are separate files, so a run stopping between them leaves a
+        mismatched pair, and the pair is trusted in only ONE direction. A
+        FRESH dir-mtimes map beside a STALE hash cache is trusted: the sync
+        check walks the directories that map records, finds the new one listed
+        as current, and the file loop only walks keys the hash cache already
+        names, so a file added in the gap is never indexed. Publishing the
+        hash cache first makes the surviving window the harmless one, where a
+        stale map has no entry for the new directory and the mismatch shows.
+
+        The stop is keyed on whichever publish happens SECOND rather than on
+        either by name, so reversing the two calls still constructs a real
+        mismatched pair and this measures the ordering rather than the fixture.
         """
         parsers, queries = load_parsers()
         GraphUpdater(
@@ -624,42 +667,56 @@ class TestCrashBetweenCacheSaveAndFlush:
             queries=queries,
         ).run()
 
-        (py_project / "module_c.py").write_text(
-            "def c():\n    return 1\n", encoding="utf-8"
+        package = py_project / "pkg"
+        package.mkdir()
+        (package / "added.py").write_text(
+            "def added():\n    return 1\n", encoding="utf-8"
         )
 
-        real_utime = os.utime
-        real_unlink = Path.unlink
-        refused: list[str] = []
+        real_publish = graph_updater_module._publish_hash_cache
+        real_dir_mtimes = graph_updater_module._save_dir_mtimes
+        order: list[str] = []
 
-        def _refuse_stamp(path, times=None, **kwargs):  # type: ignore[no-untyped-def]
-            if Path(path).name == cs.HASH_CACHE_FILENAME:
-                refused.append("utime")
-                raise OSError(errno.EROFS, "Read-only file system")
-            return real_utime(path, times, **kwargs)
+        def _publish_unless_second(
+            path: Path, hashes: dict[str, str], observed_at: float | None
+        ) -> None:
+            order.append("hash_cache")
+            if len(order) == 1:
+                real_publish(path, hashes, observed_at)
 
-        def _refuse_unlink(self, missing_ok=False):  # type: ignore[no-untyped-def]
-            if self.name == cs.HASH_CACHE_FILENAME:
-                refused.append("unlink")
-                raise OSError(errno.EROFS, "Read-only file system")
-            return real_unlink(self, missing_ok=missing_ok)
+        def _dir_mtimes_unless_second(path: Path, mtimes: dict[str, float]) -> None:
+            order.append("dir_mtimes")
+            if len(order) == 1:
+                real_dir_mtimes(path, mtimes)
 
-        monkeypatch.setattr(graph_updater_module.os, "utime", _refuse_stamp)
-        monkeypatch.setattr(Path, "unlink", _refuse_unlink)
-        # The run must COMPLETE. Before the unlink was guarded this raised
-        # OSError out of `run()` on exactly this pairing.
+        monkeypatch.setattr(
+            graph_updater_module, "_publish_hash_cache", _publish_unless_second
+        )
+        monkeypatch.setattr(
+            graph_updater_module, "_save_dir_mtimes", _dir_mtimes_unless_second
+        )
         GraphUpdater(
             ingestor=mock_ingestor,
             repo_path=py_project,
             parsers=parsers,
             queries=queries,
         ).run()
-        monkeypatch.setattr(Path, "unlink", real_unlink)
-        monkeypatch.setattr(graph_updater_module.os, "utime", real_utime)
+        monkeypatch.setattr(graph_updater_module, "_publish_hash_cache", real_publish)
+        monkeypatch.setattr(graph_updater_module, "_save_dir_mtimes", real_dir_mtimes)
 
-        assert refused == ["utime", "unlink"], (
-            "the run did not reach both refusals, so completing proves "
-            f"nothing about the pairing under test; saw {refused}"
+        assert order == ["hash_cache", "dir_mtimes"], (
+            "the commit point did not publish the hash cache first, so the "
+            f"surviving window is the trusted one; saw {order}"
+        )
+        successor = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        assert successor._is_already_in_sync() is False, (
+            "the successor trusts the mismatched pair this stop left, so the "
+            "file added in the gap is never indexed"
         )
 
     def test_successor_run_still_deletes_the_module(


### PR DESCRIPTION
Closes #1646.

## The defect

The hash cache was written and then stamped as two separate filesystem
operations:

```python
_save_hash_cache(*self._pending_hash_cache)   # visible immediately
...
os.utime(path, (observed_at, observed_at))    # a separate syscall later
```

Between those two calls the cache is on disk carrying its OWN write time
rather than the instant observed before hashing. `_is_already_in_sync` skips
any file whose mtime is at or below the cache's, so a run that stops in that
window hands its successor a cache that hides every edit made while the run
was hashing. The stamp exists precisely to prevent that, and the gap
republishes the bug it fixes.

## The fix

`_publish_hash_cache` builds the whole artifact on a `.<pid>.tmp` sibling —
write, then `os.utime` — and `os.replace`s it into place. `os.replace` is
atomic within a filesystem, so a successor sees either the previous cache or
a fully stamped new one, never an unstamped new one.

On any failure the temporary is removed and the PREVIOUS cache is left
untouched. That is the safe direction: a cache one run out of date costs a
rescan, a mis-stamped one loses an edit.

## Publish order at the commit point

The hash cache is now published FIRST and the directory mtimes LAST. A stop
between the two leaves a mismatched pair that is only detected in one
direction:

- **Stale map, fresh cache** (the order here): every entry still holds its old
  mtime, so an addition surfaces and the next run reconciles it.
- **Fresh map, stale cache** (the previous order): the map records every
  directory as current, so nothing is compared, and the file loop only walks
  keys the hash cache already names. A file added in the gap is never indexed.

### What actually detects an addition

The comment justifying that order has been wrong twice, each version correct
for the one shape probed and false as a general claim. The rule that survived
all shapes tried: `_is_already_in_sync` iterates only the entries the map
RECORDS, so it never reaches a directory with no entry. What catches an
addition is the recorded entry for the directory that DIRECTLY CONTAINS it,
whose stored mtime no longer matches disk.

Measured by refreshing one entry at a time — refreshing the containing entry
alone hides the addition, refreshing any other leaves it visible:

| Shape | Containing entry | Result |
|---|---|---|
| New subdirectory | the parent's entry | refresh parent → hidden; refresh others → visible |
| File added to a directory already recorded | that directory's own entry (parent contributes nothing) | refresh it → hidden; refresh others → visible |
| File added at the repo root | `'.'` (recorded keys were `['.']`) | stale `'.'` → `in_sync=False`; refresh `'.'` only → `in_sync=True` |

Each prediction was written before the probe ran, and all three matched.

## Tests

- `test_edit_during_the_deferred_window_is_not_skipped` — retargeted to
  `_publish_hash_cache`; the wrapper sleeps, then edits, and the edit must
  survive into the next run.
- `test_a_read_only_tree_still_completes_the_run` — temp write, `utime` and
  `replace` all refuse with `EROFS`; the run still finishes.
- `test_a_temp_that_cannot_be_cleaned_up_does_not_end_the_run` — `os.replace`
  refuses `EROFS`, then the `.tmp` unlink refuses `EACCES`. Asserts the run
  completes, the existing cache is byte-identical, both sites were reached
  (`reached == {"replace", "cleanup"}`), and the warning names the CLEANUP
  failure ("Permission denied") rather than the publish failure. That last
  assertion pins a regression this rewrite introduced and round 2 caught: an
  `except OSError:` with no `as` reported `e`, naming a reason unrelated to
  the removal.
- `test_a_stop_between_the_two_cache_publishes_is_still_detected` — patches
  both publishers, lets the first through and stops the second; asserts
  `order == ["hash_cache", "dir_mtimes"]` and `_is_already_in_sync() is False`.
  Keyed on whichever publish fires second rather than on a function name: an
  earlier version keyed by name passed with the order reversed.

Warnings are asserted through a loguru sink, not `caplog` — this project logs
via loguru, and `caplog` captures none of it.

## Logging

`CACHE_STAMP_FAILED` is deleted (no callers remain; verified with a grep whose
command shape returns hits for the sibling constant, so the empty result is a
real absence rather than a broken search). `CACHE_STAMP_CLEANUP_FAILED` is
retargeted to the temp-file removal and now says what is true of a `.tmp`
leftover: it is inert, because nothing reads that path.

## Suite

`9050 passed, 257 errors`, measured before the rebase onto current `main`.
The rebase changed no content (all four blobs are byte-identical and the two
diffs compare equal), and `main` had not touched any of these four files, so
the result carries. All 257 are Docker-unavailable SETUP errors in
`@memgraph-integration`:

```
_ ERROR at setup of TestCachelessRebuild.test_rebuild_without_cache_drops_renamed_symbols _
self = <docker.transport.unixconn.UnixHTTPConnectionPool ...>
method = 'GET', url = '/version'
```

`origin/main` on the same host and the same configured checkout shows an
identical `9050 passed, 257 errors, 257 memgraph-tagged, 0 untagged`, so this
branch introduces none of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved incremental updates by publishing cache changes atomically, reducing the risk of incomplete or corrupted cache state.
  - Runs now complete gracefully when cache files cannot be written or updated, including in read-only environments.
  - Interrupted cache updates are detected on the next run, allowing the system to recover and resynchronize safely.
  - Temporary cache files left after a failed update are treated as inactive and can be removed without affecting normal operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->