### PR TITLE
fix: flush the orphan-prune deletes before the caches commit (#1645)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1323,6 +1323,14 @@ class GraphUpdater:
         self._link_endpoint_resources()
 
         self._prune_orphan_nodes()
+        # The prune issues its own deletes and has no flush of its own, so the
+        # flush above cannot cover them (issue #1645). Without this they are
+        # still queued when the caches commit below, and a run that stops in
+        # between tells its successor the tree was reconciled while the
+        # deletes never became durable: the successor takes the in-sync fast
+        # path, never re-issues them, and the orphan survives until a full
+        # rebuild. Same invariant as #1615, on the writes that pass fixed.
+        self.ingestor.flush_all()
 
         self._generate_semantic_embeddings()
 

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -995,6 +995,77 @@ class TestCrashBetweenCacheSaveAndFlush:
 
         assert "module_b.py" in _deleted_module_paths(mock_ingestor)
 
+    def test_prune_deletes_are_flushed_before_the_cache_commits(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """Issue #1645: the same defect on the orphan-prune writes.
+
+        `_prune_orphan_nodes` runs after the graph flush and issues its own
+        `execute_write` deletes. Without a flush of its own, those deletes are
+        still queued when the hash cache commits, so a run that stops in
+        between hands its successor caches describing a tree whose prune was
+        never applied. The successor takes the in-sync fast path and never
+        re-issues them, and the orphan survives until a full rebuild.
+        """
+        parsers, queries = load_parsers()
+
+        # A Folder row for a directory that is not on disk is an orphan, so
+        # the prune must delete it. Driving a REAL delete is what stops this
+        # test being vacuous: the default `fetch_all` mock iterates empty, the
+        # prune finds nothing, and every ordering assertion below would hold
+        # against unfixed code simply because no delete was ever issued.
+        ghost = (py_project / "gone").resolve().as_posix()
+
+        def _fetch_all(query: str) -> list[dict[str, str]]:
+            if query == cs.CYPHER_ALL_FOLDER_PATHS:
+                return [{cs.KEY_PATH: "gone", "absolute_path": ghost}]
+            return []
+
+        mock_ingestor.fetch_all = MagicMock(side_effect=_fetch_all)
+
+        order: list[str] = []
+
+        def _record_write(*args: object, **kwargs: object) -> MagicMock:
+            if args and args[0] == cs.CYPHER_DELETE_FOLDER:
+                order.append("prune_delete")
+            return MagicMock()
+
+        def _record_flush(*args: object, **kwargs: object) -> MagicMock:
+            order.append("flush")
+            return MagicMock()
+
+        mock_ingestor.execute_write = MagicMock(side_effect=_record_write)
+        mock_ingestor.flush_all = MagicMock(side_effect=_record_flush)
+
+        real_publish = graph_updater_module._publish_hash_cache
+
+        def _record_publish(*args: object, **kwargs: object) -> None:
+            order.append("cache_commit")
+            real_publish(*args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(graph_updater_module, "_publish_hash_cache", _record_publish):
+            GraphUpdater(
+                ingestor=mock_ingestor,
+                repo_path=py_project,
+                parsers=parsers,
+                queries=queries,
+            ).run()
+
+        # The fixture must actually exercise the prune, or the ordering
+        # assertion below is satisfied by a run that pruned nothing.
+        assert "prune_delete" in order, f"prune issued no delete: {order}"
+        assert "cache_commit" in order, f"cache never committed: {order}"
+
+        # The property: every prune delete is durable before the cache that
+        # claims the tree was reconciled becomes visible. Asserting on a flush
+        # BETWEEN the two, not merely that a flush exists: the run already
+        # flushes before the prune, so `flush_all.called` is true either way.
+        deleted_at = order.index("prune_delete")
+        committed_at = order.index("cache_commit")
+        assert "flush" in order[deleted_at:committed_at], (
+            f"prune deletes were not flushed before the hash cache committed: {order}"
+        )
+
 
 class TestFastPathInSync:
     def test_second_run_skips_all_passes(


### PR DESCRIPTION
Closes #1645.

Stacked on #1656 (issue #1646), which this branch's base points at. Merge that
one first.

## The defect

`_prune_orphan_nodes` runs after the graph flush and issues its own
`execute_write` deletes, with no flush of its own:

```
1272   self.ingestor.flush_all()      # cannot cover writes issued after it
1276   self._prune_orphan_nodes()     # queues CYPHER_DELETE_FILE/MODULE/FOLDER/PACKAGE
~1345  # hash cache and dir-mtimes commit point
```

So the deletes are still queued when the caches commit. A run that stops in
between hands its successor caches describing a tree whose orphan deletes were
never applied: the successor loads them, finds nothing changed, takes the
in-sync fast path, and never re-issues them. A pruned Folder or Package node
survives until a full rebuild.

This is #1615's defect on a different set of writes. That fix moved the
hash-cache write to a post-flush commit point so a crash could not hide a
deletion; it covered the deletes issued inside `_process_files`, not the ones
the prune issues later.

## The fix

```python
self._prune_orphan_nodes()
self.ingestor.flush_all()
```

Verified against the code rather than taken from the issue body. On `main`
before this change, `_prune_orphan_nodes` spanned lines 2994-3118 and contained
two `execute_write` calls (3094, 3109) and zero `flush_all`, while the file had
six `flush_all` overall; on this branch the same body sits at 3040-3164 with
its two `execute_write` calls at 3140 and 3155, still with no `flush_all` of
its own. The only flushes after the prune's call site are inside
`_link_endpoint_resources`, which runs *before* it.

## The test, and why the fixture is the load-bearing part

`test_prune_deletes_are_flushed_before_the_cache_commits` records the order of
prune deletes, flushes and the cache commit, then asserts a flush falls
*between* the delete and the commit.

The fixture drives a real delete by returning a `Folder` row for a directory
that is not on disk. That is what stops the test being vacuous: the default
`fetch_all` mock returns a `MagicMock` that **iterates empty**, so the prune
finds no orphans and issues no deletes at all, and every ordering assertion
would then hold against unfixed code for want of anything to order. Two guard
assertions pin this — the run must have issued a prune delete and must have
committed a cache — before the ordering assertion is reached.

The ordering assertion is on a flush *between* the two, not on
`flush_all.called`: the run already flushes before the prune, so the weaker
form is true either way.

## Evidence

Red before the fix, and for the right reason — both guards passed first:

```
AssertionError: prune deletes were not flushed before the hash cache committed:
['flush', 'prune_delete', 'cache_commit']
```

Green after. Mutation check: removing the added `flush_all` turns **exactly
one** test red (this one) and leaves the other six in the class passing, so it
discriminates precisely rather than by collateral damage. Full file: 47 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured orphaned directory cleanup operations are fully applied before synchronization caches are committed.
  - Prevented subsequent incremental runs from incorrectly skipping pending orphan deletions.
  - Improved labeling for cache-stamp failures during reingestion, making synchronization logs easier to interpret.

- **Tests**
  - Added coverage verifying that orphan cleanup completes before cache updates are recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->