### PR TITLE
fix: compare tree-sitter nodes by value when skipping the import base (#1703)

### DIFF
--- a/codebase_rag/parsers/endpoint_prefixes.py
+++ b/codebase_rag/parsers/endpoint_prefixes.py
@@ -195,7 +195,12 @@ def _from_import_targets(module_qn: str, node: Node) -> dict[str, str]:
     base = _from_import_base(module_qn, base)
     out: dict[str, str] = {}
     for child in node.named_children:
-        if child is base_node:
+        # `==` not `is`: py-tree-sitter builds a fresh wrapper per lookup, so
+        # the node from child_by_field_name is never the same object as the
+        # one in named_children. With identity this never skipped the base,
+        # and a dotless module name passed the dot filter below and mapped
+        # to itself as though it were an imported symbol.
+        if child == base_node:
             continue
         if child.type == cs.TS_PY_DOTTED_NAME:
             name = _decode(child)

--- a/codebase_rag/tests/test_from_import_base_skip.py
+++ b/codebase_rag/tests/test_from_import_base_skip.py
@@ -1,0 +1,44 @@
+# `from <module> import <name>` must not report the module itself as one of
+# the imported names. The base is skipped by comparing it against each
+# named child, and that comparison used `is`: py-tree-sitter builds a fresh
+# wrapper per lookup, so the node from child_by_field_name is never the
+# same object as the one in named_children and the skip never happened.
+#
+# A dotted base (`pkg.sub`) hid the bug -- the dot filter below the skip
+# dropped it anyway -- so it only shows on a dotless module name.
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.parsers.endpoint_prefixes import _from_import_targets
+
+tree_sitter = pytest.importorskip("tree_sitter")
+tree_sitter_python = pytest.importorskip("tree_sitter_python")
+
+
+def _import_node(source: str):
+    parser = tree_sitter.Parser(tree_sitter.Language(tree_sitter_python.language()))
+    return parser.parse(source.encode("utf-8")).root_node.children[0]
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("from routers import alpha\n", {"alpha": "routers.alpha"}),
+        (
+            "from routers import alpha, beta\n",
+            {"alpha": "routers.alpha", "beta": "routers.beta"},
+        ),
+        ("from routers import alpha as a\n", {"a": "routers.alpha"}),
+        # A dotted base was already excluded by the dot filter.
+        ("from pkg.sub import alpha\n", {"alpha": "pkg.sub.alpha"}),
+    ],
+)
+def test_the_import_base_is_not_reported_as_an_imported_name(
+    source: str, expected: dict[str, str]
+) -> None:
+    targets = _from_import_targets("proj.m", _import_node(source))
+
+    # With the identity comparison the dotless cases also carried
+    # {"routers": "routers.routers"} -- the base mapped to itself.
+    assert targets == expected, targets


### PR DESCRIPTION
Closes #1703.

## What

`_from_import_targets` in `codebase_rag/parsers/endpoint_prefixes.py` skips the `from <module> import ...` base by testing each named child against it:

```python
base_node = node.child_by_field_name(cs.FIELD_MODULE_NAME)
for child in node.named_children:
    if child is base_node:      # never True
        continue
```

py-tree-sitter builds a fresh Python wrapper on every lookup, so the node returned by `child_by_field_name` is never the same object as the one in `named_children`. The skip never happened.

## Effect

A **dotted** base is saved by the `SEPARATOR_DOT not in name` filter below the skip, so the leak only shows on a dotless module name — which then maps to itself as though it had been imported:

| source | before | after |
|---|---|---|
| `from routers import alpha` | `{'routers': 'routers.routers', 'alpha': 'routers.alpha'}` | `{'alpha': 'routers.alpha'}` |
| `from routers import alpha, beta` | `{'routers': ..., 'alpha': ..., 'beta': ...}` | `{'alpha': ..., 'beta': ...}` |
| `from routers import alpha as a` | `{'routers': 'routers.routers', 'a': 'routers.alpha'}` | `{'a': 'routers.alpha'}` |
| `from pkg.sub import alpha` | `{'alpha': 'pkg.sub.alpha'}` | unchanged |
| `from . import alpha` | `{'alpha': 'proj.alpha'}` | unchanged |
| `from routers import *` | `{}` | unchanged |

`==` compares tree context as well as node id, so it is strictly stronger than `.id ==` and cannot make two distinct nodes match.

## Verification

`codebase_rag/tests/test_from_import_base_skip.py` is parametrised over four shapes, keeping a **dotted base as a control** — it must keep passing under mutation, because the dot filter covers that case independently of the skip.

| variant | result |
|---|---|
| fix applied | 4 passed |
| `is` restored | 3 failed, 1 passed |
| skip deleted outright | 3 failed, 1 passed |

The three failures in each mutant are the dotless cases by name; the control passes. That split is deliberate evidence: a fixture or collection error would have taken all four down uniformly, which is indistinguishable from real discrimination if you only check the exit code.

Also run: 168 tests across `test_route_call_endpoints`, `test_endpoint_prefix_resolution`, `test_endpoint_extraction` and the new file — all pass. `ruff check` / `ruff format --check` clean.

## Context

Same defect as #1702 (fixed in `call_processor.py` by #1704). That issue stated a grep of `main` found no other instance; this is one. The remaining `is` comparisons on nodes in `call_processor.py` (606, 2330, 2625, 6592) are safe — both sides come from cached `children`/`named_children` lists, where identity holds. `class_ingest/mixin.py:90` and `call_processor.py:188` walk `.parent`, which is not cached, so they are latently the same hazard; no divergence could be constructed for either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected import analysis so the source module is no longer incorrectly reported as an imported symbol.
  * Ensured this behavior works consistently for dotted and dotless modules, including multiple and aliased imports.

* **Tests**
  * Added coverage for import statements with single, multiple, and aliased names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->