### PR TITLE
fix: a value receiver never constructs, so value.Name() must not resolve to a class (#1641)

### DIFF
--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -124,9 +124,11 @@ KEYWORD_SUPER = "super"
 KEYWORD_SELF = "self"
 KEYWORD_CONSTRUCTOR = "constructor"
 # Receivers that name the enclosing type rather than an ordinary value, so
-# `self.Inner()` and `cls.Inner()` are real nested-class constructions. Go's
-# receiver is user-named and cannot be listed here; it is covered by the
-# local/receiver type lookup instead (issue #1641).
+# `self.Inner()` and `cls.Inner()` are real nested-class constructions.
+# Membership is not sufficient on its own: `self` is also a legal Go receiver
+# name, and a spelling test alone accepted `self.Error()` for a module-level
+# `Error`. The caller pairs this with a nesting check against the enclosing
+# type, which is what actually distinguishes the two (issue #1641).
 SELF_RECEIVER_KEYWORDS = frozenset({"self", "cls", "this"})
 
 # Incremental update hash cache

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -123,6 +123,11 @@ OPERATOR_PREFIX = "operator"
 KEYWORD_SUPER = "super"
 KEYWORD_SELF = "self"
 KEYWORD_CONSTRUCTOR = "constructor"
+# Receivers that name the enclosing type rather than an ordinary value, so
+# `self.Inner()` and `cls.Inner()` are real nested-class constructions. Go's
+# receiver is user-named and cannot be listed here; it is covered by the
+# local/receiver type lookup instead (issue #1641).
+SELF_RECEIVER_KEYWORDS = frozenset({"self", "cls", "this"})
 
 # Incremental update hash cache
 HASH_CACHE_FILENAME = ".cgr-hash-cache.json"

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -435,45 +435,50 @@ class CallResolver:
         resolve them correctly. Dropping them would delete edges `origin/main`
         gets right, so both are consulted here rather than judged by name.
         """
-        head = receiver.split(cs.SEPARATOR_DOT, 1)[0]
+        head, _, rest = receiver.partition(cs.SEPARATOR_DOT)
         if not head or not head.isidentifier():
             return False
-        # Both branches below ask a NARROWER question than the ones after them.
-        # A class or module receiver admits any name it holds, but `self` and a
-        # typed local admit only a class NESTED IN that type: `self.Inner()`
-        # constructs, while `self.Error()` naming a module-level `Error` is the
-        # #1641 defect wearing a different receiver. Answering "is the receiver
-        # constructible-through" and stopping there re-opened it.
-        if head in cs.SELF_RECEIVER_KEYWORDS and class_context:
-            if self._class_is_nested_in(resolved_qn, class_context):
-                return True
-        if local_var_types and (var_type := local_var_types.get(head)):
-            typed_qn = self._resolve_class_name(var_type, module_qn)
-            if (
-                typed_qn
-                and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS
-                and self._class_is_nested_in(resolved_qn, typed_qn)
-            ):
-                return True
+        # `self`/`cls` and a typed local name a value that is nonetheless a
+        # namespace for its OWN nested classes, so they admit only a class
+        # nested in that type: `self.Inner()` constructs, `self.Error()` naming
+        # a module-level `Error` is the #1641 defect wearing a new receiver.
+        # Single-segment only -- `self.err.Error()` reaches a FIELD, which is an
+        # ordinary value, so a chain must fall through to the checks below.
+        if not rest:
+            if head in cs.SELF_RECEIVER_KEYWORDS and class_context:
+                if self._class_is_nested_in(resolved_qn, class_context):
+                    return True
+            if local_var_types and (var_type := local_var_types.get(head)):
+                typed_qn = self._resolve_class_name(var_type, module_qn)
+                if (
+                    typed_qn
+                    and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS
+                    and self._class_is_nested_in(resolved_qn, typed_qn)
+                ):
+                    return True
+        # Resolve the WHOLE receiver, not just its head. `mod_a.instance` has a
+        # module for a head and a value for a tail, and judging it by the head
+        # alone accepted `mod_a.instance.Error()` -- the original defect reached
+        # through one more segment.
+        #
         # `_resolve_class_name` follows the import map without checking what it
         # landed on, so it answers `mod_a.helper` for an imported FUNCTION named
         # `helper`. Confirm the qn it returns really is a Class before trusting
-        # it as a receiver; the name alone is not evidence of classness.
+        # it; the name alone is not evidence of classness.
+        base: str | None = None
         class_qn = self._resolve_class_name(head, module_qn)
         if class_qn and self.function_registry.get(class_qn) == cs.NodeLabel.CLASS:
-            return True
-        import_map = self.import_processor.import_mapping.get(module_qn) or {}
-        if head in import_map:
-            # Being imported says nothing about KIND: `from m import instance`
-            # and `import m` both land here, and only the second is a namespace.
-            return self._import_target_is_a_namespace(import_map[head])
-        # No sibling-module branch here. Modules are not members of
-        # `function_registry`, so testing `parent.head` in it could never match
-        # the module it was meant to admit -- it matched only a sibling
-        # FUNCTION or CLASS, which made the guard fail open for a local sharing
-        # a name with one. An unimported sibling module is not addressable as a
-        # bare receiver in the languages this guard runs for.
-        return False
+            base = class_qn
+        else:
+            import_map = self.import_processor.import_mapping.get(module_qn) or {}
+            if head in import_map:
+                base = import_map[head]
+        if base is None:
+            return False
+        # Being imported says nothing about KIND: `from m import instance` and
+        # `import m` both land in the map, and only the second is a namespace.
+        full = base if not rest else f"{base}{cs.SEPARATOR_DOT}{rest}"
+        return self._import_target_is_a_namespace(full)
 
     def _class_is_nested_in(self, class_qn: str, owner_qn: str) -> bool:
         """Whether `class_qn` is declared inside `owner_qn` or one of its bases.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -406,7 +406,7 @@ class CallResolver:
         if cs.SEPARATOR_DOUBLE_COLON in receiver:
             return result
         if self._receiver_names_a_type_or_module(
-            receiver, module_qn, class_context, local_var_types
+            receiver, module_qn, result[1], class_context, local_var_types
         ):
             return result
         logger.debug(ls.CALL_UNRESOLVED, call_name=call_name)
@@ -416,6 +416,7 @@ class CallResolver:
         self,
         receiver: str,
         module_qn: str,
+        resolved_qn: str = "",
         class_context: str | None = None,
         local_var_types: dict[str, str] | None = None,
     ) -> bool:
@@ -434,11 +435,22 @@ class CallResolver:
         head = receiver.split(cs.SEPARATOR_DOT, 1)[0]
         if not head or not head.isidentifier():
             return False
+        # Both branches below ask a NARROWER question than the ones after them.
+        # A class or module receiver admits any name it holds, but `self` and a
+        # typed local admit only a class NESTED IN that type: `self.Inner()`
+        # constructs, while `self.Error()` naming a module-level `Error` is the
+        # #1641 defect wearing a different receiver. Answering "is the receiver
+        # constructible-through" and stopping there re-opened it.
         if head in cs.SELF_RECEIVER_KEYWORDS and class_context:
-            return True
+            if self._class_is_nested_in(resolved_qn, class_context):
+                return True
         if local_var_types and (var_type := local_var_types.get(head)):
             typed_qn = self._resolve_class_name(var_type, module_qn)
-            if typed_qn and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS:
+            if (
+                typed_qn
+                and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS
+                and self._class_is_nested_in(resolved_qn, typed_qn)
+            ):
                 return True
         # `_resolve_class_name` follows the import map without checking what it
         # landed on, so it answers `mod_a.helper` for an imported FUNCTION named
@@ -459,6 +471,11 @@ class CallResolver:
         # a name with one. An unimported sibling module is not addressable as a
         # bare receiver in the languages this guard runs for.
         return False
+
+    @staticmethod
+    def _class_is_nested_in(class_qn: str, owner_qn: str) -> bool:
+        """Whether `class_qn` is declared inside `owner_qn`."""
+        return bool(class_qn) and class_qn.startswith(f"{owner_qn}{cs.SEPARATOR_DOT}")
 
     def _import_target_is_a_namespace(self, target: str) -> bool:
         """Whether an imported name refers to something you construct THROUGH.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -438,47 +438,67 @@ class CallResolver:
         head, _, rest = receiver.partition(cs.SEPARATOR_DOT)
         if not head or not head.isidentifier():
             return False
-        # `self`/`cls` and a typed local name a value that is nonetheless a
-        # namespace for its OWN nested classes, so they admit only a class
-        # nested in that type: `self.Inner()` constructs, `self.Error()` naming
-        # a module-level `Error` is the #1641 defect wearing a new receiver.
-        # Single-segment only -- `self.err.Error()` reaches a FIELD, which is an
-        # ordinary value, so a chain must fall through to the checks below.
-        if not rest:
-            if head in cs.SELF_RECEIVER_KEYWORDS and class_context:
-                if self._class_is_nested_in(resolved_qn, class_context):
-                    return True
-            if local_var_types and (var_type := local_var_types.get(head)):
-                typed_qn = self._resolve_class_name(var_type, module_qn)
-                if (
-                    typed_qn
-                    and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS
-                    and self._class_is_nested_in(resolved_qn, typed_qn)
-                ):
-                    return True
+        # Single-segment only: `self.err.Error()` reaches a FIELD, an ordinary
+        # value, so a chain falls through to the namespace resolution below.
+        if not rest and self._receiver_owns_nested_class(
+            head, module_qn, resolved_qn, class_context, local_var_types
+        ):
+            return True
+        base = self._receiver_base_qn(head, module_qn)
+        if base is None:
+            return False
         # Resolve the WHOLE receiver, not just its head. `mod_a.instance` has a
         # module for a head and a value for a tail, and judging it by the head
         # alone accepted `mod_a.instance.Error()` -- the original defect reached
-        # through one more segment.
-        #
-        # `_resolve_class_name` follows the import map without checking what it
-        # landed on, so it answers `mod_a.helper` for an imported FUNCTION named
-        # `helper`. Confirm the qn it returns really is a Class before trusting
-        # it; the name alone is not evidence of classness.
-        base: str | None = None
-        class_qn = self._resolve_class_name(head, module_qn)
-        if class_qn and self.function_registry.get(class_qn) == cs.NodeLabel.CLASS:
-            base = class_qn
-        else:
-            import_map = self.import_processor.import_mapping.get(module_qn) or {}
-            if head in import_map:
-                base = import_map[head]
-        if base is None:
-            return False
-        # Being imported says nothing about KIND: `from m import instance` and
-        # `import m` both land in the map, and only the second is a namespace.
+        # through one more segment. Being imported also says nothing about KIND:
+        # `from m import instance` and `import m` both land in the map, and only
+        # the second is a namespace.
         full = base if not rest else f"{base}{cs.SEPARATOR_DOT}{rest}"
         return self._import_target_is_a_namespace(full)
+
+    def _receiver_owns_nested_class(
+        self,
+        head: str,
+        module_qn: str,
+        resolved_qn: str,
+        class_context: str | None,
+        local_var_types: dict[str, str] | None,
+    ) -> bool:
+        """Whether `head` names a type whose OWN nested class is being built.
+
+        `self`/`cls`/`this` and a local typed to a class are spelled as values
+        but really do construct: `self.Inner()` is a nested-class construction,
+        while `self.Error()` naming a module-level `Error` is the #1641 defect
+        wearing a new receiver. So each admits only a class nested in its type.
+        """
+        if head in cs.SELF_RECEIVER_KEYWORDS and class_context:
+            if self._class_is_nested_in(resolved_qn, class_context):
+                return True
+        if not local_var_types:
+            return False
+        var_type = local_var_types.get(head)
+        if not var_type:
+            return False
+        typed_qn = self._resolve_class_name(var_type, module_qn)
+        return bool(
+            typed_qn
+            and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS
+            and self._class_is_nested_in(resolved_qn, typed_qn)
+        )
+
+    def _receiver_base_qn(self, head: str, module_qn: str) -> str | None:
+        """The qn the receiver's first segment names, if it names a namespace.
+
+        `_resolve_class_name` follows the import map without checking what it
+        landed on, so it answers `mod_a.helper` for an imported FUNCTION named
+        `helper`. Confirm the qn it returns really is a Class before trusting
+        it; the name alone is not evidence of classness.
+        """
+        class_qn = self._resolve_class_name(head, module_qn)
+        if class_qn and self.function_registry.get(class_qn) == cs.NodeLabel.CLASS:
+            return class_qn
+        import_map = self.import_processor.import_mapping.get(module_qn) or {}
+        return import_map.get(head)
 
     def _class_is_nested_in(self, class_qn: str, owner_qn: str) -> bool:
         """Whether `class_qn` is declared inside `owner_qn` or one of its bases.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -358,6 +358,8 @@ class CallResolver:
             ),
             call_name,
             module_qn,
+            class_context,
+            local_var_types,
         )
 
     def _reject_class_via_value_receiver(
@@ -365,6 +367,8 @@ class CallResolver:
         result: tuple[str, str] | None,
         call_name: str,
         module_qn: str,
+        class_context: str | None = None,
+        local_var_types: dict[str, str] | None = None,
     ) -> tuple[str, str] | None:
         """Drop a CLASS answer for `value.Name()` -- a value never constructs.
 
@@ -392,29 +396,50 @@ class CallResolver:
             return result
         # `::` and `:` are static paths (`Type::new`, `Class::method`), where a
         # type receiver is the normal spelling; only a `.` receiver can be a value.
-        if cs.SEPARATOR_DOT not in call_name or self._has_static_path_separator(
-            call_name
-        ):
+        if cs.SEPARATOR_DOT not in call_name:
             return result
         receiver = call_name.rsplit(cs.SEPARATOR_DOT, 1)[0]
-        if self._receiver_names_a_type_or_module(receiver, module_qn):
+        # `::` is a static path (`Type::new`), where a type receiver is the
+        # normal spelling. A BARE `:` is not: in Python it is a slice or a dict
+        # key inside the receiver expression (`xs[1:2].Error()`), and exempting
+        # on it let the defect straight through.
+        if cs.SEPARATOR_DOUBLE_COLON in receiver:
+            return result
+        if self._receiver_names_a_type_or_module(
+            receiver, module_qn, class_context, local_var_types
+        ):
             return result
         logger.debug(ls.CALL_UNRESOLVED, call_name=call_name)
         return None
 
-    def _has_static_path_separator(self, call_name: str) -> bool:
-        return cs.SEPARATOR_DOUBLE_COLON in call_name or cs.CHAR_COLON in call_name
-
-    def _receiver_names_a_type_or_module(self, receiver: str, module_qn: str) -> bool:
+    def _receiver_names_a_type_or_module(
+        self,
+        receiver: str,
+        module_qn: str,
+        class_context: str | None = None,
+        local_var_types: dict[str, str] | None = None,
+    ) -> bool:
         """Whether a receiver expression names something constructible-through.
 
         A class (nested-class construction), or a module/package the caller
-        imported or that sits beside it. Anything else -- a local, a parameter,
-        a field, a chained call -- holds a VALUE at runtime.
+        imported. Anything else -- a parameter, a field, a chained call -- holds
+        a VALUE at runtime.
+
+        `self`/`cls`/`this` and a local typed to a class are the awkward cases:
+        the receiver is spelled as a value but `self.Inner()` and `o.Inner()`
+        really do construct a nested class, and the receiver-aware paths upstream
+        resolve them correctly. Dropping them would delete edges `origin/main`
+        gets right, so both are consulted here rather than judged by name.
         """
         head = receiver.split(cs.SEPARATOR_DOT, 1)[0]
         if not head or not head.isidentifier():
             return False
+        if head in cs.SELF_RECEIVER_KEYWORDS and class_context:
+            return True
+        if local_var_types and (var_type := local_var_types.get(head)):
+            typed_qn = self._resolve_class_name(var_type, module_qn)
+            if typed_qn and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS:
+                return True
         # `_resolve_class_name` follows the import map without checking what it
         # landed on, so it answers `mod_a.helper` for an imported FUNCTION named
         # `helper`. Confirm the qn it returns really is a Class before trusting
@@ -427,11 +452,13 @@ class CallResolver:
             # Being imported says nothing about KIND: `from m import instance`
             # and `import m` both land here, and only the second is a namespace.
             return self._import_target_is_a_namespace(import_map[head])
-        # A sibling module addressed without an import statement (a package
-        # `__init__` re-export, Go's same-package files): the receiver names a
-        # real module node rather than a variable.
-        parent = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-        return f"{parent}{cs.SEPARATOR_DOT}{head}" in self.function_registry
+        # No sibling-module branch here. Modules are not members of
+        # `function_registry`, so testing `parent.head` in it could never match
+        # the module it was meant to admit -- it matched only a sibling
+        # FUNCTION or CLASS, which made the guard fail open for a local sharing
+        # a name with one. An unimported sibling module is not addressable as a
+        # bare receiver in the languages this guard runs for.
+        return False
 
     def _import_target_is_a_namespace(self, target: str) -> bool:
         """Whether an imported name refers to something you construct THROUGH.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -416,7 +416,10 @@ class CallResolver:
         self,
         receiver: str,
         module_qn: str,
-        resolved_qn: str = "",
+        # Required rather than defaulted: an omitted resolved qn would make the
+        # nesting check answer False and silently reject every `self.Inner()`
+        # and typed-local construction, with no error to notice.
+        resolved_qn: str,
         class_context: str | None = None,
         local_var_types: dict[str, str] | None = None,
     ) -> bool:
@@ -472,10 +475,23 @@ class CallResolver:
         # bare receiver in the languages this guard runs for.
         return False
 
-    @staticmethod
-    def _class_is_nested_in(class_qn: str, owner_qn: str) -> bool:
-        """Whether `class_qn` is declared inside `owner_qn`."""
-        return bool(class_qn) and class_qn.startswith(f"{owner_qn}{cs.SEPARATOR_DOT}")
+    def _class_is_nested_in(self, class_qn: str, owner_qn: str) -> bool:
+        """Whether `class_qn` is declared inside `owner_qn` or one of its bases.
+
+        `self.Inner()` inside a `Derived(Base)` resolves to `Base.Inner`, which
+        is a real construction, so a prefix test against the enclosing type
+        alone rejects an edge that is correct. Walking the MRO makes this a
+        question about the TYPE rather than about qualified-name spelling.
+
+        The trailing separator is load-bearing: without it `Outer2.Inner` would
+        match owner `Outer` and a sibling class would read as a nested one.
+        """
+        if not class_qn or not owner_qn:
+            return False
+        return any(
+            class_qn.startswith(f"{ancestor}{cs.SEPARATOR_DOT}")
+            for ancestor in self._mro(owner_qn)
+        )
 
     def _import_target_is_a_namespace(self, target: str) -> bool:
         """Whether an imported name refers to something you construct THROUGH.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -344,17 +344,114 @@ class CallResolver:
         language: cs.SupportedLanguage | None = None,
         call_point: int | None = None,
     ) -> tuple[str, str] | None:
-        return self._redirect_protocol_method(
-            self._resolve_function_call(
-                call_name,
-                module_qn,
-                local_var_types,
-                class_context,
-                caller_qn,
-                language,
-                call_point,
-            )
+        return self._reject_class_via_value_receiver(
+            self._redirect_protocol_method(
+                self._resolve_function_call(
+                    call_name,
+                    module_qn,
+                    local_var_types,
+                    class_context,
+                    caller_qn,
+                    language,
+                    call_point,
+                )
+            ),
+            call_name,
+            module_qn,
         )
+
+    def _reject_class_via_value_receiver(
+        self,
+        result: tuple[str, str] | None,
+        call_name: str,
+        module_qn: str,
+    ) -> tuple[str, str] | None:
+        """Drop a CLASS answer for `value.Name()` -- a value never constructs.
+
+        Two independent paths reach a class by discarding the receiver and
+        looking the trailing name up on its own: `_try_resolve_module_method`
+        (same module) and `_try_resolve_via_trie` (cross module). Both then look
+        like construction to the emit site, which records INSTANTIATES for any
+        callee that resolved to a Class.
+
+        So `err.Error()` on a stdlib error became "constructs the first-party
+        `Error` struct", and `buf.String()` on a `bytes.Buffer` became
+        "constructs `render.text.String`". Go is worst hit because `Error()` and
+        `String()` are its two most idiomatic interface methods, but Python
+        reproduces it identically (issue #1641).
+
+        The receiver decides. `Outer.Inner()` IS a genuine instantiation whose
+        receiver is a class, and `pkg.Thing()` one whose receiver is a module,
+        so this rejects only a receiver that resolves to neither -- an ordinary
+        identifier holding a value. Guarding here rather than at either lookup
+        keeps one rule for both paths; JS/TS and Dart already carry their own
+        version of it further down (`_resolve_two_part_call`, the unique-member
+        gate), which is why neither reproduced.
+        """
+        if result is None or result[0] != cs.NodeLabel.CLASS:
+            return result
+        # `::` and `:` are static paths (`Type::new`, `Class::method`), where a
+        # type receiver is the normal spelling; only a `.` receiver can be a value.
+        if cs.SEPARATOR_DOT not in call_name or self._has_static_path_separator(
+            call_name
+        ):
+            return result
+        receiver = call_name.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        if self._receiver_names_a_type_or_module(receiver, module_qn):
+            return result
+        logger.debug(ls.CALL_UNRESOLVED, call_name=call_name)
+        return None
+
+    def _has_static_path_separator(self, call_name: str) -> bool:
+        return cs.SEPARATOR_DOUBLE_COLON in call_name or cs.CHAR_COLON in call_name
+
+    def _receiver_names_a_type_or_module(self, receiver: str, module_qn: str) -> bool:
+        """Whether a receiver expression names something constructible-through.
+
+        A class (nested-class construction), or a module/package the caller
+        imported or that sits beside it. Anything else -- a local, a parameter,
+        a field, a chained call -- holds a VALUE at runtime.
+        """
+        head = receiver.split(cs.SEPARATOR_DOT, 1)[0]
+        if not head or not head.isidentifier():
+            return False
+        # `_resolve_class_name` follows the import map without checking what it
+        # landed on, so it answers `mod_a.helper` for an imported FUNCTION named
+        # `helper`. Confirm the qn it returns really is a Class before trusting
+        # it as a receiver; the name alone is not evidence of classness.
+        class_qn = self._resolve_class_name(head, module_qn)
+        if class_qn and self.function_registry.get(class_qn) == cs.NodeLabel.CLASS:
+            return True
+        import_map = self.import_processor.import_mapping.get(module_qn) or {}
+        if head in import_map:
+            # Being imported says nothing about KIND: `from m import instance`
+            # and `import m` both land here, and only the second is a namespace.
+            return self._import_target_is_a_namespace(import_map[head])
+        # A sibling module addressed without an import statement (a package
+        # `__init__` re-export, Go's same-package files): the receiver names a
+        # real module node rather than a variable.
+        parent = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        return f"{parent}{cs.SEPARATOR_DOT}{head}" in self.function_registry
+
+    def _import_target_is_a_namespace(self, target: str) -> bool:
+        """Whether an imported name refers to something you construct THROUGH.
+
+        A class (`from m import Outer` then `Outer.Inner()`) or a module
+        (`import m` then `m.Thing()`). A function, a method or a module-level
+        instance is a VALUE, and `value.Name()` is a method call however it
+        arrived in scope.
+        """
+        kind = self.function_registry.get(target)
+        if kind is not None:
+            return kind == cs.NodeLabel.CLASS
+        # Unregistered, so it is a module IFF the registry holds anything under
+        # its qn. A module node itself is not in the function registry, but its
+        # contents are; an imported instance has an empty subtree.
+        #
+        # The label check above must stay FIRST: `find_with_prefix` returns the
+        # subtree INCLUDING the target, so an imported function reports one
+        # descendant (itself) and a prefix-only test would call it a namespace.
+        return bool(self.function_registry.find_with_prefix(target))
 
     def _resolve_js_prototype_sibling(
         self,

--- a/codebase_rag/tests/test_value_receiver_class_resolution.py
+++ b/codebase_rag/tests/test_value_receiver_class_resolution.py
@@ -360,6 +360,78 @@ def via_typed_local():
         assert ("nested.m.via_instance", "nested.m.Outer.Inner") in edges
 
 
+class TestInheritedNestedClass:
+    """`self.Inner()` in a subclass resolves to `Base.Inner`, and that is real.
+
+    A prefix test against the enclosing type alone rejects it, because the
+    resolved qn sits under the BASE rather than under the receiver's own class.
+    The check has to walk the inheritance chain, which is what makes it a
+    question about the type rather than about qualified-name spelling.
+    """
+
+    @pytest.fixture
+    def inherited_project(self, temp_repo: Path) -> Path:
+        project = temp_repo / "inh"
+        project.mkdir()
+        (project / "m.py").write_text(
+            encoding="utf-8",
+            data="""
+class Base:
+    class Inner:
+        def __init__(self, v):
+            self.v = v
+
+
+class Derived(Base):
+    pass
+
+
+def via_typed_local():
+    d = Derived()
+    return d.Inner(3)
+""",
+        )
+        return project
+
+    def test_a_typed_local_constructs_a_class_nested_in_its_base(
+        self, inherited_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        create_and_run_updater(inherited_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert ("inh.m.via_typed_local", "inh.m.Base.Inner") in edges
+
+    def test_the_predicate_walks_the_inheritance_chain(self) -> None:
+        # The `self`/`cls` half, asserted on the predicate for the #1650 reason
+        # given above. Derived declares nothing; Inner lives on Base.
+        registry = FunctionRegistryTrie()
+        registry["proj.m.Base"] = NodeLabel.CLASS
+        registry["proj.m.Base.Inner"] = NodeLabel.CLASS
+        registry["proj.m.Derived"] = NodeLabel.CLASS
+        resolver = CallResolver(
+            function_registry=registry,
+            import_processor=MagicMock(import_mapping={}),
+            type_inference=MagicMock(),
+            class_inheritance={"proj.m.Derived": ["proj.m.Base"]},
+        )
+        assert resolver._receiver_names_a_type_or_module(
+            "self", "proj.m", "proj.m.Base.Inner", class_context="proj.m.Derived"
+        )
+        # An unrelated class is still rejected in the same context, so the walk
+        # widens the check rather than disabling it.
+        assert not resolver._receiver_names_a_type_or_module(
+            "self", "proj.m", "proj.m.Unrelated", class_context="proj.m.Derived"
+        )
+
+    def test_a_sibling_sharing_a_name_prefix_is_not_nested(self) -> None:
+        # `Outer2.Inner` must not match owner `Outer`. The trailing separator
+        # in the prefix test is the only thing preventing it.
+        resolver = _resolver_with_class("proj.m.Outer")
+        assert not resolver._class_is_nested_in("proj.m.Outer2.Inner", "proj.m.Outer")
+        assert not resolver._class_is_nested_in("proj.m.OuterX", "proj.m.Outer")
+        assert not resolver._class_is_nested_in("proj.m.Outer", "proj.m.Outer")
+        assert resolver._class_is_nested_in("proj.m.Outer.A.B", "proj.m.Outer")
+
+
 class TestReceiverExpressionsContainingAColon:
     """A bare `:` inside the receiver is a slice or dict key, not a static path.
 

--- a/codebase_rag/tests/test_value_receiver_class_resolution.py
+++ b/codebase_rag/tests/test_value_receiver_class_resolution.py
@@ -1,0 +1,297 @@
+"""`value.Name()` must not resolve to a class named `Name` (#1641).
+
+Two resolution paths reach a class by discarding the receiver and looking the
+trailing name up alone -- `_try_resolve_module_method` within a module and
+`_try_resolve_via_trie` across modules. The emit site then records INSTANTIATES
+for any callee that resolved to a Class, so a method call became a construction.
+
+Measured on gin-gonic/gin before the fix: all 82 INSTANTIATES edges targeted a
+type whose name is also a method name, and every count tracked method calls
+rather than literals (`errors.Error` 27 edges against 35 `.Error()` calls and 6
+genuine literals). The spurious path also emitted CALLS to `__init__` in Python,
+so the caller appeared to run the constructor.
+
+Not a Go defect: Python reproduces it identically, which is why the guard sits
+in the shared resolver rather than in a Go path. JS/TS and Dart never
+reproduced because each already carries its own version of this rule.
+
+The controls matter as much as the defect. A receiver that names a CLASS
+(`Outer.Inner()`) or a MODULE (`mod_a.Error()`) is a genuine construction, and
+a fix phrased as "a dotted call never constructs" would silently delete both.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.constants import NodeLabel, RelationshipType
+from codebase_rag.tests.conftest import (
+    create_and_run_updater,
+    get_nodes,
+    get_qualified_names,
+    get_relationships,
+)
+
+
+def _targets(mock_ingestor: MagicMock, rel: RelationshipType) -> set[tuple[str, str]]:
+    return {
+        (call[0][0][2], call[0][2][2])
+        for call in get_relationships(mock_ingestor, rel.value)
+    }
+
+
+def _instantiations(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return _targets(mock_ingestor, RelationshipType.INSTANTIATES)
+
+
+@pytest.fixture
+def go_project(temp_repo: Path) -> Path:
+    project = temp_repo / "govalue"
+    project.mkdir()
+    (project / "go.mod").write_text(
+        encoding="utf-8", data="module govalue\n\ngo 1.22\n"
+    )
+    # `Error` is both a first-party struct and the stdlib error interface's
+    # method. `describe` calls .Error() on a stdlib error and constructs
+    # nothing; `useHelper` is the control -- a real receiver method call, which
+    # Go's row in the language table explicitly claims ("receiver methods with
+    # cross-file binding") and which must keep resolving to the METHOD.
+    (project / "m.go").write_text(
+        encoding="utf-8",
+        data="""package m
+
+import "errors"
+
+type Error struct {
+\tMsg string
+}
+
+type Box struct{}
+
+func (b Box) helper() int {
+\treturn 1
+}
+
+func useHelper(b Box) int {
+\treturn b.helper()
+}
+
+func describe() string {
+\terr := errors.New("failed")
+\treturn err.Error()
+}
+""",
+    )
+    return project
+
+
+@pytest.fixture
+def python_project(temp_repo: Path) -> Path:
+    project = temp_repo / "pyvalue"
+    project.mkdir()
+    (project / "mod_a.py").write_text(
+        encoding="utf-8",
+        data="""
+class Error:
+    def __init__(self, msg):
+        self.msg = msg
+
+    def Error(self):
+        return self.msg
+
+
+class Outer:
+    class Inner:
+        def __init__(self, v):
+            self.v = v
+
+
+instance = Error("x")
+
+
+def helper():
+    return 1
+""",
+    )
+    (project / "mod_b.py").write_text(
+        encoding="utf-8",
+        data='''
+import mod_a
+
+
+def describe(err):
+    """`err` is a parameter: a VALUE receiver, constructs nothing."""
+    return err.Error()
+
+
+def build_via_module():
+    """A MODULE receiver: a genuine construction."""
+    return mod_a.Error("boom")
+''',
+    )
+    (project / "mod_c.py").write_text(
+        encoding="utf-8",
+        data='''
+from mod_a import Outer
+
+
+def build_nested():
+    """A CLASS receiver: also a genuine construction."""
+    return Outer.Inner(1)
+''',
+    )
+    # An import brings in VALUES as well as namespaces, so "the receiver head is
+    # in the import map" is not the same question as "the receiver is a
+    # namespace". Both kinds live here.
+    (project / "mod_d.py").write_text(
+        encoding="utf-8",
+        data='''
+import mod_a
+from mod_a import Error
+from mod_a import instance
+from mod_a import helper
+
+
+def describe_imported_instance():
+    """Receiver is an imported INSTANCE -- a value."""
+    return instance.Error()
+
+
+def describe_imported_function():
+    """Receiver is an imported FUNCTION -- also a value."""
+    return helper.Error()
+
+
+def build_via_imported_module():
+    """Receiver is an imported MODULE -- a namespace."""
+    return mod_a.Error("boom")
+
+
+def build_via_imported_class():
+    """Receiver is an imported CLASS -- a namespace for nested construction."""
+    return Outer.Inner(2)
+
+
+from mod_a import Outer  # noqa: E402  (kept last so the fixture reads in order)
+''',
+    )
+    return project
+
+
+class TestGo:
+    def test_method_call_named_like_a_type_does_not_instantiate(
+        self, go_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        create_and_run_updater(go_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert ("govalue.m.describe", "govalue.m.Error") not in edges
+
+    def test_a_real_receiver_method_call_still_resolves(
+        self, go_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # The control for the claimed feature. Without it, a guard that simply
+        # refused every dotted call would pass the test above.
+        create_and_run_updater(go_project, mock_ingestor)
+        calls = _targets(mock_ingestor, RelationshipType.CALLS)
+        assert ("govalue.m.useHelper", "govalue.m.Box.helper") in calls
+
+
+class TestPython:
+    def test_method_call_named_like_a_class_does_not_instantiate(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        create_and_run_updater(python_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert ("pyvalue.mod_b.describe", "pyvalue.mod_a.Error") not in edges
+
+    def test_the_spurious_constructor_call_goes_too(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # The bad resolution also produced CALLS -> __init__, so the caller
+        # looked like it ran the constructor. Asserted separately because
+        # dropping only the INSTANTIATES edge would leave this behind.
+        create_and_run_updater(python_project, mock_ingestor)
+        calls = _targets(mock_ingestor, RelationshipType.CALLS)
+        assert ("pyvalue.mod_b.describe", "pyvalue.mod_a.Error.__init__") not in calls
+
+    def test_a_module_receiver_still_constructs(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        create_and_run_updater(python_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert ("pyvalue.mod_b.build_via_module", "pyvalue.mod_a.Error") in edges
+
+    def test_a_class_receiver_still_constructs_a_nested_class(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # `Outer.Inner()` has a receiver, and it IS an instantiation. This is
+        # the case a "dotted calls never construct" rule would delete.
+        create_and_run_updater(python_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert ("pyvalue.mod_c.build_nested", "pyvalue.mod_a.Outer.Inner") in edges
+
+
+class TestImportedReceiverKind:
+    """An import map entry says a name was imported, not what KIND it is.
+
+    `from mod_a import instance` and `import mod_a` both put a name in the same
+    map, so a guard that accepts any imported head lets the spurious edge back
+    in through the import door. The target's node kind is what separates them.
+    """
+
+    def test_an_imported_instance_does_not_construct(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        create_and_run_updater(python_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert (
+            "pyvalue.mod_d.describe_imported_instance",
+            "pyvalue.mod_a.Error",
+        ) not in edges
+
+    def test_an_imported_function_does_not_construct(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # A function is a value too. An import-kind check that special-cased
+        # only instances would pass the test above and still be wrong.
+        create_and_run_updater(python_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert (
+            "pyvalue.mod_d.describe_imported_function",
+            "pyvalue.mod_a.Error",
+        ) not in edges
+
+    def test_an_imported_module_still_constructs(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        create_and_run_updater(python_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert (
+            "pyvalue.mod_d.build_via_imported_module",
+            "pyvalue.mod_a.Error",
+        ) in edges
+
+    def test_an_imported_class_still_constructs_its_nested_class(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        create_and_run_updater(python_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert (
+            "pyvalue.mod_d.build_via_imported_class",
+            "pyvalue.mod_a.Outer.Inner",
+        ) in edges
+
+
+class TestFixtureIsLive:
+    def test_the_class_node_still_exists(
+        self, python_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # Guards against the whole fixture silently failing to parse, which
+        # would make every "not in" assertion above pass vacuously.
+        create_and_run_updater(python_project, mock_ingestor)
+        classes = get_qualified_names(get_nodes(mock_ingestor, NodeLabel.CLASS.value))
+        assert "pyvalue.mod_a.Error" in classes
+        assert "pyvalue.mod_a.Outer.Inner" in classes

--- a/codebase_rag/tests/test_value_receiver_class_resolution.py
+++ b/codebase_rag/tests/test_value_receiver_class_resolution.py
@@ -282,6 +282,46 @@ def via_instance():
         )
         return project
 
+    @pytest.fixture
+    def defect_project(self, temp_repo: Path) -> Path:
+        """The same receivers, naming a class that is NOT nested in their type."""
+        project = temp_repo / "notnested"
+        project.mkdir()
+        (project / "m.py").write_text(
+            encoding="utf-8",
+            data="""
+class Error:
+    def __init__(self, msg):
+        self.msg = msg
+
+
+class Box:
+    def describe(self):
+        # `Error` is module level, not a member of Box: this is a method call
+        # on self, not a construction, and must not instantiate.
+        return self.Error()
+
+
+def via_typed_local():
+    b = Box()
+    return b.Error()
+""",
+        )
+        return project
+
+    @pytest.mark.parametrize(
+        "caller", ["notnested.m.Box.describe", "notnested.m.via_typed_local"]
+    )
+    def test_a_self_or_typed_receiver_does_not_construct_an_unrelated_class(
+        self, defect_project: Path, mock_ingestor: MagicMock, caller: str
+    ) -> None:
+        # The negative half. Accepting a receiver because it is `self` or is
+        # typed to a class, without asking whether the resolved class is
+        # actually nested in that type, re-opens #1641 through a new door.
+        create_and_run_updater(defect_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert (caller, "notnested.m.Error") not in edges
+
     @pytest.mark.parametrize("keyword", ["self", "cls", "this"])
     def test_a_self_receiver_is_accepted_by_the_guard(self, keyword: str) -> None:
         """Asserted on the predicate, not end to end, and deliberately.
@@ -296,12 +336,18 @@ def via_instance():
         """
         resolver = _resolver_with_class("proj.m.Outer")
         assert resolver._receiver_names_a_type_or_module(
-            keyword, "proj.m", class_context="proj.m.Outer"
+            keyword, "proj.m", "proj.m.Outer.Inner", class_context="proj.m.Outer"
         )
         # Without a class context the same keyword is just a name, so the
         # acceptance is the CONTEXT's doing rather than the spelling's.
         assert not resolver._receiver_names_a_type_or_module(
-            keyword, "proj.m", class_context=None
+            keyword, "proj.m", "proj.m.Outer.Inner", class_context=None
+        )
+        # And the CALLEE must vary too: the same receiver, in the same context,
+        # naming a class that is not nested in it is a method call. Varying only
+        # the context left this branch accepting every name in the module.
+        assert not resolver._receiver_names_a_type_or_module(
+            keyword, "proj.m", "proj.m.Unrelated", class_context="proj.m.Outer"
         )
 
     def test_a_typed_local_receiver_constructs_a_nested_class(

--- a/codebase_rag/tests/test_value_receiver_class_resolution.py
+++ b/codebase_rag/tests/test_value_receiver_class_resolution.py
@@ -360,6 +360,79 @@ def via_typed_local():
         assert ("nested.m.via_instance", "nested.m.Outer.Inner") in edges
 
 
+class TestMultiPartReceiver:
+    """A namespace head does not make the whole receiver a namespace.
+
+    `mod_a.instance` reads as a module followed by a value, and judging the
+    receiver by its head alone accepted `mod_a.instance.Error()` -- the original
+    defect reached through one more segment. The whole receiver has to resolve.
+    """
+
+    @pytest.fixture
+    def chain_project(self, temp_repo: Path) -> Path:
+        project = temp_repo / "chain"
+        project.mkdir()
+        (project / "mod_a.py").write_text(
+            encoding="utf-8",
+            data="""
+class Error:
+    def __init__(self, msg):
+        self.msg = msg
+
+    def Error(self):
+        return self.msg
+
+
+instance = Error("x")
+
+
+def helper():
+    return 1
+""",
+        )
+        (project / "mod_b.py").write_text(
+            encoding="utf-8",
+            data='''
+import mod_a
+
+
+def via_module_then_instance():
+    """Head is a module, tail is an INSTANCE: a method call."""
+    return mod_a.instance.Error()
+
+
+def via_module_then_function():
+    """Head is a module, tail is a FUNCTION: also a method call."""
+    return mod_a.helper.Error()
+
+
+def via_module_direct():
+    """The whole receiver is the module: a genuine construction."""
+    return mod_a.Error("boom")
+''',
+        )
+        return project
+
+    @pytest.mark.parametrize(
+        "caller", ["via_module_then_instance", "via_module_then_function"]
+    )
+    def test_a_value_reached_through_a_module_does_not_construct(
+        self, chain_project: Path, mock_ingestor: MagicMock, caller: str
+    ) -> None:
+        create_and_run_updater(chain_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert (f"chain.mod_b.{caller}", "chain.mod_a.Error") not in edges
+
+    def test_the_module_receiver_itself_still_constructs(
+        self, chain_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # The control: the same head, with nothing after it, must keep its edge.
+        # Without this, rejecting every multi-segment receiver would pass above.
+        create_and_run_updater(chain_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert ("chain.mod_b.via_module_direct", "chain.mod_a.Error") in edges
+
+
 class TestInheritedNestedClass:
     """`self.Inner()` in a subclass resolves to `Base.Inner`, and that is real.
 

--- a/codebase_rag/tests/test_value_receiver_class_resolution.py
+++ b/codebase_rag/tests/test_value_receiver_class_resolution.py
@@ -28,6 +28,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from codebase_rag.constants import NodeLabel, RelationshipType
+from codebase_rag.function_registry import FunctionRegistryTrie
+from codebase_rag.parsers.call_resolver import CallResolver
 from codebase_rag.tests.conftest import (
     create_and_run_updater,
     get_nodes,
@@ -45,6 +47,18 @@ def _targets(mock_ingestor: MagicMock, rel: RelationshipType) -> set[tuple[str, 
 
 def _instantiations(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
     return _targets(mock_ingestor, RelationshipType.INSTANTIATES)
+
+
+def _resolver_with_class(class_qn: str) -> CallResolver:
+    """A resolver holding one registered class and nothing else."""
+    registry = FunctionRegistryTrie()
+    registry[class_qn] = NodeLabel.CLASS
+    return CallResolver(
+        function_registry=registry,
+        import_processor=MagicMock(import_mapping={}),
+        type_inference=MagicMock(),
+        class_inheritance={},
+    )
 
 
 @pytest.fixture
@@ -232,6 +246,116 @@ class TestPython:
         create_and_run_updater(python_project, mock_ingestor)
         edges = _instantiations(mock_ingestor)
         assert ("pyvalue.mod_c.build_nested", "pyvalue.mod_a.Outer.Inner") in edges
+
+
+class TestSelfAndTypedReceiversStillConstruct:
+    """`self.Inner()` is spelled like a value but really does construct.
+
+    The receiver-aware paths upstream resolve these correctly, so rejecting them
+    deletes edges main gets right. A guard judging the receiver by NAME alone
+    drops all three, and the class-name-spelled `Outer.Inner()` control does not
+    notice, because that one passes either way.
+    """
+
+    @pytest.fixture
+    def nested_project(self, temp_repo: Path) -> Path:
+        project = temp_repo / "nested"
+        project.mkdir()
+        (project / "m.py").write_text(
+            encoding="utf-8",
+            # Deliberately WITHOUT a `self.Inner()` method: that shape also
+            # emits a pre-existing `(Method)-[:CALLS]->(Class)` edge which the
+            # conftest audit rejects, and it would fail this fixture for a
+            # reason unrelated to the receiver rule. The predicate test above
+            # covers the self/cls branch instead.
+            data="""
+class Outer:
+    class Inner:
+        def __init__(self, v):
+            self.v = v
+
+
+def via_instance():
+    o = Outer()
+    return o.Inner(3)
+""",
+        )
+        return project
+
+    @pytest.mark.parametrize("keyword", ["self", "cls", "this"])
+    def test_a_self_receiver_is_accepted_by_the_guard(self, keyword: str) -> None:
+        """Asserted on the predicate, not end to end, and deliberately.
+
+        `self.Inner()` reaches the graph with the right INSTANTIATES and
+        CALLS -> `__init__` edges, but ALSO a spurious `(Method)-[:CALLS]->(Class)`
+        that the conftest audit rejects as undocumented. That extra edge is
+        pre-existing on main and unrelated to this fix -- an end-to-end
+        assertion here would fail on it and entangle the two. The predicate is
+        what this change owns; the sibling test below covers a receiver whose
+        end-to-end path is clean.
+        """
+        resolver = _resolver_with_class("proj.m.Outer")
+        assert resolver._receiver_names_a_type_or_module(
+            keyword, "proj.m", class_context="proj.m.Outer"
+        )
+        # Without a class context the same keyword is just a name, so the
+        # acceptance is the CONTEXT's doing rather than the spelling's.
+        assert not resolver._receiver_names_a_type_or_module(
+            keyword, "proj.m", class_context=None
+        )
+
+    def test_a_typed_local_receiver_constructs_a_nested_class(
+        self, nested_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # `o` is an ordinary local, so only its INFERRED TYPE distinguishes it
+        # from the `err` of the defect case.
+        create_and_run_updater(nested_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert ("nested.m.via_instance", "nested.m.Outer.Inner") in edges
+
+
+class TestReceiverExpressionsContainingAColon:
+    """A bare `:` inside the receiver is a slice or dict key, not a static path.
+
+    Exempting any call name containing `:` let the defect through untouched in
+    Python, where `xs[1:2].Error()` is ordinary code.
+    """
+
+    @pytest.fixture
+    def colon_project(self, temp_repo: Path) -> Path:
+        project = temp_repo / "colon"
+        project.mkdir()
+        (project / "mod_a.py").write_text(
+            encoding="utf-8",
+            data="""
+class Error:
+    def __init__(self, msg):
+        self.msg = msg
+
+    def Error(self):
+        return self.msg
+""",
+        )
+        (project / "mod_b.py").write_text(
+            encoding="utf-8",
+            data="""
+def sliced(xs):
+    return xs[1:2].Error()
+
+
+def dicted(d):
+    return d["a:b"].Error()
+""",
+        )
+        return project
+
+    @pytest.mark.parametrize("caller", ["sliced", "dicted"])
+    def test_a_colon_in_the_receiver_does_not_exempt_it(
+        self, colon_project: Path, mock_ingestor: MagicMock, caller: str
+    ) -> None:
+        create_and_run_updater(colon_project, mock_ingestor)
+        edges = _instantiations(mock_ingestor)
+        assert (f"colon.mod_b.{caller}", "colon.mod_a.Error") not in edges
 
 
 class TestImportedReceiverKind:


### PR DESCRIPTION
Closes #1641.

`err.Error()` on a stdlib error was recorded as **constructing** a first-party `Error` struct. On gin-gonic/gin every one of the project's 82 `INSTANTIATES` edges was an artefact of this: each targeted a type whose name is also a method name, and each count tracked method calls rather than constructions (`errors.Error` 27 edges against 35 `.Error()` calls and 6 genuine literals). "Where is this type constructed" returned a set that was entirely wrong rather than partly wrong.

Not a Go defect. Python reproduces it identically, and there the spurious resolution also emitted `CALLS -> __init__`, so the caller appeared to run the constructor.

## Root cause: the resolution, not the emission

Two paths reach a class by discarding the receiver and looking the trailing name up alone — `_try_resolve_module_method` within a module, `_try_resolve_via_trie` across modules. Which one answers depends on module layout, which is why a fix in either place alone would have missed half the cases.

`call_processor.py:3894` then emits `INSTANTIATES` for any callee that resolved to a Class. That is correct given its input: `module.Class()` in Python and `new Class()` in Java really are constructions. So the guard belongs at the resolver's exit, not at the emit site.

JS/TS and Dart never reproduced this because each already carries its own version of the rule — `_resolve_two_part_call` refuses to bind an ordinary identifier receiver, commented "an instance call: binding it to the free function is a false edge". Go and Python had no equivalent.

## The fix

`_reject_class_via_value_receiver`, applied to the result of `resolve_function_call`: one choke point covering both paths. A CLASS answer for a `.`-dotted call survives only when the receiver names something you construct *through*.

The receiver is what decides, and it has more kinds than it first appears:

| receiver | example | verdict |
|---|---|---|
| class | `Outer.Inner()` | construct |
| module | `mod_a.Error()` | construct |
| imported **module** | `import m` then `m.Thing()` | construct |
| imported **class** | `from m import Outer` then `Outer.Inner()` | construct |
| `self` / `cls` / `this`, callee nested in the enclosing type | `self.Inner()` | construct |
| local typed to a class, callee nested in that type | `o = Outer(); o.Inner()` | construct |
| `self` / `cls` / `this`, callee **not** nested | `self.Error()` | value |
| local typed to a class, callee **not** nested | `b = Box(); b.Error()` | value |
| imported **instance** | `from m import inst` then `inst.Error()` | value |
| imported **function** | `from m import helper` then `helper.Error()` | value |
| parameter, field, chained call | `err.Error()` | value |

The last four rows are the ones that make this hard. A `self` receiver is spelled like a value but `self.Inner()` really does construct, so it has to be accepted — and accepting it on the spelling alone re-opens the defect for `self.Error()`, where `Error` is a module-level class rather than a member of the enclosing type. `self` is also a legal **Go** receiver name, so `func (self Box) describe()` reaches the same branch. Both branches therefore ask a narrower question than the class and module ones: not "is this receiver constructible-through" but "is the resolved class nested inside this receiver's own type".

Being in the import map says nothing about kind, so an import is a namespace only when its target resolves to a Module or Class node. The label check runs before the subtree probe deliberately: `find_with_prefix` includes the target, so an imported function reports one descendant and a prefix-only test would call it a namespace.

`::` in the receiver exempts (a static path, where a type receiver is the normal spelling). A bare `:` does not — in Python it is a slice or a dict key inside the receiver expression, and exempting on it let `xs[1:2].Error()` straight through.

## Whole-project effect

**gin-gonic/gin — the defect surface.** `INSTANTIATES` 82 -> 0, and nothing else moves:

| relation | before | after |
|---|---|---|
| CALLS | 4245 | 4245 |
| DEFINES | 1105 | 1105 |
| DEFINES_METHOD | 428 | 428 |
| IMPORTS | 496 | 496 |
| CONTAINS_SECTION | 212 | 212 |
| REFERENCES | 91 | 91 |
| CONTAINS_MODULE | 45 | 45 |
| LINKS_TO | 3 | 3 |
| **INSTANTIATES** | **82** | **0** |

Zero is correct here: Go composite literals never produced an `INSTANTIATES` edge in the first place (#1642, a separate feature gap), so with the artefacts gone there is nothing left to emit.

Spot-checked against source with exact multiplicity: `render/` contains no `Error{` literal at all yet carried 9 edges, one per `err.Error()` call, distributed 4/1/1/1/1/1 across six functions; `TestRenderSecureJSON` carried 2 edges among 20 method-call sites, both `Body.String()` on a `bytes.Buffer`.

**requests — the no-drain control.** A Python project with no name collisions, both runs on identical flags (`CGR_CAPTURE=io`, matching the original index): **3782 edges, byte-identical**, across all 16 relation types.

That is an edge-triple diff, not a count comparison — equal counts can hide equal numbers of additions and removals. All 16 types match individually too, including the IO surface (`READS_FROM` 93, `WRITES_TO` 40) which a first attempt missed because the flags differed between the two runs.

Both controls used fresh project copies rather than the staleness warning's documented rebuild, because that rebuild does not fully reconcile edges — measured at 12 of 82 stale edges surviving it, filed as #1649.

## Tests

`codebase_rag/tests/test_value_receiver_class_resolution.py`, both languages since the defect is shared. The controls carry the weight: a fix phrased as "a dotted call never constructs" satisfies every defect assertion and silently deletes six legitimate shapes.

Four mutations, each applied to one line on its own, each with a print proving the mutated line executed:

| mutation | dies |
|---|---|
| guard disabled | the defect tests |
| receiver check always false | the receiver controls (module, nested class) |
| import-kind check always true | exactly the two import-value tests |
| inheritance walk removed | exactly the two inherited-nested-class tests |

The `self`/`cls`/typed-local acceptance was added in response to review, after the first version of the guard was found to delete `self.Inner()`, `cls.Inner()` and `o.Inner()` — constructions `origin/main` gets right, in a shape neither measured project exercises. The nesting requirement was then added after the acceptance itself was found to re-admit `self.Error()` in five shapes including a Go receiver named `self`. Both rounds are covered by tests that vary the callee, not only the receiver: the first version of the predicate test varied the context alone and so passed whether the branch admitted one name or every name in the module.

The `self`/`cls` acceptance is asserted on the **predicate** rather than end to end, deliberately: `self.Inner()` also emits a pre-existing `(Method)-[:CALLS]->(Class)` edge that the conftest audit rejects as undocumented, filed as **#1650**. An end-to-end assertion would fail on that unrelated defect and entangle the two, so the fixture omits that shape and the docstring says why. The typed-local receiver (`o = Outer(); o.Inner()`) covers the end-to-end path, which is clean.

That edge is pre-existing on main and is not fixed here.

## Suite

9292 passed at `dfca1f9e`, with 24 failures and 4 errors — the known environment set from #1639 (Ruby oracle under Node 18, C# oracle needing .NET 10, rustfmt absent behind a rustup shim).

Attribution was checked by diffing the sorted FAILED set against the baseline rather than comparing counts: **empty diff**.

An earlier run also hit `test_cli_smoke::test_help_command_works` — a 30-second timeout on a `--help` that costs ~12 seconds to import, so it flakes under `-n 2`. It passes alone and is unaffected by this branch (12.38s with these files at `origin/main` against 11.88s with the change), and it did not recur in the run above. Filed as #1655.

## Related issues found while building this

- **#1642** — Go composite literals produce no `INSTANTIATES` at all, which is why gin's count is 0 rather than 6 after the fix. A feature gap, not a regression: Go's row claims no instantiation support.
- **#1649** — the staleness warning's rebuild remedy leaves stale edges behind (12 of 82 survived on gin), which is why both whole-project controls here used fresh project copies rather than the documented cache deletion.
- **#1650** — `self.Inner()` emits an invalid `(Method)-[:CALLS]->(Class)` edge alongside the correct `__init__` call. Pre-existing, and the reason the self/cls acceptance is covered by a predicate test rather than end to end.
- **#1655** — the flaky CLI smoke timeout above.

None are fixed here.

---

This push followed a **single** local review round, per the current review-gate rule. That round raised three findings and all three are addressed in `dfca1f9e`: the inherited-nested-class regression, the silently-rejecting `resolved_qn` default, and the class-alias receiver (filed as #1672 rather than fixed, since it predates this branch and neither measured project contains an instance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code analysis to avoid incorrectly identifying ordinary value method calls as class instantiations.
  - Prevented false constructor call relationships for calls such as `err.Error()` or `buf.String()`.
  - Preserved accurate detection of genuine constructions through modules, nested classes, typed receivers, and other valid patterns.
  - Added coverage for value, imported, multipart, and language-specific receiver scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->