### PR TITLE
fix: rebuild the rehydrated qn sets instead of accumulating them (#1677)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1832,6 +1832,14 @@ class GraphUpdater:
                 raise
             logger.warning(ls.REHYDRATE_QUERY_FAILED)
             return
+        # Rebuild rather than accumulate. A reused updater runs this on every
+        # incremental pass, and remove_file_from_state only discards the qns
+        # this updater removed itself; a Module deleted from the graph by
+        # anything else (a second updater, delete_project then a re-index)
+        # would linger here and keep being offered to deferred import
+        # verification as a live target. Cleared only now that the rows are
+        # in hand, so a failed query above leaves the previous set intact.
+        self._rehydrated_module_qns.clear()
         for row in module_rows:
             qn = row.get(cs.KEY_QUALIFIED_NAME)
             label = row.get(cs.KEY_LABEL)

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -286,22 +286,23 @@ def test_a_deleted_mod_rs_is_swept_on_its_recorded_qn(temp_repo: Path) -> None:
     for qn_set in updater.simple_name_lookup.values():
         assert not [qn for qn in qn_set if "helper" in qn]
 
-def test_a_module_deleted_behind_the_updaters_back_is_forgotten(
+def test_rehydration_rebuilds_module_qns_instead_of_accumulating(
     temp_repo: Path,
 ) -> None:
-    # The set of rehydrated module qns is rebuilt from the graph on every
-    # run, not accumulated across them. `remove_file_from_state` only drops
-    # the qns this updater removed itself, so a Module deleted by anything
-    # else -- a second updater on the same project, `delete_project` then a
+    # The qn sets rehydration fills are rebuilt from the graph on every pass,
+    # not accumulated across passes. `remove_file_from_state` only drops the
+    # qns this updater removed itself, so a Module deleted by another writer
+    # -- a second updater on the same project, `delete_project` then a
     # re-index, a run in another clone -- would otherwise linger and keep
     # being offered to deferred import verification as a live target.
     root = temp_repo / "proj"
-    before = {
-        "util.py": "def helper():\n    return 1\n",
-        "main.py": "from util import helper\n\n\ndef go():\n    return helper()\n",
-        "other.py": "def x():\n    return 1\n",
-    }
-    _materialise(root, before)
+    _materialise(
+        root,
+        {
+            "util.py": "def helper():\n    return 1\n",
+            "other.py": "def x():\n    return 1\n",
+        },
+    )
     store = _StatefulIngestor()
     _updater(store, root, cs.SupportedLanguage.PYTHON).run(force=True)
 
@@ -309,21 +310,46 @@ def test_a_module_deleted_behind_the_updaters_back_is_forgotten(
     (root / "other.py").write_text("def x():\n    return 2\n", encoding="utf-8")
     _bump(root, "other.py")
     updater.run(force=False)
-    assert "proj.util" in updater.known_module_paths(), "the shape did not rehydrate"
+    assert "proj.util" in updater._rehydrated_module_qns, "the shape did not rehydrate"
 
-    # Remove the Module from the store without telling the updater, which is
-    # what a second writer on the same graph looks like from here.
+    # Another writer deletes the Module from the graph. This updater is never
+    # told: it does not re-parse the file and no removal runs through it, so
+    # rehydration is the only thing that can drop the qn.
     removed = [key for key in store.nodes if key[1] == "proj.util"]
     assert removed, "expected a proj.util node to delete"
     for key in removed:
         del store.nodes[key]
 
-    (root / "other.py").write_text("def x():\n    return 3\n", encoding="utf-8")
-    _bump(root, "other.py")
-    updater.run(force=False)
+    updater._rehydrate_registry_from_graph()
 
     assert "proj.util" not in updater._rehydrated_module_qns
-    assert "proj.util" not in updater.known_module_paths()
+
+
+def test_a_failed_module_query_leaves_the_rehydrated_set_intact(
+    temp_repo: Path,
+) -> None:
+    # The clear sits after the fetch on purpose: a full build degrades on a
+    # failed module query and returns early, and clearing before it would
+    # drop the set rather than rebuild it.
+    root = temp_repo / "proj"
+    _materialise(root, {"other.py": "def x():\n    return 1\n"})
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    updater.run(force=True)
+    updater._rehydrated_module_qns.add("proj.stale")
+
+    def _boom(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        raise RuntimeError("module query failed")
+
+    original = store.fetch_all
+    store.fetch_all = _boom  # type: ignore[method-assign]
+    try:
+        updater._is_full_build = True
+        updater._rehydrate_registry_from_graph()
+    finally:
+        store.fetch_all = original  # type: ignore[method-assign]
+
+    assert "proj.stale" in updater._rehydrated_module_qns
 
 
 JEDI_CORE = (

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -286,6 +286,7 @@ def test_a_deleted_mod_rs_is_swept_on_its_recorded_qn(temp_repo: Path) -> None:
     for qn_set in updater.simple_name_lookup.values():
         assert not [qn for qn in qn_set if "helper" in qn]
 
+
 def test_rehydration_rebuilds_module_qns_instead_of_accumulating(
     temp_repo: Path,
 ) -> None:
@@ -338,10 +339,16 @@ def test_a_failed_module_query_leaves_the_rehydrated_set_intact(
     updater.run(force=True)
     updater._rehydrated_module_qns.add("proj.stale")
 
-    def _boom(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
-        raise RuntimeError("module query failed")
-
     original = store.fetch_all
+
+    def _boom(query: str, *args: object, **kwargs: object) -> list[dict[str, object]]:
+        # Only the module query fails. Failing every query makes the
+        # definition fetch raise first, and the function returns long before
+        # it reaches the clear this test is about.
+        if query is cs.CYPHER_ALL_MODULE_QNS:
+            raise RuntimeError("module query failed")
+        return original(query, *args, **kwargs)
+
     store.fetch_all = _boom  # type: ignore[method-assign]
     try:
         updater._is_full_build = True

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -286,6 +286,45 @@ def test_a_deleted_mod_rs_is_swept_on_its_recorded_qn(temp_repo: Path) -> None:
     for qn_set in updater.simple_name_lookup.values():
         assert not [qn for qn in qn_set if "helper" in qn]
 
+def test_a_module_deleted_behind_the_updaters_back_is_forgotten(
+    temp_repo: Path,
+) -> None:
+    # The set of rehydrated module qns is rebuilt from the graph on every
+    # run, not accumulated across them. `remove_file_from_state` only drops
+    # the qns this updater removed itself, so a Module deleted by anything
+    # else -- a second updater on the same project, `delete_project` then a
+    # re-index, a run in another clone -- would otherwise linger and keep
+    # being offered to deferred import verification as a live target.
+    root = temp_repo / "proj"
+    before = {
+        "util.py": "def helper():\n    return 1\n",
+        "main.py": "from util import helper\n\n\ndef go():\n    return helper()\n",
+        "other.py": "def x():\n    return 1\n",
+    }
+    _materialise(root, before)
+    store = _StatefulIngestor()
+    _updater(store, root, cs.SupportedLanguage.PYTHON).run(force=True)
+
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    (root / "other.py").write_text("def x():\n    return 2\n", encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+    assert "proj.util" in updater.known_module_paths(), "the shape did not rehydrate"
+
+    # Remove the Module from the store without telling the updater, which is
+    # what a second writer on the same graph looks like from here.
+    removed = [key for key in store.nodes if key[1] == "proj.util"]
+    assert removed, "expected a proj.util node to delete"
+    for key in removed:
+        del store.nodes[key]
+
+    (root / "other.py").write_text("def x():\n    return 3\n", encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+
+    assert "proj.util" not in updater._rehydrated_module_qns
+    assert "proj.util" not in updater.known_module_paths()
+
 
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"


### PR DESCRIPTION
Closes #1677.

## What

`_rehydrate_registry_from_graph` refilled `_rehydrated_module_qns` on every incremental run and nothing ever cleared it, while `remove_file_from_state` discards only the qns this updater removed itself. A Module deleted from the graph by anything else — a second updater on the same project, `delete_project` then a re-index, a run in another clone — stayed in the set on a long-lived updater, so `known_module_paths()` kept offering it to `_verify_internal_import_target` and `flush_deferred_import_edges` as a live internal target.

The set is now rebuilt from the graph rather than accumulated.

## Placement

The clear sits *after* the `fetch_all(CYPHER_ALL_MODULE_QNS)` try/except, not at the top of the function. That fetch returns early on a failed query in a full build (and re-raises otherwise), so clearing before it would drop the set instead of rebuilding it — turning a degraded run into a lossy one. `test_a_failed_module_query_leaves_the_rehydrated_set_intact` pins that.

## Scope: two sibling maps deliberately left alone

Both have the same accumulate-never-rebuild shape, and neither belongs in this change:

- **`module_qn_to_file_path`** (#1687), which `known_module_paths()` also unions, is filled by a separate seeding pass with eligibility and flux-stem guards (the #1569 / #1575 shapes), so deciding which entries a run may drop needs its own correctness argument.
- **`cpp_module_interfaces`** (#1692) cannot simply be rebuilt here at all. An earlier revision of this PR did clear it, and that **lost real edges**: production's ingestor buffers node writes until `batch_size`, so an interface parsed in the current run is still unflushed when the rows are fetched, is absent from them, and is dropped. Measured on a buffering ingestor with `iface.cppm` and `impl.cpp` added together — with the clear, `before=['proj.M'] after=[]` and no `IMPLEMENTS` edge is emitted; without it, the edge is correct. Snapshotting and restoring "what this run parsed" does not work either, because the set survives across runs on a reused updater, so a planted `proj.GHOST` survives with it. Dropped from this PR and recorded in #1692 with the measurements and three candidate designs.

Note that a test using an ingestor that writes through immediately does **not** catch that regression — the edge is emitted either way. The buffering is what makes it visible.

## Verification

Two new tests:

- `test_rehydration_rebuilds_module_qns_instead_of_accumulating` — deletes the Module from the store behind the updater's back and calls `_rehydrate_registry_from_graph()` directly, so no other mechanism can mask the result.
- `test_a_failed_module_query_leaves_the_rehydrated_set_intact`

Pinned against a fix-reverted copy of the tree, on an interpreter with all 15 grammars loaded so nothing skips:

- with the fix: **13 passed**
- reverted: `test_rehydration_rebuilds_module_qns_instead_of_accumulating` **fails**

An earlier draft asserted through `known_module_paths()` and failed on this branch *and* reverted — it was measuring the #1687 map, not this fix. Replaced rather than relaxed.

`ruff check` / `ruff format --check`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved annotation and type relationship resolution when definitions span multiple files.
  - Removed stale import, registry, and type information when files or modules are deleted or re-parsed.
  - Ensured rehydrated module state reflects the current graph without accumulating deleted entries.
  - Preserved existing rehydration state when updated module data cannot be fetched.
  - Improved persistence of cleanup operations during incremental updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->