### PR TITLE
fix: scope single-file GraphUpdater runs so they cannot sweep siblings or truncate the cache (#1619)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2682,6 +2682,14 @@ class GraphUpdater:
         cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
         old_hashes = _load_hash_cache(cache_path) if not force else {}
+        # Snapshot before the stale-key pop: a single-file run merges over the
+        # cache it found, and this run does not commit the delombok state
+        # (see `run`), so it must not act on the stale-key pop either. Merging
+        # over the popped dict would DROP every Lombok-affected sibling, which
+        # then takes the `is_new` path next run and skips delete-before-
+        # reingest, leaving the previous parse's entities beside the fresh
+        # ones (#1619 review).
+        pristine_hashes = dict(old_hashes)
         for stale_key in self._delombok_stale_keys:
             old_hashes.pop(stale_key, None)
         is_full_build = (force or not old_hashes) and self._single_file is None
@@ -3059,7 +3067,24 @@ class GraphUpdater:
             # (`_collect_eligible_files` returns above the walk that populates
             # them), so there is nothing to merge and writing the empty
             # collection would wipe the previous walk's record wholesale.
-            self._pending_hash_cache = (cache_path, {**old_hashes, **new_hashes})
+            self._pending_hash_cache = (
+                cache_path,
+                {**pristine_hashes, **new_hashes},
+            )
+            # And it must carry the PREVIOUS cache's mtime forward rather
+            # than stamping this run's instant. The merged entries are mostly
+            # the previous run's hashes, so stamping now would assert every
+            # sibling was observed just now: a sibling edited before this run
+            # then satisfies `file_mtime <= cache_mtime` with a hash that
+            # still matches, and the next project run reports "already in
+            # sync" and never indexes the edit (#1619 review).
+            #
+            # Note this must be the previous mtime, NOT None. None skips the
+            # `os.utime` in `run` altogether, which leaves the file its own
+            # write time -- LATER than this run's instant, so it makes the
+            # trap worse rather than closing it. `cache_mtime` was read at the
+            # top of this method, before anything wrote to the cache.
+            self._pending_cache_observed_at = cache_mtime or None
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry
         # the old parser's edges.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2888,10 +2888,23 @@ class GraphUpdater:
             if preexisting_paths
             else frozenset()
         )
-        deleted_before_parse = sorted(
-            (set(old_hashes) | self._delombok_stale_keys | graph_only_gone)
-            - eligible_by_key.keys()
-            - unreadable_keys
+        # Empty on a single-file run, for the same reason `deleted_keys`
+        # below is: every term here is PROJECT-WIDE (the whole hash cache, the
+        # whole Delombok-stale set, every module the graph holds), and the
+        # only thing subtracted is `eligible_by_key` -- which on a single-file
+        # run names just the walked file. So each sibling falls straight
+        # through and is deleted before the parse, which is the sweep #1619
+        # exists to stop. It was previously bounded only by accident, because
+        # nothing on this path populated the set (issue #1671); that is not a
+        # property to rely on, so the scope rule is stated here.
+        deleted_before_parse = (
+            sorted(
+                (set(old_hashes) | self._delombok_stale_keys | graph_only_gone)
+                - eligible_by_key.keys()
+                - unreadable_keys
+            )
+            if self._single_file is None
+            else []
         )
         # A directory whose package-ness flipped since the last run (an
         # __init__.py or Cargo.toml added or deleted) changes the container

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2748,19 +2748,26 @@ class GraphUpdater:
         # from it and no on-disk hash names it any more. Only the graph still
         # does. It costs a query only on the runs where the set actually
         # moved.
-        # A forced single-file run needs this too, for the same reason a full
-        # build does: `force` empties `old_hashes`, so the cache can no longer
-        # say whether the target is already in the graph, and `is_new` would
-        # fall through to True on a file the previous parse already indexed.
-        # It would then skip delete-before-reingest and stack a second parse's
-        # entities on the first -- renamed-away symbols and their
-        # CALLS/REFERENCES edges surviving beside the fresh ones (#1619 review,
-        # round 3). Only the graph still knows, so ask it.
-        forced_single_file = force and self._single_file is not None
+        # A single-file run whose cache cannot name the target needs this too,
+        # for the same reason a full build does. `is_new` would otherwise fall
+        # through to True on a file the previous parse already indexed, skip
+        # delete-before-reingest, and stack a second parse's entities on the
+        # first -- renamed-away symbols and their CALLS/REFERENCES edges
+        # surviving beside the fresh ones (#1619 review, round 3).
+        #
+        # The condition mirrors `is_full_build` above deliberately: `force`
+        # empties `old_hashes`, and a missing or evicted cache leaves it empty
+        # the same way, so both must ask the graph. Guarding on `force` alone
+        # left the identical defect on a fresh clone of an already-indexed
+        # repo -- the cache lives in the working tree, the graph does not --
+        # and after any cache eviction (#1619 review, round 4).
+        cacheless_single_file = (force or not old_hashes) and (
+            self._single_file is not None
+        )
         preexisting_paths = (
             self._existing_module_paths()
             if is_full_build
-            or forced_single_file
+            or cacheless_single_file
             or not self._exclusions_match_last_run()
             else frozenset()
         )

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3001,8 +3001,14 @@ class GraphUpdater:
         graph_paths = (
             preexisting_paths if preexisting_paths is not None else frozenset()
         )
+        # A single-file run walked exactly one file, so `current_file_keys`
+        # names only that file and every sibling looks deleted. It cannot
+        # speak for the project's file set, for the same reason `run` guards
+        # the exclusion stamp with `self._single_file is None` (#1619).
         deleted_keys = (
             (set(old_hashes.keys()) | graph_paths) - current_file_keys - unreadable_keys
+            if self._single_file is None
+            else set()
         )
         if deleted_keys:
             logger.info(ls.INCREMENTAL_DELETED, count=len(deleted_keys))
@@ -3041,8 +3047,19 @@ class GraphUpdater:
         # between tell its successor the file was already reconciled, and the
         # successor computes an empty `deleted_keys` and never re-issues the
         # delete. The subtree then stays in the graph until a full rebuild.
-        self._pending_hash_cache = (cache_path, new_hashes)
-        self._pending_dir_mtimes = (dir_mtimes_path, self._collected_dir_mtimes)
+        if self._single_file is None:
+            self._pending_hash_cache = (cache_path, new_hashes)
+            self._pending_dir_mtimes = (dir_mtimes_path, self._collected_dir_mtimes)
+        else:
+            # Two different remedies, because the run has different standing
+            # on each (#1619). It DID hash its one file, so that hash is worth
+            # recording -- merged over the previous run's entries, never
+            # replacing them, or the next full run treats every sibling as
+            # new. It collected NO directory mtimes at all
+            # (`_collect_eligible_files` returns above the walk that populates
+            # them), so there is nothing to merge and writing the empty
+            # collection would wipe the previous walk's record wholesale.
+            self._pending_hash_cache = (cache_path, {**old_hashes, **new_hashes})
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry
         # the old parser's edges.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2682,14 +2682,27 @@ class GraphUpdater:
         cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
         old_hashes = _load_hash_cache(cache_path) if not force else {}
-        # Snapshot before the stale-key pop: a single-file run merges over the
-        # cache it found, and this run does not commit the delombok state
-        # (see `run`), so it must not act on the stale-key pop either. Merging
-        # over the popped dict would DROP every Lombok-affected sibling, which
-        # then takes the `is_new` path next run and skips delete-before-
-        # reingest, leaving the previous parse's entities beside the fresh
-        # ones (#1619 review).
-        pristine_hashes = dict(old_hashes)
+        # Snapshot for the single-file merge, read from DISK and independently
+        # of `force`. Two distinct reasons it cannot reuse `old_hashes`:
+        #
+        # 1. the stale-key pop below -- a single-file run does not commit the
+        #    delombok state (see `run`), so it must not act on that pop
+        #    either. Merging over the popped dict would DROP every
+        #    Lombok-affected sibling, which then takes the `is_new` path next
+        #    run and skips delete-before-reingest, leaving the previous
+        #    parse's entities beside the fresh ones (#1619 review).
+        # 2. `force` -- which empties `old_hashes` to make this run RE-PARSE
+        #    what it walked. A single-file run walked one file, so `force`
+        #    says nothing about the siblings it never looked at. Reusing the
+        #    emptied dict would persist a cache holding only the target and
+        #    erase every sibling's hash, which is the same data loss the
+        #    unforced path already guards (#1619 review, round 2).
+        #
+        # Only the single-file commit reads this; a project run replaces the
+        # cache wholesale from its own complete walk, as it always has.
+        pristine_hashes = (
+            _load_hash_cache(cache_path) if self._single_file is not None else {}
+        )
         for stale_key in self._delombok_stale_keys:
             old_hashes.pop(stale_key, None)
         is_full_build = (force or not old_hashes) and self._single_file is None

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3111,9 +3111,21 @@ class GraphUpdater:
             # (`_collect_eligible_files` returns above the walk that populates
             # them), so there is nothing to merge and writing the empty
             # collection would wipe the previous walk's record wholesale.
+            # ...but only when there IS a previous run's cache to merge over.
+            # With none (missing, empty or unreadable), publishing the one
+            # hash this run took would create a cache naming a single file,
+            # which the next PROJECT run reads as authoritative: every
+            # sibling is then absent from `old_hashes`, takes the `is_new`
+            # path, skips delete-before-reingest, and an edited sibling's
+            # previous entities survive beside the fresh parse. Writing
+            # nothing keeps the next project run a full build, which
+            # reconciles properly (#1619 review, round 5). Measured: with the
+            # cache removed, a single-file run then a project run left
+            # `module_b.py` undeleted after an edit.
             self._pending_hash_cache = (
-                cache_path,
-                {**pristine_hashes, **new_hashes},
+                (cache_path, {**pristine_hashes, **new_hashes})
+                if pristine_hashes
+                else None
             )
             # And it must carry the PREVIOUS cache's mtime forward rather
             # than stamping this run's instant. The merged entries are mostly

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2748,9 +2748,20 @@ class GraphUpdater:
         # from it and no on-disk hash names it any more. Only the graph still
         # does. It costs a query only on the runs where the set actually
         # moved.
+        # A forced single-file run needs this too, for the same reason a full
+        # build does: `force` empties `old_hashes`, so the cache can no longer
+        # say whether the target is already in the graph, and `is_new` would
+        # fall through to True on a file the previous parse already indexed.
+        # It would then skip delete-before-reingest and stack a second parse's
+        # entities on the first -- renamed-away symbols and their
+        # CALLS/REFERENCES edges surviving beside the fresh ones (#1619 review,
+        # round 3). Only the graph still knows, so ask it.
+        forced_single_file = force and self._single_file is not None
         preexisting_paths = (
             self._existing_module_paths()
-            if is_full_build or not self._exclusions_match_last_run()
+            if is_full_build
+            or forced_single_file
+            or not self._exclusions_match_last_run()
             else frozenset()
         )
         # None is "the sink claims readability and the query failed", not

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -427,3 +427,58 @@ class TestSingleFileRunScope:
             "the run's own file must still be recorded; the merge must add to "
             "the previous cache, not be replaced by it"
         )
+
+    @pytest.mark.parametrize("force", [False, True])
+    def test_single_file_run_deletes_the_target_before_reingest(
+        self, tmp_path: Path, mock_ingestor: MagicMock, force: bool
+    ) -> None:
+        """An already-indexed target must be cleared before it is re-parsed.
+
+        `force=True` empties `old_hashes`, so the hash cache can no longer say
+        whether the target is already in the graph. With `preexisting_paths`
+        left empty on this path, `is_new` came out True for a file the
+        previous parse had indexed, so the run skipped
+        `_delete_module_entities` and stacked a second parse on top of the
+        first -- a renamed-away function keeping its old node and its inbound
+        CALLS/REFERENCES edges beside the fresh ones.
+
+        Asserts the DELETE is issued rather than checking the cache: the cache
+        is written identically either way, so a cache assertion is satisfied
+        by both the working and the broken code. Parametrised so the unforced
+        case stays a control -- it reaches the same delete through
+        `old_hashes`, and must keep doing so.
+        """
+        repo = self._three_module_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        # A real second run queries a graph that still holds the first run's
+        # modules; the fake sink has to say so or nothing is "pre-existing"
+        # and the test could not tell the two paths apart.
+        second = _MockIngestor()
+        second.fetch_all.return_value = [
+            {cs.KEY_PATH: "module_a.py"},
+            {cs.KEY_PATH: "module_b.py"},
+        ]
+        GraphUpdater(
+            ingestor=second,
+            repo_path=repo / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+        ).run(force=force)
+
+        deleted = {
+            call.args[1][cs.KEY_PATH]
+            for call in second.execute_write.call_args_list
+            if call.args and call.args[0] == cs.CYPHER_DELETE_MODULE
+        }
+        assert "module_a.py" in deleted, (
+            f"run(force={force}) re-parsed an already-indexed file without "
+            "deleting its previous entities first, so the old parse's nodes "
+            "and edges survive alongside the new ones"
+        )

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -277,3 +277,103 @@ class TestSingleFileRunScope:
             "a single-file run records no directory mtimes, so writing its "
             "empty collection wipes the project's record wholesale"
         )
+
+    def test_single_file_run_does_not_hide_a_sibling_edit_from_the_next_run(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The merged cache must not be stamped with this run's instant.
+
+        The merge keeps the previous run's hashes for siblings. Restamping the
+        cache to now would assert those hashes were observed now, so a sibling
+        edited BEFORE the single-file run satisfies `file_mtime <=
+        cache_mtime` while its cached hash still matches -- and the next
+        project run reports "already in sync" and never indexes the edit.
+
+        Ordering matters: the edit must precede the single-file run. An edit
+        made afterwards is newer than any stamp and is safe either way, so a
+        test written that way passes on the broken code too.
+        """
+        repo = self._three_module_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        (repo / "module_b.py").write_text(
+            "def renamed_b():\n    pass\n", encoding="utf-8"
+        )
+        GraphUpdater(
+            ingestor=_MockIngestor(),
+            repo_path=repo / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        third = _MockIngestor()
+        GraphUpdater(
+            ingestor=third,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        assert "scoped.module_b.renamed_b" in get_node_names(third, "Function"), (
+            "the sibling's edit never reached the graph: the single-file run "
+            "stamped the merged cache with its own instant, so the project "
+            "run treated the edited file as already in sync"
+        )
+
+    def test_single_file_run_keeps_lombok_stale_siblings_in_the_cache(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The merge must read the cache as found, not after the stale pop.
+
+        `_process_files` pops `_delombok_stale_keys` from `old_hashes` before
+        the merge sees it. A single-file run does not commit the delombok
+        state, so it must not act on that pop either: merging over the popped
+        dict DROPS those siblings from the cache, and a dropped key takes the
+        `is_new` path next run, skipping delete-before-reingest.
+
+        The stale set is DERIVED, not assigned: `_collect_delombok_state`
+        recomputes both delombok fields from the on-disk state file during
+        `run`, so setting the attributes on the updater beforehand is
+        overwritten and the test would pass on broken code too. Planting a
+        state file that names a key the current (empty) overlay lacks is what
+        genuinely makes `_delombok_state_changed` true and puts that key in
+        `_delombok_stale_keys`.
+        """
+        repo = self._three_module_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        (repo / cs.DELOMBOK_STATE_FILENAME).write_text(
+            json.dumps({"identity": "stale", "keys": ["module_b.py"], "lombok": "x"}),
+            encoding="utf-8",
+        )
+
+        second = GraphUpdater(
+            ingestor=_MockIngestor(),
+            repo_path=repo / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+        )
+        second.run()
+        assert second._delombok_stale_keys == {"module_b.py"}, (
+            "fixture guard: the planted state file must make module_b.py "
+            "stale, or this test cannot see the defect it exists for"
+        )
+
+        cache = json.loads((repo / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8"))
+        assert "module_b.py" in cache, (
+            "a Lombok-stale sibling was dropped from the cache by a run that "
+            "does not commit the delombok state; the next run then treats it "
+            "as new and skips delete-before-reingest"
+        )

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -377,3 +377,53 @@ class TestSingleFileRunScope:
             "does not commit the delombok state; the next run then treats it "
             "as new and skips delete-before-reingest"
         )
+
+    @pytest.mark.parametrize("force", [False, True])
+    def test_single_file_run_keeps_sibling_hashes_whatever_force_says(
+        self, tmp_path: Path, mock_ingestor: MagicMock, force: bool
+    ) -> None:
+        """`force` must not empty the snapshot the single-file merge reads.
+
+        `force=True` sets `old_hashes = {}` so the run RE-PARSES what it
+        walked. A single-file run walked one file, so that says nothing about
+        the siblings it never looked at -- but the merge snapshot was taken
+        from `old_hashes`, so the commit persisted a cache holding only the
+        target and erased every sibling's hash.
+
+        Parametrised rather than written for `force=True` alone: the unforced
+        case is the control. It passed before this fix and must keep passing,
+        which is what shows the repair is about `force` specifically and not a
+        blanket change to how the merge reads the cache.
+        """
+        repo = self._three_module_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        before = json.loads((repo / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8"))
+        assert "module_b.py" in before, (
+            "fixture guard: the project run must have cached the sibling, or "
+            "this test cannot observe it being erased"
+        )
+
+        GraphUpdater(
+            ingestor=_MockIngestor(),
+            repo_path=repo / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+        ).run(force=force)
+
+        cache = json.loads((repo / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8"))
+        assert "module_b.py" in cache, (
+            f"run(force={force}) on a single file erased the sibling's hash: "
+            "the next project run then treats every sibling as new, skipping "
+            "delete-before-reingest and duplicating their entities"
+        )
+        assert "module_a.py" in cache, (
+            "the run's own file must still be recorded; the merge must add to "
+            "the previous cache, not be replaced by it"
+        )

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -428,9 +428,17 @@ class TestSingleFileRunScope:
             "the previous cache, not be replaced by it"
         )
 
-    @pytest.mark.parametrize("force", [False, True])
+    @pytest.mark.parametrize(
+        ("force", "drop_cache"),
+        [(False, False), (True, False), (False, True)],
+        ids=["cache-names-target", "forced", "cacheless"],
+    )
     def test_single_file_run_deletes_the_target_before_reingest(
-        self, tmp_path: Path, mock_ingestor: MagicMock, force: bool
+        self,
+        tmp_path: Path,
+        mock_ingestor: MagicMock,
+        force: bool,
+        drop_cache: bool,
     ) -> None:
         """An already-indexed target must be cleared before it is re-parsed.
 
@@ -444,9 +452,18 @@ class TestSingleFileRunScope:
 
         Asserts the DELETE is issued rather than checking the cache: the cache
         is written identically either way, so a cache assertion is satisfied
-        by both the working and the broken code. Parametrised so the unforced
-        case stays a control -- it reaches the same delete through
-        `old_hashes`, and must keep doing so.
+        by both the working and the broken code.
+
+        The deciding axis is whether the cache can NAME THE TARGET, and
+        `force` is only one of two ways to make it not: a missing or evicted
+        cache leaves `old_hashes` empty exactly as `force` does. So the cases
+        are (a) the cache names it -- the control, which reaches the delete
+        through `old_hashes` and must keep doing so; (b) `force` empties it;
+        (c) the cache is gone, which is reachable WITHOUT `force` on a fresh
+        clone of an already-indexed repo, since the cache lives in the working
+        tree and the graph does not. Parametrising on `force` alone left (c)
+        invisible and a guard covering only `force` passed (#1619 review,
+        round 4).
         """
         repo = self._three_module_project(tmp_path)
         parsers, queries = load_parsers()
@@ -460,6 +477,14 @@ class TestSingleFileRunScope:
         # A real second run queries a graph that still holds the first run's
         # modules; the fake sink has to say so or nothing is "pre-existing"
         # and the test could not tell the two paths apart.
+        cache_path = repo / cs.HASH_CACHE_FILENAME
+        assert cache_path.is_file(), (
+            "fixture guard: the project run must have written a hash cache, "
+            "or the cacheless case below would be indistinguishable from it"
+        )
+        if drop_cache:
+            cache_path.unlink()
+
         second = _MockIngestor()
         second.fetch_all.return_value = [
             {cs.KEY_PATH: "module_a.py"},
@@ -478,7 +503,8 @@ class TestSingleFileRunScope:
             if call.args and call.args[0] == cs.CYPHER_DELETE_MODULE
         }
         assert "module_a.py" in deleted, (
-            f"run(force={force}) re-parsed an already-indexed file without "
-            "deleting its previous entities first, so the old parse's nodes "
-            "and edges survive alongside the new ones"
+            f"run(force={force}) with drop_cache={drop_cache} re-parsed an "
+            "already-indexed file without deleting its previous entities "
+            "first, so the old parse's nodes and edges survive alongside the "
+            "new ones"
         )

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -176,12 +176,28 @@ class TestSingleFileRunScope:
         return repo
 
     @staticmethod
-    def _deleted_module_keys(ingestor: MagicMock) -> set[str]:
-        return {
+    def _swept_module_keys(ingestor: MagicMock) -> set[str]:
+        """Modules deleted and NOT re-added -- i.e. genuinely swept.
+
+        `CYPHER_DELETE_MODULE` serves two different purposes, so counting the
+        query alone would flag correct behaviour. The reconciliation path
+        issues it to sweep a file that is gone; the changed-file path issues
+        it for a file that still exists, to clear the previous parse's
+        entities immediately before `_process_single_file` re-adds them
+        (graph_updater.py:2731). Only the first is a deletion, and the
+        difference is visible in whether a Module node is written afterwards.
+        """
+        deleted = {
             call.args[1][cs.KEY_PATH]
             for call in ingestor.execute_write.call_args_list
             if call.args and call.args[0] == cs.CYPHER_DELETE_MODULE
         }
+        readded = {
+            call[0][1][cs.KEY_PATH]
+            for call in ingestor.ensure_node_batch.call_args_list
+            if call[0][0] == cs.NodeLabel.MODULE and cs.KEY_PATH in call[0][1]
+        }
+        return deleted - readded
 
     def _build_then_single_file(
         self, tmp_path: Path, mock_ingestor: MagicMock
@@ -214,7 +230,7 @@ class TestSingleFileRunScope:
         self, tmp_path: Path, mock_ingestor: MagicMock
     ) -> None:
         _repo, second = self._build_then_single_file(tmp_path, mock_ingestor)
-        assert self._deleted_module_keys(second) == set(), (
+        assert self._swept_module_keys(second) == set(), (
             "a single-file run reconciled the whole project and swept every "
             "module the cache named, including the one it was asked to index"
         )

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -1,9 +1,14 @@
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
 from codebase_rag.tests.conftest import (
+    _MockIngestor,
     get_node_names,
     get_relationships,
     run_updater,
@@ -136,3 +141,123 @@ int main() { doStuff(); return 0; }
     functions = get_node_names(mock_ingestor, "Function")
     assert any("doStuff" in qn for qn in functions)
     assert any("main" in qn for qn in functions)
+
+
+class TestSingleFileRunScope:
+    """A single-file run must speak only for the file it walked (#1619).
+
+    `GraphUpdater(repo_path=<a file>)` walks exactly one file, but the
+    reconciliation that follows treats the walked set as the project's whole
+    set. So the run deletes every module the hash cache names, replaces the
+    cache with its single entry, and writes an EMPTY directory-mtime record
+    (single-file collection returns before the walk that populates it, so
+    there is nothing to truncate -- the previous project walk's record is
+    wiped outright).
+
+    The principle is already stated in `run()`, where the exclusion-state
+    stamp is guarded by `if self._single_file is None` because "a single-file
+    run walks one file and cannot speak for the project's exclusion set".
+    These tests extend it to deletions, the hash cache and the mtime record.
+
+    Latent today: `cli.py` and `mcp/tools.py` always pass a directory. The
+    constructor accepts a file without complaint, so the next caller wanting a
+    targeted re-index would silently drop the rest of the repository.
+    """
+
+    @staticmethod
+    def _three_module_project(tmp_path: Path) -> Path:
+        repo = tmp_path / "scoped"
+        repo.mkdir()
+        (repo / "__init__.py").touch()
+        (repo / "module_a.py").write_text(
+            "class Alpha:\n    def greet(self):\n        return 1\n", encoding="utf-8"
+        )
+        (repo / "module_b.py").write_text("def func_b():\n    pass\n", encoding="utf-8")
+        return repo
+
+    @staticmethod
+    def _deleted_module_keys(ingestor: MagicMock) -> set[str]:
+        return {
+            call.args[1][cs.KEY_PATH]
+            for call in ingestor.execute_write.call_args_list
+            if call.args and call.args[0] == cs.CYPHER_DELETE_MODULE
+        }
+
+    def _build_then_single_file(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> tuple[Path, MagicMock]:
+        """Full build, then a single-file run on module_a with a fresh ingestor.
+
+        The second ingestor must satisfy `QueryProtocol`: the deletion is
+        gated on `isinstance(self.ingestor, QueryProtocol)`, so a plain
+        `MagicMock` makes the defect silently invisible rather than absent.
+        """
+        repo = self._three_module_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        second = _MockIngestor()
+        GraphUpdater(
+            ingestor=second,
+            repo_path=repo / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        return repo, second
+
+    def test_single_file_run_deletes_no_sibling_modules(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        _repo, second = self._build_then_single_file(tmp_path, mock_ingestor)
+        assert self._deleted_module_keys(second) == set(), (
+            "a single-file run reconciled the whole project and swept every "
+            "module the cache named, including the one it was asked to index"
+        )
+
+    def test_single_file_run_keeps_sibling_hash_cache_entries(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        repo, _second = self._build_then_single_file(tmp_path, mock_ingestor)
+        cache = json.loads((repo / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8"))
+        assert set(cache) == {"__init__.py", "module_a.py", "module_b.py"}, (
+            "the cache must keep every sibling's hash; replacing it with the "
+            "one walked file makes the next full run treat the rest as new"
+        )
+
+    def test_single_file_run_leaves_the_directory_mtime_record_alone(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """Skipped, not merged: this run collected no directory mtimes at all.
+
+        Distinct from the hash cache, where the single walked file DID yield a
+        fresh hash worth recording. Here there is nothing to merge, so the
+        only correct action is to leave the previous walk's record untouched.
+        """
+        repo = self._three_module_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        mtimes_path = repo / cs.DIR_MTIMES_FILENAME
+        before = json.loads(mtimes_path.read_text(encoding="utf-8"))
+        assert before, "fixture guard: the full build must record at least one"
+
+        GraphUpdater(
+            ingestor=_MockIngestor(),
+            repo_path=repo / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        assert json.loads(mtimes_path.read_text(encoding="utf-8")) == before, (
+            "a single-file run records no directory mtimes, so writing its "
+            "empty collection wipes the project's record wholesale"
+        )

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -337,7 +337,7 @@ class TestSingleFileRunScope:
         dict DROPS those siblings from the cache, and a dropped key takes the
         `is_new` path next run, skipping delete-before-reingest.
 
-        The stale set is DERIVED, not assigned: `_collect_delombok_state`
+        The stale set is DERIVED, not assigned: `_register_generated_sources`
         recomputes both delombok fields from the on-disk state file during
         `run`, so setting the attributes on the updater beforehand is
         overwritten and the test would pass on broken code too. Planting a

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -428,6 +428,79 @@ class TestSingleFileRunScope:
             "the previous cache, not be replaced by it"
         )
 
+    def test_single_file_run_publishes_no_cache_when_there_was_none(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """A cacheless single-file run must not leave a one-entry cache.
+
+        Publishing the single hash it took would create a cache naming one
+        file, and the NEXT PROJECT run reads that as authoritative: every
+        sibling is absent from `old_hashes`, so it takes the `is_new` path,
+        skips delete-before-reingest, and an edited sibling's previous
+        entities survive beside the fresh parse.
+
+        The assertion is on the LATER project run's deletes, not on the cache
+        contents, because the cache is written either way -- `{}` by
+        `_touch_empty_json` when suppressed, `{"module_a.py": ...}` when not.
+        Only the consequence one run later tells the two apart, which is the
+        whole point of the finding (#1619 review, round 5).
+        """
+        repo = self._three_module_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        cache_path = repo / cs.HASH_CACHE_FILENAME
+        assert cache_path.is_file(), (
+            "fixture guard: the project run must have written a cache, or "
+            "removing it below would not establish the precondition"
+        )
+        cache_path.unlink()
+
+        graph_rows = [
+            {cs.KEY_PATH: "module_a.py"},
+            {cs.KEY_PATH: "module_b.py"},
+            {cs.KEY_PATH: "__init__.py"},
+        ]
+        single = _MockIngestor()
+        single.fetch_all.return_value = graph_rows
+        GraphUpdater(
+            ingestor=single,
+            repo_path=repo / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        # Edit a sibling the single-file run never looked at.
+        (repo / "module_b.py").write_text(
+            "def module_b_function():\n    return 99\n", encoding="utf-8"
+        )
+
+        project = _MockIngestor()
+        project.fetch_all.return_value = graph_rows
+        GraphUpdater(
+            ingestor=project,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        deleted = {
+            call.args[1][cs.KEY_PATH]
+            for call in project.execute_write.call_args_list
+            if call.args and call.args[0] == cs.CYPHER_DELETE_MODULE
+        }
+        assert "module_b.py" in deleted, (
+            "the single-file run published a cache naming only its own file, "
+            "so this project run treated the edited sibling as new and "
+            "skipped delete-before-reingest; its previous entities now "
+            "survive alongside the fresh parse"
+        )
+
     @pytest.mark.parametrize(
         ("force", "drop_cache"),
         [(False, False), (True, False), (False, True)],


### PR DESCRIPTION
Fixes #1619.

A `GraphUpdater` rooted at a single file walks exactly one file, so
`current_file_keys` names only that file. Three consumers then treated that
one-file view as if it described the whole project.

## The three guards

Each needed a *different* remedy, so they are not one change repeated:

| Consumer | Wrong behaviour | Remedy |
|---|---|---|
| `deleted_keys` | every sibling looked deleted and was swept from the graph | **skip** |
| hash cache | the cache was truncated to one entry | **merge** over the pristine cache |
| dir mtimes | `.cgr-dir-mtimes.json` overwritten with `{}` | **skip** |

This extends the existing `self._single_file is None` precedent already used
to guard the exclusion stamp.

## Cache staleness

The merge alone is not enough. `run()` restamps the cache with this run's
`observed_at`, which is *later* than a sibling edited before the run started,
so `_is_already_in_sync` would see `file_mtime <= cache_mtime` with a matching
hash and skip the edit permanently. A single-file run therefore carries the
previous cache's mtime forward rather than restamping.

The merge also reads a snapshot taken *before* the `_delombok_stale_keys` pop.
That pop exists to force stale files through a reparse in the current run; it
must not be persisted, because this run does not commit the delombok state.

## Tests

Two tests, both verified to fail without the fix:

- a sibling edited *before* a single-file run must still be indexed by the
  next project run (ordering is the discriminating power)
- Lombok-stale siblings must survive in the cache

The Lombok test plants a real `.cgr-delombok-state.json` rather than assigning
the attribute, because `run()` recomputes `_delombok_stale_keys` from disk
mid-run; a fixture guard asserts the precondition actually held.

Full suite: 9311 passed, 0 failures.

## Known limitations, unchanged by this PR

- A single-file run does not reparse the changed file's **dependents**.
- All four production call sites pass a directory, so the single-file path
  remains latent.
- A hash-cache mtime in the **future** makes `_is_already_in_sync` skip every
  file. Base accidentally healed this by restamping on every single-file run,
  which is the P0 behaviour this PR had to remove. The hole is in
  `_is_already_in_sync` and wants its own PR; filing separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-file processing no longer incorrectly treats sibling files as deleted.
  * Existing sibling file data remains available in the hash cache, including files affected by Lombok changes.
  * Subsequent project-wide runs now correctly detect edits made to sibling files.
  * Single-file runs preserve directory metadata and prior cache timestamps.
  * Already-indexed target files are correctly refreshed before being ingested again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->