### PR TITLE
fix: let a run finish and rebuild when an orphaned cache cannot be discarded (#1647)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -479,6 +479,10 @@ class GraphUpdater:
         # them: the reconciliation it was meant to do may not have happened,
         # so that run must not stamp its exclusion set as reconciled.
         self._graph_state_unknown: bool = False
+        # Set when an orphaned cache could not be deleted: the file is still on
+        # disk, so this run must ignore it in memory rather than trust it
+        # (issue #1647).
+        self._cache_discarded_in_memory: bool = False
         # Written at the post-flush commit point in `run`, never inside
         # `_process_files` (issue #1615).
         self._pending_hash_cache: tuple[Path, FileHashCache] | None = None
@@ -1178,6 +1182,10 @@ class GraphUpdater:
         )
         logger.info(ls.ENSURING_PROJECT, name=self.project_name)
 
+        # Reset BEFORE the discard below, which is what SETS it: a reset after
+        # that call would clear the flag it just raised and make the in-memory
+        # discard dead code (issue #1647).
+        self._cache_discarded_in_memory = False
         if not force and self._single_file is None:
             self._drop_cache_if_graph_lost()
             self._warn_if_parser_changed()
@@ -2549,8 +2557,26 @@ class GraphUpdater:
         if count:
             return
         logger.warning(ls.HASH_CACHE_ORPHANED.format(project=self.project_name))
-        cache_path.unlink(missing_ok=True)
-        (self.repo_path / cs.DIR_MTIMES_FILENAME).unlink(missing_ok=True)
+        # Discarding is best-effort by intent: `missing_ok=True` already says a
+        # cache that is not there is fine, and a cache that cannot be REMOVED
+        # is the same situation one step later. Every other filesystem writer
+        # on this path degrades quietly, so a read-only tree reaches here
+        # having survived all of them and must not lose the whole indexing run
+        # to a file it only wanted to delete (issue #1647).
+        for stale in (cache_path, self.repo_path / cs.DIR_MTIMES_FILENAME):
+            try:
+                stale.unlink(missing_ok=True)
+            except OSError as e:
+                # Failing to DELETE the file must not resurrect TRUSTING it.
+                # The mtime fast path (`file_mtime <= cache_mtime`) skips a
+                # file before its hash is ever compared, and a real run stamps
+                # the cache at or after its sources, so a surviving cache makes
+                # every file look unchanged against hashes already known dead:
+                # the run indexes nothing, and the next run repeats it forever
+                # because the graph is still empty. Ignoring the cache in
+                # memory gives this run the full rebuild the discard intended.
+                self._cache_discarded_in_memory = True
+                logger.warning(ls.HASH_CACHE_DISCARD_FAILED, path=stale, error=e)
 
     def _warn_if_parser_changed(self) -> None:
         # No hash cache means a full build is coming: nothing to compare.
@@ -2611,7 +2637,9 @@ class GraphUpdater:
             return False
         cache_mtime = cache_path.stat().st_mtime
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
-        old_hashes = _load_hash_cache(cache_path)
+        old_hashes = (
+            {} if self._cache_discarded_in_memory else _load_hash_cache(cache_path)
+        )
         old_dir_mtimes = _load_dir_mtimes(dir_mtimes_path)
         if not old_hashes or not old_dir_mtimes:
             return False
@@ -2738,7 +2766,14 @@ class GraphUpdater:
         self.factory.import_processor.reset_java_path_caches()
         cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
-        old_hashes = _load_hash_cache(cache_path) if not force else {}
+        # `_cache_discarded_in_memory`: the orphan discard could not delete the
+        # file, so treat it as gone for this run (issue #1647). Without this the
+        # mtime fast path below skips every file against hashes known dead, and
+        # the run indexes nothing on every subsequent run too.
+        cache_is_dead = self._cache_discarded_in_memory
+        old_hashes = (
+            _load_hash_cache(cache_path) if not (force or cache_is_dead) else {}
+        )
         # Snapshot for the single-file merge, read from DISK and independently
         # of `force`. Two distinct reasons it cannot reuse `old_hashes`:
         #
@@ -2757,8 +2792,12 @@ class GraphUpdater:
         #
         # Only the single-file commit reads this; a project run replaces the
         # cache wholesale from its own complete walk, as it always has.
+        # A discarded cache is dead for the snapshot too: merging over it
+        # would carry forward the very hashes the discard rejected.
         pristine_hashes = (
-            _load_hash_cache(cache_path) if self._single_file is not None else {}
+            _load_hash_cache(cache_path)
+            if self._single_file is not None and not cache_is_dead
+            else {}
         )
         for stale_key in self._delombok_stale_keys:
             old_hashes.pop(stale_key, None)

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -902,6 +902,12 @@ HASH_CACHE_ORPHANED = (
     "the database was likely wiped since the last sync. Discarding the cache "
     "and rebuilding fully."
 )
+HASH_CACHE_DISCARD_FAILED = (
+    "Could not discard the orphaned cache file {path} ({error}); this run "
+    "ignores it and rebuilds fully, so nothing is lost, but the stale file is "
+    "still on disk and EVERY later run pays the same full rebuild until it "
+    "goes. Delete it by hand, or re-run once the path is writable"
+)
 PARSER_FINGERPRINT_SAVE_FAILED = "Failed to save parser fingerprint to {path}: {error}"
 PARSER_FINGERPRINT_MISMATCH = (
     "A parser input changed since this graph was built: parser code, a grammar "

--- a/codebase_rag/tests/test_hash_cache_guard.py
+++ b/codebase_rag/tests/test_hash_cache_guard.py
@@ -4,12 +4,16 @@
 # aborted the whole non-forced sync instead.
 from __future__ import annotations
 
+import errno
 import json
 import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from codebase_rag import constants as cs
+from codebase_rag import graph_updater as graph_updater_module
 from codebase_rag.tests.conftest import create_and_run_updater
 
 
@@ -46,3 +50,90 @@ def test_query_failure_keeps_cache_and_sync(
         if c.args[0] == cs.NodeLabel.MODULE
     }
     assert any(str(qn).endswith(".m") for qn in module_qns), module_qns
+
+
+def test_a_cache_that_cannot_be_discarded_does_not_end_the_run(
+    temp_repo: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #1647: the discard is best-effort, so a refused unlink must not raise.
+
+    Every other filesystem writer on this path swallows `OSError` and degrades,
+    so a read-only tree reaches the discard having survived all of them. Losing
+    the whole indexing run to a file the tool only wanted to DELETE is the
+    worst of both: no index, and the stale cache still there.
+    """
+    (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    cache_path = temp_repo / cs.HASH_CACHE_FILENAME
+    cache_path.write_text(json.dumps({"m.py": "stale"}), encoding="utf-8")
+    mtimes_path = temp_repo / cs.DIR_MTIMES_FILENAME
+    mtimes_path.write_text(json.dumps({".": 1.0}), encoding="utf-8")
+    # Stamp the cache AFTER the sources, which is what a real completed run
+    # leaves behind (`os.utime(observed_at)` at the commit point). Backdating
+    # it here would hide the defect this test exists to catch: the mtime fast
+    # path skips a file before its hash is compared, so a surviving cache
+    # makes every file look unchanged against hashes known dead, and the run
+    # indexes NOTHING -- on every subsequent run, because the graph stays
+    # empty. Verified: with the cache backdated this test passes even when the
+    # run indexes nothing in production (issue #1647).
+    fresh_time = cache_path.stat().st_mtime + 5
+    os.utime(cache_path, (fresh_time, fresh_time))
+
+    # An empty project is what makes the graph look wiped, which is the only
+    # branch that reaches the discard at all.
+    def empty_project(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_COUNT_PROJECT_MODULES:
+            return [{"count": 0}]
+        return []
+
+    mock_ingestor.fetch_all.side_effect = empty_project
+
+    real_unlink = Path.unlink
+    refused: list[str] = []
+
+    def _refuse(self: Path, missing_ok: bool = False) -> None:
+        if self.name in (cs.HASH_CACHE_FILENAME, cs.DIR_MTIMES_FILENAME):
+            refused.append(self.name)
+            raise OSError(errno.EROFS, "Read-only file system")
+        real_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", _refuse)
+
+    warnings: list[str] = []
+    sink_id = graph_updater_module.logger.add(warnings.append, level="WARNING")
+    try:
+        create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+    finally:
+        graph_updater_module.logger.remove(sink_id)
+
+    monkeypatch.undo()
+
+    # Without this the run could complete for the trivial reason that it never
+    # reached the discard, and the assertion below would prove nothing. BOTH
+    # files must be attempted: guarding only the first would leave the second
+    # unguarded and still raise.
+    assert refused == [cs.HASH_CACHE_FILENAME, cs.DIR_MTIMES_FILENAME], refused
+
+    # The run must still have indexed the repo, which is the whole point of
+    # degrading rather than raising. The cache entry is a hash that cannot
+    # match `m.py`, so the file is re-read on its own merits; asserting this
+    # with a MATCHING hash would pass for the wrong reason, since the run
+    # would skip the file as unchanged rather than because the discard failed.
+    module_qns = {
+        c.args[1].get(cs.KEY_QUALIFIED_NAME)
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.MODULE
+    }
+    assert any(str(qn).endswith(".m") for qn in module_qns), module_qns
+
+    # The stale cache is still on disk, which is the documented cost of the
+    # degraded path. The INDEX is not lost, because the run ignores the cache
+    # in memory once the discard fails.
+    assert cache_path.is_file()
+
+    # Both refusals must be reported by name. Without this, deleting the log
+    # line and swallowing silently keeps every assertion above green, so
+    # nothing pins the new constant or names the file a user must remove.
+    discard_warnings = [w for w in warnings if "Could not discard" in w]
+    assert len(discard_warnings) == 2, warnings
+    assert any(cs.HASH_CACHE_FILENAME in w for w in discard_warnings), warnings
+    assert any(cs.DIR_MTIMES_FILENAME in w for w in discard_warnings), warnings


### PR DESCRIPTION
Closes #1647.

## The crash

`_drop_cache_if_graph_lost` ended with two unguarded `unlink` calls:

```python
cache_path.unlink(missing_ok=True)
(self.repo_path / cs.DIR_MTIMES_FILENAME).unlink(missing_ok=True)
```

On a read-only tree that raises `OSError: [Errno 30]` straight out of
`GraphUpdater.run()`. Every other filesystem writer on that path
(`_touch_empty_json`, `_save_hash_cache`, `_save_dir_mtimes`,
`_save_exclusion_state`, `_save_parser_fingerprint`) logs and returns, so such
a tree reaches this function having degraded quietly everywhere else, then
loses the whole indexing run to a file the tool only wanted to delete.

## The part the issue did not predict

Guarding the unlinks alone is not enough, and the first version of this branch
was wrong in a way worth writing down.

Refusing to DELETE the cache must not resurrect TRUSTING it. The incremental
pass short-circuits on mtime before any hash comparison:

```python
if file_mtime <= cache_mtime:
    new_hashes[file_key] = old_hashes[file_key]
    continue
```

A real completed run stamps the cache at or after its sources
(`os.utime(observed_at)` at the commit point), so a cache that survives the
discard makes every file look unchanged against hashes already known dead. The
run indexes nothing. The graph stays empty, so the next run reaches the same
discard, fails the same way, and indexes nothing again — permanently.

Measured, three consecutive runs on a read-only tree with an orphaned cache:

| Cache mtime | Discard | run1 | run2 | run3 |
|---|---|---|---|---|
| Realistic (>= sources) | refused | `[]` | `[]` | `[]` |
| Realistic | allowed (control) | `['proj.m']` | `['proj.m']` | — |
| Backdated 60s | refused | `['proj.m']` | — | — |

The control isolates the cause: the read-only tree parses fine, so the mtime
fast path is the only thing stopping it.

So the fix has two halves: guard the unlinks, and set
`_cache_discarded_in_memory` so this run ignores the cache it could not delete.
That gives the run the full rebuild the discard intended.

The flag is reset immediately BEFORE the discard that sets it, not with the
other per-run resets further down `run()` — those execute after
`_drop_cache_if_graph_lost` and would clear the flag just raised, making the
whole fix dead code.

## How the fixture nearly hid it

The first version of the test backdated the cache mtime 60s, copying the
sibling test in the same file. That made it pass while production indexed
nothing: the table above is exactly the difference between the two fixture
choices. The test now stamps the cache AFTER the sources, which is what a real
run leaves behind, and the comment says why so nobody re-introduces the
backdate.

Credit where due: the local reviewer asked whether the backdating was masking
a product bug rather than arranging a fixture. It was.

## Discrimination

Every mutation of the production code turns this test red:

| Mutation | Result |
|---|---|
| Remove the guard entirely | red |
| Guard only the FIRST unlink, leave the second bare | red |
| Swap the loop order | red |
| Drop the `logger.warning`, swallow silently | red |
| Keep the guard, ignore `_cache_discarded_in_memory` | red |

The last two matter most. Without the log assertions, deleting the warning line
kept the test green, so nothing pinned the new constant. Without the realistic
mtime, the in-memory discard could be removed and the test still passed.

## Note on CI

`ty check` fails on this branch with `Module codebase_rag.logs has no member
CACHE_STAMP_FAILED` at `graph_updater.py:3574`. That is pre-existing on `main`
(the reference is there and the constant is defined zero times) and is being
fixed by #1690; it is unrelated to this diff and will clear once that merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when stale cache files cannot be removed.
  * The current run now ignores undeletable cache data and rebuilds instead of failing or using stale results.
  * Added warnings identifying cache cleanup failures while allowing indexing to continue.
  * Improved accuracy of type-annotation information for unchanged, re-parsed, and removed files.
  * Single-file indexing now preserves existing cache data and avoids unnecessary project-wide cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->