### PR TITLE
fix: compare tree-sitter nodes by value in the property-access guard (#1702)

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6329,7 +6329,12 @@ class CallProcessor:
                     is_call_target = (
                         parent is not None
                         and parent.type == call_type
-                        and parent.child_by_field_name(func_field) is node
+                        # `==` not `is`: py-tree-sitter builds a fresh
+                        # wrapper per lookup, so the node returned here is
+                        # never the same object as the one taken from
+                        # .children, and identity would leave this guard
+                        # permanently False.
+                        and parent.child_by_field_name(func_field) == node
                     )
                     if not is_call_target and (
                         callee_info := resolve_func(

--- a/codebase_rag/tests/test_property_call_target.py
+++ b/codebase_rag/tests/test_property_call_target.py
@@ -1,0 +1,60 @@
+# The property-access pass must skip the attribute that is a call's own
+# function -- the call path has already resolved it -- while still resolving
+# an ordinary read of the same property. The guard compared tree-sitter
+# nodes with `is`, and py-tree-sitter builds a fresh wrapper per lookup, so
+# it never fired: the pass resolved the call target instead and the plain
+# read on the line above was left with no edge at all.
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+# `value` is read on one line and called on the next, so the two sites are
+# told apart by position rather than by a total that other passes also feed.
+SOURCE = """
+class Config:
+    @property
+    def value(self):
+        return lambda: 1
+
+    def go(self):
+        x = self.value
+        return self.value()
+"""
+READ_LINE = 8
+CALL_LINE = 9
+
+
+@pytest.fixture
+def prop_project(temp_repo: Path) -> Path:
+    project = temp_repo / "prop_call_target"
+    project.mkdir()
+    return project
+
+
+def _getter_edge_lines(mock_ingestor: MagicMock) -> list[int]:
+    return [
+        call.kwargs["properties"]["line"]
+        for call in get_relationships(mock_ingestor, "CALLS")
+        if call.args[2][2].endswith("Config.value")
+        and "properties" in call.kwargs
+        and "line" in call.kwargs["properties"]
+    ]
+
+
+def test_property_read_beside_a_call_through_the_property(
+    prop_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (prop_project / "m.py").write_text(SOURCE, encoding="utf-8")
+
+    run_updater(prop_project, mock_ingestor)
+
+    lines = _getter_edge_lines(mock_ingestor)
+    # The plain read resolves to the getter.
+    assert READ_LINE in lines, lines
+    # The call site is the call path's to resolve. With the identity
+    # comparison the pass claimed it too, and every edge landed on the call
+    # line while the read above got none.
+    assert lines.count(CALL_LINE) < len(lines), lines

--- a/codebase_rag/tests/test_property_call_target.py
+++ b/codebase_rag/tests/test_property_call_target.py
@@ -25,6 +25,9 @@ class Config:
 """
 READ_LINE = 8
 CALL_LINE = 9
+# What the call path alone emits for the call site, measured with the
+# property pass disabled outright.
+CALL_PATH_EDGES = 2
 
 
 @pytest.fixture
@@ -52,9 +55,10 @@ def test_property_read_beside_a_call_through_the_property(
     run_updater(prop_project, mock_ingestor)
 
     lines = _getter_edge_lines(mock_ingestor)
-    # The plain read resolves to the getter.
-    assert READ_LINE in lines, lines
-    # The call site is the call path's to resolve. With the identity
-    # comparison the pass claimed it too, and every edge landed on the call
-    # line while the read above got none.
-    assert lines.count(CALL_LINE) < len(lines), lines
+    # The property pass owns exactly one edge here, for the plain read.
+    assert lines.count(READ_LINE) == 1, lines
+    # The call site belongs to the call path, which emits two edges for it
+    # (a dispatch fan-out and the resolved call). The property pass must add
+    # nothing on top: with the identity comparison it claimed the call
+    # target too, giving 3 on this line and none on the read line.
+    assert lines.count(CALL_LINE) == CALL_PATH_EDGES, lines


### PR DESCRIPTION
Closes #1702.

## What

The guard in `_ingest_property_accesses` that skips the attribute which is a call's own function compared tree-sitter nodes with `is`:

```python
and parent.child_by_field_name(func_field) is node
```

py-tree-sitter builds a fresh Python wrapper on every lookup, so `child_by_field_name` never returns the same object as the node taken from `.children`, and the comparison was permanently `False`:

```
>>> f = call.child_by_field_name("function")
>>> f is attr, f == attr, f.id == attr.id
(False, True, True)
```

`==` compares tree context as well as node id, so it is strictly stronger than `.id ==` and cannot make two distinct nodes match. Verified exhaustively over an 82-node tree: no two distinct nodes compare equal, including nodes sharing an exact byte span.

## Effect

Not merely a duplicate edge. On a method that reads a property and calls through it on the next line:

```python
def go(self):
    x = self.value        # line 8, a read
    return self.value()   # line 9, a call through the property
```

| | line 8 (read) | line 9 (call) |
|---|---|---|
| with `is` | **0 edges** | 3 |
| with `==` | 1 | 2 |

The pass claimed the call target — already resolved by the call path — and the plain read was left with no edge at all.

## Verification

`codebase_rag/tests/test_property_call_target.py` drives that shape and tells the two sites apart **by line**, not by a total. Checked three ways:

- fix applied → **passes**
- `is` restored → **fails**
- `_ingest_property_accesses` disabled outright → **fails**

The third case matters: an earlier version of this test asserted a total of 2 getter edges, and it passed with the pass deleted, because those 2 come from `_ingest_function_calls` and the property pass contributes none to that shape. It guarded nothing. (Those 2 are also byte-identical duplicates that the production `MERGE` collapses, so the count was not a number a correct implementation would have chosen either.)

Also run: 172 tests across `test_call_resolver`, `test_chained_attribute_resolution`, `test_callback_reference_edges`, `test_csharp_property_reads`, `test_dart_getter_reads` and the new file — all pass. `ruff check` / `ruff format --check` clean.

## Scope

The issue states a grep of `main` found no other instance of this pattern. That is not correct: `endpoint_prefixes.py:198` compares `named_children` elements against a `child_by_field_name` result the same way, and a dotless `from X import y` leaks the module itself as an imported symbol (`['routers.alpha', 'routers.routers']` where only the first is real). Filed as #1703 rather than widened into this PR.

The remaining `is` comparisons on nodes in `call_processor.py` (606, 2330, 2625, 6592) are safe — both sides come from cached `children`/`named_children` lists, where identity holds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Property access analysis now correctly distinguishes ordinary property reads from properties used as call targets.
  * Getter relationships are resolved for property reads without incorrectly attributing calls through the property.

* **Tests**
  * Added regression coverage to verify accurate getter-related call results for reads and calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->