### PR TITLE
fix: a nested class is not a self-dispatch target, so self.Inner() emits no CALLS to it (#1650)

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -731,7 +731,13 @@ class CallResolver:
                 self.function_registry.is_abstract(override_qn)
             ):
                 targets.add((self.function_registry[override_qn], override_qn))
-        return targets
+        # `self.Inner()` where `Inner` is a NESTED CLASS is a construction, not a
+        # virtual method call: the name resolves to `Outer.Inner`, which is a
+        # Class node, and CALLS may only target a Function/Method/Enum/Type. The
+        # construction already reaches the graph as INSTANTIATES plus a CALLS to
+        # `__init__`, so a class here is a duplicate the schema rejects outright
+        # (issue #1650).
+        return {target for target in targets if target[0] != cs.NodeLabel.CLASS.value}
 
     def js_member_twin_targets(self, callee_qn: str) -> set[tuple[str, str]]:
         # `View.prototype.lookup = function lookup(...)` registers TWO nodes for

--- a/codebase_rag/tests/test_self_nested_class_construction.py
+++ b/codebase_rag/tests/test_self_nested_class_construction.py
@@ -1,0 +1,114 @@
+"""`self.Inner()` constructs a nested class; it is not a virtual method call (#1650).
+
+`self.M()` fans out to every concrete override of `M`, so a method reached only
+polymorphically is not reported dead. That fan-out resolved `self.Inner()` to
+the nested CLASS `Outer.Inner` and emitted a `CALLS` edge to it, alongside the
+correct `CALLS -> __init__` and `INSTANTIATES`.
+
+`RELATIONSHIP_SCHEMAS` allows `CALLS` to target a Function, Method, Enum or Type
+-- never a Class; construction is what `INSTANTIATES` records. So the extra edge
+was both a duplicate and undocumented, and the suite's own `_audit_recorded_graph`
+rejected it, which is why no existing test could exercise this shape: any test
+that did aborted before it could assert anything.
+
+The controls matter here. The fan-out is load-bearing for real overrides, so a
+fix phrased as "drop the self-dispatch edges" would satisfy the assertion below
+and silently break dead-code reachability for every polymorphic method.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.constants import RelationshipType
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _edges(mock_ingestor: MagicMock, rel: RelationshipType) -> set[tuple[str, str]]:
+    return {
+        (call[0][0][2], call[0][2][2])
+        for call in get_relationships(mock_ingestor, rel.value)
+    }
+
+
+def _labelled_calls(mock_ingestor: MagicMock) -> set[tuple[str, str, str]]:
+    """(source qn, TARGET LABEL, target qn) for every CALLS edge."""
+    return {
+        (call[0][0][2], call[0][2][0], call[0][2][2])
+        for call in get_relationships(mock_ingestor, RelationshipType.CALLS.value)
+    }
+
+
+@pytest.fixture
+def nested_project(temp_repo: Path) -> Path:
+    project = temp_repo / "selfnested"
+    project.mkdir()
+    (project / "m.py").write_text(
+        encoding="utf-8",
+        data="""
+class Outer:
+    class Inner:
+        def __init__(self, v):
+            self.v = v
+
+    def make(self):
+        return self.Inner(1)
+
+
+class Base:
+    def render(self):
+        return "base"
+
+    def draw(self):
+        return self.render()
+
+
+class Derived(Base):
+    def render(self):
+        return "derived"
+""",
+    )
+    return project
+
+
+class TestSelfNestedClassConstruction:
+    def test_no_calls_edge_targets_a_class(
+        self, nested_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # Asserted over EVERY CALLS edge rather than the one pair, because the
+        # schema forbids the shape outright: a second construction elsewhere in
+        # the fixture would otherwise slip past a narrower assertion.
+        create_and_run_updater(nested_project, mock_ingestor)
+        to_classes = {
+            edge for edge in _labelled_calls(mock_ingestor) if edge[1] == "Class"
+        }
+        assert not to_classes, f"CALLS may not target a Class: {sorted(to_classes)}"
+
+    def test_the_construction_still_reaches_the_graph(
+        self, nested_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # The other half: removing the bad edge must not remove the good ones.
+        create_and_run_updater(nested_project, mock_ingestor)
+        assert (
+            "selfnested.m.Outer.make",
+            "selfnested.m.Outer.Inner",
+        ) in _edges(mock_ingestor, RelationshipType.INSTANTIATES)
+        assert (
+            "selfnested.m.Outer.make",
+            "selfnested.m.Outer.Inner.__init__",
+        ) in _edges(mock_ingestor, RelationshipType.CALLS)
+
+    def test_self_dispatch_to_a_real_override_survives(
+        self, nested_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # The control. `self.render()` inside Base.draw must still fan out to
+        # Derived.render, or a method reached only polymorphically reads as
+        # dead. A fix that dropped self-dispatch edges wholesale would pass the
+        # first test and break this.
+        create_and_run_updater(nested_project, mock_ingestor)
+        calls = _edges(mock_ingestor, RelationshipType.CALLS)
+        assert ("selfnested.m.Base.draw", "selfnested.m.Base.render") in calls
+        assert ("selfnested.m.Base.draw", "selfnested.m.Derived.render") in calls

--- a/codebase_rag/tests/test_self_nested_class_construction.py
+++ b/codebase_rag/tests/test_self_nested_class_construction.py
@@ -27,7 +27,9 @@ from codebase_rag.constants import RelationshipType
 from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
 
 
-def _edges(mock_ingestor: MagicMock, rel: RelationshipType) -> set[tuple[str, str]]:
+def _source_target_pairs(
+    mock_ingestor: MagicMock, rel: RelationshipType
+) -> set[tuple[str, str]]:
     return {
         (call[0][0][2], call[0][2][2])
         for call in get_relationships(mock_ingestor, rel.value)
@@ -95,11 +97,11 @@ class TestSelfNestedClassConstruction:
         assert (
             "selfnested.m.Outer.make",
             "selfnested.m.Outer.Inner",
-        ) in _edges(mock_ingestor, RelationshipType.INSTANTIATES)
+        ) in _source_target_pairs(mock_ingestor, RelationshipType.INSTANTIATES)
         assert (
             "selfnested.m.Outer.make",
             "selfnested.m.Outer.Inner.__init__",
-        ) in _edges(mock_ingestor, RelationshipType.CALLS)
+        ) in _source_target_pairs(mock_ingestor, RelationshipType.CALLS)
 
     def test_self_dispatch_to_a_real_override_survives(
         self, nested_project: Path, mock_ingestor: MagicMock
@@ -109,6 +111,6 @@ class TestSelfNestedClassConstruction:
         # dead. A fix that dropped self-dispatch edges wholesale would pass the
         # first test and break this.
         create_and_run_updater(nested_project, mock_ingestor)
-        calls = _edges(mock_ingestor, RelationshipType.CALLS)
+        calls = _source_target_pairs(mock_ingestor, RelationshipType.CALLS)
         assert ("selfnested.m.Base.draw", "selfnested.m.Base.render") in calls
         assert ("selfnested.m.Base.draw", "selfnested.m.Derived.render") in calls


### PR DESCRIPTION
Closes #1650.

`self.Inner()` — constructing a nested class — emitted a `CALLS` edge pointing at the **Class** node, alongside the correct `CALLS -> __init__` and `INSTANTIATES`. `RELATIONSHIP_SCHEMAS` allows `CALLS` to target a Function, Method, Enum or Type, never a Class; construction is what `INSTANTIATES` records. So the edge was both a duplicate and undocumented, and the suite's own `_audit_recorded_graph` rejects it.

## Root cause

`self_dispatch_targets` fans `self.M()` out to the enclosing class's `M` and every concrete override, so a method reached only polymorphically is not reported dead. For `self.Inner(1)` the name resolves through `_try_resolve_method` to `Outer.Inner`, which is a **Class** node, and the fan-out emitted a `CALLS` edge to it like any other dispatch target.

The fix drops Class-labelled targets from that fan-out. Construction already reaches the graph through the paths beside it.

## Effect, measured on the same file

| caller | before | after |
|---|---|---|
| `Outer.make` (`self.Inner()`) | `CALLS -> Class`, `CALLS -> __init__`, `INSTANTIATES` | `CALLS -> __init__`, `INSTANTIATES` |
| `via_instance` (`o.Inner()`) | `CALLS -> __init__`, `INSTANTIATES` | unchanged |

The typed-local receiver in the same fixture was already correct, which is what identified the `self.` path as the one at fault rather than the constructor redirect.

## Why no test covered this

Any test exercising `self.Inner()` aborted in `create_and_run_updater` before it could assert anything, because the conftest audit rejects the undocumented edge. That is why #1641 had to omit the shape from its fixture and assert on the resolver predicate instead; this PR is what lets that shape be tested at all.

## Tests

`codebase_rag/tests/test_self_nested_class_construction.py`.

The first assertion is over **every** `CALLS` edge in the fixture rather than the one pair, because the schema forbids the shape outright — a narrower assertion would miss a second construction elsewhere.

Two mutations, each with an execution count proving the line ran:

| mutation | dies |
|---|---|
| class filter removed (6 execs) | all three, but via the audit aborting the run — so it proves less than the count suggests |
| **self-dispatch dropped wholesale** (6 execs) | **only the control** |

The second is why the control exists. Deleting the fan-out satisfies "no CALLS targets a Class" perfectly while silently breaking dead-code reachability for every polymorphic method — a fix that passes the defect test and causes a worse bug. `Base.draw` calling `self.render()` must still reach both `Base.render` and `Derived.render`.

## Suite

10419 passed; the 24 failures and 4 errors are the known #1639 environment set, and the sorted FAILED set diffs empty against that baseline. Rebased onto `1dc99ccd` after the #1690 type-check hotfix.

Pushed after a single local review round, per the current review-gate rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected code relationship analysis for nested class construction.
  - Nested class calls are no longer incorrectly reported as method calls to a class.
  - Construction relationships continue to include instantiation and initializer calls.
  - Valid polymorphic method dispatch remains supported.

- **Tests**
  - Added coverage for nested class construction and polymorphic dispatch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->