### PR TITLE
fix(security): block rm targeting project root

### DIFF
--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -1179,6 +1179,21 @@ class TestDangerousRmPath:
         is_dangerous, _ = _is_dangerous_rm_path(["rm", "-rf", target], project_root)
         assert not is_dangerous
 
+    @pytest.mark.parametrize("target", ["absolute", "subdir/.."])
+    def test_project_root_spelling_is_dangerous(
+        self, tmp_path: Path, target: str
+    ) -> None:
+        project_root = (tmp_path / "project").resolve()
+        project_root.mkdir()
+        path_arg = str(project_root) if target == "absolute" else target
+
+        is_dangerous, reason = _is_dangerous_rm_path(
+            ["rm", "-rf", path_arg], project_root
+        )
+
+        assert is_dangerous
+        assert reason == "rm targeting the project root"
+
     def test_dash_prefixed_operand_after_end_of_options_is_checked(
         self, tmp_path: Path
     ) -> None:

--- a/codebase_rag/tools/shell_command.py
+++ b/codebase_rag/tools/shell_command.py
@@ -197,6 +197,8 @@ def _is_dangerous_rm_path(cmd_parts: list[str], project_root: Path) -> tuple[boo
             resolved = (project_root / path_arg).resolve()
         except (OSError, ValueError):
             return True, f"rm with invalid path: {path_arg}"
+        if resolved == project_root:
+            return True, "rm targeting the project root"
         resolved_str = str(resolved)
         if resolved == resolved.parent:
             return True, "rm targeting root directory"


### PR DESCRIPTION
## Summary

- reject `rm` operands that resolve exactly to the configured project root
- cover both an absolute root spelling and a normalized `subdir/..` spelling
- preserve existing handling for safe descendants, filesystem roots, invalid paths, and out-of-project targets

Closes #1667

## Validation

- `uv run --extra test pytest codebase_rag/tests/test_shell_command.py::TestDangerousRmPath -q -n 0 --basetemp=.pytest-tmp-1667` — 17 passed
- `uv run ruff check codebase_rag/tools/shell_command.py codebase_rag/tests/test_shell_command.py` — passed
- `uv run ty check codebase_rag/tools/shell_command.py` — passed
- staged-file Ruff format checks — passed
- remaining staged-file pre-commit hooks — passed

The full local `ty` hook is not green on this Windows host because it reports existing cross-platform diagnostics outside this change (`resource.getrusage` / `RUSAGE_SELF` in `evals/indexing_bench.py`, plus two existing warnings). CI will run the full check on Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protection against accidental deletion of the project root through shell commands.
  - Both absolute and relative path forms targeting the project root are now blocked with a clear safety message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->