### PR TITLE
test: share one CLI subprocess deadline with real headroom (#1655)

### DIFF
--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -119,6 +119,10 @@ CLI_MSG_EXPORTING_DATA = "Exporting graph data..."
 CLI_MSG_OPTIMIZATION_TERMINATED = "\nOptimization session terminated by user."
 CLI_MSG_MCP_TERMINATED = "\nMCP server terminated by user."
 PACKAGE_NAME = "code-graph-rag"
+# How a test spawns the CLI as a subprocess. Shared so the deadline gate in
+# test_cli_smoke can assert no other test file spawns it outside that gate
+# (issue #1655).
+CLI_MODULE_INVOCATION = "codebase_rag.cli"
 CLI_MSG_VERSION = "{package} version {version}"
 CLI_MSG_HINT_TARGET_REPO = (
     "\nHint: Make sure TARGET_REPO_PATH environment variable is set."

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -121,8 +121,11 @@ CLI_MSG_MCP_TERMINATED = "\nMCP server terminated by user."
 PACKAGE_NAME = "code-graph-rag"
 # How a test spawns the CLI as a subprocess. Shared so the deadline gate in
 # test_cli_smoke can assert no other test file spawns it outside that gate
-# (issue #1655).
+# (issue #1655). Both spellings pay the same startup cost, so both need the
+# same deadline: `-m codebase_rag.cli`, and the console scripts in
+# [project.scripts].
 CLI_MODULE_INVOCATION = "codebase_rag.cli"
+CLI_ENTRY_POINT_NAMES: frozenset[str] = frozenset({"cgr", PACKAGE_NAME})
 CLI_MSG_VERSION = "{package} version {version}"
 CLI_MSG_HINT_TARGET_REPO = (
     "\nHint: Make sure TARGET_REPO_PATH environment variable is set."

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -13,11 +13,13 @@ from codebase_rag import constants as cs
 from codebase_rag.cli import app
 
 # Deadline for a CLI subprocess, not a performance assertion. Starting the CLI
-# costs ~12s because `--help` imports the whole parser stack before it can
-# render, so a 30s deadline left barely 2.5x headroom and the tests below
-# flaked under `pytest -n 2` while passing alone (issue #1655). These tests ask
-# "does the CLI start and print", and a generous deadline does not weaken that;
-# the startup cost itself is the separate question.
+# costs ~10s idle because `--help` imports the whole parser stack before it can
+# render, but the number that matters is the CONCURRENT one: measured on 4
+# vCPUs it is 19.5s at 4-way and 41.4s at 8-way, so the old 30s deadline held
+# 1.5x headroom under the load `-n auto` produces and could not pass at all
+# beyond it (issue #1655). These tests ask "does the CLI start and print", and
+# a generous deadline does not weaken that; the startup cost is its own
+# question.
 _CLI_TIMEOUT_SECONDS = 120
 # Call names that start a real process, so a deadline applies to them.
 _SUBPROCESS_LAUNCHERS = frozenset({"run", "Popen", "check_output", "check_call"})

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -23,6 +23,8 @@ from codebase_rag.cli import app
 _CLI_TIMEOUT_SECONDS = 120
 # Call names that start a real process, so a deadline applies to them.
 _SUBPROCESS_LAUNCHERS = frozenset({"run", "Popen", "check_output", "check_call"})
+# A deadline that is set but whose final value cannot be read statically.
+_UNRESOLVED = "<unresolved>"
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 # rich draws the options table with box-drawing borders whose glyphs land
@@ -166,9 +168,10 @@ def _deadlines_not_using_the_constant(tree: ast.AST) -> list[int]:
     scan, and both are legal at these call sites. Mirrors the detector in
     `test_frontend_subprocess_timeouts.py`, which exists for the same class.
 
-    A `**{"timeout": 30}` splat is resolved too, via `_deadline_expression`;
-    only an opaque `**kwargs` built elsewhere stays invisible, and no amount of
-    AST reading fixes that one.
+    A `**{"timeout": 30}` splat is resolved too, via `_deadline_expression`,
+    including the case where a later unpacking silently replaces the value. A
+    `**kwargs` that sets no visible deadline at all is the other gate's
+    business and stays quiet here.
     """
     found: list[int] = []
     for node in ast.walk(tree):
@@ -184,26 +187,48 @@ def _deadlines_not_using_the_constant(tree: ast.AST) -> list[int]:
     return found
 
 
-def _deadline_expression(call: ast.Call) -> ast.expr | None:
+def _deadline_expression(call: ast.Call) -> ast.expr | str | None:
     """The `timeout=` value of a call, however it was spelled.
+
+    Returns the value expression, `_UNRESOLVED` when a deadline is set but its
+    final value cannot be read statically, or None when no deadline is set at
+    all (that case belongs to `test_frontend_subprocess_timeouts`).
 
     A `**{"timeout": 30}` splat carries `arg=None` in the AST, so a plain
     keyword-name lookup reads it as "no deadline set" and the call escapes the
-    gate entirely. The literal-dict form is resolvable, so it is resolved.
+    gate. Within such a mapping, later entries win, so
+    `**{"timeout": _CLI_TIMEOUT_SECONDS, **overrides}` really passes whatever
+    `overrides` holds -- while `**{**overrides, "timeout": _CLI_TIMEOUT_SECONDS}`
+    really passes the constant. Order decides, so the scan tracks the LAST
+    statically known entry rather than the first.
     """
+    resolved: ast.expr | str | None = None
     for keyword in call.keywords:
         if keyword.arg == "timeout":
-            return keyword.value
+            resolved = keyword.value
+            continue
+        if keyword.arg is not None:
+            continue
         # `**{...}` -- a literal mapping splatted into the call.
-        if keyword.arg is None and isinstance(keyword.value, ast.Dict):
+        if isinstance(keyword.value, ast.Dict):
             for key, value in zip(keyword.value.keys, keyword.value.values):
-                if (
+                if key is None:
+                    # A nested `**something` after a deadline can replace it,
+                    # and cannot be read. Set-but-unverifiable is reported, not
+                    # waved through: this gate is about the VALUE, so a
+                    # deadline it cannot certify is exactly what it must catch.
+                    if resolved is not None:
+                        resolved = _UNRESOLVED
+                elif (
                     isinstance(key, ast.Constant)
                     and key.value == "timeout"
                     and value is not None
                 ):
-                    return value
-    return None
+                    resolved = value
+        elif resolved is not None:
+            # `**kwargs` built elsewhere, after a deadline was set.
+            resolved = _UNRESOLVED
+    return resolved
 
 
 def test_cli_spawns_in_this_file_share_the_deadline() -> None:
@@ -375,10 +400,31 @@ def test_the_detector_recognises_compliant_and_offending_deadlines() -> None:
         )
         == []
     )
-    # A splat of something built elsewhere is genuinely unresolvable; it stays
-    # quiet rather than being reported on a guess.
+    # A splat of something built elsewhere sets no deadline this gate can see,
+    # and no deadline at all is the other gate's business, so it stays quiet
+    # rather than being reported on a guess.
     assert (
         _deadlines_not_using_the_constant(ast.parse("subprocess.run(['x'], **kwargs)"))
+        == []
+    )
+    # Later entries win in a dict literal, so an override AFTER the constant
+    # really does replace it at runtime and must not read as compliant...
+    assert _deadlines_not_using_the_constant(
+        ast.parse(
+            "subprocess.run(['x'], **{'timeout': _CLI_TIMEOUT_SECONDS, **overrides})"
+        )
+    ) == [1]
+    assert _deadlines_not_using_the_constant(
+        ast.parse("subprocess.run(['x'], timeout=_CLI_TIMEOUT_SECONDS, **overrides)")
+    ) == [1]
+    # ...while the same unpacking BEFORE the constant is genuinely fine, because
+    # the explicit key wins. Order decides, not the presence of a splat.
+    assert (
+        _deadlines_not_using_the_constant(
+            ast.parse(
+                "subprocess.run(['x'], **{**overrides, 'timeout': _CLI_TIMEOUT_SECONDS})"
+            )
+        )
         == []
     )
     # No `timeout=` at all is a different gate's business

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -195,6 +195,41 @@ def test_cli_spawns_in_this_file_share_the_deadline() -> None:
     )
 
 
+def _names_the_cli(node: ast.AST | None) -> bool:
+    """Whether any string constant reachable from `node` launches the CLI."""
+    if node is None:
+        return False
+    for element in ast.walk(node):
+        if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+            continue
+        if cs.CLI_MODULE_INVOCATION in element.value:
+            return True
+        # The console scripts in [project.scripts] pay the same startup cost as
+        # `-m codebase_rag.cli`, so they need the same deadline.
+        if element.value in cs.CLI_ENTRY_POINT_NAMES:
+            return True
+    return False
+
+
+def _argv_bindings(tree: ast.AST) -> dict[str, ast.AST]:
+    """Every `name = <expr>` in the tree, so an argv held in a variable resolves.
+
+    `cmd = [sys.executable, "-m", "codebase_rag.cli"]` followed by `run(cmd)`
+    is the same spawn as the inline form, and a detector that only reads the
+    call's own arguments cannot see it.
+    """
+    bindings: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    bindings[target.id] = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is not None:
+                bindings[node.target.id] = node.value
+    return bindings
+
+
 def _cli_spawn_lines(tree: ast.AST) -> list[int]:
     """Lines that launch the CLI as a SUBPROCESS.
 
@@ -203,7 +238,13 @@ def _cli_spawn_lines(tree: ast.AST) -> list[int]:
     pay no startup cost and need no deadline. A substring scan counts them as
     spawns, which is how the first version of this gate reported twenty
     offenders that were all imports.
+
+    Covers the argv spellings that reach a real process: positional, the
+    `args=` keyword, an argv bound to a local first, and the console-script
+    names as well as `-m codebase_rag.cli`. Each was a confirmed bypass of an
+    earlier version of this detector, so the control below pins all of them.
     """
+    bindings = _argv_bindings(tree)
     found: list[int] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -212,16 +253,17 @@ def _cli_spawn_lines(tree: ast.AST) -> list[int]:
         name = target.attr if isinstance(target, ast.Attribute) else None
         if name is None and isinstance(target, ast.Name):
             name = target.id
-        if name not in _SUBPROCESS_LAUNCHERS or not node.args:
+        if name not in _SUBPROCESS_LAUNCHERS:
             continue
-        for element in ast.walk(node.args[0]):
-            if (
-                isinstance(element, ast.Constant)
-                and isinstance(element.value, str)
-                and cs.CLI_MODULE_INVOCATION in element.value
-            ):
-                found.append(node.lineno)
-                break
+        argv = node.args[0] if node.args else None
+        if argv is None:
+            argv = next((kw.value for kw in node.keywords if kw.arg == "args"), None)
+        if argv is None:
+            continue
+        if _names_the_cli(argv) or (
+            isinstance(argv, ast.Name) and _names_the_cli(bindings.get(argv.id))
+        ):
+            found.append(node.lineno)
     return found
 
 
@@ -258,9 +300,23 @@ def test_the_spawn_detector_separates_spawns_from_imports() -> None:
     assert _cli_spawn_lines(
         ast.parse("subprocess.Popen([sys.executable, '-m', 'codebase_rag.cli'])")
     ) == [1]
+    # Three forms that bypassed an earlier version of this detector. Each is
+    # ordinary Python that a future test could reasonably be written in, so
+    # each stays pinned rather than being fixed and forgotten.
+    assert _cli_spawn_lines(
+        ast.parse("subprocess.run(args=[sys.executable, '-m', 'codebase_rag.cli'])")
+    ) == [1]
+    assert _cli_spawn_lines(
+        ast.parse(
+            "cmd = [sys.executable, '-m', 'codebase_rag.cli']\nsubprocess.run(cmd)"
+        )
+    ) == [2]
+    assert _cli_spawn_lines(ast.parse("subprocess.run(['cgr', '--help'])")) == [1]
     # An in-process CliRunner test imports the same module and must NOT count.
     assert _cli_spawn_lines(ast.parse("from codebase_rag.cli import app")) == []
     assert _cli_spawn_lines(ast.parse("_RUNNER.invoke(app, ['help'])")) == []
+    # A subprocess that is not the CLI must not be swept in.
+    assert _cli_spawn_lines(ast.parse("subprocess.run(['git', 'status'])")) == []
     # This file is the one place that really does spawn it.
     assert len(_cli_spawn_lines(ast.parse(Path(__file__).read_text("utf-8")))) == 2
 

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -11,6 +11,14 @@ from codebase_rag import cli_help as ch
 from codebase_rag import constants as cs
 from codebase_rag.cli import app
 
+# Deadline for a CLI subprocess, not a performance assertion. Starting the CLI
+# costs ~12s because `--help` imports the whole parser stack before it can
+# render, so a 30s deadline left barely 2.5x headroom and the tests below
+# flaked under `pytest -n 2` while passing alone (issue #1655). These tests ask
+# "does the CLI start and print", and a generous deadline does not weaken that;
+# the startup cost itself is the separate question.
+_CLI_TIMEOUT_SECONDS = 120
+
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 # rich draws the options table with box-drawing borders whose glyphs land
 # BETWEEN the words of a wrapped cell (legacy Windows consoles wrap one column
@@ -35,7 +43,7 @@ def test_help_command_works() -> None:
         capture_output=True,
         text=True,
         encoding=cs.ENCODING_UTF8,
-        timeout=30,
+        timeout=_CLI_TIMEOUT_SECONDS,
         env={**__import__("os").environ, "NO_COLOR": "1"},
     )
 
@@ -66,7 +74,7 @@ def test_version_flag() -> None:
             capture_output=True,
             text=True,
             encoding=cs.ENCODING_UTF8,
-            timeout=30,
+            timeout=_CLI_TIMEOUT_SECONDS,
         )
 
         assert result.returncode == 0, (
@@ -143,6 +151,19 @@ def test_help_command_rejects_unknown_command() -> None:
 
     assert result.exit_code == 2
     assert "not a cgr command" in result.stderr
+
+
+def test_every_cli_subprocess_uses_the_shared_deadline() -> None:
+    # Guards the class rather than the two sites fixed in #1655: a new CLI
+    # subprocess written with its own literal deadline would reintroduce the
+    # flake silently, and only under parallel load, which is the hardest kind
+    # of failure to attribute. Matching on the value rather than on a forbidden
+    # number so any literal fails, not just the one that bit us.
+    source = Path(__file__).read_text(encoding=cs.ENCODING_UTF8)
+    values = set(re.findall(r"timeout=(\w+)", source))
+    assert values == {"_CLI_TIMEOUT_SECONDS"}, (
+        f"CLI subprocesses must share the deadline constant; found {sorted(values)}"
+    )
 
 
 def test_command_summaries_are_single_line() -> None:

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -265,6 +265,23 @@ def _argv_bindings(tree: ast.AST) -> dict[str, ast.AST]:
     `cmd = [sys.executable, "-m", "codebase_rag.cli"]` followed by `run(cmd)`
     is the same spawn as the inline form, and a detector that only reads the
     call's own arguments cannot see it.
+
+    DELIBERATELY FLAT, and therefore best-effort. Bindings are keyed by name
+    across the whole module, so a name rebound later, or reused in a second
+    function, resolves to whichever assignment `ast.walk` reached last. A
+    module where one function builds a CLI argv into `cmd` and another builds
+    something else into `cmd` can hide the first.
+
+    Scope-correct resolution means per-function symbol tables and a dataflow
+    pass, which is a disproportionate amount of machinery for what this check
+    buys: its only job is to justify keeping the DEADLINE gate above scoped to
+    this file, and its failure mode is a false negative that returns the repo
+    to where it was before any of this existed. The deadline gate itself reads
+    one file exhaustively and does not depend on this.
+
+    So the limit is recorded rather than engineered away. If a CLI spawn ever
+    does appear elsewhere, the honest fix is to give that file its own deadline
+    constant, not to make this resolver cleverer.
     """
     bindings: dict[str, ast.AST] = {}
     for node in ast.walk(tree):

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -1,3 +1,4 @@
+import ast
 import re
 import subprocess
 import sys
@@ -18,6 +19,8 @@ from codebase_rag.cli import app
 # "does the CLI start and print", and a generous deadline does not weaken that;
 # the startup cost itself is the separate question.
 _CLI_TIMEOUT_SECONDS = 120
+# Call names that start a real process, so a deadline applies to them.
+_SUBPROCESS_LAUNCHERS = frozenset({"run", "Popen", "check_output", "check_call"})
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 # rich draws the options table with box-drawing borders whose glyphs land
@@ -153,17 +156,138 @@ def test_help_command_rejects_unknown_command() -> None:
     assert "not a cgr command" in result.stderr
 
 
-def test_every_cli_subprocess_uses_the_shared_deadline() -> None:
-    # Guards the class rather than the two sites fixed in #1655: a new CLI
-    # subprocess written with its own literal deadline would reintroduce the
-    # flake silently, and only under parallel load, which is the hardest kind
-    # of failure to attribute. Matching on the value rather than on a forbidden
-    # number so any literal fails, not just the one that bit us.
-    source = Path(__file__).read_text(encoding=cs.ENCODING_UTF8)
-    values = set(re.findall(r"timeout=(\w+)", source))
-    assert values == {"_CLI_TIMEOUT_SECONDS"}, (
-        f"CLI subprocesses must share the deadline constant; found {sorted(values)}"
+def _deadlines_not_using_the_constant(tree: ast.AST) -> list[int]:
+    """Lines of calls whose `timeout=` is anything but the shared constant.
+
+    AST rather than a regex on the source: `timeout = 30` with spaces and
+    `timeout=_CLI_TIMEOUT_SECONDS // 8` both read as compliant to a textual
+    scan, and both are legal at these call sites. Mirrors the detector in
+    `test_frontend_subprocess_timeouts.py`, which exists for the same class.
+
+    A `**{"timeout": 30}` splat stays invisible to this too -- the keyword has
+    no `arg` -- so the sibling gate's rule applies: over-reporting is the safe
+    direction, and this one cannot see that shape at all.
+    """
+    found: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        timeout = next((kw for kw in node.keywords if kw.arg == "timeout"), None)
+        if timeout is None:
+            continue
+        if not (
+            isinstance(timeout.value, ast.Name)
+            and timeout.value.id == "_CLI_TIMEOUT_SECONDS"
+        ):
+            found.append(node.lineno)
+    return found
+
+
+def test_cli_spawns_in_this_file_share_the_deadline() -> None:
+    # A new CLI subprocess written with its own literal deadline reintroduces
+    # the #1655 flake silently, and only under parallel load -- the hardest
+    # kind of failure to attribute.
+    tree = ast.parse(Path(__file__).read_text(encoding=cs.ENCODING_UTF8))
+    offenders = _deadlines_not_using_the_constant(tree)
+    assert not offenders, (
+        "CLI subprocesses here must use _CLI_TIMEOUT_SECONDS; "
+        f"lines with another deadline: {offenders}"
     )
+
+
+def _cli_spawn_lines(tree: ast.AST) -> list[int]:
+    """Lines that launch the CLI as a SUBPROCESS.
+
+    Matched on the argv, not on the text of the file: twenty test files import
+    `codebase_rag.cli` to drive it in-process through `CliRunner`, and those
+    pay no startup cost and need no deadline. A substring scan counts them as
+    spawns, which is how the first version of this gate reported twenty
+    offenders that were all imports.
+    """
+    found: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        name = target.attr if isinstance(target, ast.Attribute) else None
+        if name is None and isinstance(target, ast.Name):
+            name = target.id
+        if name not in _SUBPROCESS_LAUNCHERS or not node.args:
+            continue
+        for element in ast.walk(node.args[0]):
+            if (
+                isinstance(element, ast.Constant)
+                and isinstance(element.value, str)
+                and cs.CLI_MODULE_INVOCATION in element.value
+            ):
+                found.append(node.lineno)
+                break
+    return found
+
+
+def test_no_other_test_file_spawns_the_cli() -> None:
+    """What makes the file-scoped gate above sufficient coverage.
+
+    That gate can only police this file, so its reach is a claim about the
+    suite rather than about itself. A CLI spawn elsewhere inherits none of the
+    deadline discipline and nothing reports the hole, so assert the premise
+    instead of assuming it.
+    """
+    here = Path(__file__)
+    others = sorted(
+        path.name
+        for path in here.parent.rglob("test_*.py")
+        if path != here
+        and _cli_spawn_lines(ast.parse(path.read_text(encoding=cs.ENCODING_UTF8)))
+    )
+    assert not others, (
+        "these files spawn the CLI and are outside this deadline gate: "
+        f"{others}; bring them under a shared constant or widen the gate"
+    )
+
+
+def test_the_spawn_detector_separates_spawns_from_imports() -> None:
+    """A control: the premise test above passes vacuously if nothing matches.
+
+    An empty offender list and a detector that never fires are the same
+    assertion, which is the shape this repo keeps meeting.
+    """
+    assert _cli_spawn_lines(
+        ast.parse("subprocess.run([sys.executable, '-m', 'codebase_rag.cli'])")
+    ) == [1]
+    assert _cli_spawn_lines(
+        ast.parse("subprocess.Popen([sys.executable, '-m', 'codebase_rag.cli'])")
+    ) == [1]
+    # An in-process CliRunner test imports the same module and must NOT count.
+    assert _cli_spawn_lines(ast.parse("from codebase_rag.cli import app")) == []
+    assert _cli_spawn_lines(ast.parse("_RUNNER.invoke(app, ['help'])")) == []
+    # This file is the one place that really does spawn it.
+    assert len(_cli_spawn_lines(ast.parse(Path(__file__).read_text("utf-8")))) == 2
+
+
+def test_the_detector_recognises_compliant_and_offending_deadlines() -> None:
+    """A control: the gate above passes vacuously if the matcher never fires."""
+    assert _deadlines_not_using_the_constant(
+        ast.parse("subprocess.run(['x'], timeout=30)")
+    ) == [1]
+    assert _deadlines_not_using_the_constant(
+        ast.parse("subprocess.run(['x'], timeout = 30)")
+    ) == [1]
+    assert _deadlines_not_using_the_constant(
+        ast.parse("subprocess.run(['x'], timeout=_CLI_TIMEOUT_SECONDS // 8)")
+    ) == [1]
+    assert _deadlines_not_using_the_constant(
+        ast.parse("subprocess.run(['x'], timeout=_OTHER)")
+    ) == [1]
+    assert (
+        _deadlines_not_using_the_constant(
+            ast.parse("subprocess.run(['x'], timeout=_CLI_TIMEOUT_SECONDS)")
+        )
+        == []
+    )
+    # No `timeout=` at all is a different gate's business
+    # (test_frontend_subprocess_timeouts), so this one stays quiet.
+    assert _deadlines_not_using_the_constant(ast.parse("subprocess.run(['x'])")) == []
 
 
 def test_command_summaries_are_single_line() -> None:

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -164,23 +164,44 @@ def _deadlines_not_using_the_constant(tree: ast.AST) -> list[int]:
     scan, and both are legal at these call sites. Mirrors the detector in
     `test_frontend_subprocess_timeouts.py`, which exists for the same class.
 
-    A `**{"timeout": 30}` splat stays invisible to this too -- the keyword has
-    no `arg` -- so the sibling gate's rule applies: over-reporting is the safe
-    direction, and this one cannot see that shape at all.
+    A `**{"timeout": 30}` splat is resolved too, via `_deadline_expression`;
+    only an opaque `**kwargs` built elsewhere stays invisible, and no amount of
+    AST reading fixes that one.
     """
     found: list[int] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        timeout = next((kw for kw in node.keywords if kw.arg == "timeout"), None)
-        if timeout is None:
+        deadline = _deadline_expression(node)
+        if deadline is None:
             continue
         if not (
-            isinstance(timeout.value, ast.Name)
-            and timeout.value.id == "_CLI_TIMEOUT_SECONDS"
+            isinstance(deadline, ast.Name) and deadline.id == "_CLI_TIMEOUT_SECONDS"
         ):
             found.append(node.lineno)
     return found
+
+
+def _deadline_expression(call: ast.Call) -> ast.expr | None:
+    """The `timeout=` value of a call, however it was spelled.
+
+    A `**{"timeout": 30}` splat carries `arg=None` in the AST, so a plain
+    keyword-name lookup reads it as "no deadline set" and the call escapes the
+    gate entirely. The literal-dict form is resolvable, so it is resolved.
+    """
+    for keyword in call.keywords:
+        if keyword.arg == "timeout":
+            return keyword.value
+        # `**{...}` -- a literal mapping splatted into the call.
+        if keyword.arg is None and isinstance(keyword.value, ast.Dict):
+            for key, value in zip(keyword.value.keys, keyword.value.values):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value == "timeout"
+                    and value is not None
+                ):
+                    return value
+    return None
 
 
 def test_cli_spawns_in_this_file_share_the_deadline() -> None:
@@ -339,6 +360,23 @@ def test_the_detector_recognises_compliant_and_offending_deadlines() -> None:
         _deadlines_not_using_the_constant(
             ast.parse("subprocess.run(['x'], timeout=_CLI_TIMEOUT_SECONDS)")
         )
+        == []
+    )
+    # A literal mapping splatted into the call hides the keyword name, so a
+    # plain lookup reads it as "no deadline" and the call escapes entirely.
+    assert _deadlines_not_using_the_constant(
+        ast.parse("subprocess.run(['x'], **{'timeout': 30})")
+    ) == [1]
+    assert (
+        _deadlines_not_using_the_constant(
+            ast.parse("subprocess.run(['x'], **{'timeout': _CLI_TIMEOUT_SECONDS})")
+        )
+        == []
+    )
+    # A splat of something built elsewhere is genuinely unresolvable; it stays
+    # quiet rather than being reported on a guess.
+    assert (
+        _deadlines_not_using_the_constant(ast.parse("subprocess.run(['x'], **kwargs)"))
         == []
     )
     # No `timeout=` at all is a different gate's business


### PR DESCRIPTION
Closes #1655.

`test_cli_smoke.py` gave each CLI subprocess a 30-second deadline for a command that takes ~10 seconds to start, so the tests flaked under `pytest -n 2` and passed alone. It failed exactly that way in a full-suite run, with the complete help text present in the captured stdout — the CLI had done its job and simply had not exited by the deadline.

## Why 30s was never enough

`--help` costs what it does because it imports the whole parser stack before it can render. Measured on a 4-vCPU host, all runs exiting 0:

| concurrency | `--help` wall clock | margin at 30s | margin at 120s |
|---|---|---|---|
| 1 (idle) | 10.6s | 2.8x | 11.3x |
| 4 (what `-n auto` gives a 4-core runner) | **19.5s** | **1.5x** | 6.2x |
| 8 (2x oversubscription) | **41.4s** | **fails outright** | 2.9x |

So this was not bad luck: at realistic CI parallelism the old deadline had 1.5x headroom, and beyond that it could not pass at all. `--version` costs about the same (9.8s idle) and `test_version_flag` spawns the CLI twice.

Both call sites now share `_CLI_TIMEOUT_SECONDS = 120`. These tests ask "does the CLI start and print"; a generous deadline does not weaken that claim. The ~10s startup cost is a real question for users, but it is a separate and much larger one than de-flaking a test deadline.

## Why the flake matters more than one red test

Attribution on this repo is done by diffing the sorted FAILED set against a known baseline — this host carries 24 known environment failures (#1639), so "did my change break anything" is answered by set comparison, not by a count. A failure that comes and goes makes that diff unanswerable and trains a reader to discount the failure list.

## The guard, and what it does not cover

Fixing two call sites does not stop the third, so `_deadlines_not_using_the_constant` walks this file's AST and asserts every `timeout=` keyword resolves to the shared constant.

It is AST rather than a regex on the source because a textual scan reads `timeout = 30` (spaces) and `timeout=_CLI_TIMEOUT_SECONDS // 8` as compliant, and both are legal at these call sites. This follows `test_frontend_subprocess_timeouts.py`, which already solves the same class the same way. A `**{"timeout": 30}` splat remains invisible to both — the keyword has no `arg` — and that limit is recorded in the docstring rather than left for someone to discover.

Three controls, because a gate whose detector never fires is indistinguishable from a clean tree:

- `test_the_detector_recognises_compliant_and_offending_deadlines` — the deadline matcher fires on a literal, on a spaced literal, on an arithmetic expression over the constant, and on a different constant; stays quiet on the constant itself and on a call with no `timeout=` at all (that is the other gate's business).
- `test_the_spawn_detector_separates_spawns_from_imports` — pins the distinction below.
- `test_no_other_test_file_spawns_the_cli` — the premise that makes a file-scoped gate sufficient coverage.

That last one is worth explaining. The gate can only police this file, so its reach is a claim about the suite rather than about itself; if a CLI spawn appears elsewhere it inherits none of this discipline and nothing reports the hole. The first version of that check matched the substring `codebase_rag.cli` and reported twenty offenders — every one an `import` for an in-process `CliRunner` test, which spawns nothing and pays no startup cost. Matching on argv through the AST gives the real answer: exactly one file spawns the CLI, at exactly the two call sites fixed here.

## What is deliberately absent

No test claims to prove the flake is gone. A load-dependent timeout cannot be demonstrated by a passing test, and the obvious candidate — timing the spawn and asserting `elapsed * K < _CLI_TIMEOUT_SECONDS` — is a performance assertion measured under the same contention it is meant to survive, so it would flake for the original reason. The honest artifact justifying 120 is the table above.

## Suite

10340 passed. The 24 failures and 4 errors are the known #1639 environment set (Ruby oracle under Node 18, C# oracle needing .NET 10, rustfmt absent behind a rustup shim); the sorted FAILED set diffs empty against the baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved command-line interface test reliability by standardizing execution time limits.
  * Added automated coverage for supported CLI invocation methods, including direct module launches and installed command-line entry points.
  * Expanded validation for timeout overrides and invocation formats.
  * Strengthened safeguards to ensure CLI startup checks consistently use the appropriate deadline across supported launch methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->