### PR TITLE
fix: judge git repo-location targets with a platform-neutral join

### DIFF
--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -3052,9 +3052,22 @@ class TestYoloLauncherConfinement:
             "ls",
             "xargs cat",
             # Read-only find keeps working: it launches nothing without a
-            # mutating action, and yolo exists to run unattended work.
-            "find . -name '*.py'",
-            "find . -type f",
+            # mutating action, and yolo exists to run unattended work. On
+            # Windows `find` is find.exe, an unrelated string-search program
+            # that exits 2 on these arguments, so the cases run only where
+            # the POSIX utility exists.
+            pytest.param(
+                "find . -name '*.py'",
+                marks=pytest.mark.skipif(
+                    sys.platform == "win32", reason="Unix find not on Windows"
+                ),
+            ),
+            pytest.param(
+                "find . -type f",
+                marks=pytest.mark.skipif(
+                    sys.platform == "win32", reason="Unix find not on Windows"
+                ),
+            ),
             # A KNOWN value flag still resolves to the real program, so the
             # fail-closed rule has not collapsed into blocking all of xargs.
             "xargs -n 1 cat",
@@ -3064,7 +3077,6 @@ class TestYoloLauncherConfinement:
             # above while having simply stopped allowing anything.
             "xargs -n1 cat",
             "xargs -I{} cat {}",
-            "xargs -0pt cat",
             "xargs -- cat",
             "xargs -P4 cat",
             # The GNU optional-argument spellings are checked against the
@@ -3072,7 +3084,11 @@ class TestYoloLauncherConfinement:
             # instead: this test EXECUTES the command, and BSD/macOS xargs
             # rejects -i/-l/--replace outright, so running them here would
             # fail on the platform's own argument parsing rather than on
-            # anything this fix controls.
+            # anything this fix controls. `xargs -0pt cat` is out for the
+            # mirror-image reason: GNU xargs -p prompts on /dev/tty, which
+            # CI does not have, so it exits 1 there while BSD xargs exits 0.
+            # The validator allows it either way (test_xargs_p_cluster
+            # below); only its execution is platform-bound.
             # `-c` after the subcommand is git's reuse-message flag, not a
             # config setter. `git log -c HEAD` would not discriminate: HEAD is
             # not an exec key, so it passes either way. This spelling puts a
@@ -3095,6 +3111,14 @@ class TestYoloLauncherConfinement:
         mock_ctx.tool_call_approved = False
         result = await tool.function(mock_ctx, command)
         assert result.return_code == 0, f"yolo over-blocked ordinary work: {command}"
+
+    def test_xargs_p_cluster(self) -> None:
+        # The `-0pt` cluster used to sit in the executing list above. It is
+        # asserted against the validator now, and on the resolved program
+        # rather than only the verdict, so that clustering value-less flags
+        # ahead of the utility keeps naming `cat` on every platform.
+        assert _xargs_launched_command(["xargs", "-0pt", "cat"]) == "cat"
+        assert _validate_segment("xargs -0pt cat", "", True) is None
 
 
 def test_symlink_write_target_keeps_the_slash_anchor_broad() -> None:
@@ -3433,6 +3457,13 @@ def test_git_bare_exec_path_still_passes() -> None:
     assert _validate_segment("git --exec-path /tmp/evil pwn", "git", True) is None
 
 
+# Resolved so the root is drive-qualified on Windows. The bare literal is NOT
+# absolute there (no drive letter), while the helper's resolve() gives the
+# target the CWD's drive, so relative_to() failed on every in-root target and
+# these tests could not tell a correct guard from the over-blocking one.
+GIT_GUARD_ROOT = Path("/project/root").resolve()
+
+
 class TestGitRepoLocationEscape:
     """`--git-dir`/`-C`/`--work-tree` pointed outside the project root.
 
@@ -3442,7 +3473,7 @@ class TestGitRepoLocationEscape:
     rc=0 through `git --git-dir=SCRATCH/.git pwn`.
     """
 
-    ROOT = Path("/project/root")
+    ROOT = GIT_GUARD_ROOT
 
     @pytest.mark.parametrize(
         "argv",
@@ -3501,7 +3532,7 @@ def test_git_repo_escape_survives_nesting_under_xargs(inner: str, bypass: bool) 
     # execute() on the top-level segment, so `xargs git --git-dir=EVIL pwn`
     # executed the planted alias with rc=0 while the direct spelling was
     # refused. Placing it inside _validate_segment puts it on the recursion.
-    root = Path("/project/root")
+    root = GIT_GUARD_ROOT
     assert _validate_segment(inner, "", bypass, 0, root) is not None, inner
     nested = f"xargs {inner}"
     assert _validate_segment(nested, "", bypass, 0, root) is not None, (
@@ -3520,6 +3551,6 @@ def test_git_repo_escape_survives_nesting_under_xargs(inner: str, bypass: bool) 
 )
 def test_in_root_git_still_passes_nested(inner: str) -> None:
     # The guard must not cost the everyday nested spelling its pass either.
-    root = Path("/project/root")
+    root = GIT_GUARD_ROOT
     assert _validate_segment(inner, "", True, 0, root) is None, inner
     assert _validate_segment(f"xargs {inner}", "", True, 0, root) is None, inner

--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -3511,6 +3511,27 @@ class TestGitRepoLocationEscape:
     def test_a_non_git_command_is_not_examined(self) -> None:
         assert _git_escapes_project(["rm", "-C", "/tmp/evil"], self.ROOT) == (False, "")
 
+    @pytest.mark.skipif(sys.platform != "win32", reason="drive letters are Windows")
+    def test_a_rooted_target_is_judged_on_the_root_drive(self) -> None:
+        # A rooted, drive-less target such as `/project/root/inside` takes the
+        # drive of whatever it is joined onto. The root's drive is git's own,
+        # since git runs with the root as its cwd, so that is where the target
+        # must be judged. The old `startswith("/")` branch resolved the target
+        # alone, which put it on the Python process's drive and refused an
+        # in-root target whenever the two drives differ. The root is placed on
+        # a drive the process is not on so that the two readings disagree.
+        process_drive = Path.cwd().drive.upper()
+        other_drive = "C:" if process_drive != "C:" else "D:"
+        root = Path(f"{other_drive}/project/root")
+        assert Path("/project/root/inside").resolve().drive.upper() == process_drive
+        inside = ["git", "-C", "/project/root/inside", "status"]
+        assert _git_escapes_project(inside, root) == (False, "")
+        # The same drive-taking must not turn an escape into a pass.
+        outside = ["git", "-C", "/tmp/evil", "pwn"]
+        blocked, reason = _git_escapes_project(outside, root)
+        assert blocked
+        assert "outside the project" in reason
+
 
 @pytest.mark.parametrize(
     "inner",

--- a/codebase_rag/tools/shell_command.py
+++ b/codebase_rag/tools/shell_command.py
@@ -199,11 +199,14 @@ def _git_escapes_project(cmd_parts: list[str], project_root: Path) -> tuple[bool
 
         if not target:
             continue
+        # Joining onto the root is the platform's own absoluteness test: an
+        # absolute target replaces the root outright, a relative one lands
+        # under it. A `startswith("/")` check is POSIX-only: on Windows a
+        # rooted, drive-less target such as `/x` would resolve on the Python
+        # process's drive rather than the root's, which is the drive git
+        # itself runs on (its cwd is the root).
         try:
-            if target.startswith("/"):
-                resolved = Path(target).resolve()
-            else:
-                resolved = (project_root / target).resolve()
+            resolved = (project_root / target).resolve()
         except (OSError, ValueError):
             return True, f"git pointed at an unresolvable path: {target}"
 


### PR DESCRIPTION
## What is broken

CI on `main` has been red since the GHSA-wvxg-744g-6pcg merge (`033b64be`, run 33685599965). On **windows-latest** the git-guard tests fail:

```
TestGitRepoLocationEscape::test_a_target_inside_the_root_still_passes[argv0-4]
test_in_root_git_still_passes_nested[git -C . status | git --git-dir .git log | git -C sub diff]
test_yolo_still_runs_ordinary_commands[find . -name '*.py' | find . -type f | xargs -0pt cat]
```

and on **ubuntu-latest** and the base install, `test_yolo_still_runs_ordinary_commands[xargs -0pt cat]`.

**Production is not affected.** `ShellCommander` resolves the project root in its constructor, and that is the only path into `_git_escapes_project`, so on Windows a relative target joined onto that drive-qualified root and `relative_to()` succeeded. The security fix is correct and effective; the failures are in the fixture and in two platform-bound executing cases. (An earlier internal write-up described this as a Windows user-facing over-block of `git -C`; that was inferred from the red CI, and tracing the call path shows it does not happen.)

## Cause

- **Test root literal.** `ROOT = Path("/project/root")` has no drive letter and is **not absolute on Windows**. The helper's `resolve()` gives the target the CWD's drive while the comparison root keeps none, so `relative_to()` raises for every in-root target. The fixture could not tell a correct guard from an over-blocking one.
- **`startswith("/")` in the guard** is a POSIX-only absoluteness test. With a resolved root it gives the same verdict as a plain join on every case except a rooted, drive-less target such as `/x` on Windows, which it resolved on the Python process's drive instead of the root's (the drive git runs on, since git's cwd is the root).
- **Executing cases.** `test_yolo_still_runs_ordinary_commands` runs each command and asserts `rc == 0`, so a command whose own parsing differs by platform fails regardless of the validator's verdict. GNU `xargs -p` opens `/dev/tty` to prompt and exits 1 in CI (`xargs: failed to open /dev/tty for reading`); BSD/macOS xargs exits 0, which is why local runs passed. Windows `find` is `find.exe`, an unrelated program (`File not found - *.py`, exit 2).

Why it shipped red: the fix was developed in the GHSA private fork where Actions do not run, the first CI run was on the merge commit, and `version-bump.yml` released v0.0.845 without waiting for `ci.yml`.

## Fix

**Guard** (`codebase_rag/tools/shell_command.py`): one platform-neutral join.

```diff
-            if target.startswith("/"):
-                resolved = Path(target).resolve()
-            else:
-                resolved = (project_root / target).resolve()
+            resolved = (project_root / target).resolve()
```

`Path.__truediv__` applies the platform's own rule for absoluteness. On POSIX the verdicts are identical to the old form (`/a / "/b" == /b`), so every escape the old form blocked is still blocked.

**Test root** (`test_shell_command.py`): `Path("/project/root")` is resolved once at module level (`GIT_GUARD_ROOT`) and used by `TestGitRepoLocationEscape`, `test_git_repo_escape_survives_nesting_under_xargs` and `test_in_root_git_still_passes_nested`, so the fixture matches what production passes.

**Executing cases.** `xargs -0pt cat` moves from the executing list to `test_xargs_p_cluster`, which asserts the resolved program and the validator verdict. The two `find` cases are `skipif(sys.platform == "win32")`, kept because read-only `find` continuing to run is worth asserting where the POSIX utility exists.

## Verification

- `codebase_rag/tests/test_shell_command.py`: 1144 passed (macOS, via the host suite lock).
- `ruff check` / `ruff format --check`: clean.
- Escape-vs-allow table against the real helper (macOS): `git -C . status`, `git --git-dir .git log`, `git -C sub diff`, `git -C /project/root/sub log` allowed; `git -C ../other log`, `git --git-dir=/tmp/evil/.git pwn`, `git -C /tmp/evil pwn`, `git --git-dir=/project/root/../escape/.git pwn`, `git -C /project/rootx log` blocked.
- Old-vs-new verdicts simulated with `PurePosixPath`/`PureWindowsPath` across `..` traversal, rooted drive-less, drive-relative (`D:evil`, `C:evil`), UNC and `\\?\` spellings, `~`/`$HOME`, and the empty string: no spelling is allowed by the new join that the old form blocked. The single changed verdict is a rooted drive-less target under the root when the process drive differs from the root drive, which the old form falsely blocked.
- **Windows CI on this PR (head `78743781`):** both `windows-latest` jobs pass. py3.13: 9977 passed, 45 skipped, 0 failed, against `main`'s 11 failed, 9967 passed, 43 skipped. The difference is fully accounted for: the eleven `main` failures now pass, the two `find` cases skip, the executing `xargs -0pt cat` case is gone, and the two new tests (`test_xargs_p_cluster`, `test_a_rooted_target_is_judged_on_the_root_drive`) ran and passed. This is the evidence that was missing when v0.0.845 shipped.

## Sonar gate

The Sonar Zero Issues Gate fails with 12 issues, 11 of them in functions this PR does not touch. They were introduced by the advisory merge `033b64be`, which was never Sonar-analysed (GHSA fork), and `main`'s own Sonar workflow has failed since because its test step hits the `xargs -0pt cat` case this PR fixes. SonarCloud charges every issue missing from the target's last analysis (`ee6458f2`) to the PR. Details and the owner options are in #1669. This PR does not attempt to fix those 12; refactoring the guard's parsing functions under a red `main` is the wrong move.

## Follow-ups (not in this PR)

- `_is_dangerous_rm_path` uses the same `startswith("/")` two-branch form. Harmless for the same reason (resolved root), but the same simplification applies.
- `version-bump.yml` cut and published v0.0.845 while `ci.yml` was red for the same SHA. Gating the release on green CI for that SHA would close that path.
- The temporary private fork for the advisory is still undeleted.
