### PR TITLE
feat: persist the incomplete-run marker so a fresh MCP process refuses reingest (#1679)

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -127,6 +127,9 @@ KEY_PROJECT_PREFIX = "project_prefix"
 KEY_VERSION_SPEC = "version_spec"
 KEY_PREFIX = "prefix"
 KEY_PROJECT_NAME = "project_name"
+# The incomplete-run marker's phase (#1705 review): whether the run it records
+# had reached its first graph write when the marker was last updated.
+KEY_WRITING = "writing"
 # ast-grep finding node properties (issue #413)
 KEY_MESSAGE = "message"
 KEY_SNIPPET = "snippet"

--- a/codebase_rag/constants/mcp.py
+++ b/codebase_rag/constants/mcp.py
@@ -126,6 +126,13 @@ MCP_REINGEST_NEEDS_INDEX = (
     "Project {project} is not indexed; run index_repository or update_repository "
     "before reingest"
 )
+MCP_INCOMPLETE_MARKER_REQUIRED = (
+    "Refusing to index or update {project}: the incomplete-run marker could "
+    "not be written. Without it a crash part way through would leave a "
+    "partial graph that a fresh process cannot recognise, and a later scoped "
+    "reingest would treat it as authoritative. Check the graph store is "
+    "writable and retry."
+)
 MCP_REINGEST_AFTER_FAILED_RUN = (
     "The last index or update of project {project} failed part way, so its "
     "graph is incomplete; run update_repository before reingest"

--- a/codebase_rag/constants/mcp.py
+++ b/codebase_rag/constants/mcp.py
@@ -132,7 +132,7 @@ MCP_INCOMPLETE_MARKER_STUCK = (
     "index or update retries the removal; check the graph store is writable."
 )
 MCP_INCOMPLETE_MARKER_REQUIRED = (
-    "Refusing to index or update {project}: the incomplete-run marker could "
+    "Refusing to change the graph of {project}: the incomplete-run marker could "
     "not be written. Without it a crash part way through would leave a "
     "partial graph that a fresh process cannot recognise, and a later scoped "
     "reingest would treat it as authoritative. Check the graph store is "

--- a/codebase_rag/constants/mcp.py
+++ b/codebase_rag/constants/mcp.py
@@ -126,6 +126,11 @@ MCP_REINGEST_NEEDS_INDEX = (
     "Project {project} is not indexed; run index_repository or update_repository "
     "before reingest"
 )
+MCP_INCOMPLETE_MARKER_STUCK = (
+    "{project} was processed, but its incomplete-run marker could not be "
+    "cleared. Later scoped re-ingests will refuse until it goes. The next "
+    "index or update retries the removal; check the graph store is writable."
+)
 MCP_INCOMPLETE_MARKER_REQUIRED = (
     "Refusing to index or update {project}: the incomplete-run marker could "
     "not be written. Without it a crash part way through would leave a "

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -39,6 +39,27 @@ CYPHER_PROJECT_ROOT_PATH = (
     "MATCH (p:Project {name: $project_name}) RETURN p.root_path AS root_path"
 )
 
+# The incomplete-run marker (issue #1679). `_graph_incomplete` on the tools
+# registry only ever covered the process that ran the failed update: a crash or
+# an MCP server restart left a fresh registry seeing a project that looks whole,
+# so it would hydrate a scoped updater from the partial graph and treat its
+# missing definitions as authoritative. Persisting the flag beside the project
+# means the refusal survives the process that earned it.
+#
+# Set with `SET`, cleared by REMOVING the property rather than setting false, so
+# a project indexed before this existed reads the same as one that completed:
+# absent means complete, and no migration is needed.
+CYPHER_MARK_PROJECT_INCOMPLETE = (
+    "MATCH (p:Project {name: $project_name}) SET p.run_incomplete = true"
+)
+CYPHER_CLEAR_PROJECT_INCOMPLETE = (
+    "MATCH (p:Project {name: $project_name}) REMOVE p.run_incomplete"
+)
+CYPHER_PROJECT_IS_INCOMPLETE = (
+    "MATCH (p:Project {name: $project_name}) "
+    "RETURN coalesce(p.run_incomplete, false) AS run_incomplete"
+)
+
 CYPHER_DELETE_PROJECT = """
 MATCH (p:Project {name: $project_name})
 OPTIONAL MATCH (p)-[:CONTAINS_PACKAGE|CONTAINS_FOLDER|CONTAINS_FILE|CONTAINS_MODULE|CONTAINS_SECTION*]->(container)

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -41,23 +41,35 @@ CYPHER_PROJECT_ROOT_PATH = (
 
 # The incomplete-run marker (issue #1679). `_graph_incomplete` on the tools
 # registry only ever covered the process that ran the failed update: a crash or
-# an MCP server restart left a fresh registry seeing a project that looks whole,
-# so it would hydrate a scoped updater from the partial graph and treat its
-# missing definitions as authoritative. Persisting the flag beside the project
-# means the refusal survives the process that earned it.
+# an MCP restart left a fresh registry seeing a project that looks whole, so it
+# would hydrate a scoped updater from the partial graph and treat its missing
+# definitions as authoritative. Persisting the flag means the refusal survives
+# the process that earned it.
 #
-# Set with `SET`, cleared by REMOVING the property rather than setting false, so
-# a project indexed before this existed reads the same as one that completed:
-# absent means complete, and no migration is needed.
+# It lives on its OWN node, not as a property of the Project, for two reasons
+# found in review:
+#
+# 1. `MERGE` on a dedicated label works before any Project exists. A first
+#    index creates the Project inside `GraphUpdater.run()`, so a `MATCH
+#    (p:Project ...)` set beforehand updated ZERO rows and a failed first run
+#    left no marker at all -- exactly the case the guard exists for.
+# 2. `CYPHER_DELETE_PROJECT` detaches and deletes the Project and everything
+#    it CONTAINS, so a marker stored on the Project would be deleted by the
+#    very rebuild whose failure it is meant to record. An unconnected
+#    `:IncompleteRun` node is not reachable from that traversal and survives.
+#
+# Cleared by DELETING the node rather than setting false, so a project indexed
+# before this existed reads exactly like one that completed: absent means
+# complete, and no migration is needed.
 CYPHER_MARK_PROJECT_INCOMPLETE = (
-    "MATCH (p:Project {name: $project_name}) SET p.run_incomplete = true"
+    "MERGE (m:IncompleteRun {project: $project_name}) SET m.run_incomplete = true"
 )
 CYPHER_CLEAR_PROJECT_INCOMPLETE = (
-    "MATCH (p:Project {name: $project_name}) REMOVE p.run_incomplete"
+    "MATCH (m:IncompleteRun {project: $project_name}) DELETE m"
 )
 CYPHER_PROJECT_IS_INCOMPLETE = (
-    "MATCH (p:Project {name: $project_name}) "
-    "RETURN coalesce(p.run_incomplete, false) AS run_incomplete"
+    "MATCH (m:IncompleteRun {project: $project_name}) "
+    "RETURN coalesce(m.run_incomplete, false) AS run_incomplete"
 )
 
 CYPHER_DELETE_PROJECT = """

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -61,15 +61,27 @@ CYPHER_PROJECT_ROOT_PATH = (
 # Cleared by DELETING the node rather than setting false, so a project indexed
 # before this existed reads exactly like one that completed: absent means
 # complete, and no migration is needed.
+#
+# `writing` is the marker's PHASE. Every mutating path marks before anything
+# destructive, but some of them then do read-only or graph-external work first
+# (a reingest's prologue, the embedding purge before an index or delete) and
+# can stop there -- an abort, a crash, a cleanup failure -- with the graph
+# exactly as it was. A marker from such a run says `writing = false`, and a
+# fresh process may clear it and carry on; one that reached its first graph
+# write says `writing = true` and refuses scoped work until a full update
+# recovers the graph (#1705 review). An absent property reads as `true`: a
+# marker written before the phase existed is treated the fail-closed way.
 CYPHER_MARK_PROJECT_INCOMPLETE = (
-    "MERGE (m:IncompleteRun {project: $project_name}) SET m.run_incomplete = true"
+    "MERGE (m:IncompleteRun {project: $project_name}) "
+    "SET m.run_incomplete = true, m.writing = $writing"
 )
 CYPHER_CLEAR_PROJECT_INCOMPLETE = (
     "MATCH (m:IncompleteRun {project: $project_name}) DELETE m"
 )
 CYPHER_PROJECT_IS_INCOMPLETE = (
     "MATCH (m:IncompleteRun {project: $project_name}) "
-    "RETURN coalesce(m.run_incomplete, false) AS run_incomplete"
+    "RETURN coalesce(m.run_incomplete, false) AS run_incomplete, "
+    "coalesce(m.writing, true) AS writing"
 )
 
 CYPHER_DELETE_PROJECT = """

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -71,9 +71,14 @@ CYPHER_PROJECT_ROOT_PATH = (
 # write says `writing = true` and refuses scoped work until a full update
 # recovers the graph (#1705 review). An absent property reads as `true`: a
 # marker written before the phase existed is treated the fail-closed way.
+# The phase only ever advances: a mark with `writing=false` must not demote a
+# marker another process left at `writing=true` over a graph it had started to
+# change, or that process's abort would clear a guard it does not own (#1705
+# review). Ownership of the DELETE is the remaining half, tracked in #1709.
 CYPHER_MARK_PROJECT_INCOMPLETE = (
     "MERGE (m:IncompleteRun {project: $project_name}) "
-    "SET m.run_incomplete = true, m.writing = $writing"
+    "SET m.run_incomplete = true, "
+    "m.writing = coalesce(m.writing, false) OR $writing"
 )
 CYPHER_CLEAR_PROJECT_INCOMPLETE = (
     "MATCH (m:IncompleteRun {project: $project_name}) DELETE m"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -4707,12 +4707,16 @@ class GraphUpdater:
     ) -> ReingestReport:
         """Re-ingest the given files with file-scoped call resolution.
 
-        `before_write`, when given, runs once at the exact point the read-only
-        prologue ends and the first delete is about to be issued. A caller
-        persisting recovery state uses it to record that the graph is about
-        to change; if it raises, the run aborts as `ReingestAborted` with the
-        graph untouched, the same as any other prologue failure (#1705
-        review).
+        `before_write`, when given, runs once at the exact point the prologue
+        ends and the first DELETE or content write is about to be issued. A
+        caller persisting recovery state uses it to record that the graph is
+        about to change; if it raises, the run aborts as `ReingestAborted`
+        with the graph as it was, the same as any other prologue failure
+        (#1705 review). "As it was" rather than "untouched": on a fresh
+        updater the prologue's structure hydration re-emits Package and
+        Folder upserts, which are idempotent and change nothing a later run
+        would not write identically; nothing is deleted and no definition is
+        written before the hook.
 
         The batch incremental path already knows how to do this for the
         files a hash walk finds changed: re-parse them plus the files that

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -800,6 +800,11 @@ class GraphUpdater:
         self._configured_unignore_paths = unignore_paths
         self._delombok_overlay: dict[str, bytes] = {}
         self._delombok_state_changed = False
+        # Whether the LAST `reingest` call got past its read-only prologue
+        # into deletes and writes. Callers persisting recovery state use it to
+        # tell "nothing changed, retry freely" from "partial, needs recovery"
+        # (#1705 review, round 7).
+        self.reingest_mutated = False
         self._delombok_stale_keys: set[str] = set()
         self._delombok_state_candidate: dict = _EMPTY_DELOMBOK_STATE.copy()
         self.exclude_paths = exclude_paths
@@ -4723,6 +4728,9 @@ class GraphUpdater:
         # aborts (it must, or the run drops cross-file edges under a
         # success log) and whether unchanged handlers rehydrate.
         self._is_full_build = False
+        # Per call: a caller holding this updater across many events must see
+        # THIS call's answer, not the last one's.
+        self.reingest_mutated = False
         present, gone, skipped = self._reingest_split(paths, deleted)
         if skipped:
             logger.warning(ls.REINGEST_SKIPPED_IGNORED, paths=sorted(skipped))
@@ -4768,6 +4776,13 @@ class GraphUpdater:
             captured = self._capture_inbound_edges(all_keys)
         except Exception as exc:
             raise ReingestAborted(str(exc)) from exc
+        # Past this point the run WILL issue deletes and writes. Callers that
+        # persist recovery state need to know whether a failure left the graph
+        # untouched or partial, and classifying by exception TYPE is not
+        # enough: a future abort raised mid-run would be misread as "nothing
+        # changed" and clear a marker that is protecting a partial graph
+        # (#1705 review, round 7). This flag records what actually happened.
+        self.reingest_mutated = True
         self._reparsed_file_keys = set(all_keys)
 
         # Walk order, as the batch path re-parses (issue #1569): the first

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -4703,8 +4703,16 @@ class GraphUpdater:
         self,
         paths: Iterable[Path | str],
         deleted: Iterable[Path | str] = (),
+        before_write: Callable[[], None] | None = None,
     ) -> ReingestReport:
         """Re-ingest the given files with file-scoped call resolution.
+
+        `before_write`, when given, runs once at the exact point the read-only
+        prologue ends and the first delete is about to be issued. A caller
+        persisting recovery state uses it to record that the graph is about
+        to change; if it raises, the run aborts as `ReingestAborted` with the
+        graph untouched, the same as any other prologue failure (#1705
+        review).
 
         The batch incremental path already knows how to do this for the
         files a hash walk finds changed: re-parse them plus the files that
@@ -4776,6 +4784,15 @@ class GraphUpdater:
             captured = self._capture_inbound_edges(all_keys)
         except Exception as exc:
             raise ReingestAborted(str(exc)) from exc
+        # The caller's last word before the first write. Still inside the
+        # read-only prologue: a refusal here leaves the graph exactly as it
+        # was, and `reingest_mutated` stays False so the caller classifies
+        # it as "nothing changed".
+        if before_write is not None:
+            try:
+                before_write()
+            except Exception as exc:
+                raise ReingestAborted(str(exc)) from exc
         # Past this point the run WILL issue deletes and writes. Callers that
         # persist recovery state need to know whether a failure left the graph
         # untouched or partial, and classifying by exception TYPE is not

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -878,10 +878,10 @@ MCP_SERVER_FATAL_ERROR = "[GraphCode MCP] Fatal error: {error}"
 # errors: the run itself is unaffected, but the cross-process guard silently
 # degrades to the in-process flag, which an operator can only notice here.
 MCP_INCOMPLETE_MARKER_STUCK_AFTER_ABORT = (
-    "[GraphCode MCP] A scoped reingest for {project} stopped before writing "
-    "anything, but its incomplete-run marker could not be cleared. Later "
-    "scoped reingests will refuse until an update_repository clears it, even "
-    "though this run changed nothing."
+    "[GraphCode MCP] A run for {project} stopped before writing anything to "
+    "the graph, but its incomplete-run marker could not be cleared. The marker "
+    "records that nothing was written, so the next scoped reingest or process "
+    "clears it once the graph store accepts writes again."
 )
 MCP_INCOMPLETE_MARKER_FAILED = (
     "[GraphCode MCP] Could not persist the incomplete-run marker for "

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -877,6 +877,12 @@ MCP_SERVER_FATAL_ERROR = "[GraphCode MCP] Fatal error: {error}"
 # The incomplete-run marker (issue #1679). Both are warnings rather than
 # errors: the run itself is unaffected, but the cross-process guard silently
 # degrades to the in-process flag, which an operator can only notice here.
+MCP_INCOMPLETE_MARKER_STUCK_AFTER_ABORT = (
+    "[GraphCode MCP] A scoped reingest for {project} stopped before writing "
+    "anything, but its incomplete-run marker could not be cleared. Later "
+    "scoped reingests will refuse until an update_repository clears it, even "
+    "though this run changed nothing."
+)
 MCP_INCOMPLETE_MARKER_FAILED = (
     "[GraphCode MCP] Could not persist the incomplete-run marker for "
     "{project} (incomplete={incomplete}): {error}. A crash from here would "

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -890,7 +890,13 @@ MCP_INCOMPLETE_MARKER_FAILED = (
 )
 MCP_INCOMPLETE_MARKER_UNREADABLE = (
     "[GraphCode MCP] Could not read the incomplete-run marker for {project}: "
-    "{error}. Treating the previous run as complete."
+    "{error}. Refusing scoped reingest until it can be read; update_repository "
+    "recovers either way."
+)
+MCP_INCOMPLETE_MARKER_RECOVERED = (
+    "[GraphCode MCP] The incomplete-run marker for {project} was left by a run "
+    "that stopped before its first graph write, so the graph is as that run "
+    "found it; cleared it and continuing."
 )
 MCP_SERVER_SHUTDOWN = "[GraphCode MCP] Shutting down server..."
 MCP_HTTP_SERVER_STARTING = "[GraphCode MCP] Starting HTTP server on {host}:{port}..."

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -874,6 +874,18 @@ MCP_SERVER_STARTING = "[GraphCode MCP] Starting MCP server..."
 MCP_SERVER_CREATED = "[GraphCode MCP] Server created, starting stdio transport..."
 MCP_SERVER_CONNECTED = "[GraphCode MCP] Connected to Memgraph at {host}:{port}"
 MCP_SERVER_FATAL_ERROR = "[GraphCode MCP] Fatal error: {error}"
+# The incomplete-run marker (issue #1679). Both are warnings rather than
+# errors: the run itself is unaffected, but the cross-process guard silently
+# degrades to the in-process flag, which an operator can only notice here.
+MCP_INCOMPLETE_MARKER_FAILED = (
+    "[GraphCode MCP] Could not persist the incomplete-run marker for "
+    "{project} (incomplete={incomplete}): {error}. A crash from here would "
+    "leave the next process unable to tell the update did not finish."
+)
+MCP_INCOMPLETE_MARKER_UNREADABLE = (
+    "[GraphCode MCP] Could not read the incomplete-run marker for {project}: "
+    "{error}. Treating the previous run as complete."
+)
 MCP_SERVER_SHUTDOWN = "[GraphCode MCP] Shutting down server..."
 MCP_HTTP_SERVER_STARTING = "[GraphCode MCP] Starting HTTP server on {host}:{port}..."
 MCP_HTTP_EXPOSURE_REFUSED = (

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1117,10 +1117,57 @@ class MCPToolsRegistry:
         until a full update runs. Best effort, never raising: the caller's
         own error stays primary. A clear that FAILS is logged rather than
         discarded, and leaves a `writing=False` marker that a later process
-        clears for itself (`_persisted_incomplete`); the local flag follows
-        the durable state through `_require_marker_cleared` (#1705 review).
+        clears for itself (`_persisted_incomplete`).
+
+        This run wrote NOTHING, so it must not touch the in-process flag or
+        its attribution at all -- neither to set them nor to clear them. It
+        deliberately does not go through `_require_marker_cleared`, which
+        assigns both unconditionally:
+
+        * setting them relabels damage another failure recorded. A failed
+          wipe leaves `_graph_incomplete=True` with NO attribution, because
+          no marker records it; a later run that stops before writing then
+          stamped its own project onto that flag, and the next reingest
+          healed it against a recoverable marker -- discarding the wipe's
+          refusal and hydrating over a half-wiped graph (#1705 review).
+        * clearing them outright is the same bug from the other side: it
+          would discard an earlier run's damage just as readily.
+
+        So the flag is restored to whatever it was on entry.
+
+        The captured values are read HERE rather than saved by each caller:
+        a caller-side save is defeated by the next caller that forgets one,
+        which leaves a stale value in the slot and restores something
+        arbitrary. Capturing at entry cannot be bypassed that way.
+
+        The scenario needs the abandoning run to name the SAME project as the
+        later reingest -- that is what makes `recoverable_here` true at the
+        guard. A run abandoning a DIFFERENT project reads as a near-miss and
+        refuses correctly, so a test written that way passes with or without
+        this fix (measured both ways).
         """
-        if self._require_marker_cleared(project_name) is not None:
+        flag_before = self._graph_incomplete
+        attributed_before = self._flag_from_failed_clear
+        cleared = self._persist_incomplete(project_name, False)
+        # A failed clear strands a marker, so the flag must go up: this
+        # process has to know later reingests will refuse. But the
+        # ATTRIBUTION -- the licence to heal that flag from the marker -- is
+        # only this run's to grant when the flag is this run's to explain.
+        #
+        # If the flag was ALREADY set on entry it records damage some earlier
+        # failure found, and a wipe records damage no marker can describe.
+        # Claiming it here is what let a recoverable marker lift a wipe's
+        # refusal (#1705 review). So attribute only when this run raised the
+        # flag from clean; otherwise leave the earlier owner in place, and
+        # the stranded marker stays unhealable until a full update clears it.
+        if not cleared:
+            self._graph_incomplete = True
+            if not flag_before:
+                self._flag_from_failed_clear = project_name
+        else:
+            self._graph_incomplete = flag_before
+            self._flag_from_failed_clear = attributed_before
+        if not cleared:
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_STUCK_AFTER_ABORT.format(project=project_name)
             )

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1144,9 +1144,11 @@ class MCPToolsRegistry:
 
         An absent property means complete, so a project indexed before this
         marker existed reads exactly like one whose run finished and no
-        migration is needed. A store that cannot answer returns False rather
-        than blocking every reingest on an unreadable graph; the not-indexed
-        guard and the in-process flag both still apply.
+        migration is needed. A store that cannot answer returns True: "I
+        cannot tell" and "the last run finished" are different answers and
+        only refusing is safe to act on; update_repository recovers either
+        way (#1705 review). A marker whose run never reached a graph write
+        (`writing=false`) is cleared here and does not refuse.
         """
         try:
             rows = self.ingestor.fetch_all(

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -848,6 +848,12 @@ class MCPToolsRegistry:
         # whatever partial graph a failure left behind.
         self._live_updater = None
         self._graph_incomplete = True
+        # Persisted BEFORE the delete, and on a node the delete cannot reach:
+        # this path removes the Project and rebuilds it, so a marker stored on
+        # the Project would be destroyed by the very operation whose failure it
+        # records. A crash between here and the final flush must still refuse
+        # the next process's reingest (#1705 review).
+        self._persist_incomplete(project_name, True)
         self._cleanup_project_embeddings(project_name)
         self.ingestor.delete_project(project_name)
 
@@ -868,8 +874,14 @@ class MCPToolsRegistry:
         self.ingestor.flush_all()
         # Cleared only after the flush: the marker must outlive any failure
         # that leaves batches uncommitted.
-        self._persist_incomplete(project_name, False)
-        self._graph_incomplete = False
+        #
+        # The in-process flag follows the DURABLE state, not the intention. If
+        # the clear failed, the graph still says incomplete, and reporting this
+        # run complete would leave a fresh registry refusing reingest forever
+        # while this one believed all was well. Staying incomplete locally
+        # keeps the two in agreement and makes the next update retry the clear
+        # (#1705 review).
+        self._graph_incomplete = not self._persist_incomplete(project_name, False)
         self._live_updater = updater
 
         return cs.MCP_INDEX_SUCCESS_PROJECT.format(
@@ -915,8 +927,10 @@ class MCPToolsRegistry:
         self._live_updater = None
         self._graph_incomplete = True
         self.ingestor.ensure_constraints()
-        # After ensure_constraints so the Project node the marker attaches to
-        # exists even on a first index.
+        # The marker MERGEs its own node, so this works before any Project
+        # exists. An earlier version set a property on the Project with MATCH,
+        # which updated zero rows on a first index and left a failed first run
+        # unmarked -- the exact case the guard exists for (#1705 review).
         self._persist_incomplete(project_name, True)
         self.ingestor.flush_all()
 
@@ -934,12 +948,18 @@ class MCPToolsRegistry:
         self.ingestor.flush_all()
         # Cleared only after the flush: the marker must outlive any failure
         # that leaves batches uncommitted.
-        self._persist_incomplete(project_name, False)
-        self._graph_incomplete = False
+        #
+        # The in-process flag follows the DURABLE state, not the intention. If
+        # the clear failed, the graph still says incomplete, and reporting this
+        # run complete would leave a fresh registry refusing reingest forever
+        # while this one believed all was well. Staying incomplete locally
+        # keeps the two in agreement and makes the next update retry the clear
+        # (#1705 review).
+        self._graph_incomplete = not self._persist_incomplete(project_name, False)
         self._live_updater = updater
         return cs.MCP_UPDATE_SUCCESS.format(path=self.project_root)
 
-    def _persist_incomplete(self, project_name: str, incomplete: bool) -> None:
+    def _persist_incomplete(self, project_name: str, incomplete: bool) -> bool:
         """Record (or clear) the incomplete-run marker on the Project node.
 
         `_graph_incomplete` lives on this registry, so it only ever covered
@@ -948,12 +968,16 @@ class MCPToolsRegistry:
         scoped updater from the partial graph and treating its missing
         definitions as authoritative (issue #1679). The marker survives that.
 
-        Never raises. A store that cannot take the marker must not turn a
-        working update into a failed one: the in-process flag still guards
-        this process, and the persisted one is an extra net for the next.
-        Logged rather than silently swallowed, because a marker that never
-        persists degrades this guard back to the old behaviour and an
-        operator should be able to see that in the log.
+        Returns whether the write reached the store. Never raises: a store
+        that cannot take the marker must not turn a working update into a
+        failed one. But the caller MUST act on the answer rather than discard
+        it -- a failed CLEAR after a successful run leaves the graph marked
+        incomplete, and reporting the run complete would strand a fresh
+        registry refusing reingest forever (#1705 review).
+
+        Logged as well as returned, because a marker that never persists
+        degrades this guard back to the old in-process behaviour and only the
+        log would show it.
         """
         query = (
             cq.CYPHER_MARK_PROJECT_INCOMPLETE
@@ -968,6 +992,8 @@ class MCPToolsRegistry:
                     project=project_name, incomplete=incomplete, error=error
                 )
             )
+            return False
+        return True
 
     def _persisted_incomplete(self, project_name: str) -> bool:
         """Whether a previous process left this project mid-update.

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -10,6 +10,7 @@ from pydantic_ai import Agent
 from rich.console import Console
 
 from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
 from codebase_rag import graph_query
 from codebase_rag import logs as lg
 from codebase_rag import structural_delta as sd
@@ -865,6 +866,9 @@ class MCPToolsRegistry:
         )
         updater.run()
         self.ingestor.flush_all()
+        # Cleared only after the flush: the marker must outlive any failure
+        # that leaves batches uncommitted.
+        self._persist_incomplete(project_name, False)
         self._graph_incomplete = False
         self._live_updater = updater
 
@@ -911,6 +915,9 @@ class MCPToolsRegistry:
         self._live_updater = None
         self._graph_incomplete = True
         self.ingestor.ensure_constraints()
+        # After ensure_constraints so the Project node the marker attaches to
+        # exists even on a first index.
+        self._persist_incomplete(project_name, True)
         self.ingestor.flush_all()
 
         exclude_paths, unignore_paths = self._ignore_sets()
@@ -925,9 +932,65 @@ class MCPToolsRegistry:
         )
         updater.run()
         self.ingestor.flush_all()
+        # Cleared only after the flush: the marker must outlive any failure
+        # that leaves batches uncommitted.
+        self._persist_incomplete(project_name, False)
         self._graph_incomplete = False
         self._live_updater = updater
         return cs.MCP_UPDATE_SUCCESS.format(path=self.project_root)
+
+    def _persist_incomplete(self, project_name: str, incomplete: bool) -> None:
+        """Record (or clear) the incomplete-run marker on the Project node.
+
+        `_graph_incomplete` lives on this registry, so it only ever covered
+        the process that ran the failed update. A crash or an MCP restart
+        left a fresh registry seeing a project that looks whole, hydrating a
+        scoped updater from the partial graph and treating its missing
+        definitions as authoritative (issue #1679). The marker survives that.
+
+        Never raises. A store that cannot take the marker must not turn a
+        working update into a failed one: the in-process flag still guards
+        this process, and the persisted one is an extra net for the next.
+        Logged rather than silently swallowed, because a marker that never
+        persists degrades this guard back to the old behaviour and an
+        operator should be able to see that in the log.
+        """
+        query = (
+            cq.CYPHER_MARK_PROJECT_INCOMPLETE
+            if incomplete
+            else cq.CYPHER_CLEAR_PROJECT_INCOMPLETE
+        )
+        try:
+            self.ingestor.execute_write(query, {cs.KEY_PROJECT_NAME: project_name})
+        except Exception as error:  # noqa: BLE001 -- see docstring
+            logger.warning(
+                lg.MCP_INCOMPLETE_MARKER_FAILED.format(
+                    project=project_name, incomplete=incomplete, error=error
+                )
+            )
+
+    def _persisted_incomplete(self, project_name: str) -> bool:
+        """Whether a previous process left this project mid-update.
+
+        An absent property means complete, so a project indexed before this
+        marker existed reads exactly like one whose run finished and no
+        migration is needed. A store that cannot answer returns False rather
+        than blocking every reingest on an unreadable graph; the not-indexed
+        guard and the in-process flag both still apply.
+        """
+        try:
+            rows = self.ingestor.fetch_all(
+                cq.CYPHER_PROJECT_IS_INCOMPLETE,
+                {cs.KEY_PROJECT_NAME: project_name},
+            )
+        except Exception as error:  # noqa: BLE001 -- see docstring
+            logger.warning(
+                lg.MCP_INCOMPLETE_MARKER_UNREADABLE.format(
+                    project=project_name, error=error
+                )
+            )
+            return False
+        return any(bool(row.get("run_incomplete")) for row in rows or [])
 
     def _updater_for_reingest(self) -> GraphUpdater:
         updater = self._live_updater
@@ -965,30 +1028,41 @@ class MCPToolsRegistry:
     def _reingest_sync(
         self, paths: list[str], deleted: list[str]
     ) -> ReingestToolResult:
-        updater = self._updater_for_reingest()
-        try:
-            report = updater.reingest(paths, deleted=deleted)
-        except (ValueError, ReingestAborted):
-            # A refusal (a path outside the repository, a directory) is
-            # raised while the paths are split, and an abort while the call
-            # was still reading the graph; neither touched anything, so the
-            # updater is still valid and the call may simply be retried.
-            raise
-        except Exception:
-            # The run may have deleted the affected subtrees and never
-            # rebuilt them: the retained updater describes a graph that no
-            # longer exists, and the next scoped call must not reuse it
-            # over that partial state. update_repository is the recovery.
-            self._live_updater = None
-            self._graph_incomplete = True
-            raise
-        return ReingestToolResult(
-            reparsed=list(report.reparsed),
-            affected=list(report.affected),
-            removed=list(report.removed),
-            skipped=list(report.skipped),
-            elapsed_ms=round(report.elapsed_ms, 1),
-        )
+        updater = self._live_updater
+        if updater is None:
+            # A scoped re-ingest completes a graph; it cannot stand in for
+            # the first index. After delete_project or wipe_database the
+            # project is gone, and hydrating from nothing would leave every
+            # unrelated definition missing.
+            project_name = derive_project_name(Path(self.project_root))
+            # The persisted marker is what makes this survive the process
+            # that earned it: with no retained updater this may be a fresh
+            # registry after a crash, where `_graph_incomplete` is False
+            # because nothing in THIS process failed (issue #1679).
+            if self._graph_incomplete or self._persisted_incomplete(project_name):
+                raise ValueError(
+                    cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
+                )
+            if project_name not in self.ingestor.list_projects():
+                raise ValueError(
+                    cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name)
+                )
+            self.ingestor.ensure_constraints()
+            # The same exclusion set the index and update paths use, or an
+            # agent-named path under a CLI-excluded directory would be
+            # indexed here and kept by every later update.
+            exclude_paths, unignore_paths = self._ignore_sets()
+            updater = GraphUpdater(
+                ingestor=self.ingestor,
+                repo_path=Path(self.project_root),
+                parsers=self.parsers,
+                queries=self.queries,
+                unignore_paths=unignore_paths,
+                exclude_paths=exclude_paths,
+                project_name=project_name,
+            )
+            self._live_updater = updater
+        return updater
 
     async def reingest(
         self, paths: list[str], deleted: list[str] | None = None

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1110,22 +1110,30 @@ class MCPToolsRegistry:
             )
 
     def _cleanup_embeddings_then_begin_writing(self, project_name: str) -> None:
-        """The step between a `writing=False` mark and the first graph write.
+        """The step between a `writing=False` mark and the first destructive write.
 
-        The embedding purge touches the vector store, not the graph, so a
-        failure in it leaves the graph as it was and the marker must come
-        off (or, failing that, stay `writing=False`) rather than strand a
-        fresh process behind a marker for a run that never reached the graph
-        (#1705 review). Then the phase advances, and a refusal there stops
-        the run before anything destructive.
+        The embedding purge has a READ half and a DELETE half, and the phase
+        advances between them (#1705 review, both directions):
+
+        * Reading the project's node ids touches nothing. A failure there
+          leaves graph and vectors as they were, so the marker comes off (or,
+          failing that, stays `writing=False`) rather than strand a fresh
+          process behind a marker for a run that never changed anything.
+        * Deleting the vectors IS destructive: a scoped reingest restores
+          vectors only for its own paths, so a crash mid-purge followed by a
+          fresh process clearing a `writing=False` marker would leave every
+          unselected path without embeddings. The phase therefore says
+          WRITING before the first vector goes, and a refusal there stops the
+          run with nothing deleted.
         """
         try:
-            self._cleanup_project_embeddings(project_name)
+            node_ids = self._get_project_node_ids(project_name)
         except Exception:
             self._abandon_before_writing(project_name)
             raise
         if (refusal := self._require_writing(project_name)) is not None:
             raise RuntimeError(refusal)
+        delete_project_embeddings(project_name, node_ids)
 
     def _require_marker_cleared(self, project_name: str) -> str | None:
         """Invariant (b): a run is complete only once its marker is gone.

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1205,11 +1205,19 @@ class MCPToolsRegistry:
             self._graph_incomplete = True
             raise
         if marked_here is not None:
-            # The hydration above marked before its destructive migration;
-            # a completed reingest must lift that, or this path refuses every
-            # later call. The local flag follows the durable state, as
-            # everywhere else (#1705 review, round 3).
-            self._graph_incomplete = not self._persist_incomplete(marked_here, False)
+            # Invariant (b), same as every other path: the hydration above
+            # marked before its destructive migration, so a completed reingest
+            # must lift that or this path refuses every later call -- and if
+            # the clear FAILS, this is a retryable failure, not a success with
+            # the marker retained.
+            #
+            # This site was hand-written in round 3 rather than routed through
+            # the helper, and that is exactly why it kept the old
+            # report-success-anyway behaviour when every other path had been
+            # fixed. Going through `_require_marker_cleared` is the point of
+            # having the helper (#1705 review, round 5).
+            if (stuck := self._require_marker_cleared(marked_here)) is not None:
+                raise RuntimeError(stuck)
         return ReingestToolResult(
             reparsed=list(report.reparsed),
             affected=list(report.affected),

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1138,6 +1138,75 @@ class MCPToolsRegistry:
             self._live_updater = updater
         return updater
 
+    def _reingest_mutated(updater: object, exc: BaseException) -> bool:
+        """Whether a failed reingest got as far as writing.
+
+        Classifies by WHAT HAPPENED rather than by exception type: the updater
+        sets `reingest_mutated` at the exact point its read-only prologue
+        ends, so a future abort raised mid-run is still classified as partial
+        (#1705 review). Split out of `_reingest_sync` to keep that function
+        under the cognitive-complexity limit.
+        """
+        flag = getattr(updater, "reingest_mutated", None)
+        if isinstance(flag, bool):
+            return flag
+        # No usable flag (an updater predating it, or a test double). Fall
+        # back to the exception type, which carries the same information less
+        # precisely: `GraphUpdater.reingest` converts EVERY prologue failure to
+        # `ReingestAborted` and rejects bad paths with `ValueError` before
+        # touching anything, so any other exception means writing had begun.
+        #
+        # `isinstance` on the flag rather than `getattr(..., True)`: any
+        # attribute of a MagicMock is a truthy child mock, which would classify
+        # every failure as mutated (measured).
+        return not isinstance(exc, ValueError | ReingestAborted)
+
+    def _hydrate_reingest_updater(self, project_name: str) -> GraphUpdater:
+        """Build a scoped updater when none is retained.
+
+        Split out of `_reingest_sync` to keep it under the
+        cognitive-complexity limit; the guards and their reasoning are
+        unchanged. Raises rather than returning on a refusal, exactly as
+        it did inline.
+        """
+        # A scoped re-ingest completes a graph; it cannot stand in for
+        # the first index. After delete_project or wipe_database the
+        # project is gone, and hydrating from nothing would leave every
+        # unrelated definition missing.
+        # The persisted marker is what makes this survive the process
+        # that earned it: with no retained updater this may be a fresh
+        # registry after a crash, where `_graph_incomplete` is False
+        # because nothing in THIS process failed (issue #1679).
+        if self._graph_incomplete or self._persisted_incomplete(project_name):
+            raise ValueError(
+                cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
+            )
+        if project_name not in self.ingestor.list_projects():
+            raise ValueError(cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name))
+        # Marked after the guards above -- they ask whether a PREVIOUS run
+        # left the graph partial, so marking first would make every
+        # reingest refuse on its own marker -- and before
+        # `ensure_constraints`, which runs the same destructive migration
+        # the index and update paths mark before. Invariant (c).
+        if (refusal := self._require_marker(project_name)) is not None:
+            raise RuntimeError(refusal)
+        self.ingestor.ensure_constraints()
+        # The same exclusion set the index and update paths use, or an
+        # agent-named path under a CLI-excluded directory would be
+        # indexed here and kept by every later update.
+        exclude_paths, unignore_paths = self._ignore_sets()
+        updater = GraphUpdater(
+            ingestor=self.ingestor,
+            repo_path=Path(self.project_root),
+            parsers=self.parsers,
+            queries=self.queries,
+            unignore_paths=unignore_paths,
+            exclude_paths=exclude_paths,
+            project_name=project_name,
+        )
+        self._live_updater = updater
+        return updater
+
     def _reingest_sync(
         self, paths: list[str], deleted: list[str]
     ) -> ReingestToolResult:
@@ -1159,29 +1228,7 @@ class MCPToolsRegistry:
         project_name = derive_project_name(Path(self.project_root))
         marked_here: str | None = None
         if updater is None:
-            # A scoped re-ingest completes a graph; it cannot stand in for
-            # the first index. After delete_project or wipe_database the
-            # project is gone, and hydrating from nothing would leave every
-            # unrelated definition missing.
-            # The persisted marker is what makes this survive the process
-            # that earned it: with no retained updater this may be a fresh
-            # registry after a crash, where `_graph_incomplete` is False
-            # because nothing in THIS process failed (issue #1679).
-            if self._graph_incomplete or self._persisted_incomplete(project_name):
-                raise ValueError(
-                    cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
-                )
-            if project_name not in self.ingestor.list_projects():
-                raise ValueError(
-                    cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name)
-                )
-            # Marked after the guards above -- they ask whether a PREVIOUS run
-            # left the graph partial, so marking first would make every
-            # reingest refuse on its own marker -- and before
-            # `ensure_constraints`, which runs the same destructive migration
-            # the index and update paths mark before. Invariant (c).
-            if (refusal := self._require_marker(project_name)) is not None:
-                raise RuntimeError(refusal)
+            updater = self._hydrate_reingest_updater(project_name)
             marked_here = project_name
             self.ingestor.ensure_constraints()
             # The same exclusion set the index and update paths use, or an
@@ -1228,24 +1275,7 @@ class MCPToolsRegistry:
             # ReingestAborted instead would misread a future abort raised
             # mid-run as "nothing changed" and clear a marker that is
             # protecting a partial graph.
-            flag = getattr(updater, "reingest_mutated", None)
-            if isinstance(flag, bool):
-                # The updater told us directly: set at the exact point its
-                # read-only prologue ends.
-                mutated = flag
-            else:
-                # No usable flag (an updater predating it, or a test double).
-                # Fall back to the exception type, which carries the same
-                # information less precisely: `GraphUpdater.reingest` converts
-                # EVERY prologue failure to `ReingestAborted` and rejects bad
-                # paths with `ValueError` before touching anything, so any
-                # other exception means the write phase had begun.
-                #
-                # `isinstance` on the flag rather than `getattr(..., True)`:
-                # any attribute of a MagicMock is a truthy child mock, which
-                # would classify every failure as mutated (measured -- it
-                # broke the retained-updater tests).
-                mutated = not isinstance(exc, ValueError | ReingestAborted)
+            mutated = self._reingest_mutated(updater, exc)
             if mutated:
                 self._live_updater = None
                 self._graph_incomplete = True

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -105,7 +105,8 @@ class MCPToolsRegistry:
         self._graph_incomplete = False
         # Set when `_persisted_incomplete` clears a recoverable marker, so the
         # in-process flag can follow the durable state out of a wedged refusal
-        # without discarding a failure only this process knows about (#1705).
+        # without discarding a failure only this process knows about. Reset
+        # before each read so it never outlives the call that set it (#1705).
         self._marker_recovered = False
 
         self.parsers, self.queries = load_parsers()
@@ -1302,6 +1303,13 @@ class MCPToolsRegistry:
         # knows the graph is partial, and dropping the flag would accept
         # scoped work over it. The flag is cleared only when the recovery
         # above actually cleared the marker, which is exactly the wedged case.
+        # Cleared first so the flag reports only THIS call's recovery. As a
+        # process-lifetime latch it would go on authorising a clear long after
+        # the recovery that set it: an earlier recovered marker, then a later
+        # failure that could not persist a marker at all, and the next
+        # reingest would drop a `_graph_incomplete` that is the only record
+        # the graph is partial.
+        self._marker_recovered = False
         persisted_incomplete = self._persisted_incomplete(project_name)
         if not persisted_incomplete and self._marker_recovered:
             self._graph_incomplete = False

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1161,7 +1161,7 @@ class MCPToolsRegistry:
         self._graph_incomplete = not cleared
         # Attribute the flag to this project's stranded marker (or drop a
         # stale attribution when the clear succeeded), so the recovery in
-        # `_refuse_reingest_if_unsafe` heals only the flag it explains.
+        # `_hydrate_reingest_updater` heals only the flag it explains.
         self._flag_from_failed_clear = project_name if not cleared else None
         if cleared:
             return None
@@ -1444,15 +1444,14 @@ class MCPToolsRegistry:
                 self._graph_incomplete = True
                 # Not a stranded marker: this flag must not be healed by one.
                 #
-                # Defensive here, unlike the other four sites, and no test
-                # can discriminate it: `reingest_mutated` is only set after
-                # `before_write()`, so this project's own marker is already
-                # `writing=true` by now and `_persisted_incomplete` refuses
-                # on its own account whatever the attribution says. Kept so
-                # the invariant "a flag no marker explains carries no
-                # attribution" holds at every site rather than at the four
-                # that happen to be observable -- a later change to when the
-                # marker is promoted would otherwise make this the one hole.
+                # Load-bearing across PROCESSES, which is easy to miss: this
+                # project's marker is `writing=true` by now, so within one
+                # registry `_persisted_incomplete` refuses on its own. But
+                # another process completing a full update clears that marker
+                # durably, and a stale attribution from an earlier failed
+                # clear would then satisfy `recoverable_here`, heal the flag,
+                # and let a scoped reingest run over the partial graph this
+                # very branch left (#1705 review, final round).
                 self._flag_from_failed_clear = None
             elif marked_here is not None:
                 # Nothing was written, so the marker this call created is a

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1443,6 +1443,16 @@ class MCPToolsRegistry:
                 self._live_updater = None
                 self._graph_incomplete = True
                 # Not a stranded marker: this flag must not be healed by one.
+                #
+                # Defensive here, unlike the other four sites, and no test
+                # can discriminate it: `reingest_mutated` is only set after
+                # `before_write()`, so this project's own marker is already
+                # `writing=true` by now and `_persisted_incomplete` refuses
+                # on its own account whatever the attribution says. Kept so
+                # the invariant "a flag no marker explains carries no
+                # attribution" holds at every site rather than at the four
+                # that happen to be observable -- a later change to when the
+                # marker is promoted would otherwise make this the one hole.
                 self._flag_from_failed_clear = None
             elif marked_here is not None:
                 # Nothing was written, so the marker this call created is a

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -853,7 +853,18 @@ class MCPToolsRegistry:
         # the Project would be destroyed by the very operation whose failure it
         # records. A crash between here and the final flush must still refuse
         # the next process's reingest (#1705 review).
-        self._persist_incomplete(project_name, True)
+        # A failed MARK aborts before anything destructive happens. The marker
+        # is the ONLY protection that survives a restart, so continuing into
+        # the delete and rebuild without it means a crash leaves a partial
+        # graph that a fresh registry cannot tell from a complete one, and it
+        # will happily hydrate a scoped reingest from it. Nothing is lost by
+        # stopping here: no graph state has changed yet. That is the opposite
+        # of a failed CLEAR, which must not fail a run that already succeeded
+        # (#1705 review).
+        if not self._persist_incomplete(project_name, True):
+            raise RuntimeError(
+                cs.MCP_INCOMPLETE_MARKER_REQUIRED.format(project=project_name)
+            )
         self._cleanup_project_embeddings(project_name)
         self.ingestor.delete_project(project_name)
 
@@ -931,7 +942,14 @@ class MCPToolsRegistry:
         # exists. An earlier version set a property on the Project with MATCH,
         # which updated zero rows on a first index and left a failed first run
         # unmarked -- the exact case the guard exists for (#1705 review).
-        self._persist_incomplete(project_name, True)
+        #
+        # Aborts on failure for the same reason as the index path: the flush
+        # below commits batches left by earlier calls, so continuing without a
+        # marker risks a partial graph no later process can recognise.
+        if not self._persist_incomplete(project_name, True):
+            raise RuntimeError(
+                cs.MCP_INCOMPLETE_MARKER_REQUIRED.format(project=project_name)
+            )
         self.ingestor.flush_all()
 
         exclude_paths, unignore_paths = self._ignore_sets()
@@ -968,12 +986,17 @@ class MCPToolsRegistry:
         scoped updater from the partial graph and treating its missing
         definitions as authoritative (issue #1679). The marker survives that.
 
-        Returns whether the write reached the store. Never raises: a store
-        that cannot take the marker must not turn a working update into a
-        failed one. But the caller MUST act on the answer rather than discard
-        it -- a failed CLEAR after a successful run leaves the graph marked
-        incomplete, and reporting the run complete would strand a fresh
-        registry refusing reingest forever (#1705 review).
+        Returns whether the write reached the store, and never raises itself;
+        the CALLER decides what a failure means, because the two directions
+        are not symmetric (#1705 review):
+
+        * A failed MARK must abort before any destructive work. The marker is
+          the only protection that survives a restart, so proceeding without
+          it means a crash leaves a partial graph indistinguishable from a
+          complete one. Nothing is lost by stopping: no state has changed.
+        * A failed CLEAR must NOT fail a run that already succeeded. It
+          leaves the graph marked incomplete, so the local flag follows the
+          durable state and the next update retries the clear.
 
         Logged as well as returned, because a marker that never persists
         degrades this guard back to the old in-process behaviour and only the
@@ -1015,7 +1038,13 @@ class MCPToolsRegistry:
                     project=project_name, error=error
                 )
             )
-            return False
+            # Refuse rather than assume complete. "I cannot tell" and "the
+            # last run finished" are different answers, and only one of them
+            # is safe to act on: treating an unreadable marker as absent
+            # hydrates a scoped reingest from a graph that may be partial,
+            # which is the failure this guard exists to prevent. An
+            # update_repository recovers either way (#1705 review).
+            return True
         return any(bool(row.get("run_incomplete")) for row in rows or [])
 
     def _updater_for_reingest(self) -> GraphUpdater:

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -978,7 +978,7 @@ class MCPToolsRegistry:
         return cs.MCP_UPDATE_SUCCESS.format(path=self.project_root)
 
     def _persist_incomplete(self, project_name: str, incomplete: bool) -> bool:
-        """Record (or clear) the incomplete-run marker on the Project node.
+        """Record (or clear) the incomplete-run marker on its own node.
 
         `_graph_incomplete` lives on this registry, so it only ever covered
         the process that ran the failed update. A crash or an MCP restart

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1210,19 +1210,49 @@ class MCPToolsRegistry:
             marked_here = project_name
         try:
             report = updater.reingest(paths, deleted=deleted)
-        except (ValueError, ReingestAborted):
-            # A refusal (a path outside the repository, a directory) is
-            # raised while the paths are split, and an abort while the call
-            # was still reading the graph; neither touched anything, so the
-            # updater is still valid and the call may simply be retried.
-            raise
-        except Exception:
-            # The run may have deleted the affected subtrees and never
-            # rebuilt them: the retained updater describes a graph that no
-            # longer exists, and the next scoped call must not reuse it
-            # over that partial state. update_repository is the recovery.
-            self._live_updater = None
-            self._graph_incomplete = True
+        except Exception as exc:
+            # One classification for every failure, by WHAT HAPPENED rather
+            # than by exception type (#1705 review, round 7):
+            #
+            #   nothing written -> the graph is exactly as it was, so the
+            #     marker this call created is a lie about a run that changed
+            #     nothing. Clear it, or a fresh process refuses scoped
+            #     reingests against a complete graph until someone runs a
+            #     full update.
+            #   something written -> the graph may be partial. The marker
+            #     stays, and the retained updater goes, because it describes
+            #     a graph that no longer exists.
+            #
+            # `reingest_mutated` is set inside `GraphUpdater.reingest` at the
+            # exact point its read-only prologue ends. Classifying on
+            # ReingestAborted instead would misread a future abort raised
+            # mid-run as "nothing changed" and clear a marker that is
+            # protecting a partial graph.
+            flag = getattr(updater, "reingest_mutated", None)
+            if isinstance(flag, bool):
+                # The updater told us directly: set at the exact point its
+                # read-only prologue ends.
+                mutated = flag
+            else:
+                # No usable flag (an updater predating it, or a test double).
+                # Fall back to the exception type, which carries the same
+                # information less precisely: `GraphUpdater.reingest` converts
+                # EVERY prologue failure to `ReingestAborted` and rejects bad
+                # paths with `ValueError` before touching anything, so any
+                # other exception means the write phase had begun.
+                #
+                # `isinstance` on the flag rather than `getattr(..., True)`:
+                # any attribute of a MagicMock is a truthy child mock, which
+                # would classify every failure as mutated (measured -- it
+                # broke the retained-updater tests).
+                mutated = not isinstance(exc, ValueError | ReingestAborted)
+            if mutated:
+                self._live_updater = None
+                self._graph_incomplete = True
+            elif marked_here is not None:
+                # Best effort: a failing clear must not replace the caller's
+                # real error (a bad path, an abort) with a marker error.
+                self._require_marker_cleared(marked_here)
             raise
         if marked_here is not None:
             # Invariant (b), same as every other path: the hydration above

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -103,11 +103,14 @@ class MCPToolsRegistry:
         # scoped reingest must not hydrate from, because it would treat the
         # missing and stale definitions as authoritative.
         self._graph_incomplete = False
-        # Set when `_persisted_incomplete` clears a recoverable marker, so the
-        # in-process flag can follow the durable state out of a wedged refusal
-        # without discarding a failure only this process knows about. Reset
-        # before each read so it never outlives the call that set it (#1705).
-        self._marker_recovered = False
+        # The project whose FAILED MARKER CLEAR set `_graph_incomplete`, or
+        # None when the flag came from somewhere else (a failed wipe, delete
+        # or update, which set it while writing no marker for this project).
+        # Only a flag with this provenance may be healed by a marker
+        # recovery: a bare "a marker was recovered" boolean discards a flag
+        # an unrelated marker-less failure earned, whenever some recoverable
+        # marker happens to be pending at guard time (#1705 review).
+        self._flag_from_failed_clear: str | None = None
 
         self.parsers, self.queries = load_parsers()
 
@@ -787,6 +790,8 @@ class MCPToolsRegistry:
         # project is gone and the not-indexed guard takes over.
         self._live_updater = None
         self._graph_incomplete = True
+        # Not a stranded marker: this flag must not be healed by one.
+        self._flag_from_failed_clear = None
         # Invariant (a). Nothing has been touched yet, so refusing costs
         # nothing; proceeding would leave a half-removed graph a fresh
         # registry cannot tell from a completed delete.
@@ -831,6 +836,8 @@ class MCPToolsRegistry:
                 # its failure keeps the updater dropped and nothing else.
                 self._live_updater = None
                 self._graph_incomplete = True
+                # Not a stranded marker: this flag must not be healed by one.
+                self._flag_from_failed_clear = None
                 await asyncio.to_thread(self.ingestor.clean_database)
                 self._graph_incomplete = False
                 await asyncio.to_thread(clear_all_embeddings)
@@ -867,6 +874,8 @@ class MCPToolsRegistry:
         # whatever partial graph a failure left behind.
         self._live_updater = None
         self._graph_incomplete = True
+        # Not a stranded marker: this flag must not be healed by one.
+        self._flag_from_failed_clear = None
         # Persisted BEFORE the delete, and on a node the delete cannot reach:
         # this path removes the Project and rebuilds it, so a marker stored on
         # the Project would be destroyed by the very operation whose failure it
@@ -961,6 +970,8 @@ class MCPToolsRegistry:
         # the partial graph would be no better.
         self._live_updater = None
         self._graph_incomplete = True
+        # Not a stranded marker: this flag must not be healed by one.
+        self._flag_from_failed_clear = None
         # The marker goes down BEFORE ensure_constraints, not after.
         # `ensure_constraints` runs `_migrate_legacy_path_keys`, which drops
         # constraints and can run purge queries -- autocommitted, destructive
@@ -1148,6 +1159,10 @@ class MCPToolsRegistry:
         """
         cleared = self._persist_incomplete(project_name, False)
         self._graph_incomplete = not cleared
+        # Attribute the flag to this project's stranded marker (or drop a
+        # stale attribution when the clear succeeded), so the recovery in
+        # `_refuse_reingest_if_unsafe` heals only the flag it explains.
+        self._flag_from_failed_clear = project_name if not cleared else None
         if cleared:
             return None
         return cs.MCP_INCOMPLETE_MARKER_STUCK.format(project=project_name)
@@ -1200,7 +1215,6 @@ class MCPToolsRegistry:
                 # that would follow could not mark itself either; refuse now
                 # and let the next attempt retry.
                 return True
-            self._marker_recovered = True
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_RECOVERED.format(project=project_name)
             )
@@ -1309,10 +1323,11 @@ class MCPToolsRegistry:
         # failure that could not persist a marker at all, and the next
         # reingest would drop a `_graph_incomplete` that is the only record
         # the graph is partial.
-        self._marker_recovered = False
+        recoverable_here = self._flag_from_failed_clear == project_name
         persisted_incomplete = self._persisted_incomplete(project_name)
-        if not persisted_incomplete and self._marker_recovered:
+        if not persisted_incomplete and recoverable_here:
             self._graph_incomplete = False
+            self._flag_from_failed_clear = None
         if self._graph_incomplete or persisted_incomplete:
             raise ValueError(
                 cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
@@ -1427,6 +1442,8 @@ class MCPToolsRegistry:
             if mutated:
                 self._live_updater = None
                 self._graph_incomplete = True
+                # Not a stranded marker: this flag must not be healed by one.
+                self._flag_from_failed_clear = None
             elif marked_here is not None:
                 # Nothing was written, so the marker this call created is a
                 # lie about a run that changed nothing and must come off.

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -103,6 +103,10 @@ class MCPToolsRegistry:
         # scoped reingest must not hydrate from, because it would treat the
         # missing and stale definitions as authoritative.
         self._graph_incomplete = False
+        # Set when `_persisted_incomplete` clears a recoverable marker, so the
+        # in-process flag can follow the durable state out of a wedged refusal
+        # without discarding a failure only this process knows about (#1705).
+        self._marker_recovered = False
 
         self.parsers, self.queries = load_parsers()
 
@@ -1195,6 +1199,7 @@ class MCPToolsRegistry:
                 # that would follow could not mark itself either; refuse now
                 # and let the next attempt retry.
                 return True
+            self._marker_recovered = True
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_RECOVERED.format(project=project_name)
             )
@@ -1282,7 +1287,25 @@ class MCPToolsRegistry:
         # that earned it: with no retained updater this may be a fresh
         # registry after a crash, where `_graph_incomplete` is False
         # because nothing in THIS process failed (issue #1679).
-        if self._graph_incomplete or self._persisted_incomplete(project_name):
+        # The durable check runs FIRST and unconditionally, because
+        # `_persisted_incomplete` is also what CLEARS a recoverable
+        # `writing=false` marker. Short-circuiting on `_graph_incomplete`
+        # skipped that recovery: after a read-only abort whose marker clear
+        # failed transiently, `_require_marker_cleared` left the flag True and
+        # this process refused every later scoped reingest, even once the
+        # store became writable again, until a full update or a restart
+        # (#1705 review).
+        #
+        # Its answer does NOT override the local flag, it joins it. The flag
+        # can be the only evidence there is: a failure that could not persist
+        # a marker at all leaves the durable state clean while this process
+        # knows the graph is partial, and dropping the flag would accept
+        # scoped work over it. The flag is cleared only when the recovery
+        # above actually cleared the marker, which is exactly the wedged case.
+        persisted_incomplete = self._persisted_incomplete(project_name)
+        if not persisted_incomplete and self._marker_recovered:
+            self._graph_incomplete = False
+        if self._graph_incomplete or persisted_incomplete:
             raise ValueError(
                 cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
             )

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1280,9 +1280,26 @@ class MCPToolsRegistry:
                 self._live_updater = None
                 self._graph_incomplete = True
             elif marked_here is not None:
-                # Best effort: a failing clear must not replace the caller's
-                # real error (a bad path, an abort) with a marker error.
-                self._require_marker_cleared(marked_here)
+                # Nothing was written, so the marker this call created is a
+                # lie about a run that changed nothing and must come off.
+                #
+                # The caller's real error (a bad path, an abort) stays
+                # primary -- replacing it with a marker error would hide why
+                # the reingest actually failed. But a FAILED clear cannot be
+                # discarded either: it leaves the project marked incomplete,
+                # so every later scoped reingest is refused until a full
+                # update runs, for a run that touched nothing (#1705 review).
+                #
+                # `_require_marker_cleared` already syncs `_graph_incomplete`
+                # to the durable state, so this process stops believing the
+                # graph is clean; the warning it logs is what tells an
+                # operator why later reingests refuse.
+                if self._require_marker_cleared(marked_here) is not None:
+                    logger.warning(
+                        lg.MCP_INCOMPLETE_MARKER_STUCK_AFTER_ABORT.format(
+                            project=marked_here
+                        )
+                    )
             raise
         if marked_here is not None:
             # Invariant (b), same as every other path: the hydration above

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -781,9 +781,17 @@ class MCPToolsRegistry:
         # project is gone and the not-indexed guard takes over.
         self._live_updater = None
         self._graph_incomplete = True
+        self._persist_incomplete(project_name, True)
         self._cleanup_project_embeddings(project_name)
         self.ingestor.delete_project(project_name)
-        self._graph_incomplete = False
+        # The durable marker must go too. It lives on its own node precisely
+        # so `delete_project` cannot reach it -- which is what lets it survive
+        # an index's delete-then-rebuild -- but that means an INTENTIONAL
+        # delete leaves it behind, and a fresh registry would then refuse
+        # reingest forever for a project the user deliberately removed
+        # (#1705 review, round 2). The in-process flag follows the durable
+        # state, as everywhere else.
+        self._graph_incomplete = not self._persist_incomplete(project_name, False)
         return DeleteProjectSuccessResult(
             success=True,
             project=project_name,
@@ -937,19 +945,26 @@ class MCPToolsRegistry:
         # the partial graph would be no better.
         self._live_updater = None
         self._graph_incomplete = True
-        self.ingestor.ensure_constraints()
-        # The marker MERGEs its own node, so this works before any Project
-        # exists. An earlier version set a property on the Project with MATCH,
-        # which updated zero rows on a first index and left a failed first run
-        # unmarked -- the exact case the guard exists for (#1705 review).
+        # The marker goes down BEFORE ensure_constraints, not after.
+        # `ensure_constraints` runs `_migrate_legacy_path_keys`, which drops
+        # constraints and can run purge queries -- autocommitted, destructive
+        # work. Writing the marker after it left a window where a crash
+        # during migration produced a damaged graph with nothing recording
+        # that a run had started (#1705 review, round 2).
         #
-        # Aborts on failure for the same reason as the index path: the flush
-        # below commits batches left by earlier calls, so continuing without a
-        # marker risks a partial graph no later process can recognise.
+        # It MERGEs its own node, so it works before any Project exists: an
+        # earlier version set a property on the Project with MATCH, which
+        # updated zero rows on a first index and left a failed first run
+        # unmarked.
+        #
+        # Aborts on failure because the marker is the only protection that
+        # survives a restart; nothing has been touched yet, so stopping costs
+        # nothing.
         if not self._persist_incomplete(project_name, True):
             raise RuntimeError(
                 cs.MCP_INCOMPLETE_MARKER_REQUIRED.format(project=project_name)
             )
+        self.ingestor.ensure_constraints()
         self.ingestor.flush_all()
 
         exclude_paths, unignore_paths = self._ignore_sets()

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1277,39 +1277,7 @@ class MCPToolsRegistry:
         if (refusal := self._require_writing(project_name)) is not None:
             raise RuntimeError(refusal)
 
-    def _updater_for_reingest(self) -> GraphUpdater:
-        updater = self._live_updater
-        if updater is None:
-            # A scoped re-ingest completes a graph; it cannot stand in for
-            # the first index. After delete_project or wipe_database the
-            # project is gone, and hydrating from nothing would leave every
-            # unrelated definition missing.
-            project_name = derive_project_name(Path(self.project_root))
-            if self._graph_incomplete:
-                raise ValueError(
-                    cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
-                )
-            if project_name not in self.ingestor.list_projects():
-                raise ValueError(
-                    cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name)
-                )
-            self.ingestor.ensure_constraints()
-            # The same exclusion set the index and update paths use, or an
-            # agent-named path under a CLI-excluded directory would be
-            # indexed here and kept by every later update.
-            exclude_paths, unignore_paths = self._ignore_sets()
-            updater = GraphUpdater(
-                ingestor=self.ingestor,
-                repo_path=Path(self.project_root),
-                parsers=self.parsers,
-                queries=self.queries,
-                unignore_paths=unignore_paths,
-                exclude_paths=exclude_paths,
-                project_name=project_name,
-            )
-            self._live_updater = updater
-        return updater
-
+    @staticmethod
     def _reingest_mutated(updater: object, exc: BaseException) -> bool:
         """Whether a failed reingest got as far as writing.
 
@@ -1405,6 +1373,39 @@ class MCPToolsRegistry:
         self._live_updater = updater
         return updater
 
+    def _updater_for_reingest(self) -> GraphUpdater:
+        updater = self._live_updater
+        if updater is None:
+            # A scoped re-ingest completes a graph; it cannot stand in for
+            # the first index. After delete_project or wipe_database the
+            # project is gone, and hydrating from nothing would leave every
+            # unrelated definition missing.
+            project_name = derive_project_name(Path(self.project_root))
+            if self._graph_incomplete:
+                raise ValueError(
+                    cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
+                )
+            if project_name not in self.ingestor.list_projects():
+                raise ValueError(
+                    cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name)
+                )
+            self.ingestor.ensure_constraints()
+            # The same exclusion set the index and update paths use, or an
+            # agent-named path under a CLI-excluded directory would be
+            # indexed here and kept by every later update.
+            exclude_paths, unignore_paths = self._ignore_sets()
+            updater = GraphUpdater(
+                ingestor=self.ingestor,
+                repo_path=Path(self.project_root),
+                parsers=self.parsers,
+                queries=self.queries,
+                unignore_paths=unignore_paths,
+                exclude_paths=exclude_paths,
+                project_name=project_name,
+            )
+            self._live_updater = updater
+        return updater
+
     def _reingest_sync(
         self, paths: list[str], deleted: list[str]
     ) -> ReingestToolResult:
@@ -1428,22 +1429,6 @@ class MCPToolsRegistry:
         if updater is None:
             updater = self._hydrate_reingest_updater(project_name)
             marked_here = project_name
-            self.ingestor.ensure_constraints()
-            # The same exclusion set the index and update paths use, or an
-            # agent-named path under a CLI-excluded directory would be
-            # indexed here and kept by every later update.
-            exclude_paths, unignore_paths = self._ignore_sets()
-            updater = GraphUpdater(
-                ingestor=self.ingestor,
-                repo_path=Path(self.project_root),
-                parsers=self.parsers,
-                queries=self.queries,
-                unignore_paths=unignore_paths,
-                exclude_paths=exclude_paths,
-                project_name=project_name,
-            )
-            self._live_updater = updater
-        return updater
         else:
             # The RETAINED-updater branch reaches the same mutating call below
             # but skipped every marker step, because the mark lived inside the
@@ -1688,6 +1673,15 @@ class MCPToolsRegistry:
             logger.warning(lg.MCP_DELTA_FAILED.format(error=e))
             self._live_updater = None
             self._graph_incomplete = True
+            # Not a stranded marker: this flag must not be healed by one.
+            # This path invalidates precisely BECAUSE a subtree may have been
+            # deleted and not rebuilt, so the flag records real damage that no
+            # marker describes. Leaving an earlier attribution in place would
+            # let an unrelated marker recovery lift it -- the same overwrite
+            # the abandon path was fixed for, arriving from the other side.
+            # Added on the rebase: this site landed on main (#1525) after the
+            # attribution was written, so it had no way to know about it.
+            self._flag_from_failed_clear = None
             return "\n\n" + cs.MCP_DELTA_ERROR.format(error=e)
         return (
             "\n\n"

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -52,6 +52,7 @@ from codebase_rag.types_defs import (
     MCPInputSchema,
     MCPInputSchemaProperty,
     MCPToolSchema,
+    PropertyValue,
     QueryResultDict,
     ReingestToolResult,
     StructuralReplaceChange,
@@ -784,9 +785,11 @@ class MCPToolsRegistry:
         # Invariant (a). Nothing has been touched yet, so refusing costs
         # nothing; proceeding would leave a half-removed graph a fresh
         # registry cannot tell from a completed delete.
-        if (refusal := self._require_marker(project_name)) is not None:
+        # `writing=False` for the same reason as the index path: the
+        # embedding purge is not a graph write (#1705 review).
+        if (refusal := self._require_marker(project_name, writing=False)) is not None:
             return DeleteProjectErrorResult(success=False, error=refusal)
-        self._cleanup_project_embeddings(project_name)
+        self._cleanup_embeddings_then_begin_writing(project_name)
         self.ingestor.delete_project(project_name)
         # Invariant (b). The marker sits on its own node so `delete_project`
         # cannot reach it -- which is what lets it survive an index's
@@ -872,9 +875,15 @@ class MCPToolsRegistry:
         # stopping here: no graph state has changed yet. That is the opposite
         # of a failed CLEAR, which must not fail a run that already succeeded
         # (#1705 review).
-        if (refusal := self._require_marker(project_name)) is not None:
+        #
+        # `writing=False`: the embedding purge that follows is not a graph
+        # write, so a failure or a crash in it leaves the graph as it was, and
+        # a marker saying so lets a fresh process clear it and carry on rather
+        # than refuse until a full update (#1705 review). The phase advances
+        # to writing immediately before `delete_project`.
+        if (refusal := self._require_marker(project_name, writing=False)) is not None:
             raise RuntimeError(refusal)
-        self._cleanup_project_embeddings(project_name)
+        self._cleanup_embeddings_then_begin_writing(project_name)
         self.ingestor.delete_project(project_name)
 
         self.ingestor.ensure_constraints()
@@ -1014,8 +1023,14 @@ class MCPToolsRegistry:
     # that decide what a marker failure means; call sites choose the failure
     # VALUE, not the policy.
 
-    def _persist_incomplete(self, project_name: str, incomplete: bool) -> bool:
+    def _persist_incomplete(
+        self, project_name: str, incomplete: bool, *, writing: bool = True
+    ) -> bool:
         """Record (or clear) the incomplete-run marker on its own node.
+
+        `writing` is the marker's phase (see `CYPHER_MARK_PROJECT_INCOMPLETE`):
+        False while the run is still doing read-only or graph-external work,
+        True from its first graph write. Ignored when clearing.
 
         `_graph_incomplete` lives on this registry, so it only ever covered
         the process that ran the failed update. A crash or an MCP restart
@@ -1039,13 +1054,14 @@ class MCPToolsRegistry:
         degrades this guard back to the old in-process behaviour and only the
         log would show it.
         """
-        query = (
-            cq.CYPHER_MARK_PROJECT_INCOMPLETE
-            if incomplete
-            else cq.CYPHER_CLEAR_PROJECT_INCOMPLETE
-        )
+        params: dict[str, PropertyValue] = {cs.KEY_PROJECT_NAME: project_name}
+        if incomplete:
+            query = cq.CYPHER_MARK_PROJECT_INCOMPLETE
+            params[cs.KEY_WRITING] = writing
+        else:
+            query = cq.CYPHER_CLEAR_PROJECT_INCOMPLETE
         try:
-            self.ingestor.execute_write(query, {cs.KEY_PROJECT_NAME: project_name})
+            self.ingestor.execute_write(query, params)
         except Exception as error:  # noqa: BLE001 -- see docstring
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_FAILED.format(
@@ -1055,14 +1071,61 @@ class MCPToolsRegistry:
             return False
         return True
 
-    def _require_marker(self, project_name: str) -> str | None:
+    def _require_marker(self, project_name: str, *, writing: bool = True) -> str | None:
         """Invariant (a): mark before destructive work, or refuse to start.
 
         Returns None when the marker is down, or the message to fail with.
+        `writing=False` marks a run that has not yet reached a graph write;
+        it must call `_require_writing` before its first one.
         """
-        if self._persist_incomplete(project_name, True):
+        if self._persist_incomplete(project_name, True, writing=writing):
             return None
         return cs.MCP_INCOMPLETE_MARKER_REQUIRED.format(project=project_name)
+
+    def _require_writing(self, project_name: str) -> str | None:
+        """Invariant (a), second half: say WRITING before the first graph write.
+
+        A run marked `writing=False` has told a fresh process it may clear the
+        marker and carry on. Once this run is about to change the graph that
+        is no longer true, and it must be recorded durably BEFORE the change:
+        if the record cannot be written the run stops here, with the graph
+        untouched and the marker still honest. Returns None or the refusal.
+        """
+        return self._require_marker(project_name, writing=True)
+
+    def _abandon_before_writing(self, project_name: str) -> None:
+        """A run stopped before its first graph write: take its marker off.
+
+        Nothing was written, so the marker is a lie about a run that changed
+        nothing, and left in place it refuses every later scoped reingest
+        until a full update runs. Best effort, never raising: the caller's
+        own error stays primary. A clear that FAILS is logged rather than
+        discarded, and leaves a `writing=False` marker that a later process
+        clears for itself (`_persisted_incomplete`); the local flag follows
+        the durable state through `_require_marker_cleared` (#1705 review).
+        """
+        if self._require_marker_cleared(project_name) is not None:
+            logger.warning(
+                lg.MCP_INCOMPLETE_MARKER_STUCK_AFTER_ABORT.format(project=project_name)
+            )
+
+    def _cleanup_embeddings_then_begin_writing(self, project_name: str) -> None:
+        """The step between a `writing=False` mark and the first graph write.
+
+        The embedding purge touches the vector store, not the graph, so a
+        failure in it leaves the graph as it was and the marker must come
+        off (or, failing that, stay `writing=False`) rather than strand a
+        fresh process behind a marker for a run that never reached the graph
+        (#1705 review). Then the phase advances, and a refusal there stops
+        the run before anything destructive.
+        """
+        try:
+            self._cleanup_project_embeddings(project_name)
+        except Exception:
+            self._abandon_before_writing(project_name)
+            raise
+        if (refusal := self._require_writing(project_name)) is not None:
+            raise RuntimeError(refusal)
 
     def _require_marker_cleared(self, project_name: str) -> str | None:
         """Invariant (b): a run is complete only once its marker is gone.
@@ -1103,7 +1166,39 @@ class MCPToolsRegistry:
             # which is the failure this guard exists to prevent. An
             # update_repository recovers either way (#1705 review).
             return True
-        return any(bool(row.get("run_incomplete")) for row in rows or [])
+        for row in rows or []:
+            if not row.get("run_incomplete"):
+                continue
+            # The marker's phase decides. A run that reached its first graph
+            # write may have left the graph partial: refuse. One that stopped
+            # before it -- an aborted prologue, a failed embedding purge, a
+            # crash in either -- left the graph as it found it and simply
+            # could not (or did not live to) clear its own marker. That marker
+            # is safe to clear here, and clearing it is what stops a no-write
+            # abort from blocking every later process until someone runs a
+            # full update (#1705 review). An absent phase reads as writing, so
+            # a marker from before the phase existed stays fail-closed.
+            if row.get("writing", True):
+                return True
+            if not self._persist_incomplete(project_name, False):
+                # Could not clear it. The store refused a write, so the run
+                # that would follow could not mark itself either; refuse now
+                # and let the next attempt retry.
+                return True
+            logger.warning(
+                lg.MCP_INCOMPLETE_MARKER_RECOVERED.format(project=project_name)
+            )
+        return False
+
+    def _begin_writing_or_refuse(self, project_name: str) -> None:
+        """`before_write` for `GraphUpdater.reingest`: advance the phase or stop.
+
+        Raising here is caught by the updater and re-raised as
+        `ReingestAborted` with the graph untouched, which `_reingest_sync`
+        then classifies as "nothing changed" and clears the marker.
+        """
+        if (refusal := self._require_writing(project_name)) is not None:
+            raise RuntimeError(refusal)
 
     def _updater_for_reingest(self) -> GraphUpdater:
         updater = self._live_updater
@@ -1252,11 +1347,23 @@ class MCPToolsRegistry:
             # hydration branch. An interruption here left a partially mutated
             # graph a restarted process could not tell from a complete one
             # (#1705 review, round 6). Same invariant, fifth path.
-            if (refusal := self._require_marker(project_name)) is not None:
+            #
+            # `writing=False` because the updater's prologue is read-only:
+            # the phase advances through `before_write` below, at the exact
+            # point the updater is about to issue its first delete. Until
+            # then the marker tells a fresh process the graph is untouched
+            # (#1705 review).
+            if (
+                refusal := self._require_marker(project_name, writing=False)
+            ) is not None:
                 raise RuntimeError(refusal)
             marked_here = project_name
         try:
-            report = updater.reingest(paths, deleted=deleted)
+            report = updater.reingest(
+                paths,
+                deleted=deleted,
+                before_write=lambda: self._begin_writing_or_refuse(project_name),
+            )
         except Exception as exc:
             # One classification for every failure, by WHAT HAPPENED rather
             # than by exception type (#1705 review, round 7):
@@ -1290,16 +1397,13 @@ class MCPToolsRegistry:
                 # so every later scoped reingest is refused until a full
                 # update runs, for a run that touched nothing (#1705 review).
                 #
-                # `_require_marker_cleared` already syncs `_graph_incomplete`
-                # to the durable state, so this process stops believing the
-                # graph is clean; the warning it logs is what tells an
-                # operator why later reingests refuse.
-                if self._require_marker_cleared(marked_here) is not None:
-                    logger.warning(
-                        lg.MCP_INCOMPLETE_MARKER_STUCK_AFTER_ABORT.format(
-                            project=marked_here
-                        )
-                    )
+                # `_abandon_before_writing` syncs `_graph_incomplete` to the
+                # durable state, so this process stops believing the graph is
+                # clean, and the warning it logs is what tells an operator
+                # why later reingests refuse. The marker it could not clear
+                # still says `writing=False`, so a later process clears it
+                # for itself rather than refusing forever (#1705 review).
+                self._abandon_before_writing(marked_here)
             raise
         if marked_here is not None:
             # Invariant (b), same as every other path: the hydration above

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1142,15 +1142,27 @@ class MCPToolsRegistry:
         self, paths: list[str], deleted: list[str]
     ) -> ReingestToolResult:
         updater = self._live_updater
-        # Only set when THIS call marked the project, so the success path
-        # clears its own marker and never one an earlier failure left behind.
+        # Invariant (a) for EVERY reingest, before either branch does anything.
+        # Both branches reach `updater.reingest` below, which mutates, and the
+        # hydrating branch additionally runs `ensure_constraints` -- the same
+        # destructive migration the index and update paths mark before. The
+        # mark used to live INSIDE `if updater is None:`, so a reingest through
+        # a retained updater ran entirely unmarked and an interruption left a
+        # partial graph a restarted process could not tell from a complete one
+        # (#1705 review, round 6).
+        #
+        # Marking here rather than in each branch is the same lesson as the
+        # helpers: enumerate the paths once, at the point they share.
+        # The refusal guard must run BEFORE this call marks anything: it asks
+        # whether a PREVIOUS run left the graph partial, and marking first
+        # would make every reingest refuse on its own marker.
+        project_name = derive_project_name(Path(self.project_root))
         marked_here: str | None = None
         if updater is None:
             # A scoped re-ingest completes a graph; it cannot stand in for
             # the first index. After delete_project or wipe_database the
             # project is gone, and hydrating from nothing would leave every
             # unrelated definition missing.
-            project_name = derive_project_name(Path(self.project_root))
             # The persisted marker is what makes this survive the process
             # that earned it: with no retained updater this may be a fresh
             # registry after a crash, where `_graph_incomplete` is False
@@ -1163,12 +1175,11 @@ class MCPToolsRegistry:
                 raise ValueError(
                     cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name)
                 )
-            # `ensure_constraints` runs the same destructive migration here
-            # as on the index and update paths -- it drops constraints and can
-            # purge -- so it needs the same marker in front of it. This is the
-            # THIRD caller; fixing the other two and leaving this one meant a
-            # fresh scoped reingest could still fail mid-migration and leave a
-            # partial graph nothing recorded (#1705 review, round 3).
+            # Marked after the guards above -- they ask whether a PREVIOUS run
+            # left the graph partial, so marking first would make every
+            # reingest refuse on its own marker -- and before
+            # `ensure_constraints`, which runs the same destructive migration
+            # the index and update paths mark before. Invariant (c).
             if (refusal := self._require_marker(project_name)) is not None:
                 raise RuntimeError(refusal)
             marked_here = project_name
@@ -1188,6 +1199,15 @@ class MCPToolsRegistry:
             )
             self._live_updater = updater
         return updater
+        else:
+            # The RETAINED-updater branch reaches the same mutating call below
+            # but skipped every marker step, because the mark lived inside the
+            # hydration branch. An interruption here left a partially mutated
+            # graph a restarted process could not tell from a complete one
+            # (#1705 review, round 6). Same invariant, fifth path.
+            if (refusal := self._require_marker(project_name)) is not None:
+                raise RuntimeError(refusal)
+            marked_here = project_name
         try:
             report = updater.reingest(paths, deleted=deleted)
         except (ValueError, ReingestAborted):

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -781,17 +781,20 @@ class MCPToolsRegistry:
         # project is gone and the not-indexed guard takes over.
         self._live_updater = None
         self._graph_incomplete = True
-        self._persist_incomplete(project_name, True)
+        # Invariant (a). Nothing has been touched yet, so refusing costs
+        # nothing; proceeding would leave a half-removed graph a fresh
+        # registry cannot tell from a completed delete.
+        if (refusal := self._require_marker(project_name)) is not None:
+            return DeleteProjectErrorResult(success=False, error=refusal)
         self._cleanup_project_embeddings(project_name)
         self.ingestor.delete_project(project_name)
-        # The durable marker must go too. It lives on its own node precisely
-        # so `delete_project` cannot reach it -- which is what lets it survive
-        # an index's delete-then-rebuild -- but that means an INTENTIONAL
-        # delete leaves it behind, and a fresh registry would then refuse
-        # reingest forever for a project the user deliberately removed
-        # (#1705 review, round 2). The in-process flag follows the durable
-        # state, as everywhere else.
-        self._graph_incomplete = not self._persist_incomplete(project_name, False)
+        # Invariant (b). The marker sits on its own node so `delete_project`
+        # cannot reach it -- which is what lets it survive an index's
+        # delete-then-rebuild -- so a deliberate delete must remove it. The
+        # data is gone either way; reporting success while the marker remains
+        # blocks every later reingest for a project that no longer exists.
+        if (stuck := self._require_marker_cleared(project_name)) is not None:
+            return DeleteProjectErrorResult(success=False, error=stuck)
         return DeleteProjectSuccessResult(
             success=True,
             project=project_name,
@@ -869,10 +872,8 @@ class MCPToolsRegistry:
         # stopping here: no graph state has changed yet. That is the opposite
         # of a failed CLEAR, which must not fail a run that already succeeded
         # (#1705 review).
-        if not self._persist_incomplete(project_name, True):
-            raise RuntimeError(
-                cs.MCP_INCOMPLETE_MARKER_REQUIRED.format(project=project_name)
-            )
+        if (refusal := self._require_marker(project_name)) is not None:
+            raise RuntimeError(refusal)
         self._cleanup_project_embeddings(project_name)
         self.ingestor.delete_project(project_name)
 
@@ -900,7 +901,8 @@ class MCPToolsRegistry:
         # while this one believed all was well. Staying incomplete locally
         # keeps the two in agreement and makes the next update retry the clear
         # (#1705 review).
-        self._graph_incomplete = not self._persist_incomplete(project_name, False)
+        if (stuck := self._require_marker_cleared(project_name)) is not None:
+            raise RuntimeError(stuck)
         self._live_updater = updater
 
         return cs.MCP_INDEX_SUCCESS_PROJECT.format(
@@ -960,10 +962,8 @@ class MCPToolsRegistry:
         # Aborts on failure because the marker is the only protection that
         # survives a restart; nothing has been touched yet, so stopping costs
         # nothing.
-        if not self._persist_incomplete(project_name, True):
-            raise RuntimeError(
-                cs.MCP_INCOMPLETE_MARKER_REQUIRED.format(project=project_name)
-            )
+        if (refusal := self._require_marker(project_name)) is not None:
+            raise RuntimeError(refusal)
         self.ingestor.ensure_constraints()
         self.ingestor.flush_all()
 
@@ -988,9 +988,31 @@ class MCPToolsRegistry:
         # while this one believed all was well. Staying incomplete locally
         # keeps the two in agreement and makes the next update retry the clear
         # (#1705 review).
-        self._graph_incomplete = not self._persist_incomplete(project_name, False)
+        if (stuck := self._require_marker_cleared(project_name)) is not None:
+            raise RuntimeError(stuck)
         self._live_updater = updater
         return cs.MCP_UPDATE_SUCCESS.format(path=self.project_root)
+
+    # The incomplete-run invariant, stated once and applied by every mutating
+    # path (#1705 review, round 4). Three rounds of review each found the same
+    # shape next to the previous fix, because the rule was being re-derived per
+    # call site instead of written down:
+    #
+    #   (a) No destructive step starts unless the durable marker was
+    #       persisted. A failed persist aborts BEFORE any cleanup, embedding
+    #       purge, constraint migration or delete_project, and reports a
+    #       retryable failure. Nothing has changed yet, so aborting is free.
+    #   (b) Success is reported only after the marker is durably cleared. A
+    #       failed clear after a successful operation is a retryable failure,
+    #       never success with the marker retained -- that state blocks every
+    #       later reingest and the user cannot see why.
+    #   (c) The fresh scoped-reingest path is a destructive step too: its
+    #       `ensure_constraints` runs the same migration that drops
+    #       constraints and can purge, so it marks first like the others.
+    #
+    # `_require_marker` and `_require_marker_cleared` are the only two places
+    # that decide what a marker failure means; call sites choose the failure
+    # VALUE, not the policy.
 
     def _persist_incomplete(self, project_name: str, incomplete: bool) -> bool:
         """Record (or clear) the incomplete-run marker on its own node.
@@ -1032,6 +1054,27 @@ class MCPToolsRegistry:
             )
             return False
         return True
+
+    def _require_marker(self, project_name: str) -> str | None:
+        """Invariant (a): mark before destructive work, or refuse to start.
+
+        Returns None when the marker is down, or the message to fail with.
+        """
+        if self._persist_incomplete(project_name, True):
+            return None
+        return cs.MCP_INCOMPLETE_MARKER_REQUIRED.format(project=project_name)
+
+    def _require_marker_cleared(self, project_name: str) -> str | None:
+        """Invariant (b): a run is complete only once its marker is gone.
+
+        Also syncs the in-process flag to the durable state, so this process
+        and the next agree. Returns None on success, or the failure message.
+        """
+        cleared = self._persist_incomplete(project_name, False)
+        self._graph_incomplete = not cleared
+        if cleared:
+            return None
+        return cs.MCP_INCOMPLETE_MARKER_STUCK.format(project=project_name)
 
     def _persisted_incomplete(self, project_name: str) -> bool:
         """Whether a previous process left this project mid-update.
@@ -1099,6 +1142,9 @@ class MCPToolsRegistry:
         self, paths: list[str], deleted: list[str]
     ) -> ReingestToolResult:
         updater = self._live_updater
+        # Only set when THIS call marked the project, so the success path
+        # clears its own marker and never one an earlier failure left behind.
+        marked_here: str | None = None
         if updater is None:
             # A scoped re-ingest completes a graph; it cannot stand in for
             # the first index. After delete_project or wipe_database the
@@ -1117,6 +1163,15 @@ class MCPToolsRegistry:
                 raise ValueError(
                     cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name)
                 )
+            # `ensure_constraints` runs the same destructive migration here
+            # as on the index and update paths -- it drops constraints and can
+            # purge -- so it needs the same marker in front of it. This is the
+            # THIRD caller; fixing the other two and leaving this one meant a
+            # fresh scoped reingest could still fail mid-migration and leave a
+            # partial graph nothing recorded (#1705 review, round 3).
+            if (refusal := self._require_marker(project_name)) is not None:
+                raise RuntimeError(refusal)
+            marked_here = project_name
             self.ingestor.ensure_constraints()
             # The same exclusion set the index and update paths use, or an
             # agent-named path under a CLI-excluded directory would be
@@ -1133,6 +1188,35 @@ class MCPToolsRegistry:
             )
             self._live_updater = updater
         return updater
+        try:
+            report = updater.reingest(paths, deleted=deleted)
+        except (ValueError, ReingestAborted):
+            # A refusal (a path outside the repository, a directory) is
+            # raised while the paths are split, and an abort while the call
+            # was still reading the graph; neither touched anything, so the
+            # updater is still valid and the call may simply be retried.
+            raise
+        except Exception:
+            # The run may have deleted the affected subtrees and never
+            # rebuilt them: the retained updater describes a graph that no
+            # longer exists, and the next scoped call must not reuse it
+            # over that partial state. update_repository is the recovery.
+            self._live_updater = None
+            self._graph_incomplete = True
+            raise
+        if marked_here is not None:
+            # The hydration above marked before its destructive migration;
+            # a completed reingest must lift that, or this path refuses every
+            # later call. The local flag follows the durable state, as
+            # everywhere else (#1705 review, round 3).
+            self._graph_incomplete = not self._persist_incomplete(marked_here, False)
+        return ReingestToolResult(
+            reparsed=list(report.reparsed),
+            affected=list(report.affected),
+            removed=list(report.removed),
+            skipped=list(report.skipped),
+            elapsed_ms=round(report.elapsed_ms, 1),
+        )
 
     async def reingest(
         self, paths: list[str], deleted: list[str] | None = None

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1232,7 +1232,7 @@ class TestIncompleteMarkerInvariant:
             project_root=str(root), ingestor=ingestor, cypher_gen=MagicMock()
         )
 
-    @pytest.mark.parametrize("path", ["index", "update", "delete"])
+    @pytest.mark.parametrize("path", ["index", "update", "delete", "reingest"])
     @pytest.mark.parametrize("failure", ["mark", "clear"])
     async def test_a_marker_failure_never_reports_success(
         self, temp_project_root: Path, path: str, failure: str
@@ -1254,8 +1254,16 @@ class TestIncompleteMarkerInvariant:
                 result = str(await registry.index_repository())
             elif path == "update":
                 result = str(await registry.update_repository())
-            else:
+            elif path == "delete":
                 result = str(await registry.delete_project(project))
+            else:
+                # The fresh-reingest path: no retained updater, so it
+                # hydrates, marks before its constraint migration, and must
+                # clear on success. Its clear was hand-written rather than
+                # routed through the helper and kept reporting success on a
+                # failed clear after every other path was fixed (#1705 r5).
+                registry._live_updater = None
+                result = str(await registry.reingest(["a.py"]))
 
         assert "Error" in result or "error" in result, (
             f"{path} with a failing {failure} reported success: {result}"

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -880,22 +880,47 @@ class TestIncompleteMarkerSurvivesTheProcess:
         store: dict[str, bool] = {}
         ingestor = MagicMock()
 
+        # A plain dict, never an attribute on the MagicMock: `getattr` on a
+        # MagicMock returns a truthy child mock for ANY name, so a
+        # `getattr(ingestor, "_fail_clear", False)` switch is permanently on.
+        failing: set[str] = set()
+
         def _write(query: str, params: dict | None = None) -> None:
-            name = (params or {}).get(cs.KEY_PROJECT_NAME)
-            if "SET p.run_incomplete" in query:
-                store[str(name)] = True
-            elif "REMOVE p.run_incomplete" in query:
-                store.pop(str(name), None)
+            name = str((params or {}).get(cs.KEY_PROJECT_NAME))
+            if "clear" in failing and "DELETE m" in query:
+                raise RuntimeError("clear write refused")
+            # MERGE creates the node when absent; MATCH does not, and a
+            # MATCH-based mark therefore writes NOTHING on a first run. The
+            # fake has to honour that difference or it answers the question
+            # the code is supposed to answer: with a branch keyed only on
+            # "SET m.run_incomplete", reverting MERGE to MATCH left every
+            # test green (#1705 review).
+            if "SET m.run_incomplete" in query:
+                if query.lstrip().startswith("MERGE") or name in store:
+                    store[name] = True
+            elif "DELETE m" in query:
+                store.pop(name, None)
 
         def _read(query: str, params: dict | None = None) -> list[dict]:
             if "run_incomplete" not in query:
                 return []
             name = str((params or {}).get(cs.KEY_PROJECT_NAME))
-            return [{"run_incomplete": store.get(name, False)}]
+            # A real MATCH returns NO ROWS when the marker node is absent, not
+            # a row saying false. Modelling the empty result matters: code that
+            # reads rows[0] would pass against a canned false and fail here.
+            return [{"run_incomplete": True}] if store.get(name) else []
+
+        def _delete_project(name: str) -> None:
+            # Models CYPHER_DELETE_PROJECT: it detaches the Project and
+            # everything it CONTAINS. A marker kept ON the Project would go
+            # with it; one on its own unconnected node must survive.
+            store.pop(f"__project_anchored__{name}", None)
 
         ingestor.execute_write.side_effect = _write
         ingestor.fetch_all.side_effect = _read
+        ingestor.delete_project.side_effect = _delete_project
         ingestor._marker_store = store
+        ingestor._failing = failing
         return ingestor
 
     def _registry(self, root: Path, ingestor: MagicMock) -> MCPToolsRegistry:
@@ -978,3 +1003,81 @@ class TestIncompleteMarkerSurvivesTheProcess:
             )
             result = await second.reingest(["a.py"])
         assert "error" not in result, f"a completed run must not refuse: {result}"
+
+    async def test_a_failed_first_index_leaves_a_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """A FIRST index has no Project node yet, and must still mark.
+
+        The marker used to be a property set on the Project with `MATCH`,
+        which updates zero rows when no Project exists. `GraphUpdater.run()`
+        is what creates it, so a first index that failed left no marker at
+        all -- precisely the run the guard exists to catch (#1705 review).
+        """
+        ingestor = self._store()
+        first = self._registry(temp_project_root, ingestor)
+        from codebase_rag.utils.path_utils import derive_project_name
+
+        project = derive_project_name(Path(first.project_root))
+        # No list_projects entry: nothing has ever been indexed.
+        ingestor.list_projects.return_value = []
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.run.side_effect = RuntimeError("first index died")
+            assert "Error" in await first.index_repository()
+
+        assert ingestor._marker_store.get(project) is True, (
+            "a failed FIRST index left no marker, so a fresh process cannot "
+            "tell the graph is partial"
+        )
+
+    async def test_the_marker_survives_the_project_delete_an_index_performs(
+        self, temp_project_root: Path
+    ) -> None:
+        """`index_repository` deletes the Project before rebuilding it.
+
+        A marker stored on the Project would be destroyed by the very
+        operation whose failure it records, so it lives on its own
+        unconnected node instead (#1705 review). The fake's delete_project
+        drops Project-anchored keys, so a regression to that storage fails
+        here rather than passing quietly.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.run.side_effect = RuntimeError("rebuild died")
+            assert "Error" in await registry.index_repository()
+
+        ingestor.delete_project.assert_called_once()
+        assert ingestor._marker_store.get(project) is True, (
+            "the project delete removed the marker it was supposed to outlive"
+        )
+
+    async def test_a_failed_clear_does_not_report_the_run_complete(
+        self, temp_project_root: Path
+    ) -> None:
+        """A clear that never reached the store must not read as complete.
+
+        Otherwise this process believes the run finished while the graph
+        still says incomplete, and a fresh registry refuses reingest forever
+        with nothing to explain it (#1705 review).
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        ingestor._failing.add("clear")
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            result = await registry.update_repository()
+
+        assert "Error" not in result, "the run itself succeeded and must say so"
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the clear must actually have failed, or this test "
+            "proves nothing"
+        )
+        assert registry._graph_incomplete is True, (
+            "the local flag reported complete while the graph still says "
+            "incomplete; a fresh registry would refuse reingest forever"
+        )

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -889,6 +889,8 @@ class TestIncompleteMarkerSurvivesTheProcess:
             name = str((params or {}).get(cs.KEY_PROJECT_NAME))
             if "clear" in failing and "DELETE m" in query:
                 raise RuntimeError("clear write refused")
+            if "mark" in failing and "SET m.run_incomplete" in query:
+                raise RuntimeError("mark write refused")
             # MERGE creates the node when absent; MATCH does not, and a
             # MATCH-based mark therefore writes NOTHING on a first run. The
             # fake has to honour that difference or it answers the question
@@ -904,6 +906,8 @@ class TestIncompleteMarkerSurvivesTheProcess:
         def _read(query: str, params: dict | None = None) -> list[dict]:
             if "run_incomplete" not in query:
                 return []
+            if "read" in failing:
+                raise RuntimeError("marker read refused")
             name = str((params or {}).get(cs.KEY_PROJECT_NAME))
             # A real MATCH returns NO ROWS when the marker node is absent, not
             # a row saying false. Modelling the empty result matters: code that
@@ -1080,4 +1084,57 @@ class TestIncompleteMarkerSurvivesTheProcess:
         assert registry._graph_incomplete is True, (
             "the local flag reported complete while the graph still says "
             "incomplete; a fresh registry would refuse reingest forever"
+        )
+
+    async def test_an_unwritable_marker_aborts_before_destructive_work(
+        self, temp_project_root: Path
+    ) -> None:
+        """A mark that cannot be stored must stop the run, not proceed.
+
+        The marker is the only protection that survives a restart. Indexing
+        on without it means a crash leaves a partial graph a fresh process
+        cannot distinguish from a complete one, and a scoped reingest then
+        treats it as authoritative. Nothing is lost by refusing: no graph
+        state has changed yet (#1705 review).
+
+        Asserts the DELETE never happened, not merely that an error was
+        returned: an abort that still wiped the project would satisfy an
+        error-message assertion while doing the exact damage this prevents.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        _mark_indexed(registry)
+        ingestor._failing.add("mark")
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            result = await registry.index_repository()
+
+        assert "Error" in result, "an unstorable marker must fail the run"
+        (
+            ingestor.delete_project.assert_not_called(),
+            (
+                "the run destroyed the existing graph despite having no marker "
+                "to record that it had started"
+            ),
+        )
+        updater_cls.assert_not_called()
+
+    async def test_an_unreadable_marker_refuses_reingest(
+        self, temp_project_root: Path
+    ) -> None:
+        """ "Cannot tell" must not be read as "the last run finished".
+
+        Returning False on a failed read hydrates a scoped reingest from a
+        graph that may be partial, which is precisely the failure the marker
+        exists to prevent. An update_repository recovers either way.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        _mark_indexed(registry)
+        ingestor._failing.add("read")
+
+        refused = await registry.reingest(["a.py"])
+
+        assert "failed part way" in refused.get("error", ""), (
+            f"an unreadable marker was treated as a completed run; got {refused}"
         )

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1482,3 +1482,59 @@ class TestIncompleteMarkerInvariant:
             "reported that it had not mutated, so a failure afterwards would "
             "clear the marker protecting a partial graph"
         )
+
+    async def test_a_failed_clear_on_an_abort_is_not_silently_swallowed(
+        self, temp_project_root: Path
+    ) -> None:
+        """An abort that wrote nothing must not leave the project stuck quietly.
+
+        The clear on this path is best effort so a marker error cannot replace
+        the caller's real exception. But discarding its RESULT left the project
+        marked incomplete after a run that changed nothing, refusing every
+        later scoped reingest until a full update ran (#1705 review).
+
+        Asserts the in-process flag follows the durable state, which is what
+        stops this process believing the graph is clean, and that the caller's
+        original error still surfaces rather than being replaced.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        ingestor._failing.add("clear")
+
+        aborting = MagicMock()
+        aborting.reingest_mutated = False
+        aborting.reingest.side_effect = ReingestAborted("graph read failed")
+        registry._live_updater = aborting
+
+        # loguru, not stdlib logging, so `caplog` sees nothing: capture via a
+        # sink, the same way conftest's pass-failure watcher does.
+        from loguru import logger
+
+        logged: list[str] = []
+        sink = logger.add(lambda m: logged.append(m.record["message"]), level="WARNING")
+        try:
+            result = await registry.reingest(["a.py"])
+        finally:
+            logger.remove(sink)
+
+        assert "graph read failed" in result.get("error", ""), (
+            "the caller's real error must stay primary, not be replaced by a "
+            f"marker error: {result}"
+        )
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the clear must actually have failed, or this test "
+            "proves nothing"
+        )
+        assert registry._graph_incomplete is True, (
+            "the local flag reported clean while the durable marker is still "
+            "set, so this process would not know later reingests will refuse"
+        )
+        # The flag alone does NOT discriminate: `_require_marker_cleared` sets
+        # it as a side effect whether or not the caller inspects the result,
+        # so a version that swallowed the failure passed this test until the
+        # log assertion below was added (measured).
+        assert any("could not be cleared" in m for m in logged), (
+            "a stuck marker after a no-op abort was not reported, so an "
+            f"operator has nothing explaining why reingests refuse: {logged}"
+        )

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1179,8 +1179,9 @@ class TestIncompleteMarkerSurvivesTheProcess:
         with patch("codebase_rag.mcp.tools.GraphUpdater"):
             await registry.update_repository()
 
-        assert "mark" in order and "constraints" in order, (
-            f"fixture guard: both steps must run, saw {order}"
+        assert "mark" in order, f"fixture guard: the mark must run, saw {order}"
+        assert "constraints" in order, (
+            f"fixture guard: the migration must run, saw {order}"
         )
         assert order.index("mark") < order.index("constraints"), (
             "the constraint migration ran before the marker was written, so a "

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1076,10 +1076,18 @@ class TestIncompleteMarkerSurvivesTheProcess:
         with patch("codebase_rag.mcp.tools.GraphUpdater"):
             result = await registry.update_repository()
 
-        assert "Error" not in result, "the run itself succeeded and must say so"
         assert ingestor._marker_store.get(project) is True, (
             "fixture guard: the clear must actually have failed, or this test "
             "proves nothing"
+        )
+        # Invariant (b): a run whose marker could not be cleared is a
+        # RETRYABLE FAILURE, not a success. Reporting success would leave the
+        # marker blocking every later reingest with nothing to show the user
+        # why (#1705 review, round 4). This assertion was inverted before that
+        # round: it required the run to report success, which is precisely the
+        # state the invariant now forbids.
+        assert "Error" in result, (
+            f"a run that left its marker stuck must report a failure: {result}"
         )
         assert registry._graph_incomplete is True, (
             "the local flag reported complete while the graph still says "
@@ -1200,4 +1208,96 @@ class TestIncompleteMarkerSurvivesTheProcess:
         assert project not in ingestor._marker_store, (
             "the deleted project kept its incomplete-run marker, so a fresh "
             "registry would refuse reingest for a project that is gone"
+        )
+
+
+class TestIncompleteMarkerInvariant:
+    """The invariant, over every mutating path and both failure points.
+
+    Stated once in `tools.py` and asserted once here, because three review
+    rounds each found the same shape next to the previous fix -- the rule was
+    being re-derived per call site instead of written down (#1705 round 4):
+
+      (a) no destructive step starts unless the marker was persisted
+      (b) success is reported only after the marker is durably cleared
+      (c) the fresh scoped-reingest path marks before its constraint migration
+    """
+
+    @staticmethod
+    def _store() -> MagicMock:
+        return TestIncompleteMarkerSurvivesTheProcess._store()
+
+    def _registry(self, root: Path, ingestor: MagicMock) -> MCPToolsRegistry:
+        return MCPToolsRegistry(
+            project_root=str(root), ingestor=ingestor, cypher_gen=MagicMock()
+        )
+
+    @pytest.mark.parametrize("path", ["index", "update", "delete"])
+    @pytest.mark.parametrize("failure", ["mark", "clear"])
+    async def test_a_marker_failure_never_reports_success(
+        self, temp_project_root: Path, path: str, failure: str
+    ) -> None:
+        """Every path, both failure points: a failure is reported, never success.
+
+        The `mark` case additionally pins invariant (a) by asserting the
+        destructive call never happened -- an abort that still deleted the
+        project would satisfy an error-message assertion while doing the exact
+        damage the marker exists to prevent.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        ingestor._failing.add(failure)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            if path == "index":
+                result = str(await registry.index_repository())
+            elif path == "update":
+                result = str(await registry.update_repository())
+            else:
+                result = str(await registry.delete_project(project))
+
+        assert "Error" in result or "error" in result, (
+            f"{path} with a failing {failure} reported success: {result}"
+        )
+        if failure == "mark":
+            assert not ingestor.delete_project.called, (
+                f"{path} began destructive work despite failing to persist "
+                "the marker, so a crash would leave nothing recording it"
+            )
+
+    async def test_a_fresh_scoped_reingest_marks_before_migrating(
+        self, temp_project_root: Path
+    ) -> None:
+        """Invariant (c): the third `ensure_constraints` caller, easy to miss.
+
+        The index and update paths were fixed first; this one was found a
+        round later, still running the migration that drops constraints and
+        can purge with nothing recording the run. Asserts the ORDER, because
+        after a success both have happened either way.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        _mark_indexed(registry)
+
+        order: list[str] = []
+        ingestor.ensure_constraints.side_effect = lambda: order.append("constraints")
+        real_write = ingestor.execute_write.side_effect
+
+        def _tracking(query: str, params: dict | None = None) -> None:
+            if "SET m.run_incomplete" in query:
+                order.append("mark")
+            return real_write(query, params)
+
+        ingestor.execute_write.side_effect = _tracking
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = SimpleNamespace(
+                reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+            )
+            await registry.reingest(["a.py"])
+
+        assert order[:2] == ["mark", "constraints"], (
+            "the fresh scoped reingest ran its destructive constraint "
+            f"migration before recording the run: {order}"
         )

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1351,3 +1351,133 @@ class TestIncompleteMarkerInvariant:
             "the fresh scoped reingest ran its destructive constraint "
             f"migration before recording the run: {order}"
         )
+
+    async def test_an_abort_before_mutation_releases_its_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """Nothing written means nothing to recover: the marker must come off.
+
+        The reingest path marks BEFORE the mutating call, so an abort raised
+        in the read-only prologue would otherwise leave durable state claiming
+        a run was interrupted -- and a fresh process would refuse scoped
+        reingests against a graph that is perfectly complete, until someone
+        ran a full update (#1705 review, round 7).
+
+        The second reingest on a FRESH registry is the real assertion: it is
+        the process that would have been wrongly blocked.
+        """
+        ingestor = self._store()
+        first = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(first)
+
+        aborting = MagicMock()
+        aborting.reingest_mutated = False
+        aborting.reingest.side_effect = ReingestAborted("graph read failed")
+        first._live_updater = aborting
+
+        aborted = await first.reingest(["a.py"])
+        assert "error" in aborted, "the abort must still surface to the caller"
+        assert project not in ingestor._marker_store, (
+            "an abort that wrote nothing left its marker behind, which blocks "
+            "every later scoped reingest on a graph that is complete"
+        )
+
+        second = self._registry(temp_project_root, ingestor)
+        _mark_indexed(second)
+        retained = MagicMock()
+        retained.reingest_mutated = False
+        retained.reingest.return_value = SimpleNamespace(
+            reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+        )
+        second._live_updater = retained
+        assert "error" not in await second.reingest(["a.py"]), (
+            "a fresh registry refused a scoped reingest after an abort that "
+            "changed nothing"
+        )
+
+    async def test_a_failure_after_the_first_write_keeps_its_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """Partial means recoverable state must survive.
+
+        The mirror of the case above, and the reason the classification is on
+        WHAT HAPPENED rather than the exception type: a failure once writing
+        has begun leaves a graph that may be half-rewritten, so the marker
+        stays and a fresh process refuses until a full update recovers it.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        mutating = MagicMock()
+        mutating.reingest_mutated = True
+        mutating.reingest.side_effect = RuntimeError("died after the delete")
+        registry._live_updater = mutating
+
+        failed = await registry.reingest(["a.py"])
+        assert "error" in failed
+        assert ingestor._marker_store.get(project) is True, (
+            "a failure after the first write cleared its marker, so a fresh "
+            "process would treat a partially rewritten graph as complete"
+        )
+        assert registry._live_updater is None, (
+            "the retained updater describes a graph that no longer exists"
+        )
+
+    async def test_the_updater_itself_reports_whether_it_mutated(
+        self, temp_project_root: Path
+    ) -> None:
+        """Drives the REAL `GraphUpdater`, not a mock with the flag preset.
+
+        The three tests above set `reingest_mutated` by hand on a double, so
+        they pin the MCP handler's classification but say nothing about
+        whether `GraphUpdater` sets the flag in the right place. Mutating the
+        production line that sets it left every one of them green (measured),
+        which is exactly the gap this closes (#1705 review, round 7).
+
+        A prologue failure must leave the flag False: `_hydrate_for_reingest`
+        raising is converted to `ReingestAborted` before any delete or write.
+        """
+        from codebase_rag.graph_updater import GraphUpdater, ReingestAborted
+        from codebase_rag.parser_loader import load_parsers
+        from codebase_rag.tests.conftest import _MockIngestor
+
+        (temp_project_root / "mod.py").write_text("def f(): pass\n", encoding="utf-8")
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=_MockIngestor(),
+            repo_path=temp_project_root,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.reingest_mutated = True  # stale value from a previous call
+
+        with patch.object(
+            updater, "_hydrate_for_reingest", side_effect=RuntimeError("read failed")
+        ):
+            with pytest.raises(ReingestAborted):
+                updater.reingest(["mod.py"])
+
+        assert updater.reingest_mutated is False, (
+            "a failure in the read-only prologue left the mutation flag set, "
+            "so the caller would keep a marker for a run that changed nothing"
+        )
+
+        # And the other direction, which is the half that actually pins the
+        # production line: a run that gets PAST the prologue must report True.
+        # Asserting only the False case above cannot distinguish the real code
+        # from one that never sets the flag at all -- both leave it False, so
+        # mutating `reingest_mutated = True` to False left this test green
+        # (measured, #1705 review round 7).
+        fresh = GraphUpdater(
+            ingestor=_MockIngestor(),
+            repo_path=temp_project_root,
+            parsers=parsers,
+            queries=queries,
+        )
+        fresh.reingest(["mod.py"])
+        assert fresh.reingest_mutated is True, (
+            "a reingest that got past the read-only prologue and issued writes "
+            "reported that it had not mutated, so a failure afterwards would "
+            "clear the marker protecting a partial graph"
+        )

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1138,3 +1138,66 @@ class TestIncompleteMarkerSurvivesTheProcess:
         assert "failed part way" in refused.get("error", ""), (
             f"an unreadable marker was treated as a completed run; got {refused}"
         )
+
+    async def test_the_marker_precedes_constraint_migration(
+        self, temp_project_root: Path
+    ) -> None:
+        """`ensure_constraints` is destructive, so the marker must precede it.
+
+        It runs `_migrate_legacy_path_keys`, which drops constraints and can
+        run purge queries -- autocommitted work. Marking after it left a
+        window where a crash during migration produced a damaged graph with
+        nothing recording that a run had started (#1705 review, round 2).
+
+        Asserts the ORDER of calls rather than the end state: after a
+        successful run both have happened either way, so only the sequence
+        distinguishes the fixed code from the broken code.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        _mark_indexed(registry)
+
+        order: list[str] = []
+        ingestor.ensure_constraints.side_effect = lambda: order.append("constraints")
+        real_write = ingestor.execute_write.side_effect
+
+        def _tracking_write(query: str, params: dict | None = None) -> None:
+            if "SET m.run_incomplete" in query:
+                order.append("mark")
+            return real_write(query, params)
+
+        ingestor.execute_write.side_effect = _tracking_write
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            await registry.update_repository()
+
+        assert "mark" in order and "constraints" in order, (
+            f"fixture guard: both steps must run, saw {order}"
+        )
+        assert order.index("mark") < order.index("constraints"), (
+            "the constraint migration ran before the marker was written, so a "
+            f"crash during it would leave no record of the run: {order}"
+        )
+
+    async def test_deleting_a_project_clears_its_durable_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """An intentional delete must not strand the marker.
+
+        The marker lives on its own node so `delete_project` cannot reach it,
+        which is what lets it survive an index's delete-then-rebuild. The
+        consequence is that a deliberate deletion leaves it behind, and a
+        fresh registry then refuses reingest forever for a project the user
+        removed on purpose (#1705 review, round 2).
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        result = await registry.delete_project(project)
+
+        assert result.get("success"), f"the delete itself must succeed: {result}"
+        assert project not in ingestor._marker_store, (
+            "the deleted project kept its incomplete-run marker, so a fresh "
+            "registry would refuse reingest for a project that is gone"
+        )

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1274,6 +1274,48 @@ class TestIncompleteMarkerInvariant:
                 "the marker, so a crash would leave nothing recording it"
             )
 
+    async def test_a_retained_updater_reingest_is_marked_too(
+        self, temp_project_root: Path
+    ) -> None:
+        """The fifth mutating path: reingest through a RETAINED updater.
+
+        Both branches of `_reingest_sync` reach `updater.reingest`, which
+        mutates, but the marker was established only inside the hydrating
+        branch. A reingest through a retained updater therefore ran entirely
+        unmarked, and an interruption left a partially mutated graph a
+        restarted process could not tell from a complete one (#1705 round 6).
+
+        Drives the retained path by leaving `_live_updater` set, which is the
+        state a previous successful call leaves behind.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        retained = MagicMock()
+        retained.reingest.return_value = SimpleNamespace(
+            reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+        )
+        registry._live_updater = retained
+
+        marked_during: list[bool] = []
+        retained.reingest.side_effect = lambda *a, **k: (
+            marked_during.append(ingestor._marker_store.get(project) is True)
+            or SimpleNamespace(
+                reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+            )
+        )
+
+        await registry.reingest(["a.py"])
+
+        assert marked_during == [True], (
+            "the retained-updater reingest mutated the graph without the "
+            "durable marker set, so an interruption would leave no record"
+        )
+        assert project not in ingestor._marker_store, (
+            "the marker must be cleared once the reingest completes"
+        )
+
     async def test_a_fresh_scoped_reingest_marks_before_migrating(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -862,3 +863,118 @@ class TestReingest:
             result = await mcp_registry.wipe_database(confirm=True)
             assert "rror" in result
             assert mcp_registry._live_updater is None
+
+
+class TestIncompleteMarkerSurvivesTheProcess:
+    """The refusal must outlive the process that earned it (issue #1679)."""
+
+    @staticmethod
+    def _store() -> MagicMock:
+        """An ingestor whose marker property persists across registries.
+
+        Backed by a dict rather than a canned return value: the point of the
+        fix is that the SECOND registry reads what the FIRST one wrote, and a
+        static return value would satisfy the assertion without any write
+        having happened.
+        """
+        store: dict[str, bool] = {}
+        ingestor = MagicMock()
+
+        def _write(query: str, params: dict | None = None) -> None:
+            name = (params or {}).get(cs.KEY_PROJECT_NAME)
+            if "SET p.run_incomplete" in query:
+                store[str(name)] = True
+            elif "REMOVE p.run_incomplete" in query:
+                store.pop(str(name), None)
+
+        def _read(query: str, params: dict | None = None) -> list[dict]:
+            if "run_incomplete" not in query:
+                return []
+            name = str((params or {}).get(cs.KEY_PROJECT_NAME))
+            return [{"run_incomplete": store.get(name, False)}]
+
+        ingestor.execute_write.side_effect = _write
+        ingestor.fetch_all.side_effect = _read
+        ingestor._marker_store = store
+        return ingestor
+
+    def _registry(self, root: Path, ingestor: MagicMock) -> MCPToolsRegistry:
+        """A registry sharing `ingestor` but nothing else.
+
+        Each call is a separate process as far as `_graph_incomplete` is
+        concerned, which is precisely the case the persisted marker exists
+        for; `cypher_gen` is per-registry because nothing here queries it.
+        """
+        return MCPToolsRegistry(
+            project_root=str(root), ingestor=ingestor, cypher_gen=MagicMock()
+        )
+
+    async def test_a_fresh_registry_refuses_reingest_after_a_crashed_update(
+        self, temp_project_root: Path
+    ) -> None:
+        """A new process must still refuse, which is the whole gap.
+
+        `_graph_incomplete` lives on the registry, so the ORIGINAL process
+        refuses correctly. The defect was that a crash or an MCP restart
+        produced a registry whose flag is False, which then hydrated a scoped
+        updater from the partial graph and treated its missing definitions as
+        authoritative.
+
+        The second registry here shares only the store, never the flag, which
+        is exactly what a restarted server has.
+        """
+        ingestor = self._store()
+        first = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(first)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.run.side_effect = RuntimeError("update died")
+            assert "Error" in await first.update_repository()
+
+        assert ingestor._marker_store.get(project) is True, (
+            "the failed update left no persisted marker, so a fresh process "
+            "has nothing to read"
+        )
+
+        # The crash: a brand new registry over the same store.
+        second = self._registry(temp_project_root, ingestor)
+        _mark_indexed(second)
+        assert second._graph_incomplete is False, (
+            "fixture guard: the new registry must NOT carry the in-process "
+            "flag, or this test cannot tell the persisted marker apart from it"
+        )
+
+        refused = await second.reingest(["a.py"])
+        assert "failed part way" in refused.get("error", ""), (
+            "a fresh registry hydrated a scoped updater from the partial "
+            f"graph left by a crashed update; got {refused}"
+        )
+
+    async def test_a_completed_update_lifts_the_refusal_for_a_fresh_registry(
+        self, temp_project_root: Path
+    ) -> None:
+        """The marker must be CLEARED, not merely set.
+
+        Without this the fix would be indistinguishable from one that refuses
+        every reingest forever, which also passes the test above.
+        """
+        ingestor = self._store()
+        first = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(first)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            assert "Error" not in await first.update_repository()
+
+        assert project not in ingestor._marker_store, (
+            "a completed update left the marker set, so every later reingest "
+            "would refuse for a run that actually finished"
+        )
+
+        second = self._registry(temp_project_root, ingestor)
+        _mark_indexed(second)
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = SimpleNamespace(
+                reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+            )
+            result = await second.reingest(["a.py"])
+        assert "error" not in result, f"a completed run must not refuse: {result}"

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -2376,6 +2376,54 @@ class TestIncompleteMarkerInvariant:
             f"the half-wiped graph it left: {result}"
         )
 
+    async def test_a_failed_structural_delta_does_not_inherit_an_attribution(
+        self, temp_project_root: Path
+    ) -> None:
+        """The seventh flag setter, which arrived on main after this branch.
+
+        `_delta_after_write` invalidates the graph when its re-ingest raised,
+        precisely because a subtree may have been deleted and not rebuilt. So
+        the flag it sets records real damage that NO marker describes, and a
+        stranded marker must not be allowed to heal it.
+
+        That site (#1525) landed on `main` while this branch was in review, so
+        it was written against a file where `_flag_from_failed_clear` does not
+        exist. Without the reset added on the rebase it sets the flag and
+        leaves whatever attribution happened to be there -- letting the next
+        reingest lift a refusal the delta path earned. Same overwrite as the
+        abandon path, reached from the other direction.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # A pending recoverable marker, attributed to this project.
+        assert registry._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert registry._require_marker_cleared(project) is not None, (
+            "fixture guard: the clear was expected to fail"
+        )
+        ingestor._failing.discard("clear")
+        assert registry._flag_from_failed_clear == project, (
+            "fixture guard: the failed clear must attribute the flag, or "
+            "there is no attribution for the delta path to inherit"
+        )
+
+        # The delta path's re-ingest dies after the graph may have changed.
+        failing = MagicMock()
+        failing.reingest.side_effect = RuntimeError("delta re-ingest died")
+        registry._live_updater = failing
+        registry._delta_after_write(["a.py"])
+
+        assert registry._graph_incomplete is True, (
+            "fixture guard: the failed delta must invalidate the graph"
+        )
+        assert registry._flag_from_failed_clear is None, (
+            "the structural-delta path set the incomplete flag while leaving "
+            "an unrelated attribution in place, so a pending marker recovery "
+            "can lift a refusal that records a half-rebuilt subtree"
+        )
+
     def test_the_mark_query_never_lowers_the_phase(self) -> None:
         """Pins the production Cypher the fake store models.
 

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -2065,12 +2065,13 @@ class TestIncompleteMarkerInvariant:
         else:  # pragma: no cover - guards against a typo in the parametrise
             raise AssertionError(f"unknown failure path {path!r}")
 
-    # `reingest_mutated` is deliberately absent: that path promotes this
-    # project's own marker to `writing=true` before it sets the flag, so
-    # `_persisted_incomplete` refuses on its own and no assertion here can
-    # tell its attribution-drop apart from its absence. Including it would
-    # add a variant that stays green when the line is deleted -- assurance
-    # the test cannot actually give (#1705 review, final round).
+    # `reingest_mutated` is absent from this parametrise because it cannot
+    # be driven through the same helper: within ONE registry that path leaves
+    # the marker `writing=true`, so `_persisted_incomplete` refuses on its own
+    # and the attribution is never the deciding factor. It is not untestable,
+    # only untestable HERE -- a second process clearing the marker exposes it,
+    # which `test_another_process_clearing_the_marker_cannot_heal_a_mutating_
+    # failure` below does (#1705 review, final round).
     @pytest.mark.parametrize("failure", ["wipe", "delete", "index", "update"])
     async def test_a_pending_recovery_cannot_heal_a_marker_less_failure(
         self, temp_project_root: Path, failure: str
@@ -2132,6 +2133,90 @@ class TestIncompleteMarkerInvariant:
             "an unrelated marker recovery cleared the flag a failed "
             f"{failure} earned, and scoped reingest ran over a partial "
             f"graph: {result}"
+        )
+
+    async def test_another_process_clearing_the_marker_cannot_heal_a_mutating_failure(
+        self, temp_project_root: Path
+    ) -> None:
+        """The fifth attribution site, which only a SECOND process exposes.
+
+        A reingest that got past `before_write` may have left the graph
+        partial, so it sets `_graph_incomplete`. Within one registry the
+        durable marker is `writing=true` by then and `_persisted_incomplete`
+        refuses on its own, which is why this site looks untestable.
+
+        It is not. Another process completing a full update clears that
+        marker durably. `_persisted_incomplete` then returns False while THIS
+        registry still knows its own graph is partial, and a stale
+        attribution left by an earlier failed clear satisfies
+        `recoverable_here` -- healing a flag no marker explains and letting a
+        scoped reingest run over the partial graph (#1705 review).
+
+        The updater is RETAINED on `_live_updater` and its `reingest` must
+        RAISE after calling `before_write`. Both matter: a patched
+        `GraphUpdater` class never reaches the retained-updater path, and a
+        reingest that returns instead of raising never enters the `mutated`
+        branch at all -- the call then falls through to
+        `_require_marker_cleared`, whose successful clear nulls the
+        attribution for an unrelated reason and the test discriminates
+        nothing. The fixture guards below pin both.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # An earlier failed clear attributes the flag to this project.
+        assert registry._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert registry._require_marker_cleared(project) is not None, (
+            "fixture guard: the clear was expected to fail"
+        )
+        ingestor._failing.discard("clear")
+        assert registry._flag_from_failed_clear == project, (
+            "fixture guard: the failed clear must attribute the flag, or "
+            "there is no stale attribution for the heal to act on"
+        )
+
+        # A retained updater that writes, then dies: the graph may be partial.
+        retained = MagicMock()
+
+        def _reingest(paths, deleted=None, before_write=None, **kwargs):
+            if before_write is not None:
+                before_write()  # promotes this project's marker to writing
+            retained.reingest_mutated = True  # the read-only prologue ended
+            raise RuntimeError("died after writing began")
+
+        retained.reingest_mutated = False
+        retained.reingest.side_effect = _reingest
+        registry._live_updater = retained
+        assert "error" in str(await registry.reingest(["a.py"]))
+        assert registry._graph_incomplete is True, (
+            "fixture guard: the mutating failure must set the in-process flag"
+        )
+        assert ingestor._writing_store.get(project) is True, (
+            "fixture guard: `before_write` must have promoted the marker, or "
+            "this is not the mutated branch the test exists for"
+        )
+
+        # Another process finishes a full update and clears the marker.
+        other = self._registry(temp_project_root, ingestor)
+        _mark_indexed(other)
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            assert "Error" not in await other.update_repository()
+        assert registry._persisted_incomplete(project) is False, (
+            "fixture guard: the other process must have cleared the durable "
+            "marker, or _persisted_incomplete refuses on its own and the "
+            "attribution is never the deciding factor"
+        )
+
+        registry._live_updater = None
+        _mark_indexed(registry)
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            result = str(await registry.reingest(["a.py"]))
+        assert "error" in result, (
+            "another process's marker clear healed a flag earned by THIS "
+            "process's mutating failure, so a scoped reingest ran over the "
+            f"partial graph it left: {result}"
         )
 
     def test_the_mark_query_never_lowers_the_phase(self) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -2297,12 +2297,26 @@ class TestIncompleteMarkerInvariant:
         `writing=false` marker, and lifted the flag, hydrating an updater over
         a half-wiped graph. No store outage at any point (#1705 review).
 
-        Both parameters must REFUSE, and they fail differently on broken code:
-        the same-project case is the defect, while the different-project case
-        refuses anyway because the attribution never matches at the guard.
-        The near-miss is carried as a control precisely because it looks like
-        the same test -- a future simplification to one project would keep it
-        green while removing all of its power.
+        Both parameters must REFUSE. What the near-miss case is worth,
+        measured rather than assumed:
+
+        * `recoverable_here = True` (a provenance-free heal) reddens BOTH
+          cases. So the near-miss can fail for the right reason -- its
+          abandon leaves a recoverable marker, and a blind heal lifts the
+          wipe's flag for it too. It is a real control against the heal
+          logic, not decoration.
+        * `if True:` on the refusal guard (refuse everything) leaves BOTH
+          cases green. So neither case detects OVER-refusal; both are
+          satisfied by code that refuses unconditionally. Their greenness is
+          not evidence that a legitimate reingest still succeeds. Twenty
+          other tests in this file DO catch it (measured), among them
+          `test_reingest_builds_one_updater_and_reuses_it` and
+          `test_wipe_database_drops_the_retained_updater`; the coverage is
+          real, it simply is not here.
+
+        Keep both parameters: collapsing them to one would leave the heal
+        logic pinned in a single direction. But do not read this test as
+        covering the refuse-everything failure mode; it does not.
         """
         ingestor = self._store()
         registry = self._registry(temp_project_root, ingestor)

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1975,6 +1975,48 @@ class TestIncompleteMarkerInvariant:
             "the in-process flag was not healed from the durable state"
         )
 
+    async def test_an_earlier_recovery_cannot_clear_a_later_local_failure(
+        self, temp_project_root: Path
+    ) -> None:
+        """The recovery flag must not outlive the call that set it.
+
+        A marker recovered once, then a LATER failure that could not persist a
+        marker at all: the durable state is clean and `_graph_incomplete` is
+        the only record that the graph is partial. If the recovery flag were a
+        process-lifetime latch it would still authorise clearing that flag, and
+        scoped reingest would be accepted over a partial graph (#1705 review).
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # A recoverable marker is stranded and then recovered on the next read.
+        assert registry._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert registry._require_marker_cleared(project) is not None, (
+            "fixture guard: the clear was expected to fail"
+        )
+        ingestor._failing.discard("clear")
+        assert registry._persisted_incomplete(project) is False, (
+            "fixture guard: the recoverable marker should have been cleared"
+        )
+        assert registry._marker_recovered is True, (
+            "fixture guard: the recovery flag should have been set"
+        )
+
+        # A later failure that leaves NO durable marker: only the flag knows.
+        registry._graph_incomplete = True
+        assert not ingestor._marker_store, (
+            "fixture guard: this interleaving needs a clean durable state"
+        )
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            result = str(await registry.reingest(["a.py"]))
+        assert "error" in result, (
+            "a stale recovery flag cleared a local-only incomplete marker and "
+            f"scoped reingest was accepted over a partial graph: {result}"
+        )
+
     def test_the_mark_query_never_lowers_the_phase(self) -> None:
         """Pins the production Cypher the fake store models.
 

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -2153,13 +2153,36 @@ class TestIncompleteMarkerInvariant:
         scoped reingest run over the partial graph (#1705 review).
 
         The updater is RETAINED on `_live_updater` and its `reingest` must
-        RAISE after calling `before_write`. Both matter: a patched
-        `GraphUpdater` class never reaches the retained-updater path, and a
-        reingest that returns instead of raising never enters the `mutated`
-        branch at all -- the call then falls through to
-        `_require_marker_cleared`, whose successful clear nulls the
-        attribution for an unrelated reason and the test discriminates
-        nothing. The fixture guards below pin both.
+        RAISE after calling `before_write`.
+
+        The raising matters and is guarded below: a reingest that RETURNS
+        never enters the `mutated` branch, the call falls through to
+        `_require_marker_cleared`, and that successful clear nulls the
+        attribution for an unrelated reason -- the test would then pass on
+        broken code.
+
+        The retaining is load-bearing for a reason worth stating, because a
+        patched `GraphUpdater` class LOOKS equivalent: it also reaches the
+        mutated branch (the hydrating path builds its own updater and honours
+        `reingest_mutated`) and leaves every observable identical afterwards.
+
+        The difference is that the patched form goes through
+        `_hydrate_reingest_updater`, and the heal under test lives INSIDE that
+        method. Measured: it runs 0 times on the retained path and once on the
+        patched path, where it consumes the attribution
+        (`<project>` -> `None`) during step 2. So the patched form performs at
+        step 2 the very heal this test wants to observe at step 4, and the
+        stale attribution never survives to be tested. Under mutation the
+        retained form is ACCEPTED (the bug) while the patched form still
+        refuses.
+
+        Consequence for maintenance: this test depends on `reingest` reaching
+        a RETAINED updater without hydrating. If the hydration seam moves --
+        if `_reingest_sync` starts hydrating even when `_live_updater` is set,
+        or the heal moves out of `_hydrate_reingest_updater` -- this test
+        stops discriminating and the mutation will still appear to work.
+        Re-measure the hydrate call count if that code is refactored
+        (#1705 review).
         """
         ingestor = self._store()
         registry = self._registry(temp_project_root, ingestor)
@@ -2189,13 +2212,41 @@ class TestIncompleteMarkerInvariant:
         retained.reingest_mutated = False
         retained.reingest.side_effect = _reingest
         registry._live_updater = retained
+
+        # The heal under test lives inside `_hydrate_reingest_updater`, so
+        # step 2 must NOT hydrate: a hydrating step 2 performs that heal
+        # itself and consumes the attribution before step 4 can observe it.
+        # This counts the seam directly, so a refactor that starts hydrating
+        # here fails loudly instead of quietly making the test vacuous.
+        hydrations = 0
+        real_hydrate = registry._hydrate_reingest_updater
+
+        def _counting_hydrate(name: str) -> object:
+            nonlocal hydrations
+            hydrations += 1
+            return real_hydrate(name)
+
+        registry._hydrate_reingest_updater = _counting_hydrate  # type: ignore[method-assign]
         assert "error" in str(await registry.reingest(["a.py"]))
+        registry._hydrate_reingest_updater = real_hydrate  # type: ignore[method-assign]
+        assert hydrations == 0, (
+            "fixture guard: step 2 hydrated a fresh updater, so the heal "
+            "inside `_hydrate_reingest_updater` already consumed the "
+            "attribution and step 4 tests nothing (#1705 review)"
+        )
+        # Validate the instrument: `== 0` above reads the same whether the
+        # counter works or the wrapper was never invoked (mis-scoped, or
+        # attached to the wrong object), which would make it green forever.
+        # Step 4 hydrates by construction -- `_live_updater` is cleared
+        # below -- so the counter MUST reach 1 there. Asserted after step 4.
         assert registry._graph_incomplete is True, (
             "fixture guard: the mutating failure must set the in-process flag"
         )
+        assert registry._live_updater is None, (
+            "fixture guard: the mutated branch must have dropped the retained updater"
+        )
         assert ingestor._writing_store.get(project) is True, (
-            "fixture guard: `before_write` must have promoted the marker, or "
-            "this is not the mutated branch the test exists for"
+            "fixture guard: `before_write` must have promoted the marker"
         )
 
         # Another process finishes a full update and clears the marker.
@@ -2211,8 +2262,16 @@ class TestIncompleteMarkerInvariant:
 
         registry._live_updater = None
         _mark_indexed(registry)
+        registry._hydrate_reingest_updater = _counting_hydrate  # type: ignore[method-assign]
         with patch("codebase_rag.mcp.tools.GraphUpdater"):
             result = str(await registry.reingest(["a.py"]))
+        registry._hydrate_reingest_updater = real_hydrate  # type: ignore[method-assign]
+        assert hydrations == 1, (
+            "instrument check: step 4 hydrates by construction, so the "
+            "counter must register it. A counter that stays 0 here is not "
+            "measuring anything, and the `== 0` guard above is vacuous "
+            f"(#1705 review): {hydrations}"
+        )
         assert "error" in result, (
             "another process's marker clear healed a flag earned by THIS "
             "process's mutating failure, so a scoped reingest ran over the "

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -2025,19 +2025,72 @@ class TestIncompleteMarkerInvariant:
             f"marker-less failure earned: {result}"
         )
 
+    @staticmethod
+    async def _fail_without_writing_a_marker(
+        registry: MCPToolsRegistry, ingestor: MagicMock, path: str
+    ) -> None:
+        """Drive one marker-less failure path to its `_graph_incomplete = True`.
+
+        Each branch fails a DIFFERENT tool, because each sets the flag at its
+        own site and the attribution has to be dropped at all five. The
+        failures are the ones the tests above already pin as flag-setting;
+        this only reuses their driving mechanism.
+        """
+        if path == "wipe":
+            ingestor.clean_database.side_effect = RuntimeError("wipe died")
+            with patch("codebase_rag.mcp.tools.GraphUpdater"):
+                await registry.wipe_database(confirm=True)
+            ingestor.clean_database.side_effect = None
+        elif path == "delete":
+            # A delete of ANOTHER project that dies part way. It must fail:
+            # `_delete_project_sync` marks before its first write but clears
+            # the flag again when it completes, so a successful delete tests
+            # nothing. The target is deliberately not this project, which is
+            # what makes the failure marker-less for the project under test.
+            ingestor.list_projects.return_value = ["other"]
+            ingestor.delete_project.side_effect = RuntimeError("delete died")
+            with patch("codebase_rag.mcp.tools.GraphUpdater"):
+                await registry.delete_project("other")
+            ingestor.delete_project.side_effect = None
+        elif path == "index":
+            ingestor.delete_project.side_effect = RuntimeError("delete died")
+            with patch("codebase_rag.mcp.tools.GraphUpdater"):
+                await registry.index_repository()
+            ingestor.delete_project.side_effect = None
+        elif path == "update":
+            ingestor.flush_all.side_effect = [RuntimeError("flush died")]
+            with patch("codebase_rag.mcp.tools.GraphUpdater"):
+                await registry.update_repository()
+            ingestor.flush_all.side_effect = None
+        else:  # pragma: no cover - guards against a typo in the parametrise
+            raise AssertionError(f"unknown failure path {path!r}")
+
+    # `reingest_mutated` is deliberately absent: that path promotes this
+    # project's own marker to `writing=true` before it sets the flag, so
+    # `_persisted_incomplete` refuses on its own and no assertion here can
+    # tell its attribution-drop apart from its absence. Including it would
+    # add a variant that stays green when the line is deleted -- assurance
+    # the test cannot actually give (#1705 review, final round).
+    @pytest.mark.parametrize("failure", ["wipe", "delete", "index", "update"])
     async def test_a_pending_recovery_cannot_heal_a_marker_less_failure(
-        self, temp_project_root: Path
+        self, temp_project_root: Path, failure: str
     ) -> None:
         """The heal needs PROVENANCE, not just "some marker was recovered".
 
-        A stranded `writing=false` marker is still pending, and then a wipe
+        A stranded `writing=false` marker is still pending, and then a call
         fails part way and sets `_graph_incomplete` while writing no marker
         for this project. At the next reingest the pending marker recovers,
         and a bare "a marker was recovered" flag would take that as licence
-        to clear a flag the wipe earned -- discarding the only record that
+        to clear a flag the failure earned -- discarding the only record that
         the graph is partial (#1705 review). The flag is attributed to the
         project whose failed CLEAR set it, so an unrelated recovery cannot
         consume it.
+
+        Parametrised over every marker-less failure path, because each one
+        sets the flag at its own site and drops the attribution on its own
+        line: hard-coding the wipe left the other four lines deletable with
+        the file still green, so the exact bug this fixes could come back at
+        four of the five places it was fixed (#1705 review, final round).
 
         Unlike the sibling test above, the pending marker is deliberately NOT
         consumed before the guard runs: consuming it first is what let the
@@ -2057,21 +2110,28 @@ class TestIncompleteMarkerInvariant:
         assert ingestor._marker_store.get(project) is True, (
             "fixture guard: the marker must still be pending at guard time"
         )
-
-        # A marker-less failure: the wipe dies after dropping the updater.
-        ingestor.clean_database.side_effect = RuntimeError("wipe died")
-        with patch("codebase_rag.mcp.tools.GraphUpdater"):
-            await registry.wipe_database(confirm=True)
-        assert registry._graph_incomplete is True, (
-            "fixture guard: the failed wipe must set the in-process flag"
+        assert registry._flag_from_failed_clear == project, (
+            "fixture guard: the failed clear must attribute the flag to this "
+            "project, or the recovery under test heals nothing"
         )
 
-        ingestor.clean_database.side_effect = None
+        # A failure that writes no marker for this project.
+        await self._fail_without_writing_a_marker(registry, ingestor, failure)
+        assert registry._graph_incomplete is True, (
+            f"fixture guard: the failed {failure} must set the in-process flag"
+        )
+        assert registry._flag_from_failed_clear is None, (
+            f"the failed {failure} left the flag attributed to a stranded "
+            "marker, so an unrelated recovery may consume it"
+        )
+
+        _mark_indexed(registry)
         with patch("codebase_rag.mcp.tools.GraphUpdater"):
             result = str(await registry.reingest(["a.py"]))
         assert "error" in result, (
-            "an unrelated marker recovery cleared the flag a failed wipe "
-            f"earned, and scoped reingest ran over a partial graph: {result}"
+            "an unrelated marker recovery cleared the flag a failed "
+            f"{failure} earned, and scoped reingest ran over a partial "
+            f"graph: {result}"
         )
 
     def test_the_mark_query_never_lowers_the_phase(self) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1931,6 +1931,50 @@ class TestIncompleteMarkerInvariant:
                 "still changing"
             )
 
+    async def test_a_transient_clear_failure_does_not_wedge_the_process(
+        self, temp_project_root: Path
+    ) -> None:
+        """A recoverable marker must not be masked by the in-process flag.
+
+        A read-only scoped reingest aborts and its marker clear fails because
+        the store is momentarily unwritable, so `_require_marker_cleared` sets
+        `_graph_incomplete`. The marker it left behind is `writing=false`, the
+        recoverable kind that `_persisted_incomplete` clears on sight. But the
+        refusal short-circuited on the local flag, so that recovery never ran
+        and THIS process refused every later scoped reingest until a full
+        update or a restart, long after the store became writable again
+        (#1705 review).
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # A no-write run: marked at writing=false, then its clear is refused.
+        assert registry._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert registry._require_marker_cleared(project) is not None, (
+            "fixture guard: the clear was expected to fail"
+        )
+        assert registry._graph_incomplete is True, (
+            "fixture guard: a failed clear must set the in-process flag"
+        )
+        assert ingestor._writing_store.get(project) is False, (
+            "fixture guard: the stranded marker must be the recoverable kind"
+        )
+
+        # The store recovers.
+        ingestor._failing.discard("clear")
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            result = str(await registry.reingest(["a.py"]))
+        assert "error" not in result, (
+            "the same process still refused scoped reingest after the store "
+            f"recovered and the marker was clearable: {result}"
+        )
+        assert registry._graph_incomplete is False, (
+            "the in-process flag was not healed from the durable state"
+        )
+
     def test_the_mark_query_never_lowers_the_phase(self) -> None:
         """Pins the production Cypher the fake store models.
 

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1975,22 +1975,23 @@ class TestIncompleteMarkerInvariant:
             "the in-process flag was not healed from the durable state"
         )
 
-    async def test_an_earlier_recovery_cannot_clear_a_later_local_failure(
+    async def test_a_recovery_does_not_clear_a_flag_it_cannot_explain(
         self, temp_project_root: Path
     ) -> None:
-        """The recovery flag must not outlive the call that set it.
+        """The heal is keyed to the project whose failed clear set the flag.
 
-        A marker recovered once, then a LATER failure that could not persist a
-        marker at all: the durable state is clean and `_graph_incomplete` is
-        the only record that the graph is partial. If the recovery flag were a
-        process-lifetime latch it would still authorise clearing that flag, and
-        scoped reingest would be accepted over a partial graph (#1705 review).
+        A stranded marker is recovered for one project, and a LATER failure
+        that persisted no marker sets `_graph_incomplete` again. The earlier
+        recovery must not license clearing that flag: the durable state is
+        clean and the flag is the only record the graph is partial. The
+        attribution is dropped wherever a non-marker path raises the flag,
+        so the heal has nothing to match (#1705 review).
         """
         ingestor = self._store()
         registry = self._registry(temp_project_root, ingestor)
         project = _mark_indexed(registry)
 
-        # A recoverable marker is stranded and then recovered on the next read.
+        # Strand a marker, then recover it: attribution names this project.
         assert registry._require_marker(project, writing=False) is None
         ingestor._failing.add("clear")
         assert registry._require_marker_cleared(project) is not None, (
@@ -2000,12 +2001,19 @@ class TestIncompleteMarkerInvariant:
         assert registry._persisted_incomplete(project) is False, (
             "fixture guard: the recoverable marker should have been cleared"
         )
-        assert registry._marker_recovered is True, (
-            "fixture guard: the recovery flag should have been set"
+        assert registry._flag_from_failed_clear == project, (
+            "fixture guard: the failed clear should have attributed the flag"
         )
 
-        # A later failure that leaves NO durable marker: only the flag knows.
-        registry._graph_incomplete = True
+        # A marker-less failure now raises the flag for a different reason;
+        # it must drop the stale attribution as it does so.
+        ingestor.clean_database.side_effect = RuntimeError("wipe died")
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            await registry.wipe_database(confirm=True)
+        ingestor.clean_database.side_effect = None
+        assert registry._graph_incomplete is True, (
+            "fixture guard: the failed wipe must set the in-process flag"
+        )
         assert not ingestor._marker_store, (
             "fixture guard: this interleaving needs a clean durable state"
         )
@@ -2013,8 +2021,57 @@ class TestIncompleteMarkerInvariant:
         with patch("codebase_rag.mcp.tools.GraphUpdater"):
             result = str(await registry.reingest(["a.py"]))
         assert "error" in result, (
-            "a stale recovery flag cleared a local-only incomplete marker and "
-            f"scoped reingest was accepted over a partial graph: {result}"
+            "a stale attribution from an earlier recovery cleared the flag a "
+            f"marker-less failure earned: {result}"
+        )
+
+    async def test_a_pending_recovery_cannot_heal_a_marker_less_failure(
+        self, temp_project_root: Path
+    ) -> None:
+        """The heal needs PROVENANCE, not just "some marker was recovered".
+
+        A stranded `writing=false` marker is still pending, and then a wipe
+        fails part way and sets `_graph_incomplete` while writing no marker
+        for this project. At the next reingest the pending marker recovers,
+        and a bare "a marker was recovered" flag would take that as licence
+        to clear a flag the wipe earned -- discarding the only record that
+        the graph is partial (#1705 review). The flag is attributed to the
+        project whose failed CLEAR set it, so an unrelated recovery cannot
+        consume it.
+
+        Unlike the sibling test above, the pending marker is deliberately NOT
+        consumed before the guard runs: consuming it first is what let the
+        earlier version of this fix pass while the hole was still open.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # Strand a recoverable marker and leave it pending.
+        assert registry._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert registry._require_marker_cleared(project) is not None, (
+            "fixture guard: the clear was expected to fail"
+        )
+        ingestor._failing.discard("clear")
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the marker must still be pending at guard time"
+        )
+
+        # A marker-less failure: the wipe dies after dropping the updater.
+        ingestor.clean_database.side_effect = RuntimeError("wipe died")
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            await registry.wipe_database(confirm=True)
+        assert registry._graph_incomplete is True, (
+            "fixture guard: the failed wipe must set the in-process flag"
+        )
+
+        ingestor.clean_database.side_effect = None
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            result = str(await registry.reingest(["a.py"]))
+        assert "error" in result, (
+            "an unrelated marker recovery cleared the flag a failed wipe "
+            f"earned, and scoped reingest ran over a partial graph: {result}"
         )
 
     def test_the_mark_query_never_lowers_the_phase(self) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -906,7 +906,11 @@ class TestIncompleteMarkerSurvivesTheProcess:
             if "SET m.run_incomplete" in query:
                 if query.lstrip().startswith("MERGE") or name in store:
                     store[name] = True
-                    writing[name] = bool((params or {}).get(cs.KEY_WRITING, True))
+                    # Monotonic, as the production MERGE is: a later mark can
+                    # raise the phase to writing but never lower it.
+                    writing[name] = writing.get(name, False) or bool(
+                        (params or {}).get(cs.KEY_WRITING, True)
+                    )
             elif "DELETE m" in query:
                 store.pop(name, None)
                 writing.pop(name, None)
@@ -1571,9 +1575,10 @@ class TestIncompleteMarkerInvariant:
         with (
             patch.object(
                 registry,
-                "_cleanup_project_embeddings",
-                side_effect=RuntimeError("vector store down"),
+                "_get_project_node_ids",
+                side_effect=RuntimeError("node id read failed"),
             ),
+            patch("codebase_rag.mcp.tools.delete_project_embeddings") as purge,
             patch("codebase_rag.mcp.tools.GraphUpdater"),
         ):
             if path == "index":
@@ -1581,8 +1586,11 @@ class TestIncompleteMarkerInvariant:
             else:
                 result = str(await registry.delete_project(project))
 
-        assert "vector store down" in result, (
+        assert "node id read failed" in result, (
             f"the cleanup failure must surface as the error: {result}"
+        )
+        assert not purge.called, (
+            "fixture guard: vectors were deleted, so this is not the read-only case"
         )
         assert not ingestor.delete_project.called, (
             "fixture guard: the graph was touched, so this is not the pre-write case"
@@ -1633,9 +1641,10 @@ class TestIncompleteMarkerInvariant:
             with (
                 patch.object(
                     registry,
-                    "_cleanup_project_embeddings",
-                    side_effect=RuntimeError("vector store down"),
+                    "_get_project_node_ids",
+                    side_effect=RuntimeError("node id read failed"),
                 ),
+                patch("codebase_rag.mcp.tools.delete_project_embeddings"),
                 patch("codebase_rag.mcp.tools.GraphUpdater"),
             ):
                 if path == "index":
@@ -1834,3 +1843,105 @@ class TestIncompleteMarkerInvariant:
             f"read [False, True]: {phases}"
         )
         assert project not in ingestor._marker_store
+
+    @pytest.mark.parametrize("path", ["index", "delete"])
+    async def test_the_vector_purge_runs_only_once_the_marker_says_writing(
+        self, temp_project_root: Path, path: str
+    ) -> None:
+        """The purge is destructive, so it sits AFTER the phase advance.
+
+        A scoped reingest restores vectors only for its own paths. If the
+        purge ran while the marker still said `writing=false`, a crash
+        mid-purge followed by a fresh process clearing that marker would leave
+        every unselected path without embeddings and nothing recording it
+        (#1705 review). Asserts the ORDER, because after a success both have
+        happened either way, and asserts a purge failure keeps the marker at
+        writing so the next process refuses until a full update restores them.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        phase_at_purge: list[bool | None] = []
+
+        def _purge(*_args: object, **_kwargs: object) -> None:
+            phase_at_purge.append(ingestor._writing_store.get(project))
+            raise RuntimeError("purge died half way")
+
+        with (
+            patch(
+                "codebase_rag.mcp.tools.delete_project_embeddings", side_effect=_purge
+            ),
+            patch("codebase_rag.mcp.tools.GraphUpdater"),
+        ):
+            if path == "index":
+                result = str(await registry.index_repository())
+            else:
+                result = str(await registry.delete_project(project))
+
+        assert "purge died half way" in result
+        assert phase_at_purge == [True], (
+            f"the vector purge ran with the marker's phase at {phase_at_purge}, "
+            "so a crash inside it would be cleared as a no-write stop"
+        )
+        assert ingestor._marker_store.get(project) is True
+        assert ingestor._writing_store.get(project) is True, (
+            "a failed purge left the marker at writing=false, so a fresh process "
+            "would clear it over a half-purged vector store"
+        )
+
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            assert "error" in await fresh.reingest(["a.py"]), (
+                "a fresh registry accepted scoped work over a half-purged store"
+            )
+
+    async def test_a_no_write_mark_cannot_demote_another_runs_writing_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """The phase is monotonic across processes.
+
+        Process A marks writing and starts changing the graph; process B's
+        retained reingest marks the same project `writing=false` and aborts
+        before writing. B's mark must not lower A's phase: a fresh process C
+        reading `writing=false` would clear the marker and hydrate from A's
+        partial graph (#1705 review). Whether B's CLEAR may delete A's marker
+        at all is the ownership question tracked in #1709; this pins the half
+        that a phase-monotonic mark closes.
+        """
+        ingestor = self._store()
+        a = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(a)
+        assert a._require_marker(project, writing=True) is None
+        assert ingestor._writing_store.get(project) is True
+
+        b = self._registry(temp_project_root, ingestor)
+        _mark_indexed(b)
+        assert b._require_marker(project, writing=False) is None
+        assert ingestor._writing_store.get(project) is True, (
+            "a writing=false mark demoted a marker another run left at writing"
+        )
+
+        c = self._registry(temp_project_root, ingestor)
+        _mark_indexed(c)
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            assert "error" in await c.reingest(["a.py"]), (
+                "a fresh registry cleared a marker over a graph another run is "
+                "still changing"
+            )
+
+    def test_the_mark_query_never_lowers_the_phase(self) -> None:
+        """Pins the production Cypher the fake store models.
+
+        The fake's monotonic phase is only faithful while the MERGE reads the
+        existing value back; a `SET m.writing = $writing` would demote another
+        run's marker and the fake would not notice. The query text is the one
+        place that can be asserted without a live store.
+        """
+        from codebase_rag import cypher_queries as cq
+
+        assert "coalesce(m.writing, false) OR $writing" in (
+            cq.CYPHER_MARK_PROJECT_INCOMPLETE
+        )
+        assert "m.writing = $writing" not in cq.CYPHER_MARK_PROJECT_INCOMPLETE

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -2278,6 +2278,90 @@ class TestIncompleteMarkerInvariant:
             f"partial graph it left: {result}"
         )
 
+    @pytest.mark.parametrize(
+        ("abandoned_project", "expect_refused"),
+        [("same", True), ("other", True)],
+        ids=["abandons-the-same-project", "abandons-a-different-project"],
+    )
+    async def test_a_run_that_wrote_nothing_cannot_relabel_another_failures_flag(
+        self, temp_project_root: Path, abandoned_project: str, expect_refused: bool
+    ) -> None:
+        """A no-write abandon must not touch the flag or its attribution.
+
+        A failed `wipe_database` leaves `_graph_incomplete=True` with NO
+        attribution: no marker records a wipe, so nothing may heal it. A later
+        run that stops BEFORE its first write then went through
+        `_require_marker_cleared`, which assigns the attribution
+        unconditionally -- stamping its own project onto the wipe's flag. The
+        next scoped reingest found `recoverable_here` true, recovered the
+        `writing=false` marker, and lifted the flag, hydrating an updater over
+        a half-wiped graph. No store outage at any point (#1705 review).
+
+        Both parameters must REFUSE, and they fail differently on broken code:
+        the same-project case is the defect, while the different-project case
+        refuses anyway because the attribution never matches at the guard.
+        The near-miss is carried as a control precisely because it looks like
+        the same test -- a future simplification to one project would keep it
+        green while removing all of its power.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        target = project if abandoned_project == "same" else "other"
+
+        # Marker-less damage: the wipe dies part way and no marker records it.
+        ingestor.clean_database.side_effect = RuntimeError("wipe died")
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            await registry.wipe_database(confirm=True)
+        ingestor.clean_database.side_effect = None
+        assert registry._graph_incomplete is True, (
+            "fixture guard: the failed wipe must set the flag"
+        )
+        assert registry._flag_from_failed_clear is None, (
+            "fixture guard: a wipe writes no marker, so its flag must carry "
+            "no attribution -- otherwise there is nothing for step 2 to "
+            "overwrite and this test proves nothing"
+        )
+
+        # A later run stops before its first write, and its clear fails too.
+        ingestor.list_projects.return_value = [project, "other"]
+        ingestor._failing.add("clear")
+        with (
+            patch.object(
+                registry,
+                "_get_project_node_ids",
+                side_effect=RuntimeError("node id read failed"),
+            ),
+            patch("codebase_rag.mcp.tools.delete_project_embeddings"),
+            patch("codebase_rag.mcp.tools.GraphUpdater"),
+        ):
+            await registry.delete_project(target)
+        ingestor._failing.discard("clear")
+        assert not ingestor.delete_project.called, (
+            "fixture guard: the abandon path must have stopped before the "
+            "first graph write"
+        )
+        if abandoned_project == "same":
+            # Only asserted for the defect case. The near-miss reaches the
+            # same intermediate state on broken code -- the attribution is
+            # claimed either way -- and asserting it here would redden the
+            # control too, costing it the property that makes it a control.
+            # What separates them is the VERDICT below, not this.
+            assert registry._flag_from_failed_clear is None, (
+                f"a run that abandoned {target} before writing anything "
+                "relabelled the flag a failed wipe earned, so a recoverable "
+                "marker can now heal damage no marker records"
+            )
+
+        _mark_indexed(registry)
+        registry._live_updater = None
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            result = str(await registry.reingest(["a.py"]))
+        assert ("error" in result) is expect_refused, (
+            "the wipe's refusal was discarded and a scoped reingest ran over "
+            f"the half-wiped graph it left: {result}"
+        )
+
     def test_the_mark_query_never_lowers_the_phase(self) -> None:
         """Pins the production Cypher the fake store models.
 

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1708,19 +1708,31 @@ class TestIncompleteMarkerInvariant:
         """Drives the REAL `GraphUpdater`: `before_write` runs once, at the seam.
 
         The MCP tests above preset the phase on doubles; this pins where the
-        updater actually invokes the hook. It must run AFTER the prologue
-        (so a prologue abort never reaches it) and BEFORE the first delete or
-        node write (so a crash at any later point finds `writing=true`), and
-        its failure must abort with the graph untouched.
+        updater actually invokes the hook. It must run AFTER the prologue (so
+        a prologue abort never reaches it) and BEFORE the first delete or
+        content write (so a crash at any later point finds `writing=true`),
+        and its failure must abort with the graph as it was.
+
+        The fixture has a PACKAGE, not a flat file, on purpose: on a fresh
+        updater the prologue's structure hydration re-emits the Package node
+        before the hook (idempotent, and identical to what any run writes),
+        so a flat layout would let an assertion on "any node write" pass
+        without exercising the claim (#1705 local review). The seam is the
+        first `execute_write` -- the delete of the re-parsed module -- and
+        that is what is ordered against here.
         """
         from codebase_rag.graph_updater import GraphUpdater, ReingestAborted
         from codebase_rag.parser_loader import load_parsers
         from codebase_rag.tests.conftest import _MockIngestor
 
-        (temp_project_root / "mod.py").write_text("def f(): pass\n", encoding="utf-8")
+        pkg = temp_project_root / "pkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "mod.py").write_text("def f(): pass\n", encoding="utf-8")
         parsers, queries = load_parsers()
 
-        # A hook that refuses: the run aborts, nothing is written.
+        # A hook that refuses: the run aborts, nothing is deleted or written
+        # beyond the idempotent structure upserts.
         refusing = _MockIngestor()
         updater = GraphUpdater(
             ingestor=refusing,
@@ -1730,7 +1742,7 @@ class TestIncompleteMarkerInvariant:
         )
         with pytest.raises(ReingestAborted, match="store refused"):
             updater.reingest(
-                ["mod.py"],
+                ["pkg/mod.py"],
                 before_write=lambda: (_ for _ in ()).throw(
                     RuntimeError("store refused")
                 ),
@@ -1738,17 +1750,19 @@ class TestIncompleteMarkerInvariant:
         assert updater.reingest_mutated is False, (
             "a refused before_write was classified as a mutation"
         )
-        assert not refusing.ensure_node_batch.called, (
-            "the run wrote nodes after before_write refused"
-        )
         assert not refusing.execute_write.called, (
-            "the run issued a write after before_write refused"
+            "the run issued a delete or write after before_write refused"
+        )
+        written_labels = {
+            call.args[0] for call in refusing.ensure_node_batch.call_args_list
+        }
+        assert cs.NodeLabel.FUNCTION not in written_labels, (
+            "a definition was written after before_write refused"
         )
 
         # A hook that records its place in the order of events.
         order: list[str] = []
         ingestor = _MockIngestor()
-        ingestor.ensure_node_batch.side_effect = lambda *a, **k: order.append("write")
         ingestor.execute_write.side_effect = lambda *a, **k: order.append("write")
         fresh = GraphUpdater(
             ingestor=ingestor,
@@ -1756,13 +1770,13 @@ class TestIncompleteMarkerInvariant:
             parsers=parsers,
             queries=queries,
         )
-        fresh.reingest(["mod.py"], before_write=lambda: order.append("phase"))
+        fresh.reingest(["pkg/mod.py"], before_write=lambda: order.append("phase"))
         assert order.count("phase") == 1, (
             f"before_write ran {order.count('phase')} times"
         )
         assert "write" in order, "fixture guard: the reingest issued no writes at all"
         assert order.index("phase") < order.index("write"), (
-            f"the phase advanced after the first write: {order[:5]}"
+            f"the phase advanced after the first delete or write: {order[:5]}"
         )
 
         # And the prologue abort never reaches the hook.
@@ -1778,7 +1792,7 @@ class TestIncompleteMarkerInvariant:
         ):
             with pytest.raises(ReingestAborted):
                 aborting.reingest(
-                    ["mod.py"], before_write=lambda: never.append("phase")
+                    ["pkg/mod.py"], before_write=lambda: never.append("phase")
                 )
         assert never == [], "before_write ran for a run that aborted in its prologue"
 

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -545,8 +545,8 @@ class TestReingest:
 
             mock_updater_cls.assert_called_once()
             assert mock_updater.reingest.call_args_list == [
-                call(["a.py"], deleted=[]),
-                call(["a.py"], deleted=["c.py"]),
+                call(["a.py"], deleted=[], before_write=ANY),
+                call(["a.py"], deleted=["c.py"], before_write=ANY),
             ]
             assert first == {
                 "reparsed": ["a.py"],
@@ -594,7 +594,9 @@ class TestReingest:
             await mcp_registry.reingest(["a.py"])
 
             mock_updater_cls.assert_called_once()
-            mock_updater.reingest.assert_called_once_with(["a.py"], deleted=[])
+            mock_updater.reingest.assert_called_once_with(
+                ["a.py"], deleted=[], before_write=ANY
+            )
 
     async def test_reingest_error_is_reported_not_raised(
         self, mcp_registry: MCPToolsRegistry
@@ -878,6 +880,10 @@ class TestIncompleteMarkerSurvivesTheProcess:
         having happened.
         """
         store: dict[str, bool] = {}
+        # The marker's phase, kept beside the marker itself so the existing
+        # `store[name] is True` assertions keep their meaning. Absent reads as
+        # writing, exactly as the production query's `coalesce` does.
+        writing: dict[str, bool] = {}
         ingestor = MagicMock()
 
         # A plain dict, never an attribute on the MagicMock: `getattr` on a
@@ -900,8 +906,10 @@ class TestIncompleteMarkerSurvivesTheProcess:
             if "SET m.run_incomplete" in query:
                 if query.lstrip().startswith("MERGE") or name in store:
                     store[name] = True
+                    writing[name] = bool((params or {}).get(cs.KEY_WRITING, True))
             elif "DELETE m" in query:
                 store.pop(name, None)
+                writing.pop(name, None)
 
         def _read(query: str, params: dict | None = None) -> list[dict]:
             if "run_incomplete" not in query:
@@ -912,7 +920,9 @@ class TestIncompleteMarkerSurvivesTheProcess:
             # A real MATCH returns NO ROWS when the marker node is absent, not
             # a row saying false. Modelling the empty result matters: code that
             # reads rows[0] would pass against a canned false and fail here.
-            return [{"run_incomplete": True}] if store.get(name) else []
+            if not store.get(name):
+                return []
+            return [{"run_incomplete": True, "writing": writing.get(name, True)}]
 
         def _delete_project(name: str) -> None:
             # Models CYPHER_DELETE_PROJECT: it detaches the Project and
@@ -924,6 +934,7 @@ class TestIncompleteMarkerSurvivesTheProcess:
         ingestor.fetch_all.side_effect = _read
         ingestor.delete_project.side_effect = _delete_project
         ingestor._marker_store = store
+        ingestor._writing_store = writing
         ingestor._failing = failing
         return ingestor
 
@@ -1538,3 +1549,274 @@ class TestIncompleteMarkerInvariant:
             "a stuck marker after a no-op abort was not reported, so an "
             f"operator has nothing explaining why reingests refuse: {logged}"
         )
+
+    @pytest.mark.parametrize("path", ["index", "delete"])
+    async def test_a_cleanup_failure_before_graph_work_does_not_strand_a_fresh_process(
+        self, temp_project_root: Path, path: str
+    ) -> None:
+        """The embedding purge is not a graph write; its failure must not block.
+
+        Index and delete mark, then purge the project's embeddings, then
+        delete the project. A purge that raised left the marker behind with
+        the graph untouched, and a fresh process refused every scoped reingest
+        against a complete graph until a full update ran (#1705 review). The
+        fresh registry's reingest below is the process that was wrongly
+        blocked; `delete_project` not being called is what proves the graph
+        was never touched.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        with (
+            patch.object(
+                registry,
+                "_cleanup_project_embeddings",
+                side_effect=RuntimeError("vector store down"),
+            ),
+            patch("codebase_rag.mcp.tools.GraphUpdater"),
+        ):
+            if path == "index":
+                result = str(await registry.index_repository())
+            else:
+                result = str(await registry.delete_project(project))
+
+        assert "vector store down" in result, (
+            f"the cleanup failure must surface as the error: {result}"
+        )
+        assert not ingestor.delete_project.called, (
+            "fixture guard: the graph was touched, so this is not the pre-write case"
+        )
+        assert project not in ingestor._marker_store, (
+            f"{path} left its marker behind after a failure that never reached "
+            "the graph, so a fresh process refuses scoped reingests for nothing"
+        )
+
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = SimpleNamespace(
+                reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+            )
+            assert "error" not in await fresh.reingest(["a.py"]), (
+                "a fresh registry refused a scoped reingest after a cleanup "
+                "failure that changed nothing"
+            )
+
+    @pytest.mark.parametrize("path", ["index", "delete", "reingest"])
+    async def test_a_marker_from_a_run_that_never_wrote_is_cleared_by_a_fresh_process(
+        self, temp_project_root: Path, path: str
+    ) -> None:
+        """The durable half of the recovery: the CLEAR failed, the phase saves it.
+
+        A run that stops before its first graph write clears its own marker,
+        but that clear is a write to the same store and can fail too. The
+        marker then stays, and before the phase existed a fresh process could
+        only refuse (#1705 review, the reproduction on this PR). Now the
+        marker says `writing=false`, so the fresh process knows the graph is
+        as the run found it, clears the marker itself and carries on.
+
+        Three ways to stop before the first write, one assertion each.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        ingestor._failing.add("clear")
+
+        if path == "reingest":
+            aborting = MagicMock()
+            aborting.reingest_mutated = False
+            aborting.reingest.side_effect = ReingestAborted("graph read failed")
+            registry._live_updater = aborting
+            result = str(await registry.reingest(["a.py"]))
+        else:
+            with (
+                patch.object(
+                    registry,
+                    "_cleanup_project_embeddings",
+                    side_effect=RuntimeError("vector store down"),
+                ),
+                patch("codebase_rag.mcp.tools.GraphUpdater"),
+            ):
+                if path == "index":
+                    result = str(await registry.index_repository())
+                else:
+                    result = str(await registry.delete_project(project))
+
+        assert "error" in result.lower()
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the clear must have failed and the marker stayed"
+        )
+        assert ingestor._writing_store.get(project) is False, (
+            f"{path} marked itself as writing before it had written anything, "
+            "so a fresh process has no way to tell this from a partial graph"
+        )
+        assert not ingestor.delete_project.called
+
+        # The store is writable again; the marker is still there.
+        ingestor._failing.discard("clear")
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = SimpleNamespace(
+                reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+            )
+            recovered = await fresh.reingest(["a.py"])
+        assert "error" not in recovered, (
+            "a fresh registry refused after a no-write stop whose clear failed, "
+            f"even though the marker said the graph was untouched: {recovered}"
+        )
+        assert project not in ingestor._marker_store, (
+            "the recovered marker must be gone once the reingest completes"
+        )
+
+    async def test_a_marker_that_says_writing_still_refuses_a_fresh_process(
+        self, temp_project_root: Path
+    ) -> None:
+        """The fail-closed half, and the reason the phase is needed at all.
+
+        Clearing a marker is only safe when its run never wrote. A marker
+        that says `writing=true`, or one from before the phase existed that
+        says nothing, must still refuse -- a version that cleared every
+        stale marker would satisfy the recovery tests above while hydrating a
+        scoped reingest from a partial graph. Both readings are asserted.
+        """
+        for phase in (True, None):
+            ingestor = self._store()
+            registry = self._registry(temp_project_root, ingestor)
+            project = _mark_indexed(registry)
+            ingestor._marker_store[project] = True
+            if phase is not None:
+                ingestor._writing_store[project] = phase
+
+            with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+                result = await registry.reingest(["a.py"])
+            assert "error" in result, (
+                f"a marker with writing={phase} was not refused: {result}"
+            )
+            assert not updater_cls.return_value.reingest.called, (
+                "the refusal must come before any scoped work"
+            )
+            assert ingestor._marker_store.get(project) is True, (
+                f"a marker with writing={phase} was cleared by a process that "
+                "cannot know whether the graph is partial"
+            )
+
+    async def test_the_phase_advances_exactly_before_the_first_write(
+        self, temp_project_root: Path
+    ) -> None:
+        """Drives the REAL `GraphUpdater`: `before_write` runs once, at the seam.
+
+        The MCP tests above preset the phase on doubles; this pins where the
+        updater actually invokes the hook. It must run AFTER the prologue
+        (so a prologue abort never reaches it) and BEFORE the first delete or
+        node write (so a crash at any later point finds `writing=true`), and
+        its failure must abort with the graph untouched.
+        """
+        from codebase_rag.graph_updater import GraphUpdater, ReingestAborted
+        from codebase_rag.parser_loader import load_parsers
+        from codebase_rag.tests.conftest import _MockIngestor
+
+        (temp_project_root / "mod.py").write_text("def f(): pass\n", encoding="utf-8")
+        parsers, queries = load_parsers()
+
+        # A hook that refuses: the run aborts, nothing is written.
+        refusing = _MockIngestor()
+        updater = GraphUpdater(
+            ingestor=refusing,
+            repo_path=temp_project_root,
+            parsers=parsers,
+            queries=queries,
+        )
+        with pytest.raises(ReingestAborted, match="store refused"):
+            updater.reingest(
+                ["mod.py"],
+                before_write=lambda: (_ for _ in ()).throw(
+                    RuntimeError("store refused")
+                ),
+            )
+        assert updater.reingest_mutated is False, (
+            "a refused before_write was classified as a mutation"
+        )
+        assert not refusing.ensure_node_batch.called, (
+            "the run wrote nodes after before_write refused"
+        )
+        assert not refusing.execute_write.called, (
+            "the run issued a write after before_write refused"
+        )
+
+        # A hook that records its place in the order of events.
+        order: list[str] = []
+        ingestor = _MockIngestor()
+        ingestor.ensure_node_batch.side_effect = lambda *a, **k: order.append("write")
+        ingestor.execute_write.side_effect = lambda *a, **k: order.append("write")
+        fresh = GraphUpdater(
+            ingestor=ingestor,
+            repo_path=temp_project_root,
+            parsers=parsers,
+            queries=queries,
+        )
+        fresh.reingest(["mod.py"], before_write=lambda: order.append("phase"))
+        assert order.count("phase") == 1, (
+            f"before_write ran {order.count('phase')} times"
+        )
+        assert "write" in order, "fixture guard: the reingest issued no writes at all"
+        assert order.index("phase") < order.index("write"), (
+            f"the phase advanced after the first write: {order[:5]}"
+        )
+
+        # And the prologue abort never reaches the hook.
+        never: list[str] = []
+        aborting = GraphUpdater(
+            ingestor=_MockIngestor(),
+            repo_path=temp_project_root,
+            parsers=parsers,
+            queries=queries,
+        )
+        with patch.object(
+            aborting, "_hydrate_for_reingest", side_effect=RuntimeError("read failed")
+        ):
+            with pytest.raises(ReingestAborted):
+                aborting.reingest(
+                    ["mod.py"], before_write=lambda: never.append("phase")
+                )
+        assert never == [], "before_write ran for a run that aborted in its prologue"
+
+    async def test_a_retained_reingest_is_not_writing_until_the_updater_says_so(
+        self, temp_project_root: Path
+    ) -> None:
+        """The MCP side of the seam: `writing` flips inside `before_write`.
+
+        Mirrors `test_a_retained_updater_reingest_is_marked_too`, which pins
+        that the marker is DOWN during a retained reingest; this pins its
+        phase. A double that invokes the hook it is handed observes the phase
+        before and after, and a run marked writing from the start would fail
+        the first reading.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        phases: list[bool | None] = []
+        retained = MagicMock()
+        retained.reingest_mutated = False
+
+        def _reingest(*_args: object, **kwargs: object) -> SimpleNamespace:
+            phases.append(ingestor._writing_store.get(project))
+            before_write = kwargs["before_write"]
+            assert callable(before_write)
+            before_write()
+            phases.append(ingestor._writing_store.get(project))
+            return SimpleNamespace(
+                reparsed=[], affected=[], removed=[], skipped=[], elapsed_ms=1.0
+            )
+
+        retained.reingest.side_effect = _reingest
+        registry._live_updater = retained
+
+        assert "error" not in await registry.reingest(["a.py"])
+        assert phases == [False, True], (
+            "the marker's phase across the updater's before_write hook should "
+            f"read [False, True]: {phases}"
+        )
+        assert project not in ingestor._marker_store


### PR DESCRIPTION
Closes #1679.

## The gap

`_graph_incomplete` lives on the tools registry, so it only ever covered the process that ran the failed update. If that process crashes or the MCP server restarts, a fresh registry sees the project in `list_projects`, hydrates a scoped updater from the partial graph, and treats its missing and stale definitions as authoritative.

## The marker

A `run_incomplete` property on the `Project` node, set before the first write and cleared after the flush:

* **Set** after `ensure_constraints`, so the node the marker attaches to exists even on a first index.
* **Cleared** only after `flush_all`, so it outlives any failure that leaves batches uncommitted.
* Cleared by `REMOVE`, never `SET false`. A project indexed before this existed then reads exactly like one whose run finished, so **no migration is needed** and `coalesce(p.run_incomplete, false)` gives absent the same meaning as complete.

`_reingest_sync` consults it only on the path where there is no retained updater, which is precisely the fresh-process case:

```python
if self._graph_incomplete or self._persisted_incomplete(project_name):
```

Both sites are cleared, index **and** update: they share the same mutate-then-clear shape, and patching only one would have left the index path marking a project it never unmarked.

## Failure handling

Neither helper raises. A store that cannot take the marker must not turn a working update into a failed one, and a store that cannot answer must not block every reingest on an unreadable graph. Both log a warning, because a marker that silently never persists degrades this guard back to the old in-process behaviour and only the log would show it.

## Tests

The crash is modelled as a **second registry sharing only the ingestor** — no shared flag, which is what a restarted server has. The marker store is a real dict rather than a canned return value: a static value would satisfy the assertion without any write having happened. A fixture guard asserts the new registry's `_graph_incomplete` is `False`, so the test cannot pass through the old mechanism.

Two mutations, each failing a different test and nothing else:

| mutation | fails |
|---|---|
| guard ignores the persisted marker | `test_a_fresh_registry_refuses_reingest_after_a_crashed_update` |
| never clear the marker | `test_a_completed_update_lifts_the_refusal_for_a_fresh_registry` |

The second is what stops a fix that simply refuses forever from passing: it would satisfy the first test completely.

Baseline `47 passed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incomplete repository updates are now tracked across process restarts.
  * Scoped reingests are prevented when a previous update stopped partway through.
  * Incomplete status is preserved when indexing fails, including during a first run.
  * Completion clears the status, allowing future reingests.
  * Incomplete status survives project deletion.
  * Operations stop safely when update status cannot be saved or read, with logging.

* **Tests**
  * Added coverage for restart behavior, successful completion, failed indexing, project deletion, status failures, and protection against destructive operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Known asymmetry this ships, tracked as #1783

`_updater_for_reingest` has two call sites. This PR rebuilds one — the scoped reingest — as `_hydrate_reingest_updater`, which reads the durable marker as well as the in-process flag. The other, the structural-delta path from #1525, is **not** touched.

So after this merges the two disagree: a scoped reingest after a crashed run refuses, while the delta path with the same registry in the same state guards on the in-process flag alone and proceeds. That flag dies with the process, so a restart makes it `False` and the guard passes over a partial graph.

It is worse than a weaker guard. The delta path's call sits *inside* its `try`, and `except (ValueError, ReingestAborted)` catches the guard's own `ValueError` — so the refusal is logged and becomes an appended delta-error string on a write that reports success. Same guard, opposite consequence, and neither call site looks wrong in isolation.

Deliberately not fixed here: the fix must distinguish a *refusal* (must not be swallowed) from a *delta failure* (must be, as now) when both share an exception type. That is a behaviour change on a just-merged path, inside a PR already at 23 commits and four review rounds.

Verified independently by three sessions. Tracked as #1783.
