### PR TITLE
fix: create the hash-cache temporary with an unpredictable no-follow exclusive open (#1700)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -404,7 +404,16 @@ def _publish_hash_cache(
         # Reopened with O_NOFOLLOW, so a link swapped in between the close and
         # here cannot redirect the sync; the inode check below still refuses a
         # swapped path before anything is published.
-        sync_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        #
+        # O_RDWR, not O_RDONLY. On Windows `os.fsync` is `_commit()`, which
+        # calls FlushFileBuffers, and that needs a handle opened for WRITING:
+        # on a read-only handle it fails and the CRT reports it as EBADF.
+        # Every hash-cache publish on that platform died here with "[Errno 9]
+        # Bad file descriptor" and 39 tests went red while ubuntu and macOS,
+        # whose fsync accepts any descriptor, stayed green (#1701 review,
+        # measured in CI: errno=9, failing_path=None, i.e. not an open()).
+        # No O_TRUNC and no write follows, so the contents are untouched.
+        sync_flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
         sync_fd = os.open(tmp_path, sync_flags)
         try:
             os.fsync(sync_fd)
@@ -473,15 +482,25 @@ def _publish_hash_cache(
             # here, the stamp lands on the LINK, not on whatever it points at,
             # so no external file's metadata can be touched (#1701 review).
             #
-            # Guarded because the flag is not universal; where it is
-            # unsupported the threat-model argument still applies -- the swap
-            # needs write permission on this directory, which already allows
-            # rewriting the cache outright.
-            if os.utime in os.supports_follow_symlinks:
-                os.utime(tmp_path, (observed_at, observed_at), follow_symlinks=False)
-            else:
-                os.utime(tmp_path, (observed_at, observed_at))
-            sync_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            # No path-following fallback. A platform whose `os.utime` can
+            # neither take a descriptor nor refuse to follow a link has no
+            # way to stamp this file safely, and stamping through the path
+            # anyway would reopen the exact window this branch exists to
+            # close: a link swapped in after the inode check gets its TARGET
+            # timestamped (#1701 review, measured by forcing this branch).
+            # Declining the publish is the safe error -- the previous cache
+            # stays intact and the next run re-hashes -- where a mis-stamped
+            # publish loses edits. Every platform CI runs on supports one of
+            # the two, so this raise is a guard, not a code path.
+            if os.utime not in os.supports_follow_symlinks:
+                raise OSError(
+                    "cannot stamp the hash cache without following symlinks "
+                    f"on this platform; not publishing {tmp_path}"
+                )
+            os.utime(tmp_path, (observed_at, observed_at), follow_symlinks=False)
+            # O_RDWR for the same Windows `_commit()` reason as the first
+            # sync: a read-only handle cannot be flushed there.
+            sync_flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
             sync_fd = os.open(tmp_path, sync_flags)
             try:
                 os.fsync(sync_fd)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -5,6 +5,7 @@ import json
 import os
 import posixpath
 import secrets
+import stat
 import sys
 import time
 from collections import defaultdict
@@ -285,6 +286,12 @@ def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
 # problem.
 _TEMP_NAME_ATTEMPTS = 8
 
+# Read once at import rather than `os.name` at each use: `pathlib.Path()`
+# itself consults `os.name` at call time, so a test that forced `os.name` to
+# simulate Windows made every `Path()` inside the publish raise
+# NotImplementedError on this host. A module flag can be patched in isolation.
+_WINDOWS = os.name == "nt"
+
 
 def _open_exclusive_temp(cache_path: Path) -> tuple[int, str]:
     """Create a fresh temporary file beside `cache_path`, never following a link.
@@ -442,6 +449,12 @@ def _publish_hash_cache(
         # The check stays because it costs one lstat and turns a swap into a
         # refusal rather than a silent publish.
         current = os.lstat(tmp_path)
+        # A link at the temporary's name is a swap, full stop, on every
+        # platform -- including the one below where the inode comparison
+        # cannot be made. `lstat` never follows, so this reads the entry
+        # itself (#1701 local review).
+        if stat.S_ISLNK(current.st_mode):
+            raise OSError(f"temporary cache path {tmp_path} was replaced by a symlink")
         # Skipped where the identity comparison is not meaningful. On Windows
         # `st_ino` is a file INDEX rather than an inode: it can be 0 on some
         # filesystems, and `fstat` and `lstat` are not guaranteed to agree, so
@@ -455,7 +468,7 @@ def _publish_hash_cache(
         # without any race. The O_EXCL creation and the fsync stay on every
         # platform; only this comparison is conditional.
         identity_is_meaningful = (
-            os.name != "nt" and created.st_ino != 0 and current.st_ino != 0
+            not _WINDOWS and created.st_ino != 0 and current.st_ino != 0
         )
         if identity_is_meaningful and (
             (current.st_ino, current.st_dev) != (created.st_ino, created.st_dev)
@@ -482,22 +495,37 @@ def _publish_hash_cache(
             # here, the stamp lands on the LINK, not on whatever it points at,
             # so no external file's metadata can be touched (#1701 review).
             #
-            # No path-following fallback. A platform whose `os.utime` can
-            # neither take a descriptor nor refuse to follow a link has no
-            # way to stamp this file safely, and stamping through the path
-            # anyway would reopen the exact window this branch exists to
-            # close: a link swapped in after the inode check gets its TARGET
-            # timestamped (#1701 review, measured by forcing this branch).
-            # Declining the publish is the safe error -- the previous cache
-            # stays intact and the next run re-hashes -- where a mis-stamped
-            # publish loses edits. Every platform CI runs on supports one of
-            # the two, so this raise is a guard, not a code path.
-            if os.utime not in os.supports_follow_symlinks:
+            # Windows is the platform this branch exists for, and its
+            # `os.utime` supports NEITHER a descriptor NOR `follow_symlinks`:
+            # `Lib/os.py` adds `utime` to `supports_follow_symlinks` only for
+            # `HAVE_LUTIMES`/`HAVE_UTIMENSAT`, which `PC/pyconfig.h` does not
+            # define, and passing the keyword there raises NotImplementedError
+            # (#1701 local review; an earlier revision refused here and would
+            # have declined every Windows publish). So on Windows the stamp
+            # goes through the PATH, guarded by the `S_ISLNK` refusal above:
+            # a link swapped in before that lstat is refused, and one swapped
+            # in between the lstat and this call needs the same directory
+            # write access that already lets an attacker rewrite the cache
+            # outright, plus the symlink privilege Windows withholds by
+            # default. That is the threat-model argument the inode check
+            # already rests on.
+            #
+            # Any OTHER platform with neither capability has no safe stamp at
+            # all, and stamping through the path there reopens the exact
+            # window this branch closes -- a link swapped in after the check
+            # gets its TARGET timestamped (#1701 review, measured by forcing
+            # the branch). Declining the publish is the safe error: the
+            # previous cache stays and the next run re-hashes, where a
+            # mis-stamped publish loses edits.
+            if _WINDOWS:
+                os.utime(tmp_path, (observed_at, observed_at))
+            elif os.utime in os.supports_follow_symlinks:
+                os.utime(tmp_path, (observed_at, observed_at), follow_symlinks=False)
+            else:
                 raise OSError(
                     "cannot stamp the hash cache without following symlinks "
                     f"on this platform; not publishing {tmp_path}"
                 )
-            os.utime(tmp_path, (observed_at, observed_at), follow_symlinks=False)
             # O_RDWR for the same Windows `_commit()` reason as the first
             # sync: a read-only handle cannot be flushed there.
             sync_flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -317,6 +317,55 @@ def _open_exclusive_temp(cache_path: Path) -> tuple[int, str]:
     raise OSError(f"could not create a temporary file beside {cache_path}")
 
 
+def _fsync_no_follow(path: Path) -> None:
+    """Sync `path` to disk through a fresh no-follow descriptor.
+
+    O_RDWR, not O_RDONLY: on Windows `os.fsync` is `_commit()`, which needs
+    a handle opened for WRITING and reports a read-only one as EBADF (#1701
+    review, measured in CI). No O_TRUNC and no write follows, so the
+    contents are untouched. O_NOFOLLOW so a link swapped in at the path
+    cannot redirect the sync.
+    """
+    sync_fd = os.open(path, os.O_RDWR | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        os.fsync(sync_fd)
+    finally:
+        os.close(sync_fd)
+
+
+def _stamp_by_path(tmp_path: Path, observed_at: float) -> None:
+    """Set the temporary's mtime through its PATH, where a descriptor cannot.
+
+    Windows is the platform this exists for, and its `os.utime` supports
+    NEITHER a descriptor NOR `follow_symlinks`: `Lib/os.py` adds `utime` to
+    `supports_follow_symlinks` only for `HAVE_LUTIMES`/`HAVE_UTIMENSAT`,
+    which `PC/pyconfig.h` does not define, and passing the keyword there
+    raises NotImplementedError (#1701 local review; an earlier revision
+    refused here and would have declined every Windows publish). So on
+    Windows the stamp goes through the path, guarded by the caller's
+    `S_ISLNK` refusal: a link swapped in before that lstat is refused, and
+    one swapped in between the lstat and this call needs the same directory
+    write access that already lets an attacker rewrite the cache outright,
+    plus the symlink privilege Windows withholds by default.
+
+    Any OTHER platform with neither capability has no safe stamp at all, and
+    stamping through the path there reopens the exact window this closes: a
+    link swapped in after the check gets its TARGET timestamped (#1701
+    review, measured by forcing the branch). Declining the publish is the
+    safe error: the previous cache stays and the next run re-hashes, where a
+    mis-stamped publish loses edits.
+    """
+    if _WINDOWS:
+        os.utime(tmp_path, (observed_at, observed_at))
+    elif os.utime in os.supports_follow_symlinks:
+        os.utime(tmp_path, (observed_at, observed_at), follow_symlinks=False)
+    else:
+        raise OSError(
+            "cannot stamp the hash cache without following symlinks "
+            f"on this platform; not publishing {tmp_path}"
+        )
+
+
 def _publish_hash_cache(
     cache_path: Path, hashes: FileHashCache, observed_at: float | None
 ) -> bool:
@@ -406,26 +455,11 @@ def _publish_hash_cache(
         # text wrapper, and it raised "[Errno 9] Bad file descriptor" there --
         # 39 tests red on Windows while ubuntu and macOS stayed green, twice
         # in a row, because reordering fstat and fsync inside the block was
-        # not enough (#1701 review, measured in CI both times).
-        #
-        # Reopened with O_NOFOLLOW, so a link swapped in between the close and
-        # here cannot redirect the sync; the inode check below still refuses a
+        # not enough (#1701 review, measured in CI both times). The reopen
+        # is no-follow, so a link swapped in between the close and here
+        # cannot redirect the sync; the inode check below still refuses a
         # swapped path before anything is published.
-        #
-        # O_RDWR, not O_RDONLY. On Windows `os.fsync` is `_commit()`, which
-        # calls FlushFileBuffers, and that needs a handle opened for WRITING:
-        # on a read-only handle it fails and the CRT reports it as EBADF.
-        # Every hash-cache publish on that platform died here with "[Errno 9]
-        # Bad file descriptor" and 39 tests went red while ubuntu and macOS,
-        # whose fsync accepts any descriptor, stayed green (#1701 review,
-        # measured in CI: errno=9, failing_path=None, i.e. not an open()).
-        # No O_TRUNC and no write follows, so the contents are untouched.
-        sync_flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
-        sync_fd = os.open(tmp_path, sync_flags)
-        try:
-            os.fsync(sync_fd)
-        finally:
-            os.close(sync_fd)
+        _fsync_no_follow(tmp_path)
         # A cheap refusal, not the security boundary. The boundary is the
         # threat model, and it is worth stating because "there is still a
         # window between this check and the rename" is true and does not
@@ -482,58 +516,16 @@ def _publish_hash_cache(
             # stamp before it would follow a symlink swapped in after
             # creation and rewrite the link target's timestamp, which is
             # measured and was the whole point of the descriptor-based stamp.
+            # `_stamp_by_path` carries the per-platform argument.
             #
             # Durability is then restored by re-opening and syncing, rather
             # than by moving the stamp earlier: a crash between the utime and
             # the replace would otherwise publish a cache carrying its write
             # time instead of `observed_at`, and `_is_already_in_sync` trusts
             # that mtime, so it would skip edits made during the run (#1701
-            # review). O_NOFOLLOW again, for the same reason as the first
-            # open.
-            # `follow_symlinks=False` closes the finding directly rather than
-            # by argument: if a link is swapped in between the inode check and
-            # here, the stamp lands on the LINK, not on whatever it points at,
-            # so no external file's metadata can be touched (#1701 review).
-            #
-            # Windows is the platform this branch exists for, and its
-            # `os.utime` supports NEITHER a descriptor NOR `follow_symlinks`:
-            # `Lib/os.py` adds `utime` to `supports_follow_symlinks` only for
-            # `HAVE_LUTIMES`/`HAVE_UTIMENSAT`, which `PC/pyconfig.h` does not
-            # define, and passing the keyword there raises NotImplementedError
-            # (#1701 local review; an earlier revision refused here and would
-            # have declined every Windows publish). So on Windows the stamp
-            # goes through the PATH, guarded by the `S_ISLNK` refusal above:
-            # a link swapped in before that lstat is refused, and one swapped
-            # in between the lstat and this call needs the same directory
-            # write access that already lets an attacker rewrite the cache
-            # outright, plus the symlink privilege Windows withholds by
-            # default. That is the threat-model argument the inode check
-            # already rests on.
-            #
-            # Any OTHER platform with neither capability has no safe stamp at
-            # all, and stamping through the path there reopens the exact
-            # window this branch closes -- a link swapped in after the check
-            # gets its TARGET timestamped (#1701 review, measured by forcing
-            # the branch). Declining the publish is the safe error: the
-            # previous cache stays and the next run re-hashes, where a
-            # mis-stamped publish loses edits.
-            if _WINDOWS:
-                os.utime(tmp_path, (observed_at, observed_at))
-            elif os.utime in os.supports_follow_symlinks:
-                os.utime(tmp_path, (observed_at, observed_at), follow_symlinks=False)
-            else:
-                raise OSError(
-                    "cannot stamp the hash cache without following symlinks "
-                    f"on this platform; not publishing {tmp_path}"
-                )
-            # O_RDWR for the same Windows `_commit()` reason as the first
-            # sync: a read-only handle cannot be flushed there.
-            sync_flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
-            sync_fd = os.open(tmp_path, sync_flags)
-            try:
-                os.fsync(sync_fd)
-            finally:
-                os.close(sync_fd)
+            # review).
+            _stamp_by_path(tmp_path, observed_at)
+            _fsync_no_follow(tmp_path)
         os.replace(tmp_path, cache_path)
         logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
         return True

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -400,12 +400,25 @@ def _publish_hash_cache(
             )
         if observed_at is not None and not stamp_by_fd:
             # The path branch, for platforms whose `os.utime` takes no
-            # descriptor. Safe here specifically because it runs AFTER the
-            # inode check above: the name has just been confirmed to still be
-            # the file the O_EXCL|O_NOFOLLOW open created, in a directory
-            # whose write permission already grants an attacker the same
-            # outcome without a race (see the argument above `current`).
+            # descriptor (Windows). It has to run AFTER the inode check: a
+            # stamp before it would follow a symlink swapped in after
+            # creation and rewrite the link target's timestamp, which is
+            # measured and was the whole point of the descriptor-based stamp.
+            #
+            # Durability is then restored by re-opening and syncing, rather
+            # than by moving the stamp earlier: a crash between the utime and
+            # the replace would otherwise publish a cache carrying its write
+            # time instead of `observed_at`, and `_is_already_in_sync` trusts
+            # that mtime, so it would skip edits made during the run (#1701
+            # review). O_NOFOLLOW again, for the same reason as the first
+            # open.
             os.utime(tmp_path, (observed_at, observed_at))
+            sync_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            sync_fd = os.open(tmp_path, sync_flags)
+            try:
+                os.fsync(sync_fd)
+            finally:
+                os.close(sync_fd)
         os.replace(tmp_path, cache_path)
         logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
         return True

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -352,7 +352,16 @@ def _publish_hash_cache(
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(hashes, f, indent=2)
             f.flush()
-            if observed_at is not None:
+            # Stamping through the DESCRIPTOR where the platform allows it,
+            # because a path-based utime can follow a symlink swapped in after
+            # creation. Windows does not: `os.utime` is absent from
+            # `os.supports_fd` there, so passing a descriptor raises
+            # "TypeError: utime: path should be string, bytes or os.PathLike,
+            # not int" and every hash-cache publish fails with it. This host is
+            # POSIX, so the fd branch is the only one exercised locally and the
+            # break was invisible until CI's Windows job ran (#1701 review).
+            stamp_by_fd = os.utime in os.supports_fd
+            if observed_at is not None and stamp_by_fd:
                 os.utime(f.fileno(), (observed_at, observed_at))
             # `flush` only pushes the bytes to the OS. Without the fsync a
             # power loss after `os.replace` can expose a cache file whose
@@ -389,6 +398,14 @@ def _publish_hash_cache(
             raise OSError(
                 f"temporary cache path {tmp_path} was replaced after creation"
             )
+        if observed_at is not None and not stamp_by_fd:
+            # The path branch, for platforms whose `os.utime` takes no
+            # descriptor. Safe here specifically because it runs AFTER the
+            # inode check above: the name has just been confirmed to still be
+            # the file the O_EXCL|O_NOFOLLOW open created, in a directory
+            # whose write permission already grants an attacker the same
+            # outcome without a race (see the argument above `current`).
+            os.utime(tmp_path, (observed_at, observed_at))
         os.replace(tmp_path, cache_path)
         logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
         return True

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -342,10 +342,28 @@ def _publish_hash_cache(
         logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
         return False
     try:
+        # Everything below acts on the DESCRIPTOR, never the pathname. The
+        # exclusive no-follow open protects only creation: a local writer can
+        # unlink the temporary between then and here and drop a symlink in its
+        # place, after which a path-based `os.utime` rewrites the link
+        # target's timestamp and `os.replace` publishes the link itself as the
+        # cache -- with this function still reporting success. Verified
+        # exploitable before this change (#1701 review).
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(hashes, f, indent=2)
-        if observed_at is not None:
-            os.utime(tmp_path, (observed_at, observed_at))
+            f.flush()
+            if observed_at is not None:
+                os.utime(f.fileno(), (observed_at, observed_at))
+            created = os.fstat(f.fileno())
+        # `os.replace` takes a path, so the swap window closes only if the
+        # path still names the inode the exclusive open created. A mismatch
+        # means someone replaced it: refuse rather than publish whatever is
+        # there now.
+        current = os.lstat(tmp_path)
+        if (current.st_ino, current.st_dev) != (created.st_ino, created.st_dev):
+            raise OSError(
+                f"temporary cache path {tmp_path} was replaced after creation"
+            )
         os.replace(tmp_path, cache_path)
         logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
         return True

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -269,7 +269,14 @@ def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
             json.dump(hashes, f, indent=2)
         logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
     except OSError as e:
-        logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
+        logger.warning(
+            ls.HASH_CACHE_SAVE_FAILED,
+            path=cache_path,
+            error=e,
+            errno=getattr(e, "errno", None),
+            strerror=getattr(e, "strerror", None),
+            failing_path=getattr(e, "filename", None),
+        )
 
 
 # Bounded so a directory that somehow rejects every candidate ends the publish
@@ -339,7 +346,14 @@ def _publish_hash_cache(
         fd, tmp_name = _open_exclusive_temp(cache_path)
         tmp_path = Path(tmp_name)
     except OSError as e:
-        logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
+        logger.warning(
+            ls.HASH_CACHE_SAVE_FAILED,
+            path=cache_path,
+            error=e,
+            errno=getattr(e, "errno", None),
+            strerror=getattr(e, "strerror", None),
+            failing_path=getattr(e, "filename", None),
+        )
         return False
     try:
         # Everything below acts on the DESCRIPTOR, never the pathname. The
@@ -477,7 +491,14 @@ def _publish_hash_cache(
         logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
         return True
     except OSError as e:
-        logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
+        logger.warning(
+            ls.HASH_CACHE_SAVE_FAILED,
+            path=cache_path,
+            error=e,
+            errno=getattr(e, "errno", None),
+            strerror=getattr(e, "strerror", None),
+            failing_path=getattr(e, "filename", None),
+        )
         try:
             tmp_path.unlink(missing_ok=True)
         except OSError as cleanup_error:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -355,10 +355,28 @@ def _publish_hash_cache(
             if observed_at is not None:
                 os.utime(f.fileno(), (observed_at, observed_at))
             created = os.fstat(f.fileno())
-        # `os.replace` takes a path, so the swap window closes only if the
-        # path still names the inode the exclusive open created. A mismatch
-        # means someone replaced it: refuse rather than publish whatever is
-        # there now.
+        # A cheap refusal, not the security boundary. The boundary is the
+        # threat model, and it is worth stating because "there is still a
+        # window between this check and the rename" is true and does not
+        # matter (#1701 review):
+        #
+        # The temporary is always a SIBLING of the cache (`with_name`), and
+        # `rename(2)` moves directory ENTRIES without following symlinks on
+        # either name -- measured: renaming a symlink over a file leaves the
+        # link's target untouched. So once `O_EXCL|O_NOFOLLOW` closes the
+        # open-time follow, which was the only path that could write OUTSIDE
+        # this directory, a post-creation swap can at worst leave the cache
+        # entry pointing at a link the attacker chose.
+        #
+        # Doing that needs WRITE on the directory, and anyone with directory
+        # write can unlink the cache and replace it outright without racing
+        # anything. The window grants no capability its own precondition does
+        # not already grant. The one directory shape writable by others is
+        # world-writable-plus-sticky, and the sticky bit forbids renaming or
+        # unlinking another user's entries, so the swap fails there too.
+        #
+        # The check stays because it costs one lstat and turns a swap into a
+        # refusal rather than a silent publish.
         current = os.lstat(tmp_path)
         if (current.st_ino, current.st_dev) != (created.st_ino, created.st_dev):
             raise OSError(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -380,7 +380,22 @@ def _publish_hash_cache(
             # before and after the sync, and nothing between them can change
             # which file this descriptor refers to.
             created = os.fstat(f.fileno())
-            os.fsync(f.fileno())
+        # `fsync` AFTER the writer is closed, not inside it. On Windows the
+        # sync goes through `_commit()` on a descriptor owned by the buffered
+        # text wrapper, and it raised "[Errno 9] Bad file descriptor" there --
+        # 39 tests red on Windows while ubuntu and macOS stayed green, twice
+        # in a row, because reordering fstat and fsync inside the block was
+        # not enough (#1701 review, measured in CI both times).
+        #
+        # Reopened with O_NOFOLLOW, so a link swapped in between the close and
+        # here cannot redirect the sync; the inode check below still refuses a
+        # swapped path before anything is published.
+        sync_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        sync_fd = os.open(tmp_path, sync_flags)
+        try:
+            os.fsync(sync_fd)
+        finally:
+            os.close(sync_fd)
         # A cheap refusal, not the security boundary. The boundary is the
         # threat model, and it is worth stating because "there is still a
         # window between this check and the rename" is true and does not
@@ -439,7 +454,19 @@ def _publish_hash_cache(
             # that mtime, so it would skip edits made during the run (#1701
             # review). O_NOFOLLOW again, for the same reason as the first
             # open.
-            os.utime(tmp_path, (observed_at, observed_at))
+            # `follow_symlinks=False` closes the finding directly rather than
+            # by argument: if a link is swapped in between the inode check and
+            # here, the stamp lands on the LINK, not on whatever it points at,
+            # so no external file's metadata can be touched (#1701 review).
+            #
+            # Guarded because the flag is not universal; where it is
+            # unsupported the threat-model argument still applies -- the swap
+            # needs write permission on this directory, which already allows
+            # rewriting the cache outright.
+            if os.utime in os.supports_follow_symlinks:
+                os.utime(tmp_path, (observed_at, observed_at), follow_symlinks=False)
+            else:
+                os.utime(tmp_path, (observed_at, observed_at))
             sync_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
             sync_fd = os.open(tmp_path, sync_flags)
             try:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -369,8 +369,18 @@ def _publish_hash_cache(
             # worse than none, because `_is_already_in_sync` trusts whatever
             # is there. Sync after the utime so the timestamp is durable too,
             # then take the inode: write, sync, then publish (#1701 review).
-            os.fsync(f.fileno())
+            # `fstat` BEFORE `fsync`, not after. On Windows the fsync path
+            # goes through `_commit()`, which can leave the descriptor
+            # unusable, and the following `fstat` then raised
+            # "[Errno 9] Bad file descriptor" -- every hash-cache publish
+            # failed with it and 39 tests went red on that platform while
+            # ubuntu and macOS stayed green (#1701 review, measured in CI).
+            #
+            # Order is safe either way: the inode identifies the same file
+            # before and after the sync, and nothing between them can change
+            # which file this descriptor refers to.
             created = os.fstat(f.fileno())
+            os.fsync(f.fileno())
         # A cheap refusal, not the security boundary. The boundary is the
         # threat model, and it is worth stating because "there is still a
         # window between this check and the rename" is true and does not
@@ -394,7 +404,24 @@ def _publish_hash_cache(
         # The check stays because it costs one lstat and turns a swap into a
         # refusal rather than a silent publish.
         current = os.lstat(tmp_path)
-        if (current.st_ino, current.st_dev) != (created.st_ino, created.st_dev):
+        # Skipped where the identity comparison is not meaningful. On Windows
+        # `st_ino` is a file INDEX rather than an inode: it can be 0 on some
+        # filesystems, and `fstat` and `lstat` are not guaranteed to agree, so
+        # comparing them there would refuse every publish rather than detect a
+        # swap (#1701 review, decision (a)).
+        #
+        # The premise that makes this acceptable on that platform is the one
+        # already argued for the fallback stamp: creating a symlink on Windows
+        # requires privilege in the default configuration, and an attacker who
+        # can write to the cache directory can rewrite the cache outright
+        # without any race. The O_EXCL creation and the fsync stay on every
+        # platform; only this comparison is conditional.
+        identity_is_meaningful = (
+            os.name != "nt" and created.st_ino != 0 and current.st_ino != 0
+        )
+        if identity_is_meaningful and (
+            (current.st_ino, current.st_dev) != (created.st_ino, created.st_dev)
+        ):
             raise OSError(
                 f"temporary cache path {tmp_path} was replaced after creation"
             )

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import posixpath
+import secrets
 import sys
 import time
 from collections import defaultdict
@@ -271,6 +272,37 @@ def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
         logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
 
 
+# Bounded so a directory that somehow rejects every candidate ends the publish
+# instead of spinning; with 8 random bytes a collision is already vanishingly
+# unlikely, so more than a few attempts would only mask a real filesystem
+# problem.
+_TEMP_NAME_ATTEMPTS = 8
+
+
+def _open_exclusive_temp(cache_path: Path) -> tuple[int, str]:
+    """Create a fresh temporary file beside `cache_path`, never following a link.
+
+    `O_EXCL` fails rather than reusing an existing path and `O_NOFOLLOW`
+    fails rather than opening a symlink's target, so neither a guessed name
+    nor a planted link can redirect the write. The name is random, which
+    means an attacker cannot plant the link in the first place; the flags
+    are what make that a guarantee rather than a probability.
+
+    `O_NOFOLLOW` is POSIX; on platforms lacking it the flag is 0 and the
+    random name plus `O_EXCL` still prevent reuse of a planted path.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    for _ in range(_TEMP_NAME_ATTEMPTS):
+        candidate = cache_path.with_name(
+            f"{cache_path.name}.{secrets.token_hex(8)}.tmp"
+        )
+        try:
+            return os.open(candidate, flags, 0o600), str(candidate)
+        except FileExistsError:
+            continue
+    raise OSError(f"could not create a temporary file beside {cache_path}")
+
+
 def _publish_hash_cache(
     cache_path: Path, hashes: FileHashCache, observed_at: float | None
 ) -> bool:
@@ -294,10 +326,23 @@ def _publish_hash_cache(
     left untouched, which is the safe direction: a cache that is one run out
     of date costs a rescan, while a mis-stamped one loses an edit.
     """
-    tmp_path = cache_path.with_name(f"{cache_path.name}.{os.getpid()}.tmp")
+    # The temporary name is unpredictable and the file is created with
+    # O_EXCL|O_NOFOLLOW, so a local process that can write to the repository
+    # directory cannot pre-place a symlink here and have this truncate the
+    # link's target with cache JSON. A PID-derived name opened with
+    # `Path.open("w")` did exactly that: the name was guessable and the open
+    # followed the link (issue #1700). O_EXCL also means an existing path is
+    # a publish FAILURE rather than something to unlink and retry -- removing
+    # it would be the same race one step later.
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        with tmp_path.open("w", encoding="utf-8") as f:
+        fd, tmp_name = _open_exclusive_temp(cache_path)
+        tmp_path = Path(tmp_name)
+    except OSError as e:
+        logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
+        return False
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(hashes, f, indent=2)
         if observed_at is not None:
             os.utime(tmp_path, (observed_at, observed_at))

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -354,6 +354,13 @@ def _publish_hash_cache(
             f.flush()
             if observed_at is not None:
                 os.utime(f.fileno(), (observed_at, observed_at))
+            # `flush` only pushes the bytes to the OS. Without the fsync a
+            # power loss after `os.replace` can expose a cache file whose
+            # contents were never written -- and a truncated or empty cache is
+            # worse than none, because `_is_already_in_sync` trusts whatever
+            # is there. Sync after the utime so the timestamp is durable too,
+            # then take the inode: write, sync, then publish (#1701 review).
+            os.fsync(f.fileno())
             created = os.fstat(f.fileno())
         # A cheap refusal, not the security boundary. The boundary is the
         # threat model, and it is worth stating because "there is still a

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -881,7 +881,15 @@ MCP_HTTP_SERVER_READY = (
 HASH_CACHE_LOADED = "Loaded hash cache with {count} entries from {path}"
 HASH_CACHE_LOAD_FAILED = "Failed to load hash cache from {path}: {error}"
 HASH_CACHE_SAVED = "Saved hash cache with {count} entries to {path}"
-HASH_CACHE_SAVE_FAILED = "Failed to save hash cache to {path}: {error}"
+# `errno` and `strerror` as well as the message: a publish failure names a
+# path and a bare message otherwise, which is not enough to tell WHICH
+# syscall refused on a platform the developer cannot reproduce on. A bare
+# `OSError("...")` carries errno None, so the value also distinguishes a
+# real syscall failure from one this module raised itself.
+HASH_CACHE_SAVE_FAILED = (
+    "Failed to save hash cache to {path}: {error} "
+    "(errno={errno} strerror={strerror} failing_path={failing_path})"
+)
 # A scoped re-ingest backdates the hash cache to the instant it observed
 # (`_reingest_update_hashes`); these name that step, distinct from the
 # atomic publish's own temporary-file cleanup below.

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -2139,7 +2139,7 @@ class TestHashCachePublishSymlinkSafety:
     def test_a_stamp_that_cannot_refuse_to_follow_declines_the_publish(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No descriptor stamp, no `follow_symlinks=False`, and NOT Windows.
+        """No descriptor stamp, no `follow_symlinks=False`, and not the Windows branch.
 
         The previous fallback stamped through the PATH when neither was
         available, and forcing that branch showed a link swapped in after the
@@ -2154,9 +2154,10 @@ class TestHashCachePublishSymlinkSafety:
         member of neither `os.supports_fd` nor `os.supports_follow_symlinks`,
         and it records every call so the test can assert there were none.
         """
-        assert not graph_updater_module._WINDOWS, (
-            "this host takes the Windows branch; see above"
-        )
+        # Forced off rather than asserted: the decline branch is keyed on the
+        # module flag, not on the host, so it can and should run on the
+        # Windows job too (a guard here went red there, #1701 CI).
+        monkeypatch.setattr(graph_updater_module, "_WINDOWS", False)
         stamps: list[tuple] = []
         monkeypatch.setattr(
             graph_updater_module.os, "utime", lambda *a, **k: stamps.append((a, k))

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -2072,23 +2072,91 @@ class TestHashCachePublishSymlinkSafety:
         )
         assert not published, "a publish over a swapped path must refuse"
 
+    def test_the_windows_stamp_lands_and_refuses_a_swapped_link(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows-shaped: `os.utime` in NEITHER capability set, `os.name == "nt"`.
+
+        An earlier revision refused the publish whenever `os.utime` could not
+        take a descriptor or `follow_symlinks=False`, on the belief that every
+        CI platform had one of the two. Windows has neither (#1701 local
+        review), so that revision would have declined every stamped publish
+        there and brought back the 39 red tests it set out to fix. On Windows
+        the stamp goes through the path, so this pins both halves: the
+        ordinary publish lands with the stamp applied, and a link swapped in
+        after creation is refused by the `S_ISLNK` check before the path
+        stamp can follow it.
+
+        The module's `_WINDOWS` flag is forced too, because the branch is
+        keyed on it (`os.name` itself cannot be forced: `pathlib.Path()` reads
+        it at call time and would refuse to build paths on this host). On this
+        POSIX host a path-based `os.utime` DOES follow a symlink, which is
+        exactly what makes the swap half of this test meaningful here.
+        """
+        monkeypatch.setattr(
+            os, "supports_fd", frozenset(x for x in os.supports_fd if x is not os.utime)
+        )
+        monkeypatch.setattr(
+            os,
+            "supports_follow_symlinks",
+            frozenset(x for x in os.supports_follow_symlinks if x is not os.utime),
+        )
+        monkeypatch.setattr(graph_updater_module, "_WINDOWS", True)
+        assert os.utime not in os.supports_fd
+        assert os.utime not in os.supports_follow_symlinks
+
+        cache_path = tmp_path / "cache.json"
+        assert graph_updater_module._publish_hash_cache(
+            cache_path, {"a.py": "x"}, 1_000_000.0
+        ), "the Windows-shaped publish was declined"
+        assert int(cache_path.stat().st_mtime) == 1_000_000, (
+            "the Windows-shaped publish landed without its stamp"
+        )
+
+        victim = tmp_path / "victim.txt"
+        victim.write_text("precious\n", encoding="utf-8")
+        before = victim.stat().st_mtime
+        real_open = graph_updater_module._open_exclusive_temp
+
+        def _swap_after_create(path: Path) -> tuple[int, str]:
+            fd, name = real_open(path)
+            os.unlink(name)
+            os.symlink(victim, name)
+            return fd, name
+
+        monkeypatch.setattr(
+            graph_updater_module, "_open_exclusive_temp", _swap_after_create
+        )
+        published = graph_updater_module._publish_hash_cache(
+            tmp_path / "cache2.json", {"a.py": "y"}, 2_000_000.0
+        )
+        assert not published, "a publish over a swapped link must refuse"
+        assert victim.stat().st_mtime == before, (
+            "the Windows path stamp followed a swapped symlink to the victim"
+        )
+        assert not (tmp_path / "cache2.json").exists()
+
     def test_a_stamp_that_cannot_refuse_to_follow_declines_the_publish(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No descriptor stamp and no `follow_symlinks=False`: do not publish.
+        """No descriptor stamp, no `follow_symlinks=False`, and NOT Windows.
 
         The previous fallback stamped through the PATH when neither was
         available, and forcing that branch showed a link swapped in after the
         inode check getting its target's timestamp rewritten (#1701 review,
-        measured). There is no safe way to stamp on such a platform, so the
-        publish must decline and leave the previous cache untouched, rather
-        than mis-stamp: a declined publish costs one re-hash, a mis-stamped
-        one loses edits.
+        measured). Windows has its own branch (the test above); any other
+        platform in that position has no safe way to stamp, so the publish
+        must decline and leave the previous cache untouched rather than
+        mis-stamp: a declined publish costs one re-hash, a mis-stamped one
+        loses edits.
 
         Replacing `os.utime` is what forces the branch: the replacement is a
         member of neither `os.supports_fd` nor `os.supports_follow_symlinks`,
         and it records every call so the test can assert there were none.
         """
+        assert not graph_updater_module._WINDOWS, (
+            "this host takes the Windows branch; see above"
+        )
         stamps: list[tuple] = []
         monkeypatch.setattr(
             graph_updater_module.os, "utime", lambda *a, **k: stamps.append((a, k))

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -2071,3 +2071,81 @@ class TestHashCachePublishSymlinkSafety:
             "swapped symlink target's timestamp"
         )
         assert not published, "a publish over a swapped path must refuse"
+
+    def test_a_stamp_that_cannot_refuse_to_follow_declines_the_publish(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No descriptor stamp and no `follow_symlinks=False`: do not publish.
+
+        The previous fallback stamped through the PATH when neither was
+        available, and forcing that branch showed a link swapped in after the
+        inode check getting its target's timestamp rewritten (#1701 review,
+        measured). There is no safe way to stamp on such a platform, so the
+        publish must decline and leave the previous cache untouched, rather
+        than mis-stamp: a declined publish costs one re-hash, a mis-stamped
+        one loses edits.
+
+        Replacing `os.utime` is what forces the branch: the replacement is a
+        member of neither `os.supports_fd` nor `os.supports_follow_symlinks`,
+        and it records every call so the test can assert there were none.
+        """
+        stamps: list[tuple] = []
+        monkeypatch.setattr(
+            graph_updater_module.os, "utime", lambda *a, **k: stamps.append((a, k))
+        )
+        assert graph_updater_module.os.utime not in os.supports_fd, (
+            "fixture guard: the descriptor branch was not disabled"
+        )
+        assert graph_updater_module.os.utime not in os.supports_follow_symlinks, (
+            "fixture guard: the no-follow branch was not disabled"
+        )
+
+        cache_path = tmp_path / "cache.json"
+        cache_path.write_text('{"kept.py": "old"}', encoding="utf-8")
+        victim = tmp_path / "victim.txt"
+        victim.write_text("precious\n", encoding="utf-8")
+        before = victim.stat().st_mtime
+
+        real_open = graph_updater_module._open_exclusive_temp
+
+        def _swap_after_create(path: Path) -> tuple[int, str]:
+            fd, name = real_open(path)
+            os.unlink(name)
+            os.symlink(victim, name)
+            return fd, name
+
+        # The ordinary path first: with no safe stamp there is no publish.
+        published = graph_updater_module._publish_hash_cache(
+            cache_path, {"a.py": "x"}, 1_000_000.0
+        )
+        assert not published, "a publish that could not stamp safely reported success"
+        assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+            "kept.py": "old"
+        }, "a declined publish must leave the previous cache intact"
+        assert stamps == [], (
+            f"the path-following stamp ran on a platform that cannot refuse "
+            f"to follow: {stamps}"
+        )
+
+        # Then under the swap, which is the case the old fallback got wrong.
+        monkeypatch.setattr(
+            graph_updater_module, "_open_exclusive_temp", _swap_after_create
+        )
+        published = graph_updater_module._publish_hash_cache(
+            tmp_path / "cache2.json", {"a.py": "y"}, 2_000_000.0
+        )
+        assert not published
+        assert victim.stat().st_mtime == before, (
+            "the stamp followed a swapped symlink to the victim"
+        )
+        assert stamps == [], f"utime was called: {stamps}"
+        assert not (tmp_path / "cache2.json").exists(), (
+            "a declined publish left a cache behind"
+        )
+
+        # And a publish that has nothing to stamp still goes through: the
+        # refusal is about the stamp, not about the platform.
+        monkeypatch.setattr(graph_updater_module, "_open_exclusive_temp", real_open)
+        assert graph_updater_module._publish_hash_cache(
+            tmp_path / "cache3.json", {"a.py": "z"}, None
+        ), "an unstamped publish must not be refused"

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1960,3 +1960,53 @@ class TestHashCachePublishSymlinkSafety:
         assert not any(str(os.getpid()) in name for name in seen), (
             f"the temporary name still embeds the pid, so it stays guessable: {seen}"
         )
+
+    def test_a_symlink_swapped_in_after_creation_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exclusive open guards creation only; the rest must use the fd.
+
+        A local writer able to modify the cache directory can unlink the
+        temporary between its creation and the calls that follow, then drop a
+        symlink at the same name. A path-based `os.utime` then rewrites the
+        LINK TARGET's timestamp and `os.replace` publishes the link itself as
+        the hash cache, with the publish still reporting success (#1701
+        review, verified exploitable).
+
+        Both assertions are needed and neither implies the other: stamping
+        through the descriptor stops the timestamp write, and the inode check
+        stops the symlink being published. A fix doing only the first still
+        installs the link.
+        """
+        cache_path = tmp_path / "cache.json"
+        victim = tmp_path / "victim.txt"
+        victim.write_text("precious\n", encoding="utf-8")
+        before = victim.stat().st_mtime
+
+        real_open = graph_updater_module._open_exclusive_temp
+
+        def _swap_after_create(path: Path) -> tuple[int, str]:
+            fd, name = real_open(path)
+            os.unlink(name)
+            os.symlink(victim, name)
+            return fd, name
+
+        monkeypatch.setattr(
+            graph_updater_module, "_open_exclusive_temp", _swap_after_create
+        )
+
+        published = graph_updater_module._publish_hash_cache(
+            cache_path, {"a.py": "deadbeef"}, 1_000_000.0
+        )
+
+        assert victim.stat().st_mtime == before, (
+            "the stamp followed a symlink swapped in after creation and "
+            "rewrote the victim's timestamp"
+        )
+        assert not cache_path.is_symlink(), (
+            "a symlink swapped in after creation was published as the cache"
+        )
+        assert not published, (
+            "a publish that could not use the file it created must report "
+            "failure, not success over whatever replaced it"
+        )

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1950,15 +1950,20 @@ class TestHashCachePublishSymlinkSafety:
                 seen.add(os.path.basename(name))
             return real_open(path, flags, mode, **kwargs)
 
+        # The SAME cache path both times. Publishing to cache0/cache1 would
+        # yield two distinct temporary names from any scheme at all, including
+        # a fixed `.tmp` suffix, so it could not tell an unpredictable name
+        # from a derived one (#1701 review).
+        cache_path = tmp_path / "cache.json"
         with patch.object(os, "open", _record):
-            for index in range(2):
+            for _ in range(2):
                 graph_updater_module._publish_hash_cache(
-                    tmp_path / f"cache{index}.json", {"a.py": "x"}, None
+                    cache_path, {"a.py": "x"}, None
                 )
 
-        assert len(seen) == 2, f"expected two distinct temporary names, saw {seen}"
-        assert not any(str(os.getpid()) in name for name in seen), (
-            f"the temporary name still embeds the pid, so it stays guessable: {seen}"
+        assert len(seen) == 2, (
+            "two publishes to the SAME cache path reused one temporary name, "
+            f"so the name is derived rather than unpredictable: {seen}"
         )
 
     def test_a_symlink_swapped_in_after_creation_is_refused(

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -646,6 +646,7 @@ class TestCrashBetweenCacheSaveAndFlush:
         )
 
         real_open = Path.open
+        real_os_open = os.open
         real_utime = os.utime
         real_replace = os.replace
         refused: set[str] = set()
@@ -661,6 +662,17 @@ class TestCrashBetweenCacheSaveAndFlush:
                 raise OSError(errno.EROFS, "Read-only file system")
             return real_open(self, *args, **kwargs)
 
+        # The publish creates its temporary through `os.open` with
+        # O_EXCL|O_NOFOLLOW rather than `Path.open` (issue #1700), so the
+        # read-only filesystem has to be simulated at that call too. Patching
+        # only `Path.open` left the write unrefused, which the `"write" in
+        # refused` assertion below catches rather than passing vacuously.
+        def _refuse_os_open(path, flags, mode=0o777, **kwargs):  # type: ignore[no-untyped-def]
+            if _is_cache_temp(Path(os.fspath(path))):
+                refused.add("write")
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_os_open(path, flags, mode, **kwargs)
+
         def _refuse_utime(path, times=None, **kwargs):  # type: ignore[no-untyped-def]
             if _is_cache_temp(Path(path)):
                 refused.add("utime")
@@ -674,6 +686,7 @@ class TestCrashBetweenCacheSaveAndFlush:
             return real_replace(src, dst, **kwargs)
 
         monkeypatch.setattr(Path, "open", _refuse_open)
+        monkeypatch.setattr(graph_updater_module.os, "open", _refuse_os_open)
         monkeypatch.setattr(graph_updater_module.os, "utime", _refuse_utime)
         monkeypatch.setattr(graph_updater_module.os, "replace", _refuse_replace)
         # Must COMPLETE: a cache that cannot be written is not a failed run.
@@ -685,6 +698,7 @@ class TestCrashBetweenCacheSaveAndFlush:
         ).run()
         monkeypatch.setattr(graph_updater_module.os, "replace", real_replace)
         monkeypatch.setattr(graph_updater_module.os, "utime", real_utime)
+        monkeypatch.setattr(graph_updater_module.os, "open", real_os_open)
         monkeypatch.setattr(Path, "open", real_open)
 
         assert "write" in refused, (
@@ -1876,3 +1890,73 @@ def test_a_pre_parse_failure_leaves_the_old_subtrees_in_place(
         updater.run()
 
     assert _deleted_module_paths(mock_ingestor) == set()
+
+
+class TestHashCachePublishSymlinkSafety:
+    """The publish must not write through a link planted at its temp path."""
+
+    def test_a_planted_symlink_at_the_predictable_path_is_not_followed(
+        self, tmp_path: Path
+    ) -> None:
+        """A pre-placed link at the OLD predictable name must be inert.
+
+        The temporary name used to be `<cache>.<pid>.tmp` and was opened with
+        `Path.open("w")`, which follows a symlink: a local process able to
+        write to the repository directory could point that name at any file
+        the publisher could write and have it truncated and replaced with
+        cache JSON (issue #1700).
+
+        The victim is asserted BY CONTENT rather than by mtime or size: the
+        overwrite leaves a perfectly well-formed file, so only the bytes
+        distinguish "untouched" from "replaced with someone else's data".
+        """
+        cache_path = tmp_path / "cache.json"
+        victim = tmp_path / "victim.txt"
+        original = "precious contents that must survive\n"
+        victim.write_text(original, encoding="utf-8")
+
+        planted = cache_path.with_name(f"{cache_path.name}.{os.getpid()}.tmp")
+        planted.symlink_to(victim)
+
+        published = graph_updater_module._publish_hash_cache(
+            cache_path, {"a.py": "deadbeef"}, None
+        )
+
+        assert victim.read_text(encoding="utf-8") == original, (
+            "the publish followed a symlink planted at its temporary path and "
+            "overwrote the link's target with cache JSON"
+        )
+        assert published, "the publish must still succeed around a planted link"
+        assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+            "a.py": "deadbeef"
+        }, "the cache itself must be written correctly"
+
+    def test_the_temporary_name_is_not_derived_from_the_pid(
+        self, tmp_path: Path
+    ) -> None:
+        """Two publishes must not reuse one predictable temporary name.
+
+        Pins the unpredictability directly. Asserting only that the planted
+        link survives would still pass if the name were merely CHANGED to
+        another fixed string, which an attacker reads out of the source just
+        as easily.
+        """
+        seen: set[str] = set()
+        real_open = os.open
+
+        def _record(path, flags, mode=0o777, **kwargs):  # type: ignore[no-untyped-def]
+            name = os.fspath(path)
+            if name.endswith(".tmp"):
+                seen.add(os.path.basename(name))
+            return real_open(path, flags, mode, **kwargs)
+
+        with patch.object(os, "open", _record):
+            for index in range(2):
+                graph_updater_module._publish_hash_cache(
+                    tmp_path / f"cache{index}.json", {"a.py": "x"}, None
+                )
+
+        assert len(seen) == 2, f"expected two distinct temporary names, saw {seen}"
+        assert not any(str(os.getpid()) in name for name in seen), (
+            f"the temporary name still embeds the pid, so it stays guessable: {seen}"
+        )

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -2015,3 +2015,59 @@ class TestHashCachePublishSymlinkSafety:
             "a publish that could not use the file it created must report "
             "failure, not success over whatever replaced it"
         )
+
+    def test_the_path_stamp_branch_stamps_and_stays_safe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Simulates the platform where `os.utime` takes no descriptor.
+
+        Windows has no `os.utime` in `os.supports_fd`, so passing a file
+        descriptor raises `TypeError` and every hash-cache publish fails with
+        it. This host is POSIX and always takes the fd branch, so that break
+        was invisible locally until CI's Windows job ran (#1701 review).
+
+        Asserts BOTH properties of the fallback, because the two orderings
+        that satisfy them are different and I traded one for the other once:
+        the stamp must land (durability, and `_is_already_in_sync` reads that
+        mtime), and it must not follow a symlink swapped in after creation
+        (safety, which requires it to run after the inode check).
+        """
+        monkeypatch.setattr(
+            os, "supports_fd", frozenset(x for x in os.supports_fd if x is not os.utime)
+        )
+        assert os.utime not in os.supports_fd, "fixture guard: branch not forced"
+
+        cache_path = tmp_path / "cache.json"
+        victim = tmp_path / "victim.txt"
+        victim.write_text("precious\n", encoding="utf-8")
+        before = victim.stat().st_mtime
+
+        real_open = graph_updater_module._open_exclusive_temp
+
+        def _swap_after_create(path: Path) -> tuple[int, str]:
+            fd, name = real_open(path)
+            os.unlink(name)
+            os.symlink(victim, name)
+            return fd, name
+
+        # First: the ordinary path, which must stamp.
+        assert graph_updater_module._publish_hash_cache(
+            cache_path, {"a.py": "x"}, 1_000_000.0
+        )
+        assert int(cache_path.stat().st_mtime) == 1_000_000, (
+            "the fallback branch did not apply the timestamp, so a later run "
+            "reads the write time and may skip edits made during this one"
+        )
+
+        # Then: the same branch under the post-creation swap.
+        monkeypatch.setattr(
+            graph_updater_module, "_open_exclusive_temp", _swap_after_create
+        )
+        published = graph_updater_module._publish_hash_cache(
+            tmp_path / "cache2.json", {"a.py": "y"}, 2_000_000.0
+        )
+        assert victim.stat().st_mtime == before, (
+            "the fallback stamp ran before the inode check and rewrote a "
+            "swapped symlink target's timestamp"
+        )
+        assert not published, "a publish over a swapped path must refuse"


### PR DESCRIPTION
Closes #1700.

## The defect

`_publish_hash_cache` derived its temporary filename from the cache name plus the process id and opened it with `Path.open("w")`, which follows a symlink. A local process able to write to the repository directory could pre-place a link at that predictable path and have the publisher truncate and overwrite the link's target with cache JSON.

Demonstrated against `main`:

```
planted symlink: cache.json.70201.tmp -> VICTIM.txt
publish returned: True
victim now: '{\n  "a.py": "deadbeef"\n}'
VERDICT: *** VICTIM OVERWRITTEN ***
```

The publish reported success while destroying an unrelated file.

## The fix

`_open_exclusive_temp` creates the temporary beside the cache with a `secrets.token_hex(8)` name and `O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW` at mode `0600`, then the existing write / fsync / `os.replace` sequence proceeds on that descriptor.

* `O_NOFOLLOW` refuses to open a symlink's target.
* `O_EXCL` makes an existing path a publish **failure** rather than something to unlink and retry, because removing it would be the same race one step later.
* The random name means the link cannot be planted in the first place; the flags are what make that a guarantee rather than a probability.
* `O_NOFOLLOW` is POSIX; where absent the flag degrades to `0` and the random name plus `O_EXCL` still prevent reuse of a planted path.

Same probe after the fix:

```
victim now: 'precious contents that must survive\n'
VERDICT: SAFE
```

## Tests

* `test_a_planted_symlink_at_the_predictable_path_is_not_followed` plants a link at the old `<cache>.<pid>.tmp` name and asserts the victim's **contents** are unchanged. Content rather than mtime or size, because the overwrite leaves a perfectly well-formed file and only the bytes distinguish "untouched" from "replaced with someone else's data".
* `test_the_temporary_name_is_not_derived_from_the_pid` pins the unpredictability itself. Asserting only that the planted link survives would still pass if the name were merely changed to a different fixed string, which an attacker reads out of the source just as easily.

Reverting the fix to the pid-named, symlink-following open fails **both**, and nothing else: `2 failed, 51 deselected`. Baseline `53 passed`.

## One existing test changed

`test_a_read_only_tree_still_completes_the_run` simulated a read-only filesystem by patching `Path.open`. The publish now writes through `os.open`, so that patch stopped intercepting and the simulation silently stopped firing. Its own `assert "write" in refused` guard caught this rather than letting the test pass vacuously, which is exactly what that assertion exists for. It now patches `os.open` as well.

Production behaviour there is unchanged: a read-only tree still refuses cleanly, leaves the previous cache byte-for-byte intact, and leaves no temporary files behind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache publishing safety with securely generated, non-predictable temporary files.
  - Prevented cache updates from following pre-existing or newly introduced symbolic links.
  - Ensured cache writes and timestamps are safely committed before publication.
  - Cache publishing now fails cleanly when secure file creation fails or a temporary file is unexpectedly replaced.
  - Temporary filenames no longer include process identifiers or reuse predictable names.
  - Preserved successful incremental runs on read-only filesystems where cache updates cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

## On the post-validation rename window

Review raised that an inode check before `os.replace` is check-then-use, and that an attacker can swap the entry in the gap. That is true, and it does not give them anything. Four premises, each verified on the host rather than argued from memory:

1. **The temporary is always a sibling of the cache.** Built with `cache_path.with_name(...)`; one caller; nothing stages via `tempfile` or in `/tmp`.
2. **`rename(2)` moves directory entries and never follows symlinks on either name.** Measured: renaming a symlink over a regular file left the target's contents intact and made the destination the link itself.
3. **Swapping the entry needs write permission on that directory** — and anyone with it can unlink the cache and replace it outright, no race required.
4. **The one directory shape writable by others is world-writable-plus-sticky**, and the sticky bit forbids renaming or unlinking another user's entries.

So the reachable threat — writing **through** the publisher to a file outside the directory, which is what the original finding demonstrated — is closed by `O_EXCL|O_NOFOLLOW`. What remains requires a permission that makes the race redundant.

The inode check is kept as a cheap refusal rather than a boundary: one `lstat`, turning a swap into an error instead of a silent publish. The argument and its measurements are in the code comment so the next reader need not re-derive them.
