### PR TITLE
fix: give the scoped re-ingest its own cache-stamp log constants

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3536,12 +3536,12 @@ class GraphUpdater:
         try:
             os.utime(cache_path, (observed_at, observed_at))
         except OSError as e:
-            logger.warning(ls.CACHE_STAMP_FAILED, path=cache_path, error=e)
+            logger.warning(ls.REINGEST_CACHE_STAMP_FAILED, path=cache_path, error=e)
             try:
                 cache_path.unlink(missing_ok=True)
             except OSError as unlink_error:
                 logger.warning(
-                    ls.CACHE_STAMP_CLEANUP_FAILED,
+                    ls.REINGEST_CACHE_STAMP_CLEANUP_FAILED,
                     path=cache_path,
                     error=unlink_error,
                 )

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -864,6 +864,18 @@ HASH_CACHE_LOADED = "Loaded hash cache with {count} entries from {path}"
 HASH_CACHE_LOAD_FAILED = "Failed to load hash cache from {path}: {error}"
 HASH_CACHE_SAVED = "Saved hash cache with {count} entries to {path}"
 HASH_CACHE_SAVE_FAILED = "Failed to save hash cache to {path}: {error}"
+# A scoped re-ingest backdates the hash cache to the instant it observed
+# (`_reingest_update_hashes`); these name that step, distinct from the
+# atomic publish's own temporary-file cleanup below.
+REINGEST_CACHE_STAMP_FAILED = (
+    "Could not backdate {path} to the observed instant ({error}); removing it so "
+    "the next run rebuilds rather than trusting a stamp that can hide edits"
+)
+REINGEST_CACHE_STAMP_CLEANUP_FAILED = (
+    "Could not remove {path} after its backdate failed ({error}); it keeps a write "
+    "time later than any edit made during this run, so the next run may skip that "
+    "file. Delete it by hand, or re-run once the path is writable"
+)
 CACHE_STAMP_CLEANUP_FAILED = (
     "Could not remove the temporary cache file {path} ({error}); it is inert, since "
     "nothing reads a .tmp path, but it can be deleted by hand"

--- a/codebase_rag/tests/test_reingest.py
+++ b/codebase_rag/tests/test_reingest.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from loguru import logger
 
 from codebase_rag import constants as cs
 from codebase_rag.capture import resolve_capture
@@ -420,6 +421,69 @@ def test_reingest_reparses_in_walk_order_across_directories(
 
     assert seen == [key for key in walk_order if key in set(layout)]
     assert seen != shuffled
+
+
+def _warnings_during(action: Callable[[], object]) -> list[str]:
+    lines: list[str] = []
+    sink = logger.add(lambda message: lines.append(str(message)), level="WARNING")
+    try:
+        action()
+    finally:
+        logger.remove(sink)
+    return lines
+
+
+def test_reingest_removes_the_cache_when_it_cannot_backdate_it(
+    fixture_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A cache stamped with the wrong instant hides edits from the next run,
+    # so a failed backdate removes it and says so with its own message.
+    store = _StatefulIngestor()
+    updater = _updater(store, fixture_root)
+    updater.run(force=True)
+    cache = fixture_root / cs.HASH_CACHE_FILENAME
+    changed, deleted = edit_rename_callee(fixture_root)
+
+    def failing_utime(path: object, times: object = None, **kwargs: object) -> None:
+        raise OSError(1, "EPERM utime")
+
+    monkeypatch.setattr(os, "utime", failing_utime)
+    warnings = _warnings_during(lambda: updater.reingest(changed, deleted=deleted))
+
+    assert not cache.exists()
+    assert any(
+        "Could not backdate" in line and "EPERM utime" in line for line in warnings
+    )
+
+
+def test_reingest_reports_a_cache_it_could_neither_backdate_nor_remove(
+    fixture_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _StatefulIngestor()
+    updater = _updater(store, fixture_root)
+    updater.run(force=True)
+    cache = fixture_root / cs.HASH_CACHE_FILENAME
+    changed, deleted = edit_rename_callee(fixture_root)
+
+    def failing_utime(path: object, times: object = None, **kwargs: object) -> None:
+        raise OSError(1, "EPERM utime")
+
+    real_unlink = Path.unlink
+
+    def failing_unlink(self: Path, missing_ok: bool = False) -> None:
+        if self == cache:
+            raise OSError(1, "EPERM unlink")
+        real_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(os, "utime", failing_utime)
+    monkeypatch.setattr(Path, "unlink", failing_unlink)
+    warnings = _warnings_during(lambda: updater.reingest(changed, deleted=deleted))
+
+    assert cache.exists()
+    assert any("Could not backdate" in line for line in warnings)
+    assert any(
+        "Could not remove" in line and "EPERM unlink" in line for line in warnings
+    )
 
 
 def test_reingest_reports_dependents_and_removals(fixture_root: Path) -> None:


### PR DESCRIPTION
## Problem

Main fails the type check: `ty` reports `Module codebase_rag.logs has no member CACHE_STAMP_FAILED`. #1656 removed `CACHE_STAMP_FAILED` and reworded `CACHE_STAMP_CLEANUP_FAILED` for the atomic hash-cache publish, while #1538's `GraphUpdater._reingest_update_hashes` still logs both when backdating the cache after a scoped re-ingest. The two merged independently, so no PR saw the conflict; every PR's pre-commit and Type Check job now fails on it.

## Fix

The re-ingest backdate step names its own two constants, `REINGEST_CACHE_STAMP_FAILED` and `REINGEST_CACHE_STAMP_CLEANUP_FAILED`, with the wording #1538 shipped; the publish path keeps its own. No behaviour change.

## Verification

- pre-commit on the branch, including `ty check`: passed.
- `codebase_rag/tests/test_reingest.py`: 68 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved warning messages for cache timestamping and cleanup failures during scoped re-ingest.
  - Clarified when cache entries are removed after timestamping failures or may affect subsequent update runs.
  - Added coverage for scenarios where cache timestamping or cleanup operations fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->