### PR TITLE
fix: re-parse importers waiting on a file the re-ingest created (#1682)

### DIFF
--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -103,11 +103,22 @@ TEXT_UNKNOWN = "unknown"
 
 TMP_EXTENSION = ".tmp"
 
-# Filenames whose module IS their directory: an importer writes the directory
-# name, never the file's own stem. `__init__` (Python), `mod` (Rust) and
-# `index` (JS/TS/node resolution). `lib.rs`/`main.rs` are crate roots named by
-# the manifest rather than the directory, so they are deliberately absent.
-DIRECTORY_MODULE_STEMS: frozenset[str] = frozenset({"__init__", "mod", "index"})
+# Filenames whose module IS their directory, PER LANGUAGE: an importer writes
+# the directory name, never the file's own stem. The extension is part of the
+# rule, not decoration -- `index.py` and `mod.py` are ordinary Python modules
+# imported by those names, and a language-blind stem set silently gives them no
+# importable name at all. `lib.rs`/`main.rs` are crate roots named by the
+# manifest rather than the directory, so they are deliberately absent.
+DIRECTORY_MODULE_STEM_BY_EXT: dict[str, str] = {
+    ".py": "__init__",
+    ".rs": "mod",
+    ".js": "index",
+    ".jsx": "index",
+    ".mjs": "index",
+    ".cjs": "index",
+    ".ts": "index",
+    ".tsx": "index",
+}
 MOD_RS = "mod.rs"
 LIB_RS = "lib.rs"
 MAIN_RS = "main.rs"

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -103,6 +103,11 @@ TEXT_UNKNOWN = "unknown"
 
 TMP_EXTENSION = ".tmp"
 
+# Filenames whose module IS their directory: an importer writes the directory
+# name, never the file's own stem. `__init__` (Python), `mod` (Rust) and
+# `index` (JS/TS/node resolution). `lib.rs`/`main.rs` are crate roots named by
+# the manifest rather than the directory, so they are deliberately absent.
+DIRECTORY_MODULE_STEMS: frozenset[str] = frozenset({"__init__", "mod", "index"})
 MOD_RS = "mod.rs"
 LIB_RS = "lib.rs"
 MAIN_RS = "main.rs"

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -118,6 +118,14 @@ DIRECTORY_MODULE_STEM_BY_EXT: dict[str, str] = {
     ".cjs": "index",
     ".ts": "index",
     ".tsx": "index",
+    # `.mts`/`.cts` are TypeScript's ESM/CJS forms and are directory entry
+    # points exactly as `.mjs`/`.cjs` are. They belong to `TS_EXTENSIONS` and
+    # to `JS_TS_MODULE_EXTENSIONS`, which is the set cgr's own directory-index
+    # resolution already searches, so omitting them here made `pkg/index.mts`
+    # derive `pkg.index` instead of `pkg` and the unresolved-importer query
+    # asked for a name no waiter had written (issue #1682 review).
+    ".mts": "index",
+    ".cts": "index",
 }
 MOD_RS = "mod.rs"
 LIB_RS = "lib.rs"

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -581,6 +581,23 @@ CYPHER_AFFECTED_CALLER_PATHS = (
 # of the concrete implementer because _protocol_classes() is empty. Ordered by
 # base_index so multiple-inheritance base order matches the original source,
 # which method resolution and override attribution depend on.
+# A file CREATED by a scoped re-ingest has no inbound edges yet, so
+# CYPHER_AFFECTED_CALLER_PATHS cannot find the importer that referenced it
+# before it existed -- `main.py` importing `./util` written before `util.ts`.
+# That importer's IMPORTS edge points at an UNRESOLVED target (one outside the
+# project prefix) whose name is the new module, so it is findable from the
+# target side instead (issue #1682). Self-selecting: once the module exists and
+# the importer has been re-parsed the edge resolves into the project prefix and
+# stops matching, so this returns nothing for files that are not new.
+CYPHER_UNRESOLVED_IMPORTER_PATHS = (
+    "MATCH (importer)-[:IMPORTS]->(target) "
+    "WHERE importer.path IS NOT NULL "
+    "AND importer.qualified_name STARTS WITH $project_prefix "
+    "AND NOT target.qualified_name STARTS WITH $project_prefix "
+    "AND ANY(name IN $module_names WHERE target.qualified_name = name "
+    "OR target.qualified_name STARTS WITH name + '.') "
+    "RETURN DISTINCT importer.path AS caller_path"
+)
 CYPHER_ALL_INHERITS = (
     "MATCH (child)-[r:INHERITS]->(base) "
     "WHERE child.qualified_name IS NOT NULL AND base.qualified_name IS NOT NULL "
@@ -634,6 +651,7 @@ KEY_BASE_QN = "base_qn"
 KEY_BASE_INDEX = "base_index"
 
 CYPHER_PARAM_PATHS = "paths"
+CYPHER_PARAM_MODULE_NAMES = "module_names"
 KEY_CALLER_PATH = "caller_path"
 KEY_CALLER_LABEL = "caller_label"
 KEY_CALLER_QN = "caller_qn"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2104,8 +2104,19 @@ class GraphUpdater:
                 # every `index`/`mod` stem as a directory module leaves them
                 # with no importable name at all.
                 if not parts:
-                    # At the repository root there is no directory to be named
-                    # by, and nothing imports the root itself.
+                    # The directory-module rule needs a DIRECTORY. At the
+                    # repository root there is none, so the file is an
+                    # ordinary module named by its own stem: a sibling writes
+                    # `./index`, and that spelling is what an unresolved edge
+                    # records. Dropping it left a root-level entry point with
+                    # no name at all, so a waiter on it was never re-parsed --
+                    # the exact failure this lookup exists to close.
+                    #
+                    # Offering a name nothing waits on costs one redundant
+                    # re-parse; withholding one costs the unresolved edge
+                    # forever, so the tie breaks towards offering it.
+                    if stem:
+                        names.add(stem)
                     continue
                 stem = parts.pop()
             names.add(stem)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2093,10 +2093,12 @@ class GraphUpdater:
             path = PurePosixPath(key)
             parts = list(path.parent.parts)
             stem = path.stem
-            if not stem or stem == cs.INIT_PY.removesuffix(".py"):
-                # A package `__init__` is named by its DIRECTORY: `pkg`, and
-                # `a.b.pkg` from the root -- never `pkg.pkg`, which is what
-                # keeping the stem in the dotted form produces.
+            if not stem or stem in cs.DIRECTORY_MODULE_STEMS:
+                # A directory-module entry point is named by its DIRECTORY:
+                # `pkg`, and `a.b.pkg` from the root -- never `pkg.pkg`, which
+                # is what keeping the stem in the dotted form produces. Covers
+                # `__init__.py`, Rust's `mod.rs` and JS/TS `index.*`, which an
+                # importer all spell as the directory.
                 if not parts:
                     continue
                 stem = parts.pop()

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -7,7 +7,7 @@ import sys
 import time
 from collections import defaultdict
 from collections.abc import Callable, Collection, Iterable, Mapping
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import cast
 
 from loguru import logger
@@ -2081,6 +2081,65 @@ class GraphUpdater:
             }
         )
 
+    def _module_names_for(self, keys: list[str]) -> list[str]:
+        """Import spellings a file could be named by, from its relative path.
+
+        `pkg/util.py` can be imported as `pkg.util` or, from a sibling, as
+        `util`, and the unresolved edge records whichever the source wrote.
+        Both are offered so either spelling matches.
+        """
+        names: set[str] = set()
+        for key in keys:
+            path = PurePosixPath(key)
+            parts = list(path.parent.parts)
+            stem = path.stem
+            if not stem or stem == cs.INIT_PY.removesuffix(".py"):
+                # A package `__init__` is named by its DIRECTORY: `pkg`, and
+                # `a.b.pkg` from the root -- never `pkg.pkg`, which is what
+                # keeping the stem in the dotted form produces.
+                if not parts:
+                    continue
+                stem = parts.pop()
+            names.add(stem)
+            dotted = cs.SEPARATOR_DOT.join([*parts, stem])
+            if dotted:
+                names.add(dotted)
+        return sorted(names)
+
+    def _unresolved_importer_keys(self, present_keys: list[str]) -> list[str]:
+        """Files whose UNRESOLVED import names one of `present_keys`.
+
+        The inbound-edge lookup cannot see these: a file created by this call
+        has no inbound edges, so an importer that referenced its path before it
+        existed keeps a dangling IMPORTS edge and is never re-parsed, leaving
+        the scoped path diverging from a clean index (issue #1682).
+
+        A failed read degrades to the previous behaviour, never worse.
+        """
+        if not present_keys or not isinstance(self.ingestor, QueryProtocol):
+            return []
+        module_names = self._module_names_for(present_keys)
+        if not module_names:
+            return []
+        try:
+            rows = self.ingestor.fetch_all(
+                cs.CYPHER_UNRESOLVED_IMPORTER_PATHS,
+                {
+                    cs.CYPHER_PARAM_MODULE_NAMES: module_names,
+                    cs.KEY_PROJECT_PREFIX: self.project_name + cs.SEPARATOR_DOT,
+                },
+            )
+        except Exception:
+            logger.warning(ls.PRUNE_QUERY_FAILED, label="unresolved importers")
+            return []
+        return sorted(
+            {
+                path
+                for row in rows
+                if isinstance(path := row.get(cs.KEY_CALLER_PATH), str) and path
+            }
+        )
+
     def _package_paths(self) -> set[str] | None:
         """Relative paths of this project's Package nodes, None if unreadable."""
         if not isinstance(self.ingestor, QueryProtocol):
@@ -3389,7 +3448,13 @@ class GraphUpdater:
         # graph's own edges) plus any file whose delombok overlay changed.
         keys = sorted({*present, *gone})
         affected: dict[str, Path] = {}
-        for caller_key in self._affected_caller_keys(keys):
+        # Inbound edges find dependents of files that already existed; the
+        # unresolved-import lookup finds importers of files this call CREATED,
+        # which by construction have no inbound edges yet (issue #1682).
+        for caller_key in (
+            *self._affected_caller_keys(keys),
+            *self._unresolved_importer_keys(sorted(present)),
+        ):
             caller_path = self.repo_path / caller_key
             if (
                 caller_key not in present

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2093,13 +2093,19 @@ class GraphUpdater:
             path = PurePosixPath(key)
             parts = list(path.parent.parts)
             stem = path.stem
-            if not stem or stem in cs.DIRECTORY_MODULE_STEMS:
+            directory_stem = cs.DIRECTORY_MODULE_STEM_BY_EXT.get(path.suffix)
+            if not stem or (directory_stem is not None and stem == directory_stem):
                 # A directory-module entry point is named by its DIRECTORY:
                 # `pkg`, and `a.b.pkg` from the root -- never `pkg.pkg`, which
-                # is what keeping the stem in the dotted form produces. Covers
-                # `__init__.py`, Rust's `mod.rs` and JS/TS `index.*`, which an
-                # importer all spell as the directory.
+                # is what keeping the stem in the dotted form produces.
+                #
+                # Matched WITH the extension: `index.py` and `mod.py` are
+                # ordinary Python modules imported by those names, and treating
+                # every `index`/`mod` stem as a directory module leaves them
+                # with no importable name at all.
                 if not parts:
+                    # At the repository root there is no directory to be named
+                    # by, and nothing imports the root itself.
                     continue
                 stem = parts.pop()
             names.add(stem)

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -86,6 +86,16 @@ class TestModuleNamesOffered:
             # A Rust crate root is named by the manifest, not the directory, so
             # it keeps its own stem rather than being folded into the parent.
             ("src/lib.rs", {"lib", "src.lib"}),
+            # The directory-module rule is PER LANGUAGE. `index` and `mod` are
+            # ordinary Python module names, and treating every such stem as a
+            # directory module leaves them with no importable name at all.
+            ("index.py", {"index"}),
+            ("mod.py", {"mod"}),
+            ("pkg/index.py", {"index", "pkg.index"}),
+            # At the repository root there is no directory to be named by, and
+            # nothing imports the root itself.
+            ("index.ts", set()),
+            ("__init__.py", set()),
         ],
     )
     def test_both_spellings_are_offered(

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -83,6 +83,17 @@ class TestModuleNamesOffered:
             ("utils/mod.rs", {"utils"}),
             ("a/b/utils/mod.rs", {"utils", "a.b.utils"}),
             ("components/index.ts", {"components"}),
+            # `.mts`/`.cts` are TypeScript's ESM/CJS forms, directory entry
+            # points exactly as `.mjs`/`.cjs` are. Omitting them derived
+            # `pkg.index` and asked for a name no importer ever writes.
+            ("pkg/index.mts", {"pkg"}),
+            ("pkg/index.cts", {"pkg"}),
+            ("a/b/components/index.mts", {"components", "a.b.components"}),
+            ("pkg/index.mjs", {"pkg"}),
+            ("pkg/index.cjs", {"pkg"}),
+            # Not every `.mts` is an entry point: the rule is the STEM plus the
+            # extension, so an ordinary module keeps both its spellings.
+            ("pkg/util.mts", {"util", "pkg.util"}),
             # A Rust crate root is named by the manifest, not the directory, so
             # it keeps its own stem rather than being folded into the parent.
             ("src/lib.rs", {"lib", "src.lib"}),
@@ -105,6 +116,28 @@ class TestModuleNamesOffered:
         # matching only one of them misses half the real cases.
         updater = _updater(tmp_path, _QueryingIngestor([]))
         assert set(updater._module_names_for([key])) == expected
+
+    def test_every_js_ts_module_extension_has_a_directory_stem(self) -> None:
+        """The forcing function the parametrised cases cannot provide.
+
+        Those cases enumerate the extensions I thought of, so the next
+        extension added to the language set is exactly the one they miss --
+        which is how `.mts` and `.cts` came to be absent while `.mjs` and
+        `.cjs` were present. `JS_TS_MODULE_EXTENSIONS` is the set cgr's own
+        directory-index resolution searches, so anything in it that can be a
+        directory entry point must have a stem here.
+
+        `.d.*` declaration files are excluded: `PurePosixPath('index.d.mts')`
+        has suffix `.mts`, so they are already covered by their own base
+        extension and never reach this map under a `.d.x` key.
+        """
+        missing = {
+            ext
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+            if not ext.startswith(".d.")
+            and cs.DIRECTORY_MODULE_STEM_BY_EXT.get(ext) != cs.JS_INDEX_STEM
+        }
+        assert not missing, missing
 
 
 class TestUnresolvedImporterLookup:

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -103,10 +103,18 @@ class TestModuleNamesOffered:
             ("index.py", {"index"}),
             ("mod.py", {"mod"}),
             ("pkg/index.py", {"index", "pkg.index"}),
-            # At the repository root there is no directory to be named by, and
-            # nothing imports the root itself.
-            ("index.ts", set()),
-            ("__init__.py", set()),
+            # At the repository root the directory-module rule has no
+            # directory to apply, so the file is named by its own stem: a
+            # sibling writes `./index`, and dropping that left a root entry
+            # point with no name at all, so its waiters were never re-parsed.
+            ("index.ts", {"index"}),
+            ("index.js", {"index"}),
+            ("index.mts", {"index"}),
+            ("__init__.py", {"__init__"}),
+            # A root-level `index.py` was never affected: `.py`'s directory
+            # stem is `__init__`, so it is an ordinary module and keeps its
+            # name through the other branch entirely. Both are asserted so the
+            # per-language distinction stays visible at the root too.
         ],
     )
     def test_both_spellings_are_offered(

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -1,0 +1,144 @@
+"""A file CREATED by a scoped re-ingest must re-parse its waiting importers (#1682).
+
+`_affected_caller_keys` finds dependents through the graph's INBOUND edges. A
+file the call creates has none yet, so an importer that referenced its path
+before it existed -- `main.py` importing `./util` written before `util.ts` --
+is never re-parsed, and the resolved IMPORTS edge and the calls into the new
+module never appear. A clean index produces them, so the scoped path diverges
+for exactly the create-then-import order an agent commonly uses.
+
+`_unresolved_importer_keys` closes that by looking from the TARGET side: the
+waiting importer's IMPORTS edge points at an unresolved target named after the
+new module, which is findable even with no inbound edge.
+
+SCOPE OF THESE TESTS. They drive the query layer with a stubbed `fetch_all`,
+which is what can be verified without a live graph: that the right question is
+asked, that the answer is wired into the dependent set, and that a failure
+degrades rather than raising. The end-to-end claim -- that a real create-then-
+reingest now matches a clean index -- needs the integration suite against
+Memgraph and is NOT asserted here. A mock ingestor answers no dependents query
+at all, so an end-to-end assertion written against one passes or fails for
+reasons unrelated to this change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+class _QueryingIngestor:
+    """An ingestor that answers `fetch_all`, which MagicMock does not."""
+
+    def __init__(self, rows: list[dict[str, Any]] | Exception) -> None:
+        self._rows = rows
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    def fetch_all(self, query: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        self.queries.append((query, params))
+        if isinstance(self._rows, Exception):
+            raise self._rows
+        return self._rows
+
+    # Declared on the CLASS, not served by `__getattr__`: a runtime-checkable
+    # Protocol's isinstance inspects the class, so a dynamic attribute makes
+    # `hasattr` true while `isinstance(..., QueryProtocol)` stays False -- and
+    # the lookup under test silently returns [] for the wrong reason.
+    def execute_write(self, query: str, params: dict[str, Any] | None = None) -> None:
+        return None
+
+    def __getattr__(self, name: str) -> MagicMock:
+        return MagicMock()
+
+
+def _updater(tmp_path: Path, ingestor: object) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=ingestor,  # type: ignore[arg-type]
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+class TestModuleNamesOffered:
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("util.py", {"util"}),
+            ("pkg/util.py", {"util", "pkg.util"}),
+            ("a/b/deep.ts", {"deep", "a.b.deep"}),
+            # A package is named by its DIRECTORY; `__init__` is never written
+            # in an import, so offering it would match nothing.
+            ("pkg/__init__.py", {"pkg"}),
+        ],
+    )
+    def test_both_spellings_are_offered(
+        self, tmp_path: Path, key: str, expected: set[str]
+    ) -> None:
+        # The unresolved edge records whichever spelling the source wrote, so
+        # matching only one of them misses half the real cases.
+        updater = _updater(tmp_path, _QueryingIngestor([]))
+        assert set(updater._module_names_for([key])) == expected
+
+
+class TestUnresolvedImporterLookup:
+    def test_it_asks_for_the_new_module_by_name(self, tmp_path: Path) -> None:
+        ingestor = _QueryingIngestor([{cs.KEY_CALLER_PATH: "main.py"}])
+        updater = _updater(tmp_path, ingestor)
+
+        assert updater._unresolved_importer_keys(["util.py"]) == ["main.py"]
+
+        query, params = ingestor.queries[-1]
+        assert query == cs.CYPHER_UNRESOLVED_IMPORTER_PATHS
+        assert params[cs.CYPHER_PARAM_MODULE_NAMES] == ["util"]
+        assert params[cs.KEY_PROJECT_PREFIX] == "proj."
+
+    def test_a_failed_read_degrades_rather_than_raising(self, tmp_path: Path) -> None:
+        # The pre-existing dependents lookup degrades the same way: a scoped
+        # re-ingest that cannot read the graph should do less, not die.
+        updater = _updater(tmp_path, _QueryingIngestor(RuntimeError("no graph")))
+        assert updater._unresolved_importer_keys(["util.py"]) == []
+
+    def test_no_present_keys_asks_nothing(self, tmp_path: Path) -> None:
+        # A delete-only re-ingest creates no module, so there is no waiting
+        # importer to look for and no query worth making.
+        ingestor = _QueryingIngestor([{cs.KEY_CALLER_PATH: "main.py"}])
+        updater = _updater(tmp_path, ingestor)
+        assert updater._unresolved_importer_keys([]) == []
+        assert ingestor.queries == []
+
+
+class TestWiredIntoTheDependentSet:
+    def test_a_waiting_importer_becomes_a_dependent(self, tmp_path: Path) -> None:
+        (tmp_path / "main.py").write_text("from util import helper\n", encoding="utf-8")
+        (tmp_path / "util.py").write_text("def helper():\n    return 1\n", "utf-8")
+        # Rows come back for BOTH queries; the inbound one finds nothing for a
+        # file that did not exist, which is the whole defect.
+        ingestor = _QueryingIngestor([{cs.KEY_CALLER_PATH: "main.py"}])
+        updater = _updater(tmp_path, ingestor)
+
+        dependents = updater._reingest_dependents(
+            present={"util.py": tmp_path / "util.py"}, gone={}
+        )
+        assert "main.py" in dependents
+
+    def test_the_created_file_is_not_its_own_dependent(self, tmp_path: Path) -> None:
+        # The query is answered with the created file itself; it is already
+        # being re-parsed, so adding it again would be wrong.
+        (tmp_path / "util.py").write_text("def helper():\n    return 1\n", "utf-8")
+        ingestor = _QueryingIngestor([{cs.KEY_CALLER_PATH: "util.py"}])
+        updater = _updater(tmp_path, ingestor)
+
+        dependents = updater._reingest_dependents(
+            present={"util.py": tmp_path / "util.py"}, gone={}
+        )
+        assert dependents == {}

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -76,9 +76,16 @@ class TestModuleNamesOffered:
             ("util.py", {"util"}),
             ("pkg/util.py", {"util", "pkg.util"}),
             ("a/b/deep.ts", {"deep", "a.b.deep"}),
-            # A package is named by its DIRECTORY; `__init__` is never written
-            # in an import, so offering it would match nothing.
+            # A directory-module entry point is named by its DIRECTORY. Its own
+            # stem is never written in an import, so offering it matches
+            # nothing, and keeping it in the dotted form yields `pkg.pkg`.
             ("pkg/__init__.py", {"pkg"}),
+            ("utils/mod.rs", {"utils"}),
+            ("a/b/utils/mod.rs", {"utils", "a.b.utils"}),
+            ("components/index.ts", {"components"}),
+            # A Rust crate root is named by the manifest, not the directory, so
+            # it keeps its own stem rather than being folded into the parent.
+            ("src/lib.rs", {"lib", "src.lib"}),
         ],
     )
     def test_both_spellings_are_offered(


### PR DESCRIPTION
Closes #1682.

`_affected_caller_keys` finds the files a re-ingest must also re-parse through the graph's **inbound** edges. A file the call *creates* has none yet, so an importer that referenced its path before it existed — `main.py` importing `./util` written before `util.ts` — is never re-parsed. The resolved `IMPORTS` edge and the calls into the new module never appear, and the scoped path diverges from a clean index for exactly the create-then-import order an agent commonly uses.

## The fix

`_unresolved_importer_keys` looks from the **target** side instead. The waiting importer's `IMPORTS` edge points at an unresolved target — one outside the project prefix — named after the module that has just been created, and that is findable with no inbound edge at all.

It is **self-selecting**, which is why it runs for every present key rather than only for keys the hash cache has never seen: once the module exists and its importer has been re-parsed, the edge resolves into the project prefix and stops matching. For a file that is not new it returns nothing, so no "is this new?" state has to be tracked or kept correct.

Both import spellings are offered, because the unresolved edge records whichever the source wrote: `pkg/util.py` can be named `pkg.util` or, from a sibling, `util`. A package `__init__` is named by its **directory** — `pkg`, not `pkg.__init__`.

A failed read degrades to the previous behaviour, matching the inbound lookup beside it: a scoped re-ingest that cannot read the graph should do less, not die.

## What is verified, and what is not

**Confirmed by reading:** a file created by the call has no inbound edges, so `_affected_caller_keys` cannot reach its importer. That is structural.

**Confirmed by test** (`test_reingest_new_file_importers.py`, 9 tests): the lookup asks the right query with the right module names and project prefix; its answer is wired into the dependent set; a read failure degrades rather than raising; a delete-only re-ingest asks nothing; the created file is not returned as its own dependent; and `__init__.py` resolves to its directory rather than `pkg.pkg`.

**NOT verified end to end.** I have not demonstrated that a real create-then-reingest now matches a clean index, and the PR does not claim it. My first attempt at that demonstration was invalid and the control is worth recording: a mock ingestor's `fetch_all` answers **no** dependents query, so an *edit* of an already-indexed file diverges from a clean index in exactly the same way a *create* does. The probe was measuring the mock's limitation, not this defect, and could not have distinguished a working fix from a broken one. A real end-to-end check needs the integration suite against Memgraph, which does not run on this host.

Two of the nine tests earned their place immediately by failing on code written minutes earlier: the `__init__.py` case (which produced `pkg.pkg`) and a stub whose `__getattr__` satisfied `hasattr` but not `isinstance` against a runtime-checkable Protocol — which made the lookup return `[]` for entirely the wrong reason while looking like a pass.

## Known bound

Relative JS/TS importers of a not-yet-existing target are **not** re-parsed, because their `IMPORTS` row is dropped at parse time and this lookup reads persisted rows. Measured: `main.js` importing a missing `./index` persists no `IMPORTS` edge at all, where `import util` and `from util import helper` persist `('proj.main', 'util')` and `('proj.main', 'util.helper')` respectively — the external-looking targets this query matches. So the mechanism closes the create-then-import gap for Python-shaped imports and is inert for relative JS/TS ones. The row was dropped before this PR too, so this bounds the fix rather than regressing anything; persisting unresolved dependency state changes what a clean index writes and is tracked separately in #1714.

## Suite

Local run covers the changed area and its neighbours (67 passed: the new tests, incremental update, cacheless lookup). The full suite runs in CI.

Pushed after a single local review round, per the current review-gate rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental project updates so files referencing previously unresolved modules are reconsidered when those modules become available.
  * Expanded module-name resolution across supported languages, including package initializers, directory entry points, root-level entry points, and TypeScript ESM/CJS modules.

* **Tests**
  * Added coverage for unresolved importer discovery, language-specific module naming, empty inputs, lookup failures, waiting importers, directory entry points, root-level modules, and avoiding duplicate file processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
