### PR TITLE
ci: cancel superseded PR runs of Sonar, OSV, split score and the review workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -25,6 +25,12 @@ on:
 
 permissions: read-all
 
+# A new push to the same PR supersedes the queued or running analysis of the
+# previous head; cancelling it keeps the runner queue for live heads.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build ${{ matrix.platform }}-${{ matrix.arch }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -28,7 +28,7 @@ permissions: read-all
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}-{2}', github.event_name, github.sha, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -28,7 +28,7 @@ permissions: read-all
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   # Non-PR events (main push, version-bump push, dispatch) group by SHA so each
   # commit gets its own group and can neither cancel nor be cancelled, even in a
   # burst. A cancelled run is what makes the branch CI badge flash "failing".
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}-{2}', github.event_name, github.sha, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
   # Non-PR events (main push, version-bump push, dispatch) group by SHA so each
   # commit gets its own group and can neither cancel nor be cancelled, even in a
   # burst. A cancelled run is what makes the branch CI badge flash "failing".
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ permissions: read-all
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}-{2}', github.event_name, github.sha, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,7 +15,7 @@ permissions: read-all
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,12 @@ on:
 
 permissions: read-all
 
+# A new push to the same PR supersedes the queued or running analysis of the
+# previous head; cancelling it keeps the runner queue for live heads.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   claude-review:
     name: AI Code Review

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -23,6 +23,12 @@ on:
 
 permissions: read-all
 
+# A new push to the same PR supersedes the queued or running analysis of the
+# previous head; cancelling it keeps the runner queue for live heads.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,7 +26,7 @@ permissions: read-all
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}-{2}', github.event_name, github.sha, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,7 +26,7 @@ permissions: read-all
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# A new push to the same PR supersedes the queued or running analysis of the
+# previous head; cancelling it keeps the runner queue for live heads.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   sonarcloud:
     name: SonarCloud Analysis

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,7 +12,7 @@ permissions:
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}-{2}', github.event_name, github.sha, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,7 +12,7 @@ permissions:
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -11,7 +11,7 @@ permissions:
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}-{2}', github.event_name, github.sha, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -11,7 +11,7 @@ permissions:
 # A new push to the same PR supersedes the queued or running analysis of the
 # previous head; cancelling it keeps the runner queue for live heads.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || format('{0}-{1}', github.event_name, github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -8,6 +8,12 @@ permissions:
   contents: read
   pull-requests: write
 
+# A new push to the same PR supersedes the queued or running analysis of the
+# previous head; cancelling it keeps the runner queue for live heads.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   score:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Every push to a PR queues a fresh SonarCloud, OSV-Scanner, PR Split Score and review run while the previous head's runs stay queued or running. With several sessions pushing, the runner queue reached 50 runs and a one-line hotfix waited two hours for a runner.

`ci.yml` already cancels the previous head's run through a concurrency group keyed on the PR ref; the other per-PR workflows had no concurrency setting.

## Change

The same concurrency block on the four workflows: group keyed on the workflow name and the PR ref for `pull_request` events (the commit SHA otherwise), `cancel-in-progress` only for `pull_request` events, so pushes to main and scheduled runs still run to completion.

## Verification

- `actionlint` on the four files: clean.
- All four already run on the `pull_request` merge ref; no trigger or checkout changes.