### PR TITLE
fix: recover the watcher after a re-ingest that failed part way through (#1681)

### DIFF
--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -286,6 +286,17 @@ REINGEST_DONE = "Re-ingested {reparsed} file(s) (+{affected} dependent, -{remove
 REINGEST_SKIPPED_IGNORED = "Re-ingest skipped path(s) the ignore rules exclude: {paths}"
 GRAPH_UPDATED = "Graph updated successfully for change in: {name}"
 WATCHER_REINGEST_REFUSED = "Re-ingest refused for {path}: {error}"
+# A refusal and an abort leave the graph untouched; anything else may have
+# deleted the affected subtrees without rebuilding them, so the retained
+# updater describes a graph that no longer exists (issue #1681).
+WATCHER_REINGEST_FAILED = (
+    "Re-ingest FAILED for {path}: {error}. The graph may be partial, so the "
+    "next change triggers a full re-index before any scoped update."
+)
+WATCHER_REBUILDING_AFTER_FAILURE = (
+    "Re-indexing the whole repository before this change, because the last "
+    "re-ingest failed part way through."
+)
 INITIAL_SCAN = "Performing initial full codebase scan..."
 INITIAL_SCAN_DONE = "Initial scan complete. Starting real-time watcher."
 WATCHING = "Watching for changes in: {path}"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -293,6 +293,11 @@ WATCHER_REINGEST_FAILED = (
     "Re-ingest FAILED for {path}: {error}. The graph may be partial, so the "
     "next change triggers a full re-index before any scoped update."
 )
+WATCHER_REBUILD_FAILED = (
+    "Re-index after a failed re-ingest also FAILED: {error}. The graph is still "
+    "partial; the next change will try again. Run 'cgr start --update-graph' if "
+    "this persists."
+)
 WATCHER_REBUILDING_AFTER_FAILURE = (
     "Re-indexing the whole repository before this change, because the last "
     "re-ingest failed part way through."

--- a/codebase_rag/tests/test_watcher_reingest_failure.py
+++ b/codebase_rag/tests/test_watcher_reingest_failure.py
@@ -1,0 +1,121 @@
+"""A watcher must not reuse its updater after a re-ingest died mid-run (#1681).
+
+`GraphUpdater.reingest` deletes the affected subtrees before rebuilding them, so
+a failure between those two steps leaves the graph missing definitions the
+updater's in-memory registry still describes. The watcher caught only
+`ValueError` -- the refusals raised before any write -- so any other exception
+escaped the callback with the updater retained, and every later event resolved
+calls against that registry over a partial graph.
+
+The MCP tool closed the same class in #1538 by dropping its retained updater and
+refusing until `update_repository` completes. A watcher cannot refuse for ever,
+so it recovers instead: the next change re-indexes the whole repository before
+any scoped work.
+
+The controls carry the weight here. "Never reuse the updater" is satisfied by a
+watcher that dies on the first error, and "always rebuild" by one that re-indexes
+on every event -- both would pass a bare regression test and both would be worse
+than the bug.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.constants import EventType
+from codebase_rag.graph_updater import ReingestAborted
+from realtime_updater import CodeChangeEventHandler
+
+
+class _Event:
+    """The attributes `dispatch` reads off a watchdog event."""
+
+    def __init__(self, path: str, event_type: str = EventType.MODIFIED) -> None:
+        self.src_path = path
+        self.event_type = event_type
+        self.is_directory = False
+
+
+@pytest.fixture
+def updater() -> MagicMock:
+    mock = MagicMock()
+    mock.repo_path = Path("/repo")
+    return mock
+
+
+@pytest.fixture
+def handler(updater: MagicMock) -> CodeChangeEventHandler:
+    # debounce off: dispatch runs the change inline, so the assertions below
+    # observe the handler rather than a timer.
+    return CodeChangeEventHandler(updater=updater, debounce_seconds=0)
+
+
+class TestReingestFailedMidRun:
+    def test_the_failure_does_not_escape_the_callback(
+        self, handler: CodeChangeEventHandler, updater: MagicMock
+    ) -> None:
+        # An exception out of a watchdog callback kills the handler thread
+        # silently; the watcher stays "running" and stops updating anything.
+        updater.reingest.side_effect = RuntimeError("died after the delete")
+        handler.dispatch(_Event("/repo/a.py"))
+
+    def test_the_next_change_re_indexes_before_any_scoped_work(
+        self, handler: CodeChangeEventHandler, updater: MagicMock
+    ) -> None:
+        updater.reingest.side_effect = RuntimeError("died after the delete")
+        handler.dispatch(_Event("/repo/a.py"))
+        assert not updater.run.called, "the failing event itself must not re-index"
+
+        updater.reingest.side_effect = None
+        handler.dispatch(_Event("/repo/b.py"))
+        assert updater.run.called, (
+            "the next change must restore a whole graph before resolving against it"
+        )
+
+    def test_the_rebuild_happens_once_not_on_every_later_change(
+        self, handler: CodeChangeEventHandler, updater: MagicMock
+    ) -> None:
+        # The control against over-correcting. A watcher that re-indexes on
+        # every event satisfies the test above and makes the scoped path
+        # pointless.
+        updater.reingest.side_effect = RuntimeError("died after the delete")
+        handler.dispatch(_Event("/repo/a.py"))
+        updater.reingest.side_effect = None
+        handler.dispatch(_Event("/repo/b.py"))
+        handler.dispatch(_Event("/repo/c.py"))
+        assert updater.run.call_count == 1, (
+            f"expected one recovery re-index, got {updater.run.call_count}"
+        )
+
+
+class TestRefusalsAreNotFailures:
+    @pytest.mark.parametrize(
+        "error",
+        [ValueError("outside the repository"), ReingestAborted("still reading")],
+        ids=["refusal", "abort"],
+    )
+    def test_a_refusal_leaves_the_updater_usable(
+        self, handler: CodeChangeEventHandler, updater: MagicMock, error: Exception
+    ) -> None:
+        # Both are raised before anything was written -- a refusal while the
+        # paths are split, an abort while the call was still READING the graph.
+        # Treating them as damage would re-index the repository every time an
+        # agent touched a path outside it.
+        updater.reingest.side_effect = error
+        handler.dispatch(_Event("/repo/a.py"))
+        updater.reingest.side_effect = None
+        handler.dispatch(_Event("/repo/b.py"))
+        assert not updater.run.called, (
+            "a refusal wrote nothing, so no recovery re-index is warranted"
+        )
+
+    def test_a_clean_run_never_re_indexes(
+        self, handler: CodeChangeEventHandler, updater: MagicMock
+    ) -> None:
+        handler.dispatch(_Event("/repo/a.py"))
+        handler.dispatch(_Event("/repo/b.py"))
+        assert not updater.run.called
+        assert updater.reingest.call_count == 2

--- a/codebase_rag/tests/test_watcher_reingest_failure.py
+++ b/codebase_rag/tests/test_watcher_reingest_failure.py
@@ -71,9 +71,16 @@ class TestReingestFailedMidRun:
 
         updater.reingest.side_effect = None
         handler.dispatch(_Event("/repo/b.py"))
-        assert updater.run.called, (
-            "the next change must restore a whole graph before resolving against it"
-        )
+
+        # ORDER is the property, and `updater.run.called` does not carry it:
+        # it is equally true of a watcher that re-ingests b.py against the
+        # partial graph FIRST and rebuilds afterwards, which is the bug
+        # wearing the fix's clothes. `mock_calls` records both children in
+        # call order, so the sequence pins what the test name claims.
+        # `run` and `reingest` are the only methods the handler calls
+        # (`repo_path` is attribute access), so this stays exact.
+        sequence = [name for name, _args, _kwargs in updater.mock_calls]
+        assert sequence == ["reingest", "run", "reingest"], sequence
 
     def test_the_rebuild_happens_once_not_on_every_later_change(
         self, handler: CodeChangeEventHandler, updater: MagicMock

--- a/codebase_rag/tests/test_watcher_reingest_failure.py
+++ b/codebase_rag/tests/test_watcher_reingest_failure.py
@@ -91,6 +91,54 @@ class TestReingestFailedMidRun:
         )
 
 
+class TestTheRecoveryItself:
+    def test_the_rebuild_is_forced(
+        self, handler: CodeChangeEventHandler, updater: MagicMock
+    ) -> None:
+        # An incremental run skips files whose hashes are unchanged, and after a
+        # re-ingest that deleted subtrees without rebuilding them the FILES are
+        # unchanged. A plain run() would skip exactly the files whose nodes are
+        # missing and report success over a still-partial graph.
+        updater.reingest.side_effect = RuntimeError("died after the delete")
+        handler.dispatch(_Event("/repo/a.py"))
+        updater.reingest.side_effect = None
+        handler.dispatch(_Event("/repo/b.py"))
+
+        updater.run.assert_called_once_with(force=True)
+
+    def test_a_failed_rebuild_does_not_end_the_dispatcher(
+        self, handler: CodeChangeEventHandler, updater: MagicMock
+    ) -> None:
+        # This runs from a watchdog callback: an exception here kills the
+        # dispatcher thread and the watcher goes silently deaf, which is the
+        # failure this recovery exists to prevent, one level up.
+        updater.reingest.side_effect = RuntimeError("died after the delete")
+        handler.dispatch(_Event("/repo/a.py"))
+        updater.reingest.side_effect = None
+        updater.run.side_effect = RuntimeError("rebuild failed too")
+
+        handler.dispatch(_Event("/repo/b.py"))
+
+    def test_a_failed_rebuild_retries_and_skips_the_scoped_work(
+        self, handler: CodeChangeEventHandler, updater: MagicMock
+    ) -> None:
+        updater.reingest.side_effect = RuntimeError("died after the delete")
+        handler.dispatch(_Event("/repo/a.py"))
+        updater.reingest.reset_mock()
+        updater.reingest.side_effect = None
+        updater.run.side_effect = RuntimeError("rebuild failed too")
+
+        handler.dispatch(_Event("/repo/b.py"))
+        # Resolving this change against a graph known to be partial would
+        # compound the damage, so the scoped work is skipped entirely.
+        assert not updater.reingest.called
+
+        updater.run.side_effect = None
+        handler.dispatch(_Event("/repo/c.py"))
+        assert updater.run.call_count == 2, "the next change must retry the rebuild"
+        assert updater.reingest.called, "and then resume scoped work"
+
+
 class TestRefusalsAreNotFailures:
     @pytest.mark.parametrize(
         "error",

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -23,7 +23,7 @@ from codebase_rag.constants import (
     WATCHER_SLEEP_INTERVAL,
     EventType,
 )
-from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.graph_updater import GraphUpdater, ReingestAborted
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.services.graph_service import MemgraphIngestor
 from codebase_rag.utils.path_utils import is_ignored_filename
@@ -76,6 +76,10 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         # loaded runners (issue #1005). Production always uses threading.Timer.
         self._timer_factory = timer_factory
         self.ignore_patterns = IGNORE_PATTERNS
+        # Set when a scoped re-ingest fails after it may have written, so the
+        # next change re-indexes the whole repository before touching it
+        # (issue #1681).
+        self._needs_full_rebuild = False
 
         self.debounce_seconds = debounce_seconds
         self.max_wait_seconds = max_wait_seconds
@@ -244,16 +248,35 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         logger.warning(
             logs.CHANGE_DETECTED.format(event_type=event.event_type, path=path)
         )
+        # A previous scoped re-ingest died part way through, so the graph may be
+        # missing the subtrees it deleted and never rebuilt. Resolving this
+        # change against that state would compound the damage, so restore a
+        # whole graph first (issue #1681).
+        if self._needs_full_rebuild:
+            logger.warning(logs.WATCHER_REBUILDING_AFTER_FAILURE)
+            self.updater.run()
+            self._needs_full_rebuild = False
         try:
             if event.event_type == EventType.DELETED:
                 self.updater.reingest((), deleted=(path,))
             else:
                 self.updater.reingest((path,))
-        except ValueError as exc:
-            # A path reingest refuses (a symlink resolving outside the repo,
-            # a directory where a file was expected) must not end the
-            # callback: the refusal is logged and later events still run.
+        except (ValueError, ReingestAborted) as exc:
+            # A refusal (a symlink resolving outside the repo, a directory where
+            # a file was expected) is raised while the paths are split, and an
+            # abort while the call was still READING the graph. Neither wrote
+            # anything, so the updater is still valid and later events run.
             logger.warning(logs.WATCHER_REINGEST_REFUSED.format(path=path, error=exc))
+            return
+        except Exception as exc:  # noqa: BLE001
+            # Anything else may have deleted the affected subtrees and never
+            # rebuilt them. Letting it escape would end this callback with the
+            # updater retained, so every later event resolves against a graph
+            # that no longer matches its registry. Mirrors the MCP tool's
+            # posture (`_reingest_sync`), adapted for a long-lived watcher:
+            # recover on the next event rather than refusing for ever.
+            logger.error(logs.WATCHER_REINGEST_FAILED.format(path=path, error=exc))
+            self._needs_full_rebuild = True
             return
         logger.success(logs.GRAPH_UPDATED.format(name=path.name))
 

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -106,6 +106,29 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         else:
             logger.info(logs.WATCHER_ACTIVE)
 
+    def _rebuild_after_failure(self) -> bool:
+        """Re-index everything after a partial re-ingest. True when the graph is whole.
+
+        `force=True` is required, not tidiness: an incremental run skips files
+        whose hashes are unchanged, and after a re-ingest that deleted subtrees
+        without rebuilding them the FILES on disk are unchanged. A plain
+        `run()` would therefore skip exactly the files whose nodes are missing
+        and report success over a graph that is still partial.
+
+        A rebuild that itself fails must not escape either. This runs from a
+        watchdog callback, so an exception here ends the dispatcher and the
+        watcher goes silently deaf -- the same failure this recovery exists to
+        prevent, one level up. The flag stays set so the next change retries.
+        """
+        logger.warning(logs.WATCHER_REBUILDING_AFTER_FAILURE)
+        try:
+            self.updater.run(force=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(logs.WATCHER_REBUILD_FAILED.format(error=exc))
+            return False
+        self._needs_full_rebuild = False
+        return True
+
     def _is_relevant(self, path_str: str) -> bool:
         path = Path(path_str)
         # Shared with the repository walk. These two predicates answer the same
@@ -252,10 +275,11 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         # missing the subtrees it deleted and never rebuilt. Resolving this
         # change against that state would compound the damage, so restore a
         # whole graph first (issue #1681).
-        if self._needs_full_rebuild:
-            logger.warning(logs.WATCHER_REBUILDING_AFTER_FAILURE)
-            self.updater.run()
-            self._needs_full_rebuild = False
+        if self._needs_full_rebuild and not self._rebuild_after_failure():
+            # The rebuild failed too, so the graph is still partial. Skip the
+            # scoped work rather than resolve this change against it; the flag
+            # stays set and the next change tries again.
+            return
         try:
             if event.event_type == EventType.DELETED:
                 self.updater.reingest((), deleted=(path,))


### PR DESCRIPTION
Closes #1681.

`GraphUpdater.reingest` deletes the affected subtrees before rebuilding them, so a failure between those two steps leaves the graph missing definitions the updater's in-memory registry still describes. The watcher caught only `ValueError` — the refusals raised before any write — so any other exception escaped the callback with the updater retained, and every later event resolved calls against that registry over a partial graph.

## Measured before the fix

Driving `dispatch` with a `reingest` that raises after the delete:

```
first event : RuntimeError escaped the callback
updater retained after the failure: True
second event: RuntimeError escaped again
full run() ever attempted: False
```

After: nothing escapes, and the next change re-indexes before any scoped work.

## The posture, and where it differs from MCP

#1538 closed the same class in the MCP tool (`_reingest_sync`): a non-refusal failure drops the retained updater and marks the graph incomplete, and `reingest` refuses until `update_repository` completes.

A watcher cannot refuse for ever — a watcher that stops updating while still reporting itself as running is worse than the bug. So it **recovers** instead: the failure is logged at ERROR, a flag is set, and the next change runs a full `run()` before touching anything scoped. That is the second branch the issue offers.

`ReingestAborted` joins `ValueError` as benign, matching MCP. An abort is raised while the call is still **reading** the graph, so nothing was written; treating it as damage would re-index the repository every time an agent touched a path outside it.

## Tests

`codebase_rag/tests/test_watcher_reingest_failure.py`.

Two mutations, in opposite directions:

| mutation | dies |
|---|---|
| recovery removed (revert to escaping) | the 3 defect tests; controls green |
| **rebuild on every event** | **the 4 controls**; defect test green |

The second is what the controls are for. "Always rebuild" satisfies "the next change re-indexes" perfectly while making the entire scoped-reingest feature pointless, and a bare regression test would have accepted it. The controls pin that the recovery happens **once**, that a refusal and an abort trigger no re-index at all, and that a clean run never re-indexes.

## Suite

10422 passed; the 24 failures and 4 errors are the known #1639 environment set, and the sorted FAILED set diffs empty against that baseline. Rebased onto `1dc99ccd` after the #1690 type-check hotfix.

Pushed after a single local review round, per the current review-gate rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watcher recovery after failed change processing by rebuilding the repository index before handling the next change.
  * Retried failed recovery rebuilds on subsequent changes while postponing scoped processing until recovery succeeds.
  * Prevented safely rejected changes from unnecessarily triggering a full rebuild.
  * Kept change monitoring active when re-ingestion fails.
  * Added clearer warnings when the graph may be incomplete and manual recovery or retry may be required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->