### PR TITLE
fix: sweep deleted-file state on recorded module qns, not path-derived (#1676)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2217,10 +2217,29 @@ class GraphUpdater:
             if file_path.name == cs.INIT_PY
             else relative_path.with_suffix("").parts
         )
-        module_qn_prefix = cs.SEPARATOR_DOT.join([self.project_name, *path_parts])
-        self.factory.import_processor.commonjs_direct_exports.pop(
-            module_qn_prefix, None
-        )
+        path_derived_qn = cs.SEPARATOR_DOT.join([self.project_name, *path_parts])
+        # Sweep on the qns the parse RECORDED for this path, not on the
+        # path-derived form. The two differ whenever `base_module_qn` applies
+        # its mod.rs collapse (src/a/mod.rs records as proj.src.a, while the
+        # path yields proj.src.a.mod) or `_disambiguate_module_qn` suffixes a
+        # qn an earlier-parsed sibling already owns. Keying on the path-derived
+        # form swept a qn nothing ever recorded, so a mod.rs deletion left its
+        # registry and simple-name entries behind and Pass 3 kept resolving
+        # calls into definitions that no longer exist. The Rust and C# import
+        # blocks below already re-derive the recorded qn for this reason.
+        # A file that was never parsed recorded nothing; the path-derived form
+        # is the only prefix available for it, and it owns no recorded qn that
+        # this could wipe.
+        recorded_qns = {
+            qn
+            for qn, path in (
+                self.factory.definition_processor.module_qn_to_file_path.items()
+            )
+            if path == file_path
+        }
+        module_qn_prefixes = recorded_qns or {path_derived_qn}
+        for prefix in module_qn_prefixes:
+            self.factory.import_processor.commonjs_direct_exports.pop(prefix, None)
         # A deleted file is no writer: its mod-scope registry entries must
         # not weigh in the next arbitration (a modified file re-drops this
         # in its own re-parse, harmlessly twice). The drop keys on the qn
@@ -2253,13 +2272,7 @@ class GraphUpdater:
         # they are never re-registered because it is not re-parsed. The span
         # records key by the REGISTERING file's module qn, so a qn recorded
         # under a module this event does not touch survives (issue #1025).
-        touched_modules = {
-            qn
-            for qn, path in (
-                self.factory.definition_processor.module_qn_to_file_path.items()
-            )
-            if path == file_path
-        }
+        touched_modules = recorded_qns
         foreign_qns = {
             location.qualified_name
             for (
@@ -2288,8 +2301,12 @@ class GraphUpdater:
 
         for qn in list(self.function_registry.keys()):
             if (
-                qn.startswith(f"{module_qn_prefix}.") or qn == module_qn_prefix
-            ) and qn not in foreign_qns:
+                any(
+                    qn.startswith(f"{prefix}.") or qn == prefix
+                    for prefix in module_qn_prefixes
+                )
+                and qn not in foreign_qns
+            ):
                 qns_to_remove.add(qn)
                 del self.function_registry[qn]
 

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -258,6 +258,35 @@ def test_a_rehydrated_updater_forgets_a_deleted_module_qn(temp_repo: Path) -> No
     assert "proj.util" not in updater.known_module_paths()
 
 
+def test_a_deleted_mod_rs_is_swept_on_its_recorded_qn(temp_repo: Path) -> None:
+    # `mod.rs` names its directory: src/a/mod.rs records as proj.src.a, while
+    # the path-derived prefix is proj.src.a.mod. Keying the registry sweep on
+    # the path-derived form swept a qn nothing recorded, so a reused updater
+    # (watcher, MCP server) kept the deleted file's definitions and Pass 3
+    # could still resolve calls into them.
+    #
+    # The recorded qn is seeded directly rather than parsed: the collapse is a
+    # property of remove_file_from_state, and driving it through a real parse
+    # would make the test skip wherever the Rust grammar is unavailable.
+    root = temp_repo / "proj"
+    (root / "src" / "a").mkdir(parents=True, exist_ok=True)
+    mod_rs = root / "src" / "a" / "mod.rs"
+    mod_rs.write_text("pub fn helper() -> i32 { 42 }\n", encoding="utf-8")
+
+    updater = _updater(_StatefulIngestor(), root, cs.SupportedLanguage.PYTHON)
+    updater.factory.definition_processor.module_qn_to_file_path["proj.src.a"] = mod_rs
+    updater.function_registry.insert("proj.src.a.helper", "Function")
+    updater.simple_name_lookup.setdefault("helper", set()).add("proj.src.a.helper")
+
+    updater.remove_file_from_state(mod_rs)
+
+    assert not [qn for qn in updater.function_registry.keys() if "helper" in qn], (
+        "the deleted mod.rs left registry entries behind"
+    )
+    for qn_set in updater.simple_name_lookup.values():
+        assert not [qn for qn in qn_set if "helper" in qn]
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"


### PR DESCRIPTION
Closes #1676.

## What

`remove_file_from_state` derived its sweep prefix from the file path, special-casing only `__init__.py` and so missing the `mod.rs` collapse that `base_module_qn` applies. For `src/a/mod.rs` the parse records `proj.src.a` but the sweep used `proj.src.a.mod`:

| path | recorded qn | path-derived prefix | |
|---|---|---|---|
| `src/a/mod.rs` | `proj.src.a` | `proj.src.a.mod` | **mismatch** |
| `src/a.rs` | `proj.src.a` | `proj.src.a` | ok |
| `pkg/__init__.py` | `proj.pkg` | `proj.pkg` | ok (already special-cased) |

So the function-registry prefix sweep and the `commonjs_direct_exports.pop` were keyed on a qn nothing had recorded, and `mod.rs` was the only shape affected. Deleting or re-parsing one on a reused updater (watcher, MCP server) left its registry and simple-name entries in place for Pass 3 to keep resolving calls into definitions that no longer exist.

## Fix

Both sweeps now key on the qns `module_qn_to_file_path` recorded for that path — which is exactly what the Rust and C# import-state blocks a few lines below already do, and why their comments say so. `touched_modules` was computing that identical set separately, so it now reuses it.

The path-derived form survives only as the fallback for a file that was never parsed: it recorded no qn, so it owns no state these sweeps could wipe. On the real deletion path this fallback is not reached — `reingest` calls `_seed_module_qns_from_graph` for the gone paths first, so the recorded qn is present.

## Verification

`test_a_deleted_mod_rs_is_swept_on_its_recorded_qn` seeds the recorded qn directly rather than parsing a real `mod.rs`. The collapse is a property of `remove_file_from_state`, and driving it through a parse makes the test **silently skip** wherever the Rust grammar is absent — which is any Python-only venv, where it would report as a pass while never running.

Pinned both ways against a fix-reverted copy, on an interpreter with all 15 grammars loaded:

- with the fix: **12 passed**
- reverted: the new test **fails** (`the deleted mod.rs left registry entries behind`)

Also checked, with the disambiguation shape (`src/a.rs` owning `proj.src.a` beside a `mod.rs`): the multi-prefix sweep cannot over-remove another file's qns — the `foreign_qns` ownership guard (#1025) still holds in both deletion orders, and the reverted code fails both.

`ruff check` / `ruff format --check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale in-memory entries remaining after deleting files whose recorded module identifiers differ from their path-derived identifiers.
  * Improved cleanup for collapsed module files, disambiguated identifiers, CommonJS exports, and related function lookups.

* **Tests**
  * Added coverage verifying that deleted module files are fully removed from function registries and name lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->