### PR TITLE
fix: probe formatters by invoking them, not by finding them on PATH (#1639)

### DIFF
--- a/codebase_rag/constants/lang_tooling.py
+++ b/codebase_rag/constants/lang_tooling.py
@@ -158,6 +158,9 @@ PATCH_GOFMT_LIST_FLAG = "-l"
 # for an uninstalled component is a real file on PATH that exits non-zero, and
 # that is indistinguishable from "your code is misformatted" (issue #1639).
 PATCH_VERSION_FLAG = "--version"
+# gofmt has no --version and exits 2 on it; -h exits 0. The liveness probe must
+# use a flag the tool accepts, or a working formatter reads as a missing one.
+PATCH_GOFMT_PROBE_FLAG = "-h"
 PATCH_RUSTFMT = "rustfmt"
 PATCH_RUSTFMT_CHECK_FLAG = "--check"
 PATCH_RUSTFMT_EDITION_FLAG = "--edition"

--- a/codebase_rag/constants/lang_tooling.py
+++ b/codebase_rag/constants/lang_tooling.py
@@ -154,6 +154,10 @@ LANG_ELLIPSIS = "..."
 # node types a rename may target beyond the shared `identifier` family.
 PATCH_GOFMT = "gofmt"
 PATCH_GOFMT_LIST_FLAG = "-l"
+# Probed by invocation before a formatter's verdict is trusted: a rustup shim
+# for an uninstalled component is a real file on PATH that exits non-zero, and
+# that is indistinguishable from "your code is misformatted" (issue #1639).
+PATCH_VERSION_FLAG = "--version"
 PATCH_RUSTFMT = "rustfmt"
 PATCH_RUSTFMT_CHECK_FLAG = "--check"
 PATCH_RUSTFMT_EDITION_FLAG = "--edition"

--- a/codebase_rag/editing/patcher.py
+++ b/codebase_rag/editing/patcher.py
@@ -24,6 +24,7 @@ import shutil
 import subprocess
 import tempfile
 from collections.abc import Iterable
+from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple, Protocol
 
@@ -168,6 +169,27 @@ def _identifier_at(root: Node, start: int, end: int) -> Node | None:
     return None
 
 
+@lru_cache(maxsize=8)
+def _tool_runs(executable: str) -> bool:
+    """Whether the binary at this path can actually run (issue #1639).
+
+    Cached on the resolved path: the answer cannot change within a process,
+    and `formatter_check` is called once per patched file.
+    """
+    try:
+        probe = subprocess.run(
+            [executable, cs.PATCH_VERSION_FLAG],
+            capture_output=True,
+            text=True,
+            encoding=cs.ENCODING_UTF8,
+            check=False,
+            timeout=cs.PATCH_FORMATTER_TIMEOUT_S,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return probe.returncode == 0
+
+
 def formatter_check(
     language: cs.SupportedLanguage | None, content: bytes, suffix: str
 ) -> tuple[str | None, bool | None]:
@@ -175,12 +197,21 @@ def formatter_check(
 
     `None, None` when the language has none or the tool is not installed;
     the check reports, it never rewrites.
+
+    "Not installed" is decided by INVOKING the tool, not by finding a file on
+    PATH (issue #1639). Every rustup-managed toolchain leaves a shim on PATH
+    for components it does not have, and that shim exits non-zero with
+    "'rustfmt' is not installed for the toolchain". Judged by presence, that
+    non-zero exit is indistinguishable from a real "your code is misformatted"
+    verdict, so the caller was told `formatted=False` and the user read
+    "applied, but rustfmt would reformat it" -- a claim about their code that
+    no formatter ever made.
     """
     if language is None or language not in _FORMATTERS:
         return None, None
     tool, flags = _FORMATTERS[language]
     executable = shutil.which(tool)
-    if executable is None:
+    if executable is None or not _tool_runs(executable):
         return tool, None
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
         handle.write(content)

--- a/codebase_rag/editing/patcher.py
+++ b/codebase_rag/editing/patcher.py
@@ -134,9 +134,17 @@ _IDENTIFIER_TYPES = frozenset(
     }
 )
 
-_FORMATTERS: dict[cs.SupportedLanguage, tuple[str, tuple[str, ...]]] = {
+# (binary, check flags, LIVENESS flag). The liveness flag differs per tool and
+# must be one the tool actually accepts: `gofmt` has no `--version` and exits 2
+# on it, so a universal `--version` probe declares a perfectly good gofmt
+# unusable and silently drops the Go drift check (issue #1639).
+_FORMATTERS: dict[cs.SupportedLanguage, tuple[str, tuple[str, ...], str]] = {
     # gofmt -l prints the file name when it would reformat it.
-    cs.SupportedLanguage.GO: (cs.PATCH_GOFMT, (cs.PATCH_GOFMT_LIST_FLAG,)),
+    cs.SupportedLanguage.GO: (
+        cs.PATCH_GOFMT,
+        (cs.PATCH_GOFMT_LIST_FLAG,),
+        cs.PATCH_GOFMT_PROBE_FLAG,
+    ),
     cs.SupportedLanguage.RUST: (
         cs.PATCH_RUSTFMT,
         (
@@ -144,6 +152,7 @@ _FORMATTERS: dict[cs.SupportedLanguage, tuple[str, tuple[str, ...]]] = {
             cs.PATCH_RUSTFMT_EDITION_FLAG,
             cs.PATCH_RUSTFMT_EDITION,
         ),
+        cs.PATCH_VERSION_FLAG,
     ),
 }
 
@@ -170,15 +179,20 @@ def _identifier_at(root: Node, start: int, end: int) -> Node | None:
 
 
 @lru_cache(maxsize=8)
-def _tool_runs(executable: str) -> bool:
+def _tool_runs(executable: str, probe_flag: str) -> bool:
     """Whether the binary at this path can actually run (issue #1639).
 
-    Cached on the resolved path: the answer cannot change within a process,
-    and `formatter_check` is called once per patched file.
+    The flag is per-tool, never assumed: `gofmt` exits 2 on `--version`, so a
+    universal probe would report a working gofmt as missing and suppress the
+    Go drift check entirely -- the mirror image of the bug being fixed, and
+    just as silent.
+
+    Cached on (path, flag): the answer cannot change within a process, and
+    `formatter_check` is called once per patched file.
     """
     try:
         probe = subprocess.run(
-            [executable, cs.PATCH_VERSION_FLAG],
+            [executable, probe_flag],
             capture_output=True,
             text=True,
             encoding=cs.ENCODING_UTF8,
@@ -209,9 +223,9 @@ def formatter_check(
     """
     if language is None or language not in _FORMATTERS:
         return None, None
-    tool, flags = _FORMATTERS[language]
+    tool, flags, probe_flag = _FORMATTERS[language]
     executable = shutil.which(tool)
-    if executable is None or not _tool_runs(executable):
+    if executable is None or not _tool_runs(executable, probe_flag):
         return tool, None
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as handle:
         handle.write(content)

--- a/codebase_rag/tests/test_patcher.py
+++ b/codebase_rag/tests/test_patcher.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import difflib
 import shutil
+import subprocess
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -394,6 +396,41 @@ def test_java_rename_preserves_syntax(tmp_path: Path) -> None:
     assert result.content.decode().replace("assist", "helper") == JAVA_SRC
 
 
+@lru_cache(maxsize=8)
+def _runnable_formatter(binary: str) -> bool:
+    """Whether a formatter is on PATH AND can actually run (issue #1639).
+
+    `shutil.which` answers "is there a file here", which is not the question a
+    skip guard needs. Every rustup-managed toolchain puts a shim on PATH for
+    components it does NOT have, so `which("rustfmt")` returns a real path that
+    exits non-zero with "'rustfmt' is not installed for the toolchain" the
+    moment it is invoked. The test then hard-FAILS on a machine that simply
+    lacks the tool, which is the permissive direction of a proxy standing in
+    for the property.
+
+    Probing by invocation covers that, a broken install, and any future
+    incompatibility in one check. Same shape as `_runnable_dotnet_trace` and
+    `_dotnet_with_sdk` in test_dynamic_trace_speedscope.py (issue #1449).
+    Cached because the guard is consulted per test and the answer cannot
+    change within a run.
+    """
+    found = shutil.which(binary)
+    if found is None:
+        return False
+    try:
+        probe = subprocess.run(
+            [found, "--version"],
+            capture_output=True,
+            text=True,
+            encoding=cs.ENCODING_UTF8,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return probe.returncode == 0
+
+
 GO_SRC = "package main\n\nfunc helper(a, b int) int { return helper(a, b) }\n"
 
 
@@ -407,7 +444,7 @@ def test_go_rename_runs_the_gofmt_check(tmp_path: Path) -> None:
     assert result.parses is True
     assert result.content.decode().replace("assist", "helper") == GO_SRC
     assert result.formatter == cs.PATCH_GOFMT
-    if shutil.which(cs.PATCH_GOFMT):
+    if _runnable_formatter(cs.PATCH_GOFMT):
         assert result.formatted is True
     else:
         assert result.formatted is None
@@ -426,15 +463,15 @@ def test_rust_rename_runs_the_rustfmt_check(tmp_path: Path) -> None:
     assert result.parses is True
     assert result.content.decode().replace("assist", "helper") == RUST_SRC
     assert result.formatter == cs.PATCH_RUSTFMT
-    if shutil.which(cs.PATCH_RUSTFMT):
+    if _runnable_formatter(cs.PATCH_RUSTFMT):
         assert result.formatted is True
     else:
         assert result.formatted is None
 
 
 def test_formatter_drift_is_reported_not_rewritten(tmp_path: Path) -> None:
-    if not shutil.which(cs.PATCH_GOFMT):
-        pytest.skip("gofmt not installed")
+    if not _runnable_formatter(cs.PATCH_GOFMT):
+        pytest.skip(f"{cs.PATCH_GOFMT} is not on PATH or cannot run")
     _grammar("go")
     _write(tmp_path, "m.go", GO_SRC)
     patcher = Patcher(tmp_path)

--- a/codebase_rag/tests/test_patcher.py
+++ b/codebase_rag/tests/test_patcher.py
@@ -396,6 +396,15 @@ def test_java_rename_preserves_syntax(tmp_path: Path) -> None:
     assert result.content.decode().replace("assist", "helper") == JAVA_SRC
 
 
+# The liveness flag each formatter actually accepts. `gofmt` has no
+# `--version` (it exits 2), so probing every tool the same way reports a
+# working gofmt as missing and silently skips the Go coverage (issue #1639).
+_PROBE_FLAGS = {
+    cs.PATCH_GOFMT: cs.PATCH_GOFMT_PROBE_FLAG,
+    cs.PATCH_RUSTFMT: cs.PATCH_VERSION_FLAG,
+}
+
+
 @lru_cache(maxsize=8)
 def _runnable_formatter(binary: str) -> bool:
     """Whether a formatter is on PATH AND can actually run (issue #1639).
@@ -419,7 +428,7 @@ def _runnable_formatter(binary: str) -> bool:
         return False
     try:
         probe = subprocess.run(
-            [found, "--version"],
+            [found, _PROBE_FLAGS.get(binary, cs.PATCH_VERSION_FLAG)],
             capture_output=True,
             text=True,
             encoding=cs.ENCODING_UTF8,


### PR DESCRIPTION
Part of #1639 (does not close it — the node and dotnet guards follow in a
second PR).

## A user-facing bug the issue did not mention

Chasing #1639's rustfmt guard with a real failing shim turned up a product bug,
not just a test-infrastructure one.

`formatter_check` decided "is the formatter installed" with `shutil.which`. A
rustup shim for an uninstalled component **is** a real file on PATH, so that
check passes, the tool is invoked, it exits non-zero, and the function returns
`formatted=False`. The user is then told:

```
m.rs applied, but rustfmt would reformat it
```

That is a claim about their code that no formatter ever made. The function's
own docstring promised `None` when the tool is not installed, so the code
contradicted its documented contract.

Measured with a shim that mimics rustup exactly (exit 1, `error: 'rustfmt' is
not installed for the toolchain`):

| | `formatted` | message |
|---|---|---|
| before | `False` | `m.rs applied, but rustfmt would reformat it` |
| after | `None` | `m.rs: 2 edit(s) applied` |

## The fix

`_tool_runs(executable)`, a cached `--version` probe, gating the formatter
verdict. Non-zero exit means "not usable", which is what `which` was standing
in for. Same shape as `_runnable_dotnet_trace` and `_dotnet_with_sdk` in
`test_dynamic_trace_speedscope.py` (issue #1449), which solved this class for
`dotnet-trace` and whose reasoning is written out there.

The three `shutil.which` guards in `test_patcher.py` get the same treatment via
`_runnable_formatter`, so the test half of #1639's rustfmt item is done too.

## Verification, and its limits

**Verified with a real shim.** Under an identical rustup-style shim the old
guard returns `True` (hard failure, which is #1639's reported symptom) and the
new one returns `False` (correct skip). `test_patcher.py` passes both with the
shim on PATH and without it: 20 passed, 1 skipped in each.

**One honest caveat on that green.** The `1 skipped` in *both* runs is `gofmt`,
which is genuinely absent on this machine — not rustfmt. The rustfmt test
passes under the shim by taking its `else` branch and asserting
`formatted is None`, which is exactly the production behaviour this PR fixes. I
checked that with `-rs` rather than inferring it from the counts, since
identical skip totals would otherwise have looked like the shim did nothing.

**Not covered here.** The node/ESM and dotnet/`net10.0` halves of #1639 are not
in this PR. This machine runs Node 22 and .NET SDK 10, both working, so those
two failure modes cannot be reproduced here at all; they follow in a second PR
with the constructed cases labelled as constructed.
