### PR TITLE
fix: probe the node and dotnet oracle toolchains for capability, not presence (#1639)

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -8,7 +8,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, Self
@@ -777,3 +777,24 @@ def cleanup_qdrant_client() -> Generator[None, None, None]:
         vs.close_vector_store_client()
     except Exception:
         pass
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item: pytest.Item) -> Iterator[None]:
+    """Report an unavailable node oracle as a SKIP, not an error (issue #1639).
+
+    A clean checkout cannot know whether the toolchain can run an oracle until
+    `ensure_node_deps` has installed the packages, which happens inside the
+    test. The runner raises `NodeOracleUnavailable` at that point; letting it
+    through reports a missing toolchain as a test ERROR, which is exactly the
+    misdiagnosis this issue is about. Translated here rather than at each of
+    the ~24 call sites, so a new call site cannot forget it.
+    """
+    # Imported lazily: `evals` is not on the path when conftest is loaded,
+    # only once a test that uses it has been collected.
+    from evals.oracles import NodeOracleUnavailable
+
+    outcome = yield
+    excinfo = getattr(outcome, "excinfo", None)
+    if excinfo is not None and isinstance(excinfo[1], NodeOracleUnavailable):
+        pytest.skip(str(excinfo[1]))

--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -16,7 +16,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_csharp_graph, extract_cgr_csharp_nodes
-from evals.oracles import csharp_oracle_available, run_csharp_oracle
+from evals.oracles import (
+    csharp_oracle_skip_reason,
+    run_csharp_oracle,
+)
 from evals.score import (
     score_edge_types,
     score_name_edge_types,
@@ -60,8 +63,9 @@ public class Animal { }
 
 
 def _require_csharp() -> None:
-    if not csharp_oracle_available():
-        pytest.skip("dotnet toolchain not available")
+    reason = csharp_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.CSHARP not in load_parsers()[0]:
         pytest.skip("c_sharp parser not available")
 

--- a/codebase_rag/tests/test_javascript_containment_oracle.py
+++ b/codebase_rag/tests/test_javascript_containment_oracle.py
@@ -11,7 +11,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_js_graph
-from evals.oracles import run_javascript_oracle, typescript_available
+from evals.oracles import (
+    run_javascript_oracle,
+    typescript_skip_reason,
+)
 from evals.score import score_edge_types
 
 JS_SRC = """\
@@ -75,8 +78,9 @@ function wrap(base) {
 
 
 def _require_js() -> None:
-    if not typescript_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = typescript_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.JS not in load_parsers()[0]:
         pytest.skip("javascript parser not available")
 

--- a/codebase_rag/tests/test_javascript_span_oracle.py
+++ b/codebase_rag/tests/test_javascript_span_oracle.py
@@ -12,7 +12,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_js_graph
-from evals.oracles import run_javascript_oracle, typescript_available
+from evals.oracles import (
+    run_javascript_oracle,
+    typescript_skip_reason,
+)
 from evals.score import score_span
 
 JS_SRC = """\
@@ -38,8 +41,9 @@ const arrow = (x) => {
 
 
 def _require_js() -> None:
-    if not typescript_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = typescript_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.JS not in load_parsers()[0]:
         pytest.skip("javascript parser not available")
 

--- a/codebase_rag/tests/test_javascript_structure_oracle.py
+++ b/codebase_rag/tests/test_javascript_structure_oracle.py
@@ -12,7 +12,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_js_nodes
-from evals.oracles import run_javascript_oracle, typescript_available
+from evals.oracles import (
+    run_javascript_oracle,
+    typescript_skip_reason,
+)
 from evals.score import score_node_kinds
 from evals.types_defs import GraphData
 
@@ -30,8 +33,9 @@ const obj = { method() { return 1; } };
 
 
 def _require_js() -> None:
-    if not typescript_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = typescript_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.JS not in load_parsers()[0]:
         pytest.skip("javascript parser not available")
 

--- a/codebase_rag/tests/test_lua_containment_oracle.py
+++ b/codebase_rag/tests/test_lua_containment_oracle.py
@@ -12,7 +12,7 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_lua_graph
-from evals.oracles import lua_oracle_available, run_lua_oracle
+from evals.oracles import lua_oracle_skip_reason, run_lua_oracle
 from evals.score import score_edge_types
 
 LUA_SRC = """\
@@ -32,8 +32,9 @@ local cb = function(x) return x end
 
 
 def _require_lua() -> None:
-    if not lua_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = lua_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.LUA not in load_parsers()[0]:
         pytest.skip("lua parser not available")
 

--- a/codebase_rag/tests/test_lua_span_oracle.py
+++ b/codebase_rag/tests/test_lua_span_oracle.py
@@ -12,7 +12,7 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_lua_graph
-from evals.oracles import lua_oracle_available, run_lua_oracle
+from evals.oracles import lua_oracle_skip_reason, run_lua_oracle
 from evals.score import score_span
 
 LUA_SRC = """\
@@ -32,8 +32,9 @@ return outer(handler(1), 2)
 
 
 def _require_lua() -> None:
-    if not lua_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = lua_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.LUA not in load_parsers()[0]:
         pytest.skip("lua parser not available")
 

--- a/codebase_rag/tests/test_lua_structure_oracle.py
+++ b/codebase_rag/tests/test_lua_structure_oracle.py
@@ -12,7 +12,7 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_lua_nodes
-from evals.oracles import lua_oracle_available, run_lua_oracle
+from evals.oracles import lua_oracle_skip_reason, run_lua_oracle
 from evals.score import score_node_kinds
 from evals.types_defs import GraphData
 
@@ -28,8 +28,9 @@ return M
 
 
 def _require_lua() -> None:
-    if not lua_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = lua_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.LUA not in load_parsers()[0]:
         pytest.skip("lua parser not available")
 

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -20,7 +20,11 @@ from pathlib import Path
 import pytest
 
 from evals import constants as ec
-from evals.oracles._common import _oracle_dependency, node_oracle_available
+from evals.oracles._common import (
+    _node_can_require,
+    _oracle_dependency,
+    node_oracle_available,
+)
 from evals.oracles.csharp_oracle import _sdk_major, csharp_oracle_available
 
 _ORACLE_CSPROJ = (
@@ -43,7 +47,9 @@ def _clear_guard_caches() -> None:
     # Both guards are lru_cached, so a verdict from one test would otherwise
     # answer for the next one's PATH. Clearing before each test is what makes
     # the stubs below decide the outcome.
-    node_oracle_available.cache_clear()
+    # `node_oracle_available` is deliberately NOT cached (a pre-install answer
+    # must not freeze); the real verdict cache lives on `_node_can_require`.
+    _node_can_require.cache_clear()
     csharp_oracle_available.cache_clear()
 
 
@@ -133,8 +139,9 @@ class TestNodeGuard:
     def _oracle(tmp_path: Path, package: str) -> Path:
         oracle = tmp_path / "oracle"
         (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
-        (oracle / ec.NODE_PACKAGE_MANIFEST).write_text(
-            f'{{"dependencies": {{"{package}": "1.0.0"}}}}', encoding="utf-8"
+        (oracle / "oracle_ast.js").write_text(
+            f'const fs = require("fs");\nconst p = require("{package}");\n',
+            encoding="utf-8",
         )
         return oracle
 
@@ -201,27 +208,77 @@ class TestNodeGuard:
 
 
 class TestOracleDependency:
-    def test_the_package_is_read_from_the_oracles_own_manifest(
-        self, tmp_path: Path
-    ) -> None:
-        """Read, never hard-coded: the four oracles do not share a dependency.
-
-        Ruby loads `@ruby/prism`, lua `luaparse`, php `php-parser`, ts
-        `typescript`, and only the first is ESM-only. A hard-coded package
-        would be a second copy of that fact, free to drift.
-        """
+    @staticmethod
+    def _with_script(tmp_path: Path, source: str) -> Path:
         oracle = tmp_path / "oracle"
         (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        (oracle / "oracle_ast.js").write_text(source, encoding="utf-8")
+        return oracle
+
+    def test_the_package_is_the_one_the_script_requires(self, tmp_path: Path) -> None:
+        """Read from the oracle's own `require()`, never guessed.
+
+        The four oracles do not share a dependency, and only `@ruby/prism` is
+        ESM-only, so the probe must ask about the package THIS oracle loads.
+        """
+        oracle = self._with_script(tmp_path, 'const p = require("luaparse");\n')
+        assert _oracle_dependency(oracle) == "luaparse"
+
+    def test_an_extra_dependency_does_not_displace_the_real_one(
+        self, tmp_path: Path
+    ) -> None:
+        """The alphabetical-pick defect.
+
+        Reading `package.json` and taking the first key sorts `aaa-helper`
+        ahead of `luaparse`, so the probe would validate a package the oracle
+        never loads and report a broken toolchain as usable. It picked the
+        right entry today only because each manifest happens to hold exactly
+        one dependency -- a latent bug, not a theoretical one.
+        """
+        oracle = self._with_script(tmp_path, 'const p = require("luaparse");\n')
         (oracle / ec.NODE_PACKAGE_MANIFEST).write_text(
-            '{"dependencies": {"luaparse": "0.3.1"}}', encoding="utf-8"
+            '{"dependencies": {"aaa-helper": "1.0.0", "luaparse": "0.3.1"}}',
+            encoding="utf-8",
         )
         assert _oracle_dependency(oracle) == "luaparse"
 
-    def test_a_missing_or_unreadable_manifest_yields_no_package(
+    def test_builtins_and_relative_requires_are_skipped(self, tmp_path: Path) -> None:
+        """A builtin loads on every Node, so probing one proves nothing."""
+        oracle = self._with_script(
+            tmp_path,
+            'const fs = require("fs");\nconst u = require("./util");\n'
+            'const p = require("php-parser");\n',
+        )
+        assert _oracle_dependency(oracle) == "php-parser"
+
+    def test_uninstalled_or_scriptless_oracles_yield_no_package(
         self, tmp_path: Path
     ) -> None:
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        assert _oracle_dependency(bare) is None
+        installed = tmp_path / "installed"
+        (installed / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        assert _oracle_dependency(installed) is None
+
+
+class TestGuardCacheLifecycle:
+    def test_a_pre_install_answer_is_not_cached(self, tmp_path: Path) -> None:
+        """Issue #1639: the provisional "ask again" must not become a verdict.
+
+        On a clean checkout the guard runs before `ensure_node_deps`, so it
+        cannot probe and answers True to avoid mistaking "not fetched" for
+        "toolchain broken". Caching that froze it: the real probe never ran,
+        and an incompatible Node reached the oracle anyway. Only genuine
+        verdicts are cached.
+        """
         oracle = tmp_path / "oracle"
-        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
-        assert _oracle_dependency(oracle) is None
-        (oracle / ec.NODE_PACKAGE_MANIFEST).write_text("not json {{{", encoding="utf-8")
-        assert _oracle_dependency(oracle) is None
+        oracle.mkdir()
+        (oracle / "oracle_ast.js").write_text(
+            'const p = require("definitely-not-installed");\n', encoding="utf-8"
+        )
+        assert node_oracle_available(oracle) is True
+
+        # ensure_node_deps installs them; the guard must now actually probe.
+        (oracle / ec.NODE_MODULES_DIRNAME).mkdir()
+        assert node_oracle_available(oracle) is False

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -21,11 +21,16 @@ import pytest
 
 from evals import constants as ec
 from evals.oracles._common import (
-    _node_can_require,
+    _node_require_stderr,
     _oracle_dependency,
     node_oracle_available,
+    node_oracle_skip_reason,
 )
-from evals.oracles.csharp_oracle import _sdk_major, csharp_oracle_available
+from evals.oracles.csharp_oracle import (
+    _sdk_major,
+    csharp_oracle_available,
+    csharp_oracle_skip_reason,
+)
 
 _ORACLE_CSPROJ = (
     Path(__file__).resolve().parents[2]
@@ -48,9 +53,9 @@ def _clear_guard_caches() -> None:
     # answer for the next one's PATH. Clearing before each test is what makes
     # the stubs below decide the outcome.
     # `node_oracle_available` is deliberately NOT cached (a pre-install answer
-    # must not freeze); the real verdict cache lives on `_node_can_require`.
-    _node_can_require.cache_clear()
-    csharp_oracle_available.cache_clear()
+    # must not freeze); the real verdict cache lives on `_node_require_stderr`.
+    _node_require_stderr.cache_clear()
+    csharp_oracle_skip_reason.cache_clear()
 
 
 class TestSdkMajor:
@@ -282,3 +287,68 @@ class TestGuardCacheLifecycle:
         # ensure_node_deps installs them; the guard must now actually probe.
         (oracle / ec.NODE_MODULES_DIRNAME).mkdir()
         assert node_oracle_available(oracle) is False
+
+
+class TestSkipReasons:
+    """The reason must name the obstacle, not restate the guard (#1639).
+
+    "dotnet toolchain not installed" was printed on a machine where dotnet IS
+    installed, which is the whole complaint: the skip line told a developer
+    nothing and sent them looking for a missing package that was present.
+    """
+
+    def test_an_old_sdk_reason_names_the_versions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub(tmp_path, "dotnet", 'echo "8.0.130 [/usr/share/dotnet/sdk]"')
+        monkeypatch.setenv("PATH", str(tmp_path))
+        reason = csharp_oracle_skip_reason()
+        assert reason is not None
+        # Both halves: what was found and what is needed.
+        assert "8.0.130" in reason
+        assert str(ec.CSHARP_ORACLE_MIN_SDK_MAJOR) in reason
+        # And it must not repeat the FALSE claim this replaces. Asserting only
+        # that the values appear is satisfied by "dotnet toolchain not
+        # installed" with the numbers concatenated onto it -- verified by
+        # mutation: that string passed the two assertions above.
+        assert "not installed" not in reason
+        assert "not available" not in reason
+
+    def test_a_missing_binary_reason_names_the_binary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PATH", str(tmp_path))
+        reason = csharp_oracle_skip_reason()
+        assert reason is not None and ec.DOTNET_BIN in reason
+
+    def test_a_node_reason_carries_the_require_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binaries = tmp_path / "bin"
+        binaries.mkdir()
+        _stub(
+            binaries,
+            "node",
+            'case "$2" in\n'
+            '  *require*) echo "Error [ERR_REQUIRE_ESM]: nope" >&2; exit 1 ;;\n'
+            "  *) exit 0 ;;\n"
+            "esac",
+        )
+        _stub(binaries, "npm", "exit 0")
+        monkeypatch.setenv("PATH", str(binaries))
+        oracle = tmp_path / "oracle"
+        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        (oracle / "oracle_ast.js").write_text(
+            'const p = require("@ruby/prism");\n', encoding="utf-8"
+        )
+        reason = node_oracle_skip_reason(oracle)
+        assert reason is not None
+        assert "@ruby/prism" in reason
+        assert "ERR_REQUIRE_ESM" in reason
+        # node IS on PATH here, so a reason saying otherwise is the bug.
+        assert "not available" not in reason
+        assert "not installed" not in reason
+
+    def test_a_working_toolchain_has_no_reason(self, tmp_path: Path) -> None:
+        """None is the signal the call sites branch on, so it must be exact."""
+        assert node_oracle_skip_reason(None) is None

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -15,6 +15,7 @@ the case the guards were written for.
 from __future__ import annotations
 
 import re
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -44,10 +45,57 @@ _ORACLE_CSPROJ = (
 )
 
 
-def _stub(directory: Path, name: str, body: str) -> None:
-    script = directory / name
-    script.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
-    script.chmod(0o755)
+def _stub(
+    directory: Path,
+    name: str,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    code: int = 0,
+    fail_when_arg_contains: str | None = None,
+) -> None:
+    """Put a fake `name` on PATH that behaves the same on POSIX and Windows.
+
+    A `#!/bin/sh` script with the executable bit is invisible to Windows:
+    `shutil.which` resolves through PATHEXT, so an extensionless shell script
+    is not found and the guards reported "node is not on PATH" instead of the
+    stubbed verdict -- 8 failures on both Windows jobs, in tests that pass
+    everywhere else.
+
+    The stub is therefore a Python script plus, on Windows, a `.cmd` wrapper
+    that PATHEXT does find. Python rather than batch because the bodies here
+    branch on an argument, and translating that to `.cmd` would be a second
+    implementation to keep in step with the POSIX one.
+
+    `fail_when_arg_contains` reproduces Node 18: the `require()` probe is
+    refused while anything else succeeds. It must discriminate on the
+    ARGUMENT, or a test cannot tell a probe that exercises the breaking call
+    from one that does not.
+    """
+    logic = f"""import sys
+argv = sys.argv[1:]
+needle = {fail_when_arg_contains!r}
+if needle is not None and not any(needle in a for a in argv):
+    sys.exit(0)
+if {stdout!r}:
+    sys.stdout.write({stdout!r} + "\\n")
+if {stderr!r}:
+    sys.stderr.write({stderr!r} + "\\n")
+sys.exit({code!r})
+"""
+    worker = directory / f"{name}_stub.py"
+    worker.write_text(logic, encoding="utf-8")
+    if sys.platform == "win32":
+        # PATHEXT includes .CMD, so this is what `shutil.which` finds.
+        (directory / f"{name}.cmd").write_text(
+            f'@echo off\r\n"{sys.executable}" "{worker}" %*\r\n', encoding="utf-8"
+        )
+    else:
+        launcher = directory / name
+        launcher.write_text(
+            f'#!/bin/sh\nexec "{sys.executable}" "{worker}" "$@"\n', encoding="utf-8"
+        )
+        launcher.chmod(0o755)
 
 
 @pytest.fixture(autouse=True)
@@ -97,14 +145,14 @@ class TestCsharpGuard:
 
         `which` was satisfied here and the build then died with NETSDK1045.
         """
-        _stub(tmp_path, "dotnet", 'echo "8.0.130 [/usr/share/dotnet/sdk]"')
+        _stub(tmp_path, "dotnet", stdout="8.0.130 [/usr/share/dotnet/sdk]")
         monkeypatch.setenv("PATH", str(tmp_path))
         assert csharp_oracle_available() is False
 
     def test_an_sdk_at_least_the_csproj_is_available(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _stub(tmp_path, "dotnet", 'echo "10.0.400 [/usr/share/dotnet/sdk]"')
+        _stub(tmp_path, "dotnet", stdout="10.0.400 [/usr/share/dotnet/sdk]")
         monkeypatch.setenv("PATH", str(tmp_path))
         assert csharp_oracle_available() is True
 
@@ -112,7 +160,7 @@ class TestCsharpGuard:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # An exact-TFM check would wrongly skip here: SDK 11 builds net10.0.
-        _stub(tmp_path, "dotnet", 'echo "11.0.100 [/usr/share/dotnet/sdk]"')
+        _stub(tmp_path, "dotnet", stdout="11.0.100 [/usr/share/dotnet/sdk]")
         monkeypatch.setenv("PATH", str(tmp_path))
         assert csharp_oracle_available() is True
 
@@ -121,7 +169,7 @@ class TestCsharpGuard:
     ) -> None:
         # `dotnet` exists and runs, but lists no SDKs: the launcher is present
         # for a runtime-only install, which cannot build anything.
-        _stub(tmp_path, "dotnet", "exit 0")
+        _stub(tmp_path, "dotnet")
         monkeypatch.setenv("PATH", str(tmp_path))
         assert csharp_oracle_available() is False
 
@@ -184,12 +232,11 @@ class TestNodeGuard:
         _stub(
             binaries,
             "node",
-            'case "$2" in\n'
-            '  *require*) echo "Error [ERR_REQUIRE_ESM]" >&2; exit 1 ;;\n'
-            "  *) exit 0 ;;\n"
-            "esac",
+            stderr="Error [ERR_REQUIRE_ESM]",
+            code=1,
+            fail_when_arg_contains="require",
         )
-        _stub(binaries, "npm", "exit 0")
+        _stub(binaries, "npm")
         monkeypatch.setenv("PATH", str(binaries))
         assert node_oracle_available(self._oracle(tmp_path, "@ruby/prism")) is False
 
@@ -198,8 +245,8 @@ class TestNodeGuard:
     ) -> None:
         binaries = tmp_path / "bin"
         binaries.mkdir()
-        _stub(binaries, "node", "exit 0")
-        _stub(binaries, "npm", "exit 0")
+        _stub(binaries, "node")
+        _stub(binaries, "npm")
         monkeypatch.setenv("PATH", str(binaries))
         assert node_oracle_available(self._oracle(tmp_path, "@ruby/prism")) is True
 
@@ -213,8 +260,8 @@ class TestNodeGuard:
         """
         binaries = tmp_path / "bin"
         binaries.mkdir()
-        _stub(binaries, "node", "exit 1")
-        _stub(binaries, "npm", "exit 0")
+        _stub(binaries, "node", code=1)
+        _stub(binaries, "npm")
         monkeypatch.setenv("PATH", str(binaries))
         bare = tmp_path / "oracle"
         bare.mkdir()
@@ -297,10 +344,11 @@ class TestGuardCacheLifecycle:
         """
         binaries = tmp_path / "bin"
         binaries.mkdir()
-        node = binaries / "node"
-        node.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
-        node.chmod(0o755)
-        _stub(binaries, "npm", "exit 0")
+        # Rewritten mid-test below, so it goes through `_stub` both times and
+        # stays portable: a raw `#!/bin/sh` here would be unfindable on
+        # Windows and this test would assert against "node is not on PATH".
+        _stub(binaries, "node", code=1)
+        _stub(binaries, "npm")
         monkeypatch.setenv("PATH", str(binaries))
 
         oracle = tmp_path / "oracle"
@@ -326,8 +374,7 @@ class TestGuardCacheLifecycle:
 
         # And a real success IS remembered, or rule 1 would be satisfied by
         # caching nothing at all.
-        node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-        node.chmod(0o755)
+        _stub(binaries, "node")
         assert node_oracle_available(oracle) is True
         assert _REQUIRE_OK, "a successful probe was not cached"
 
@@ -376,7 +423,7 @@ class TestSkipReasons:
     def test_an_old_sdk_reason_names_the_versions(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _stub(tmp_path, "dotnet", 'echo "8.0.130 [/usr/share/dotnet/sdk]"')
+        _stub(tmp_path, "dotnet", stdout="8.0.130 [/usr/share/dotnet/sdk]")
         monkeypatch.setenv("PATH", str(tmp_path))
         reason = csharp_oracle_skip_reason()
         assert reason is not None
@@ -406,12 +453,11 @@ class TestSkipReasons:
         _stub(
             binaries,
             "node",
-            'case "$2" in\n'
-            '  *require*) echo "Error [ERR_REQUIRE_ESM]: nope" >&2; exit 1 ;;\n'
-            "  *) exit 0 ;;\n"
-            "esac",
+            stderr="Error [ERR_REQUIRE_ESM]: nope",
+            code=1,
+            fail_when_arg_contains="require",
         )
-        _stub(binaries, "npm", "exit 0")
+        _stub(binaries, "npm")
         monkeypatch.setenv("PATH", str(binaries))
         oracle = tmp_path / "oracle"
         (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
@@ -454,12 +500,8 @@ class TestPostInstallRecheck:
         """
         binaries = tmp_path / "bin"
         binaries.mkdir()
-        _stub(
-            binaries,
-            "node",
-            'case "$2" in\n  *require*) exit 1 ;;\n  *) exit 0 ;;\nesac',
-        )
-        _stub(binaries, "npm", "exit 0")
+        _stub(binaries, "node", code=1, fail_when_arg_contains="require")
+        _stub(binaries, "npm")
         monkeypatch.setenv("PATH", str(binaries))
 
         oracle = tmp_path / "oracle"

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -22,6 +22,7 @@ import pytest
 from evals import constants as ec
 from evals.oracles import _common
 from evals.oracles._common import (
+    NodeOracleUnavailable,
     _node_require_stderr,
     _oracle_dependency,
     node_oracle_available,
@@ -320,7 +321,8 @@ class TestSkipReasons:
     ) -> None:
         monkeypatch.setenv("PATH", str(tmp_path))
         reason = csharp_oracle_skip_reason()
-        assert reason is not None and ec.DOTNET_BIN in reason
+        assert reason is not None
+        assert ec.DOTNET_BIN in reason
 
     def test_a_node_reason_carries_the_require_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -368,9 +370,12 @@ class TestPostInstallRecheck:
         ERR_REQUIRE_ESM -- an evaluation FAILURE standing in for an
         unavailable toolchain, which is the whole defect.
 
-        Asserting on the SKIP specifically: a raise reaches the report as an
-        error and an empty payload grades every node as missing, and both are
-        the misdiagnosis this issue is about.
+        Asserting on the specific exception: an empty payload would grade
+        every node as missing, and an unhandled error is the misdiagnosis this
+        issue is about. `conftest.pytest_runtest_call` turns this into a skip
+        for the ~24 real call sites; a standalone eval script sees an ordinary
+        exception it can report, which `pytest.skip` in library code could not
+        give it.
         """
         binaries = tmp_path / "bin"
         binaries.mkdir()
@@ -390,8 +395,8 @@ class TestPostInstallRecheck:
         # capability is re-checked once it has happened.
         monkeypatch.setattr(_common, "ensure_node_deps", lambda _dir: None)
 
-        with pytest.raises(BaseException) as raised:
+        with pytest.raises(NodeOracleUnavailable) as raised:
             _common.run_node_oracle_payload(oracle, script, ())
-        assert "Skipped" in type(raised.value).__name__, (
-            f"expected a skip, got {type(raised.value).__name__}"
-        )
+        # The reason travels with it, so the skip line names the real
+        # obstacle rather than restating the guard.
+        assert "@ruby/prism" in str(raised.value)

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -20,6 +20,8 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+import typer
+from loguru import logger
 
 from evals import constants as ec
 from evals.oracles import _common
@@ -528,3 +530,95 @@ class TestPostInstallRecheck:
         # The reason travels with it, so the skip line names the real
         # obstacle rather than restating the guard.
         assert "@ruby/prism" in str(raised.value)
+
+
+class TestStandaloneL1Runner:
+    """A standalone eval must REPORT an unavailable toolchain, not crash.
+
+    The four L1 scripts (`evals/lua_l1.py`, `ts_l1.py`, `php_l1.py`) call the
+    oracle outside pytest, so an exception escaping the shared runner reaches
+    the operator as a traceback rather than as the command's result.
+    """
+
+    @staticmethod
+    def _run(**overrides: object) -> int:
+        from evals import l1_eval
+        from evals.types_defs import GraphData
+
+        kwargs: dict[str, object] = {
+            "available": lambda: True,
+            "oracle_missing": "fixed message for {binary}",
+            "extract_cgr": lambda _t, _p: GraphData(nodes=[], edges=[], name_edges=[]),
+            "run_oracle": lambda _t: GraphData(nodes=[], edges=[], name_edges=[]),
+            "oracle_binary": "node",
+            "scored_node_kinds": frozenset(),
+            "extracting_cgr": "x {target} {project}",
+            "cgr_done": "y {count}",
+            "extracting_oracle": "z {binary} {target}",
+            "oracle_done": "w {count}",
+            "scores_filename": "s.csv",
+            "diff_filename": "d.json",
+            "title": "t",
+        }
+        kwargs.update(overrides)
+        with pytest.raises(typer.Exit) as exit_info:
+            l1_eval.run_l1_eval(Path("."), "", Path("."), **kwargs)  # type: ignore[arg-type]
+        return int(exit_info.value.exit_code)
+
+    def test_a_post_install_failure_exits_rather_than_raising(self) -> None:
+        """The path `available()` cannot cover.
+
+        On a clean checkout the guard runs before the deps exist, so it
+        honestly says "cannot tell yet"; the verdict only arrives inside
+        `run_oracle`, once `ensure_node_deps` has fetched them.
+        """
+
+        def _unavailable(_target: Path) -> object:
+            raise NodeOracleUnavailable("this node cannot require(luaparse): boom")
+
+        # Caught HERE rather than left to propagate. `conftest`'s
+        # `pytest_runtest_call` hook turns a leaked NodeOracleUnavailable into
+        # a SKIP, so a runner that stopped catching it would make this test
+        # vanish rather than fail -- verified by mutation: removing the
+        # try/except gave "30 passed, 1 skipped". A skipped test is not a
+        # passing one, but it is not a failing one either, and this must fail.
+        try:
+            assert self._run(run_oracle=_unavailable) == 1
+        except NodeOracleUnavailable as leaked:  # pragma: no cover - the defect
+            raise AssertionError(
+                f"the L1 runner let the exception escape: {leaked}"
+            ) from leaked
+
+    def test_the_reason_replaces_the_false_fixed_message(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ "not found on PATH" is false when the binary is present.
+
+        Asserting the fixed string is ABSENT as well as the reason present:
+        checking only for the reason would pass for a runner that logged both.
+        """
+        messages: list[str] = []
+        sink = logger.add(messages.append, level="ERROR")
+        try:
+            assert (
+                self._run(
+                    available=lambda: False,
+                    skip_reason=lambda: "this node cannot require(luaparse): boom",
+                )
+                == 1
+            )
+        finally:
+            logger.remove(sink)
+        joined = "\n".join(messages)
+        assert "cannot require(luaparse)" in joined
+        assert "fixed message" not in joined, joined
+
+    def test_an_oracle_without_a_reason_probe_keeps_the_fixed_message(self) -> None:
+        """The fallback must survive: not every oracle has a reason probe."""
+        messages: list[str] = []
+        sink = logger.add(messages.append, level="ERROR")
+        try:
+            assert self._run(available=lambda: False) == 1
+        finally:
+            logger.remove(sink)
+        assert "fixed message for node" in "\n".join(messages)

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -15,6 +15,7 @@ the case the guards were written for.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -22,8 +23,8 @@ import pytest
 from evals import constants as ec
 from evals.oracles import _common
 from evals.oracles._common import (
+    _REQUIRE_OK,
     NodeOracleUnavailable,
-    _node_require_stderr,
     _oracle_dependency,
     node_oracle_available,
     node_oracle_skip_reason,
@@ -50,13 +51,21 @@ def _stub(directory: Path, name: str, body: str) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _clear_guard_caches() -> None:
-    # Both guards are lru_cached, so a verdict from one test would otherwise
-    # answer for the next one's PATH. Clearing before each test is what makes
-    # the stubs below decide the outcome.
-    # `node_oracle_available` is deliberately NOT cached (a pre-install answer
-    # must not freeze); the real verdict cache lives on `_node_require_stderr`.
-    _node_require_stderr.cache_clear()
+def _clear_guard_caches() -> Iterator[None]:
+    """Clear both guard caches BEFORE and AFTER each test.
+
+    Teardown matters as much as setup: `csharp_oracle_skip_reason` is cached
+    with no arguments, so a verdict cached under a test's temporary PATH would
+    answer for the next test, and for production code in the same process,
+    long after `monkeypatch` restored the environment.
+
+    `_REQUIRE_OK` holds only POSITIVE verdicts (rule 1 in
+    `node_oracle_available`), so it is a set rather than an lru_cache.
+    """
+    _REQUIRE_OK.clear()
+    csharp_oracle_skip_reason.cache_clear()
+    yield
+    _REQUIRE_OK.clear()
     csharp_oracle_skip_reason.cache_clear()
 
 
@@ -146,6 +155,10 @@ class TestNodeGuard:
     def _oracle(tmp_path: Path, package: str) -> Path:
         oracle = tmp_path / "oracle"
         (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        # The MARKER, not just the directory: npm creates node_modules before
+        # populating it, so the guard treats a marker-less tree as "installing"
+        # and declines to probe it (rule 2).
+        (oracle / ec.NODE_DEPS_MARKER).write_text("ok", encoding="utf-8")
         (oracle / "oracle_ast.js").write_text(
             f'const fs = require("fs");\nconst p = require("{package}");\n',
             encoding="utf-8",
@@ -270,6 +283,54 @@ class TestOracleDependency:
 
 
 class TestGuardCacheLifecycle:
+    def test_a_failed_probe_is_never_cached(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rule 1: only a POSITIVE verdict is remembered.
+
+        Same node, same directory, same package, but the require becomes
+        loadable between two calls -- which is exactly what an install does.
+        Caching the first answer makes the second wrong for the rest of the
+        process. No other test here probes twice across a state change, so
+        without this the rule is unpinned: verified by mutation, re-enabling
+        negative caching left the whole suite green.
+        """
+        binaries = tmp_path / "bin"
+        binaries.mkdir()
+        node = binaries / "node"
+        node.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        node.chmod(0o755)
+        _stub(binaries, "npm", "exit 0")
+        monkeypatch.setenv("PATH", str(binaries))
+
+        oracle = tmp_path / "oracle"
+        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        (oracle / ec.NODE_DEPS_MARKER).write_text("ok", encoding="utf-8")
+        (oracle / "oracle_ast.js").write_text(
+            'const p = require("pkg");\n', encoding="utf-8"
+        )
+
+        assert node_oracle_available(oracle) is False
+        # The failure must not be remembered under the probe key. Caching it
+        # makes the NEXT call read the cache as a hit and report "available",
+        # which is worse than the original defect: an unusable toolchain now
+        # reports usable. Asserting the second call still says False (with the
+        # node still refusing) is what catches that -- asserting it flips to
+        # True instead would ACCEPT the poisoned cache, since a cache hit
+        # yields exactly that.
+        assert node_oracle_available(oracle) is False, (
+            "a failed probe was cached, so the second call read the cache as "
+            "a success and reported an unusable toolchain as available"
+        )
+        assert not _REQUIRE_OK, f"a failure was remembered: {_REQUIRE_OK}"
+
+        # And a real success IS remembered, or rule 1 would be satisfied by
+        # caching nothing at all.
+        node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        node.chmod(0o755)
+        assert node_oracle_available(oracle) is True
+        assert _REQUIRE_OK, "a successful probe was not cached"
+
     def test_a_pre_install_answer_is_not_cached(self, tmp_path: Path) -> None:
         """Issue #1639: the provisional "ask again" must not become a verdict.
 
@@ -286,9 +347,22 @@ class TestGuardCacheLifecycle:
         )
         assert node_oracle_available(oracle) is True
 
-        # ensure_node_deps installs them; the guard must now actually probe.
+        # ensure_node_deps installs them AND writes the completion marker;
+        # only then does the guard probe (rule 2), and it must now actually do
+        # so rather than reuse the pre-install answer (rule 1).
         (oracle / ec.NODE_MODULES_DIRNAME).mkdir()
+        (oracle / ec.NODE_DEPS_MARKER).write_text("ok", encoding="utf-8")
         assert node_oracle_available(oracle) is False
+
+        # A marker-less tree is "installing", never "unavailable": probing it
+        # measures a half-written directory, and caching that False is the
+        # third variant of this defect.
+        half = tmp_path / "half"
+        (half / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        (half / "oracle_ast.js").write_text(
+            'const p = require("definitely-not-installed");\n', encoding="utf-8"
+        )
+        assert node_oracle_available(half) is True
 
 
 class TestSkipReasons:
@@ -341,6 +415,7 @@ class TestSkipReasons:
         monkeypatch.setenv("PATH", str(binaries))
         oracle = tmp_path / "oracle"
         (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        (oracle / ec.NODE_DEPS_MARKER).write_text("ok", encoding="utf-8")
         (oracle / "oracle_ast.js").write_text(
             'const p = require("@ruby/prism");\n', encoding="utf-8"
         )
@@ -388,12 +463,23 @@ class TestPostInstallRecheck:
         monkeypatch.setenv("PATH", str(binaries))
 
         oracle = tmp_path / "oracle"
-        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        oracle.mkdir()
         script = oracle / "oracle_ast.js"
         script.write_text('const p = require("@ruby/prism");\n', encoding="utf-8")
-        # The install itself is not under test; what matters is that the
-        # capability is re-checked once it has happened.
-        monkeypatch.setattr(_common, "ensure_node_deps", lambda _dir: None)
+
+        # Start WITHOUT the deps and let the patched installer create them, so
+        # this distinguishes pre-install from post-install probing. With
+        # node_modules already present, a regression that probed too early
+        # would still see a complete tree and pass.
+        def _install(_dir: Path) -> None:
+            (oracle / ec.NODE_MODULES_DIRNAME).mkdir(exist_ok=True)
+            (oracle / ec.NODE_DEPS_MARKER).write_text("ok", encoding="utf-8")
+
+        monkeypatch.setattr(_common, "ensure_node_deps", _install)
+        # Rule 2: before the marker exists the guard says "cannot tell yet",
+        # never "unavailable". Caching a False here is what poisoned the
+        # post-install check.
+        assert node_oracle_skip_reason(oracle) is None
 
         with pytest.raises(NodeOracleUnavailable) as raised:
             _common.run_node_oracle_payload(oracle, script, ())

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -1,0 +1,227 @@
+"""The oracle skip guards must answer "can this toolchain do the job" (#1639).
+
+Every one of these guards used to be `shutil.which(...)`, which answers "is
+there a file on PATH". A toolchain that is present but too old sails past that
+and the test HARD-FAILS instead of skipping: on a machine with Node 18 and
+.NET SDK 8 that was 24 failures and 4 errors on a clean main, in tests named as
+though they were real regressions.
+
+These tests pin the guards against stub toolchains, because the failure they
+exist to prevent cannot be reproduced on a machine whose toolchains work. The
+stubs are the point: a green run on a well-provisioned host says nothing about
+the case the guards were written for.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from evals import constants as ec
+from evals.oracles._common import _oracle_dependency, node_oracle_available
+from evals.oracles.csharp_oracle import _sdk_major, csharp_oracle_available
+
+_ORACLE_CSPROJ = (
+    Path(__file__).resolve().parents[2]
+    / "evals"
+    / "oracles"
+    / ec.CSHARP_ORACLE_DIRNAME
+    / "Oracle.csproj"
+)
+
+
+def _stub(directory: Path, name: str, body: str) -> None:
+    script = directory / name
+    script.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    script.chmod(0o755)
+
+
+@pytest.fixture(autouse=True)
+def _clear_guard_caches() -> None:
+    # Both guards are lru_cached, so a verdict from one test would otherwise
+    # answer for the next one's PATH. Clearing before each test is what makes
+    # the stubs below decide the outcome.
+    node_oracle_available.cache_clear()
+    csharp_oracle_available.cache_clear()
+
+
+class TestSdkMajor:
+    """The version parse must fail CLOSED: unreadable means unusable."""
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ("10.0.400 [/usr/share/dotnet/sdk]", 10),
+            ("8.0.130 [/usr/share/dotnet/sdk]", 8),
+            # A preview SDK is still that major version.
+            ("10.0.100-preview.5.24307.3 [/x]", 10),
+            ("10.0.400", 10),
+            ("", 0),
+            ("   ", 0),
+            ("Nothing here", 0),
+        ],
+    )
+    def test_major_version_is_read_or_refused(self, line: str, expected: int) -> None:
+        assert _sdk_major(line) == expected
+
+
+class TestCsharpGuard:
+    def test_an_sdk_older_than_the_csproj_is_not_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reported failure: SDK 8 present, csproj targets net10.0.
+
+        `which` was satisfied here and the build then died with NETSDK1045.
+        """
+        _stub(tmp_path, "dotnet", 'echo "8.0.130 [/usr/share/dotnet/sdk]"')
+        monkeypatch.setenv("PATH", str(tmp_path))
+        assert csharp_oracle_available() is False
+
+    def test_an_sdk_at_least_the_csproj_is_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub(tmp_path, "dotnet", 'echo "10.0.400 [/usr/share/dotnet/sdk]"')
+        monkeypatch.setenv("PATH", str(tmp_path))
+        assert csharp_oracle_available() is True
+
+    def test_a_newer_sdk_is_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An exact-TFM check would wrongly skip here: SDK 11 builds net10.0.
+        _stub(tmp_path, "dotnet", 'echo "11.0.100 [/usr/share/dotnet/sdk]"')
+        monkeypatch.setenv("PATH", str(tmp_path))
+        assert csharp_oracle_available() is True
+
+    def test_a_runtime_only_install_is_not_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # `dotnet` exists and runs, but lists no SDKs: the launcher is present
+        # for a runtime-only install, which cannot build anything.
+        _stub(tmp_path, "dotnet", "exit 0")
+        monkeypatch.setenv("PATH", str(tmp_path))
+        assert csharp_oracle_available() is False
+
+    def test_no_dotnet_at_all_is_not_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PATH", str(tmp_path))
+        assert csharp_oracle_available() is False
+
+
+class TestCsprojDrift:
+    def test_the_minimum_sdk_matches_the_csproj_target(self) -> None:
+        """The forcing function a comment cannot provide.
+
+        `CSHARP_ORACLE_MIN_SDK_MAJOR` duplicates the csproj's TargetFramework.
+        Nothing else in the repo reads that file, so a bump to net11.0 would
+        leave the guard silently under-requiring and the NETSDK1045 failures
+        would come back exactly as reported.
+        """
+        target = re.search(
+            r"<TargetFramework>net(\d+)\.", _ORACLE_CSPROJ.read_text(encoding="utf-8")
+        )
+        assert target is not None, f"no TargetFramework in {_ORACLE_CSPROJ}"
+        assert int(target.group(1)) == ec.CSHARP_ORACLE_MIN_SDK_MAJOR
+
+
+class TestNodeGuard:
+    """The probe must be the call that BREAKS, not one that merely runs."""
+
+    @staticmethod
+    def _oracle(tmp_path: Path, package: str) -> Path:
+        oracle = tmp_path / "oracle"
+        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        (oracle / ec.NODE_PACKAGE_MANIFEST).write_text(
+            f'{{"dependencies": {{"{package}": "1.0.0"}}}}', encoding="utf-8"
+        )
+        return oracle
+
+    def test_a_node_that_cannot_require_the_dependency_is_not_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Node 18's shape: `require()` of an ESM-only package is refused.
+
+        This is the case a dynamic-`import()` probe could not see, because
+        dynamic import has worked since Node 12: such a probe returned True on
+        the very version that hard-fails the oracle.
+        """
+        binaries = tmp_path / "bin"
+        binaries.mkdir()
+        # The stub answers like Node 18: a `require()` of an ES module is
+        # refused, while anything else (a dynamic `import()`, say) succeeds.
+        # It must discriminate on the ARGUMENT, or the test cannot tell a
+        # probe that exercises the breaking call from one that does not --
+        # and a dynamic-import probe passing here is precisely the bug.
+        _stub(
+            binaries,
+            "node",
+            'case "$2" in\n'
+            '  *require*) echo "Error [ERR_REQUIRE_ESM]" >&2; exit 1 ;;\n'
+            "  *) exit 0 ;;\n"
+            "esac",
+        )
+        _stub(binaries, "npm", "exit 0")
+        monkeypatch.setenv("PATH", str(binaries))
+        assert node_oracle_available(self._oracle(tmp_path, "@ruby/prism")) is False
+
+    def test_a_node_that_can_require_the_dependency_is_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binaries = tmp_path / "bin"
+        binaries.mkdir()
+        _stub(binaries, "node", "exit 0")
+        _stub(binaries, "npm", "exit 0")
+        monkeypatch.setenv("PATH", str(binaries))
+        assert node_oracle_available(self._oracle(tmp_path, "@ruby/prism")) is True
+
+    def test_uninstalled_deps_are_not_reported_as_a_broken_toolchain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ "Not fetched yet" must not read as "node is broken".
+
+        `ensure_node_deps` installs them later; refusing here would skip a run
+        that was about to become perfectly capable.
+        """
+        binaries = tmp_path / "bin"
+        binaries.mkdir()
+        _stub(binaries, "node", "exit 1")
+        _stub(binaries, "npm", "exit 0")
+        monkeypatch.setenv("PATH", str(binaries))
+        bare = tmp_path / "oracle"
+        bare.mkdir()
+        assert node_oracle_available(bare) is True
+
+    def test_no_node_at_all_is_not_available(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PATH", str(tmp_path))
+        assert node_oracle_available(self._oracle(tmp_path, "luaparse")) is False
+
+
+class TestOracleDependency:
+    def test_the_package_is_read_from_the_oracles_own_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """Read, never hard-coded: the four oracles do not share a dependency.
+
+        Ruby loads `@ruby/prism`, lua `luaparse`, php `php-parser`, ts
+        `typescript`, and only the first is ESM-only. A hard-coded package
+        would be a second copy of that fact, free to drift.
+        """
+        oracle = tmp_path / "oracle"
+        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        (oracle / ec.NODE_PACKAGE_MANIFEST).write_text(
+            '{"dependencies": {"luaparse": "0.3.1"}}', encoding="utf-8"
+        )
+        assert _oracle_dependency(oracle) == "luaparse"
+
+    def test_a_missing_or_unreadable_manifest_yields_no_package(
+        self, tmp_path: Path
+    ) -> None:
+        oracle = tmp_path / "oracle"
+        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        assert _oracle_dependency(oracle) is None
+        (oracle / ec.NODE_PACKAGE_MANIFEST).write_text("not json {{{", encoding="utf-8")
+        assert _oracle_dependency(oracle) is None

--- a/codebase_rag/tests/test_oracle_toolchain_guards.py
+++ b/codebase_rag/tests/test_oracle_toolchain_guards.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from evals import constants as ec
+from evals.oracles import _common
 from evals.oracles._common import (
     _node_require_stderr,
     _oracle_dependency,
@@ -352,3 +353,45 @@ class TestSkipReasons:
     def test_a_working_toolchain_has_no_reason(self, tmp_path: Path) -> None:
         """None is the signal the call sites branch on, so it must be exact."""
         assert node_oracle_skip_reason(None) is None
+
+
+class TestPostInstallRecheck:
+    def test_a_toolchain_that_turns_out_unusable_skips_rather_than_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The clean-checkout gap (#1639).
+
+        The guard runs before `ensure_node_deps`, so on a fresh clone it
+        cannot probe and answers "available" to avoid mistaking "not fetched"
+        for "toolchain broken". Nothing revisited that once the deps landed,
+        so an incompatible runtime reached the oracle and died with
+        ERR_REQUIRE_ESM -- an evaluation FAILURE standing in for an
+        unavailable toolchain, which is the whole defect.
+
+        Asserting on the SKIP specifically: a raise reaches the report as an
+        error and an empty payload grades every node as missing, and both are
+        the misdiagnosis this issue is about.
+        """
+        binaries = tmp_path / "bin"
+        binaries.mkdir()
+        _stub(
+            binaries,
+            "node",
+            'case "$2" in\n  *require*) exit 1 ;;\n  *) exit 0 ;;\nesac',
+        )
+        _stub(binaries, "npm", "exit 0")
+        monkeypatch.setenv("PATH", str(binaries))
+
+        oracle = tmp_path / "oracle"
+        (oracle / ec.NODE_MODULES_DIRNAME).mkdir(parents=True)
+        script = oracle / "oracle_ast.js"
+        script.write_text('const p = require("@ruby/prism");\n', encoding="utf-8")
+        # The install itself is not under test; what matters is that the
+        # capability is re-checked once it has happened.
+        monkeypatch.setattr(_common, "ensure_node_deps", lambda _dir: None)
+
+        with pytest.raises(BaseException) as raised:
+            _common.run_node_oracle_payload(oracle, script, ())
+        assert "Skipped" in type(raised.value).__name__, (
+            f"expected a skip, got {type(raised.value).__name__}"
+        )

--- a/codebase_rag/tests/test_php_containment_oracle.py
+++ b/codebase_rag/tests/test_php_containment_oracle.py
@@ -12,7 +12,7 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_php_graph
-from evals.oracles import php_oracle_available, run_php_oracle
+from evals.oracles import php_oracle_skip_reason, run_php_oracle
 from evals.score import score_edge_types
 
 PHP_SRC = """\
@@ -35,8 +35,9 @@ function freeFn(int $a): int { return $a + 1; }
 
 
 def _require_php() -> None:
-    if not php_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = php_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.PHP not in load_parsers()[0]:
         pytest.skip("php parser not available")
 

--- a/codebase_rag/tests/test_php_inheritance_oracle.py
+++ b/codebase_rag/tests/test_php_inheritance_oracle.py
@@ -11,7 +11,7 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_php_graph
-from evals.oracles import php_oracle_available, run_php_oracle
+from evals.oracles import php_oracle_skip_reason, run_php_oracle
 from evals.score import score_name_edge_types
 
 PHP_SRC = """\
@@ -28,8 +28,9 @@ class Circle extends Base implements Shape, Drawable {}
 
 
 def _require_php() -> None:
-    if not php_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = php_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.PHP not in load_parsers()[0]:
         pytest.skip("php parser not available")
 

--- a/codebase_rag/tests/test_php_span_oracle.py
+++ b/codebase_rag/tests/test_php_span_oracle.py
@@ -12,7 +12,7 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_php_graph
-from evals.oracles import php_oracle_available, run_php_oracle
+from evals.oracles import php_oracle_skip_reason, run_php_oracle
 from evals.score import score_span
 
 PHP_SRC = """\
@@ -48,8 +48,9 @@ function standalone(int $a): int
 
 
 def _require_php() -> None:
-    if not php_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = php_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.PHP not in load_parsers()[0]:
         pytest.skip("php parser not available")
 

--- a/codebase_rag/tests/test_php_structure_oracle.py
+++ b/codebase_rag/tests/test_php_structure_oracle.py
@@ -13,7 +13,7 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_php_nodes
-from evals.oracles import php_oracle_available, run_php_oracle
+from evals.oracles import php_oracle_skip_reason, run_php_oracle
 from evals.score import score_node_kinds
 from evals.types_defs import GraphData
 
@@ -44,8 +44,9 @@ function makeHandler(): Shape {
 
 
 def _require_php() -> None:
-    if not php_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = php_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.PHP not in load_parsers()[0]:
         pytest.skip("php parser not available")
 

--- a/codebase_rag/tests/test_ruby_structure_oracle.py
+++ b/codebase_rag/tests/test_ruby_structure_oracle.py
@@ -11,7 +11,10 @@ from pathlib import Path
 
 import pytest
 
-from evals.oracles import ruby_oracle_available, run_ruby_oracle
+from evals.oracles import (
+    ruby_oracle_skip_reason,
+    run_ruby_oracle,
+)
 
 # Every construct here is one the oracle must find. Kept small so the labels
 # stay reviewable, and deliberately mixed so a parser that only handles the
@@ -46,8 +49,9 @@ end
 
 
 def _require_ruby() -> None:
-    if not ruby_oracle_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = ruby_oracle_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
 
 
 def test_oracle_finds_every_ruby_definition(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_typescript_containment_oracle.py
+++ b/codebase_rag/tests/test_typescript_containment_oracle.py
@@ -12,7 +12,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_ts_graph
-from evals.oracles import run_typescript_oracle, typescript_available
+from evals.oracles import (
+    run_typescript_oracle,
+    typescript_skip_reason,
+)
 from evals.score import score_edge_types
 
 TS_SRC = """\
@@ -35,8 +38,9 @@ export namespace geo {
 
 
 def _require_ts() -> None:
-    if not typescript_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = typescript_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.TS not in load_parsers()[0]:
         pytest.skip("typescript parser not available")
 

--- a/codebase_rag/tests/test_typescript_inheritance_oracle.py
+++ b/codebase_rag/tests/test_typescript_inheritance_oracle.py
@@ -11,7 +11,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_ts_graph
-from evals.oracles import run_typescript_oracle, typescript_available
+from evals.oracles import (
+    run_typescript_oracle,
+    typescript_skip_reason,
+)
 from evals.score import score_name_edge_types
 
 TS_SRC = """\
@@ -24,8 +27,9 @@ export class Circle extends Base implements Shape, Drawable {}
 
 
 def _require_ts() -> None:
-    if not typescript_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = typescript_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.TS not in load_parsers()[0]:
         pytest.skip("typescript parser not available")
 

--- a/codebase_rag/tests/test_typescript_span_oracle.py
+++ b/codebase_rag/tests/test_typescript_span_oracle.py
@@ -13,7 +13,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_ts_graph
-from evals.oracles import run_typescript_oracle, typescript_available
+from evals.oracles import (
+    run_typescript_oracle,
+    typescript_skip_reason,
+)
 from evals.score import score_span
 
 TS_SRC = """\
@@ -55,8 +58,9 @@ export function standalone(): number {
 
 
 def _require_ts() -> None:
-    if not typescript_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = typescript_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.TS not in load_parsers()[0]:
         pytest.skip("typescript parser not available")
 

--- a/codebase_rag/tests/test_typescript_structure_oracle.py
+++ b/codebase_rag/tests/test_typescript_structure_oracle.py
@@ -12,7 +12,10 @@ from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from evals import constants as ec
 from evals.cgr_graph import extract_cgr_ts_nodes
-from evals.oracles import run_typescript_oracle, typescript_available
+from evals.oracles import (
+    run_typescript_oracle,
+    typescript_skip_reason,
+)
 from evals.score import score_node_kinds
 from evals.types_defs import GraphData
 
@@ -34,8 +37,9 @@ export const arrow = (b: number): number => b * 2;
 
 
 def _require_ts() -> None:
-    if not typescript_available():
-        pytest.skip("node/npm toolchain not available")
+    reason = typescript_skip_reason()
+    if reason is not None:
+        pytest.skip(reason)
     if cs.SupportedLanguage.TS not in load_parsers()[0]:
         pytest.skip("typescript parser not available")
 

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -1,3 +1,4 @@
+import re
 from enum import StrEnum
 
 from codebase_rag import constants as cs
@@ -394,6 +395,14 @@ NODE_EVAL_FLAG = "-e"
 NODE_REQUIRE_PROBE = 'require("{package}")'
 NODE_PACKAGE_MANIFEST = "package.json"
 NODE_PACKAGE_DEPS_KEY = "dependencies"
+NODE_ORACLE_SCRIPT_GLOB = "*.js"
+# The oracle's own `require("pkg")` calls: the authoritative statement of what
+# it loads, and literally the call that fails on an incompatible Node. Builtins
+# are excluded because they load everywhere and would make the probe vacuous.
+NODE_REQUIRE_PATTERN = re.compile(r"""require\(\s*["']([^"']+)["']\s*\)""")
+NODE_BUILTIN_MODULES: frozenset[str] = frozenset(
+    {"fs", "path", "os", "util", "url", "process", "assert", "module", "buffer"}
+)
 NODE_PROBE_TIMEOUT_S = 30
 NPM_BIN = "npm"
 NPM_INSTALL = "install"

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -381,6 +381,17 @@ NODE_BIN = "node"
 # covers that break, a missing install and any future incompatibility, without
 # hard-coding a version to keep up to date.
 DOTNET_LIST_SDKS_FLAG = "--list-sdks"
+DOTNET_SKIP_NO_BINARY = "{binary} is not on PATH"
+DOTNET_SKIP_NO_SDKS = "dotnet --list-sdks failed: {stderr}"
+DOTNET_SKIP_SDK_TOO_OLD = (
+    "the C# oracle needs .NET SDK {needed} or newer to build its net{needed}.0 "
+    "project; installed: {found}"
+)
+DOTNET_SKIP_BUILD_FAILED = "the C# oracle could not be built: {stderr}"
+DOTNET_SKIP_BUILD_INCOMPLETE = (
+    "the C# oracle build did not complete (another process held the build lock "
+    "past the timeout)"
+)
 DOTNET_PROBE_TIMEOUT_S = 30
 DOTNET_SDK_LINE_SEP = " "
 # Oracle.csproj targets net10.0, so an older SDK cannot build it (NETSDK1045).
@@ -396,6 +407,13 @@ NODE_REQUIRE_PROBE = 'require("{package}")'
 NODE_PACKAGE_MANIFEST = "package.json"
 NODE_PACKAGE_DEPS_KEY = "dependencies"
 NODE_ORACLE_SCRIPT_GLOB = "*.js"
+# Skip reasons name what actually went wrong. "node/npm toolchain not
+# available" is FALSE on the machine that reported #1639: node is installed
+# there, and the oracle dies on ERR_REQUIRE_ESM. The stderr is truncated
+# because a full node stack trace buries the one line that explains the skip.
+NODE_SKIP_NO_BINARY = "{binary} is not on PATH"
+NODE_SKIP_CANNOT_REQUIRE = "this node cannot require({package}): {stderr}"
+SKIP_REASON_STDERR_CHARS = 400
 # The oracle's own `require("pkg")` calls: the authoritative statement of what
 # it loads, and literally the call that fails on an incompatible Node. Builtins
 # are excluded because they load everywhere and would make the probe vacuous.

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -374,6 +374,21 @@ TS_SCORED_NODE_KIND_VALUES: frozenset[str] = frozenset(
 TS_ORACLE_DIRNAME = "ts_oracle"
 TS_ORACLE_SCRIPT = "ts_ast.js"
 NODE_BIN = "node"
+# Run instead of trusting `which node` (issue #1639). `@ruby/prism` is ESM-only,
+# so a Node too old to `require()` an ES module satisfies a presence check and
+# then fails the oracle with ERR_REQUIRE_ESM. Probing the interop boundary
+# covers that break, a missing install and any future incompatibility, without
+# hard-coding a version to keep up to date.
+DOTNET_LIST_SDKS_FLAG = "--list-sdks"
+DOTNET_PROBE_TIMEOUT_S = 30
+DOTNET_SDK_LINE_SEP = " "
+# Oracle.csproj targets net10.0, so an older SDK cannot build it (NETSDK1045).
+# Kept beside the guard that reads it: if the csproj's TargetFramework moves,
+# this moves with it.
+CSHARP_ORACLE_MIN_SDK_MAJOR = 10
+NODE_EVAL_FLAG = "-e"
+NODE_ESM_PROBE = "import('node:path').then(()=>process.exit(0),()=>process.exit(1))"
+NODE_PROBE_TIMEOUT_S = 30
 NPM_BIN = "npm"
 NPM_INSTALL = "install"
 NPM_FLAGS: tuple[str, ...] = ("--no-audit", "--no-fund")

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -387,7 +387,13 @@ DOTNET_SDK_LINE_SEP = " "
 # this moves with it.
 CSHARP_ORACLE_MIN_SDK_MAJOR = 10
 NODE_EVAL_FLAG = "-e"
-NODE_ESM_PROBE = "import('node:path').then(()=>process.exit(0),()=>process.exit(1))"
+# `require()` the oracle's own entry script, which is the call that breaks: a
+# CommonJS script loading an ESM-only package (`@ruby/prism`) on a Node too old
+# for it. A dynamic `import()` probe would pass on that Node and report the
+# toolchain usable, which is worse than no guard at all.
+NODE_REQUIRE_PROBE = 'require("{package}")'
+NODE_PACKAGE_MANIFEST = "package.json"
+NODE_PACKAGE_DEPS_KEY = "dependencies"
 NODE_PROBE_TIMEOUT_S = 30
 NPM_BIN = "npm"
 NPM_INSTALL = "install"

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -393,6 +393,13 @@ DOTNET_SKIP_BUILD_INCOMPLETE = (
     "past the timeout)"
 )
 DOTNET_PROBE_TIMEOUT_S = 30
+# The build restores packages, so it needs far longer than the version probe;
+# bounded all the same, because an unreachable feed otherwise blocks forever.
+DOTNET_BUILD_TIMEOUT_S = 600
+DOTNET_SKIP_BUILD_TIMEOUT = (
+    "the C# oracle build did not finish within {seconds}s (an unreachable "
+    "package feed will do this); skipping rather than blocking the run"
+)
 DOTNET_SDK_LINE_SEP = " "
 # Oracle.csproj targets net10.0, so an older SDK cannot build it (NETSDK1045).
 # Kept beside the guard that reads it: if the csproj's TargetFramework moves,
@@ -412,6 +419,7 @@ NODE_ORACLE_SCRIPT_GLOB = "*.js"
 # there, and the oracle dies on ERR_REQUIRE_ESM. The stderr is truncated
 # because a full node stack trace buries the one line that explains the skip.
 NODE_SKIP_NO_BINARY = "{binary} is not on PATH"
+NODE_SKIP_INSTALL_FAILED = "npm install failed for this oracle: {stderr}"
 NODE_SKIP_CANNOT_REQUIRE = "this node cannot require({package}): {stderr}"
 SKIP_REASON_STDERR_CHARS = 400
 # The oracle's own `require("pkg")` calls: the authoritative statement of what

--- a/evals/l1_eval.py
+++ b/evals/l1_eval.py
@@ -18,6 +18,8 @@ from loguru import logger
 from codebase_rag import constants as cs
 
 from . import constants as ec
+from . import logs as ls
+from .oracles import NodeOracleUnavailable
 from .score import score_structure
 from .structure_report import render, write_outputs
 from .types_defs import GraphData
@@ -30,6 +32,7 @@ def run_l1_eval(
     *,
     available: Callable[[], bool],
     oracle_missing: str,
+    skip_reason: Callable[[], str | None] | None = None,
     extract_cgr: Callable[[Path, str], GraphData],
     run_oracle: Callable[[Path], GraphData],
     oracle_binary: str,
@@ -50,12 +53,23 @@ def run_l1_eval(
     title: str,
 ) -> None:
     if not available():
+        # Prefer the probe's own reason when the caller can supply one: the
+        # fixed message says "not found on PATH", which is FALSE in the case
+        # that matters -- the binary is there and cannot load the parser
+        # (issue #1639). Fall back to the fixed string for oracles with no
+        # reason probe.
+        #
         # Formatted here, as `extracting_oracle` already is below, because the
         # arm that reports a MISSING toolchain is the one arm that never runs
         # and so is never seen by whoever tested the language (issue #1518).
         # Callers that pre-format, or whose message has no placeholder, are
         # unaffected: `str.format` on a string with no fields is the identity.
-        logger.error(oracle_missing.format(binary=oracle_binary))
+        reason = skip_reason() if skip_reason is not None else None
+        logger.error(
+            ls.ORACLE_UNAVAILABLE.format(reason=reason)
+            if reason
+            else oracle_missing.format(binary=oracle_binary)
+        )
         raise typer.Exit(code=1)
 
     target = target.resolve()
@@ -66,7 +80,18 @@ def run_l1_eval(
     logger.success(cgr_done.format(count=len(cgr.nodes)))
 
     logger.info(extracting_oracle.format(binary=oracle_binary, target=target))
-    oracle = run_oracle(target)
+    try:
+        oracle = run_oracle(target)
+    except NodeOracleUnavailable as unavailable:
+        # The `available()` arm above cannot catch this one. On a clean
+        # checkout the dependencies are not installed when the guard runs, so
+        # it honestly answers "cannot tell yet"; the toolchain's real verdict
+        # only exists once `ensure_node_deps` has fetched them, which happens
+        # inside `run_oracle`. Reported the same way as the arm above rather
+        # than escaping as a traceback: an unavailable toolchain is a result
+        # this command should state, not a crash (issue #1639).
+        logger.error(ls.ORACLE_UNAVAILABLE.format(reason=unavailable))
+        raise typer.Exit(code=1) from unavailable
     logger.success(oracle_done.format(count=len(oracle.nodes)))
 
     result = score_structure(

--- a/evals/logs.py
+++ b/evals/logs.py
@@ -187,3 +187,7 @@ AGENTIC_QA_RESUME_MISMATCH = (
     "Cannot --resume from {path}: its fingerprint {stored} does not match the "
     "current run {current}. Re-run without --resume to start fresh."
 )
+
+# The toolchain could not run the oracle: a stated RESULT, not a crash.
+# Carries the probe stderr so the operator sees why (issue #1639).
+ORACLE_UNAVAILABLE = "Oracle unavailable: {reason}"

--- a/evals/lua_l1.py
+++ b/evals/lua_l1.py
@@ -7,7 +7,7 @@ from . import constants as ec
 from . import logs as ls
 from .cgr_graph import extract_cgr_lua_graph
 from .l1_eval import run_l1_eval
-from .oracles import lua_oracle_available, run_lua_oracle
+from .oracles import lua_oracle_available, lua_oracle_skip_reason, run_lua_oracle
 
 _TITLE = "cgr L1 structure eval (Lua vs luaparse)"
 
@@ -28,6 +28,7 @@ def main(
         project_name,
         out_dir,
         available=lua_oracle_available,
+        skip_reason=lua_oracle_skip_reason,
         oracle_missing=ls.LUA_ORACLE_MISSING,
         extract_cgr=extract_cgr_lua_graph,
         run_oracle=run_lua_oracle,

--- a/evals/oracles/__init__.py
+++ b/evals/oracles/__init__.py
@@ -1,3 +1,4 @@
+from ._common import NodeOracleUnavailable
 from .cpp_oracle import (
     cpp_available,
     run_c_call_oracle,
@@ -42,6 +43,7 @@ from .typescript_oracle import (
 )
 
 __all__ = [
+    "NodeOracleUnavailable",
     "cpp_available",
     "run_c_call_oracle",
     "run_cpp_call_oracle",

--- a/evals/oracles/__init__.py
+++ b/evals/oracles/__init__.py
@@ -6,14 +6,30 @@ from .cpp_oracle import (
 )
 from .csharp_oracle import (
     csharp_oracle_available,
+    csharp_oracle_skip_reason,
     run_csharp_call_oracle,
     run_csharp_oracle,
 )
 from .go_oracle import go_available, run_go_call_oracle, run_go_oracle
 from .java_oracle import java_available, run_java_call_oracle, run_java_oracle
-from .lua_oracle import lua_oracle_available, run_lua_call_oracle, run_lua_oracle
-from .php_oracle import php_oracle_available, run_php_call_oracle, run_php_oracle
-from .ruby_oracle import ruby_oracle_available, run_ruby_call_oracle, run_ruby_oracle
+from .lua_oracle import (
+    lua_oracle_available,
+    lua_oracle_skip_reason,
+    run_lua_call_oracle,
+    run_lua_oracle,
+)
+from .php_oracle import (
+    php_oracle_available,
+    php_oracle_skip_reason,
+    run_php_call_oracle,
+    run_php_oracle,
+)
+from .ruby_oracle import (
+    ruby_oracle_available,
+    ruby_oracle_skip_reason,
+    run_ruby_call_oracle,
+    run_ruby_oracle,
+)
 from .rust_oracle import run_rust_call_oracle, run_rust_oracle, rust_available
 from .scala_oracle import run_scala_call_oracle, run_scala_oracle, scala_available
 from .typescript_oracle import (
@@ -22,6 +38,7 @@ from .typescript_oracle import (
     run_typescript_call_oracle,
     run_typescript_oracle,
     typescript_available,
+    typescript_skip_reason,
 )
 
 __all__ = [
@@ -30,6 +47,7 @@ __all__ = [
     "run_cpp_call_oracle",
     "run_cpp_oracle",
     "csharp_oracle_available",
+    "csharp_oracle_skip_reason",
     "run_csharp_call_oracle",
     "run_csharp_oracle",
     "go_available",
@@ -39,12 +57,15 @@ __all__ = [
     "run_java_call_oracle",
     "run_java_oracle",
     "lua_oracle_available",
+    "lua_oracle_skip_reason",
     "ruby_oracle_available",
+    "ruby_oracle_skip_reason",
     "run_ruby_call_oracle",
     "run_ruby_oracle",
     "run_lua_call_oracle",
     "run_lua_oracle",
     "php_oracle_available",
+    "php_oracle_skip_reason",
     "run_php_call_oracle",
     "run_php_oracle",
     "run_rust_call_oracle",
@@ -58,4 +79,5 @@ __all__ = [
     "run_typescript_call_oracle",
     "run_typescript_oracle",
     "typescript_available",
+    "typescript_skip_reason",
 ]

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -7,6 +7,8 @@ import time
 from functools import lru_cache
 from pathlib import Path, PurePosixPath
 
+import pytest
+
 from codebase_rag import constants as cs
 
 from .. import constants as ec
@@ -206,6 +208,21 @@ def run_node_oracle_payload(
     node = shutil.which(ec.NODE_BIN)
     if node is None:
         return OraclePayload(nodes=[], edges=[], name_edges=[])
+    # Re-check AFTER installing. On a clean checkout the guard ran before
+    # node_modules existed, so it could not probe and answered "available" to
+    # avoid mistaking "not fetched" for "toolchain broken". That answer was
+    # provisional, and this is the first moment it can be settled: without
+    # this an incompatible runtime reaches the oracle and dies with
+    # ERR_REQUIRE_ESM, turning an unavailable toolchain into an evaluation
+    # FAILURE, which is the whole defect issue #1639 is about.
+    reason = node_oracle_skip_reason(oracle_dir)
+    if reason is not None:
+        # `pytest.skip` rather than a raise or an empty payload. An empty
+        # payload grades every node as missing, which reads as a real
+        # regression; a bare raise reaches the report as an ERROR, which is
+        # the same misdiagnosis #1639 is about. Skipping here needs no change
+        # at the ~24 call sites and cannot be forgotten at a new one.
+        pytest.skip(reason)
     proc = subprocess.run(
         [node, str(script), *args],
         capture_output=True,

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -26,6 +26,33 @@ from ..types_defs import (
 
 # The node-backed oracles (Lua, PHP, Ruby, TypeScript/JavaScript) all shell
 # out to the same toolchain, so they share one availability probe.
+def node_oracle_skip_reason(oracle_dir: Path | None = None) -> str | None:
+    """Why the node oracle cannot run here, or None when it can (issue #1639).
+
+    The fixed strings the call sites print today ("node/npm toolchain not
+    available") are wrong in the case that matters: on the reporting machine
+    node IS available, and the reason the oracle fails is an ERR_REQUIRE_ESM
+    from a Node too old for the ESM-only parser. The issue asks for the
+    captured stderr so a developer can see WHY it skipped instead of guessing.
+    """
+    node = shutil.which(ec.NODE_BIN)
+    if node is None:
+        return ec.NODE_SKIP_NO_BINARY.format(binary=ec.NODE_BIN)
+    if shutil.which(ec.NPM_BIN) is None:
+        return ec.NODE_SKIP_NO_BINARY.format(binary=ec.NPM_BIN)
+    if oracle_dir is None:
+        return None
+    package = _oracle_dependency(oracle_dir)
+    if package is None:
+        return None
+    stderr = _node_require_stderr(node, str(oracle_dir), package)
+    if stderr is None:
+        return None
+    return ec.NODE_SKIP_CANNOT_REQUIRE.format(
+        package=package, stderr=stderr.strip()[: ec.SKIP_REASON_STDERR_CHARS]
+    )
+
+
 def node_oracle_available(oracle_dir: Path | None = None) -> bool:
     """Whether the node toolchain can RUN this oracle, not merely whether it exists.
 
@@ -63,16 +90,17 @@ def node_oracle_available(oracle_dir: Path | None = None) -> bool:
         # before installation, so on a clean checkout the real probe never ran
         # at all and an incompatible Node reached the oracle anyway.
         return True
-    return _node_can_require(node, str(oracle_dir), package)
+    return _node_require_stderr(node, str(oracle_dir), package) is None
 
 
 @lru_cache(maxsize=16)
-def _node_can_require(node: str, oracle_dir: str, package: str) -> bool:
-    """Whether this node can `require()` this package from this directory.
+def _node_require_stderr(node: str, oracle_dir: str, package: str) -> str | None:
+    """None when the require succeeds, else the stderr explaining why not.
 
-    Cached on the full triple, and only ever on a REAL verdict: the answer to
-    this question cannot change within a process, whereas "are the deps
-    installed" can and must not be memoised alongside it.
+    Cached on the full triple, and only ever on a REAL verdict: the answer
+    cannot change within a process, whereas "are the deps installed" can and
+    must not be memoised alongside it (that is why the caller decides the
+    uninstalled case before reaching here).
     """
     try:
         probe = subprocess.run(
@@ -84,9 +112,9 @@ def _node_can_require(node: str, oracle_dir: str, package: str) -> bool:
             cwd=oracle_dir,
             timeout=ec.NODE_PROBE_TIMEOUT_S,
         )
-    except (subprocess.TimeoutExpired, OSError):
-        return False
-    return probe.returncode == 0
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return str(e)
+    return None if probe.returncode == 0 else (probe.stderr or probe.stdout)
 
 
 def _oracle_dependency(oracle_dir: Path) -> str | None:

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -26,7 +26,6 @@ from ..types_defs import (
 
 # The node-backed oracles (Lua, PHP, Ruby, TypeScript/JavaScript) all shell
 # out to the same toolchain, so they share one availability probe.
-@lru_cache(maxsize=8)
 def node_oracle_available(oracle_dir: Path | None = None) -> bool:
     """Whether the node toolchain can RUN this oracle, not merely whether it exists.
 
@@ -58,7 +57,23 @@ def node_oracle_available(oracle_dir: Path | None = None) -> bool:
         return True
     package = _oracle_dependency(oracle_dir)
     if package is None:
+        # Deps not installed yet, or nothing to load: `ensure_node_deps` runs
+        # later and fixes the former. NOT cached, deliberately -- this is "ask
+        # again", not "yes". Caching it locked in a provisional answer taken
+        # before installation, so on a clean checkout the real probe never ran
+        # at all and an incompatible Node reached the oracle anyway.
         return True
+    return _node_can_require(node, str(oracle_dir), package)
+
+
+@lru_cache(maxsize=16)
+def _node_can_require(node: str, oracle_dir: str, package: str) -> bool:
+    """Whether this node can `require()` this package from this directory.
+
+    Cached on the full triple, and only ever on a REAL verdict: the answer to
+    this question cannot change within a process, whereas "are the deps
+    installed" can and must not be memoised alongside it.
+    """
     try:
         probe = subprocess.run(
             [node, ec.NODE_EVAL_FLAG, ec.NODE_REQUIRE_PROBE.format(package=package)],
@@ -75,32 +90,33 @@ def node_oracle_available(oracle_dir: Path | None = None) -> bool:
 
 
 def _oracle_dependency(oracle_dir: Path) -> str | None:
-    """The package this oracle loads, read from its own `package.json`.
+    """The package this oracle actually `require()`s, read from its own script.
 
-    Read rather than hard-coded so the probe cannot drift from what the oracle
-    actually requires, and per-oracle because they do not share a dependency:
-    ruby loads `@ruby/prism`, lua `luaparse`, php `php-parser`, ts
-    `typescript`, and only the first is ESM-only.
+    Read, never guessed: the four node oracles do not share a dependency
+    (ruby `@ruby/prism`, lua `luaparse`, php `php-parser`, ts `typescript`),
+    and only the first is ESM-only. Taking the alphabetically first entry of
+    `package.json` picks the right one today ONLY because each manifest
+    happens to hold exactly one dependency; add a second and the probe
+    silently validates a package the oracle never loads.
 
-    The DEPENDENCY is the right subject, not the entry script: requiring
-    `ruby_ast.js` runs its main, which prints a usage line and exits non-zero
-    with no arguments, so a working toolchain would be reported broken.
+    The entry script's own `require()` is the authoritative source, because it
+    is literally the call that breaks. Bare builtins (`fs`, `path`) are
+    skipped: they load on every Node and would make the probe vacuous.
 
-    None when the manifest is missing or deps are not installed yet, so the
-    guard cannot mistake "not fetched" for "toolchain broken" -- that is
-    `ensure_node_deps`'s job and it runs later.
+    None when deps are not installed yet or no third-party require is found,
+    which the caller treats as "ask again later" rather than as a verdict.
     """
     if not (oracle_dir / ec.NODE_MODULES_DIRNAME).is_dir():
         return None
-    manifest = oracle_dir / ec.NODE_PACKAGE_MANIFEST
-    try:
-        deps = json.loads(manifest.read_text(encoding=cs.ENCODING_UTF8)).get(
-            ec.NODE_PACKAGE_DEPS_KEY, {}
-        )
-    except (OSError, ValueError, AttributeError):
-        return None
-    names = sorted(deps) if isinstance(deps, dict) else []
-    return names[0] if names else None
+    for script in sorted(oracle_dir.glob(ec.NODE_ORACLE_SCRIPT_GLOB)):
+        try:
+            source = script.read_text(encoding=cs.ENCODING_UTF8)
+        except OSError:
+            continue
+        for name in ec.NODE_REQUIRE_PATTERN.findall(source):
+            if name not in ec.NODE_BUILTIN_MODULES and not name.startswith("."):
+                return name
+    return None
 
 
 def _node_deps_ready(oracle_dir: Path) -> bool:

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -4,7 +4,6 @@ import json
 import shutil
 import subprocess
 import time
-from functools import lru_cache
 from pathlib import Path, PurePosixPath
 
 from codebase_rag import constants as cs
@@ -48,11 +47,11 @@ class NodeOracleUnavailable(RuntimeError):
 def node_oracle_skip_reason(oracle_dir: Path | None = None) -> str | None:
     """Why the node oracle cannot run here, or None when it can (issue #1639).
 
-    The fixed strings the call sites print today ("node/npm toolchain not
-    available") are wrong in the case that matters: on the reporting machine
-    node IS available, and the reason the oracle fails is an ERR_REQUIRE_ESM
-    from a Node too old for the ESM-only parser. The issue asks for the
-    captured stderr so a developer can see WHY it skipped instead of guessing.
+    None also covers "cannot tell yet": see rule 2 in `node_oracle_available`.
+    The fixed strings the call sites used to print ("node/npm toolchain not
+    available") were wrong in the case that matters -- node IS available on the
+    reporting machine, and the oracle dies on ERR_REQUIRE_ESM -- so the reason
+    carries the captured stderr instead.
     """
     node = shutil.which(ec.NODE_BIN)
     if node is None:
@@ -60,6 +59,11 @@ def node_oracle_skip_reason(oracle_dir: Path | None = None) -> str | None:
     if shutil.which(ec.NPM_BIN) is None:
         return ec.NODE_SKIP_NO_BINARY.format(binary=ec.NPM_BIN)
     if oracle_dir is None:
+        return None
+    # Rule 2: the MARKER, not the directory. npm creates node_modules before
+    # populating it, so a bare directory means "maybe mid-install", and
+    # probing it measures a half-written tree.
+    if not _node_deps_ready(oracle_dir):
         return None
     package = _oracle_dependency(oracle_dir)
     if package is None:
@@ -76,51 +80,47 @@ def node_oracle_available(oracle_dir: Path | None = None) -> bool:
     """Whether the node toolchain can RUN this oracle, not merely whether it exists.
 
     `shutil.which` answers "is this binary on PATH", which is not the question
-    a skip guard needs (issue #1639). Node 18 satisfies it and then cannot
-    `require()` the ESM-only `@ruby/prism` that `ruby_ast.js` loads, so the
-    node-backed oracle tests hard-FAILED on an under-provisioned machine
-    instead of skipping: 24 failures and 4 errors on a clean main, in tests
-    named as though they were real regressions.
+    a skip guard needs (issue #1639): Node 18 satisfies it and then cannot
+    `require()` the ESM-only `@ruby/prism`, so the oracle tests hard-FAILED
+    instead of skipping. The probe therefore performs the call that breaks --
+    `require()` of the oracle's own dependency from a CommonJS context. A
+    dynamic `import()` will not do: it has worked since Node 12, so it passes
+    on the very Node that fails the oracle.
 
-    The probe therefore does the thing that breaks -- `require()` of the
-    oracle's own entry script's dependency, from a CommonJS context, which is
-    exactly the failing call. A dynamic `import()` would NOT do: it has worked
-    since Node 12, so a Node that fails the real oracle passes that probe and
-    the guard is worse than none. Measured against a Node-18-shaped shim
-    (dynamic import fine, `require()` of an ES module refused), an
-    `import()`-based probe reported the toolchain as available.
+    THE INVARIANT, which three separate bugs here were each a variant of:
 
-    `oracle_dir` is required to reach that dependency, because the oracles do
-    not share one: ruby loads `@ruby/prism`, lua `luaparse`, php `php-parser`,
-    ts `typescript`, and only the first is ESM-only. Called with no directory
-    the check degrades to node+npm presence, which is all it can honestly
-    assert without knowing which package to load.
+    1. The only value ever CACHED is a positive verdict, "this node can
+       require package X in dir Y". A failed probe is never cached, so any
+       later call re-probes. A negative cached before the state it depends on
+       has settled poisons every later answer.
+    2. Before the completion marker exists the guard answers "unknown, install
+       first" (True), never "unavailable". A bare `node_modules` can exist
+       while npm is mid-install or after a failed one, and probing then
+       measures a half-written tree.
+    3. The post-install re-check probes FRESH, because only then is the state
+       it depends on settled.
+
+    Each rule exists because breaking it produced a real defect: a stale True
+    from before installation, a negative cached from a marker-less tree, and a
+    verdict reused after the tree changed underneath it.
     """
-    node = shutil.which(ec.NODE_BIN)
-    if node is None or shutil.which(ec.NPM_BIN) is None:
-        return False
-    if oracle_dir is None:
-        return True
-    package = _oracle_dependency(oracle_dir)
-    if package is None:
-        # Deps not installed yet, or nothing to load: `ensure_node_deps` runs
-        # later and fixes the former. NOT cached, deliberately -- this is "ask
-        # again", not "yes". Caching it locked in a provisional answer taken
-        # before installation, so on a clean checkout the real probe never ran
-        # at all and an incompatible Node reached the oracle anyway.
-        return True
-    return _node_require_stderr(node, str(oracle_dir), package) is None
+    return node_oracle_skip_reason(oracle_dir) is None
 
 
-@lru_cache(maxsize=16)
+_REQUIRE_OK: set[tuple[str, str, str]] = set()
+
+
 def _node_require_stderr(node: str, oracle_dir: str, package: str) -> str | None:
     """None when the require succeeds, else the stderr explaining why not.
 
-    Cached on the full triple, and only ever on a REAL verdict: the answer
-    cannot change within a process, whereas "are the deps installed" can and
-    must not be memoised alongside it (that is why the caller decides the
-    uninstalled case before reaching here).
+    Rule 1: only the SUCCESS is remembered. A failure is re-probed every time,
+    because the thing it depends on -- a fully installed dependency tree -- can
+    become true between two calls in one process, and a cached "no" from before
+    that point is wrong forever after.
     """
+    key = (node, oracle_dir, package)
+    if key in _REQUIRE_OK:
+        return None
     try:
         probe = subprocess.run(
             [node, ec.NODE_EVAL_FLAG, ec.NODE_REQUIRE_PROBE.format(package=package)],
@@ -133,7 +133,10 @@ def _node_require_stderr(node: str, oracle_dir: str, package: str) -> str | None
         )
     except (subprocess.TimeoutExpired, OSError) as e:
         return str(e)
-    return None if probe.returncode == 0 else (probe.stderr or probe.stdout)
+    if probe.returncode == 0:
+        _REQUIRE_OK.add(key)
+        return None
+    return probe.stderr or probe.stdout
 
 
 def _oracle_dependency(oracle_dir: Path) -> str | None:
@@ -214,6 +217,16 @@ def ensure_node_deps(oracle_dir: Path) -> None:
                 check=True,
             )
             marker.touch()
+    except subprocess.CalledProcessError as e:
+        # A failed `npm install` is an unavailable toolchain, not a test error:
+        # its stderr is the most useful thing a developer can be shown here.
+        raise NodeOracleUnavailable(
+            ec.NODE_SKIP_INSTALL_FAILED.format(
+                stderr=((e.stderr or e.stdout or "").strip())[
+                    : ec.SKIP_REASON_STDERR_CHARS
+                ]
+            )
+        ) from e
     finally:
         lock.rmdir()
 
@@ -232,6 +245,9 @@ def run_node_oracle_payload(
     # this an incompatible runtime reaches the oracle and dies with
     # ERR_REQUIRE_ESM, turning an unavailable toolchain into an evaluation
     # FAILURE, which is the whole defect issue #1639 is about.
+    # Rule 3: probe fresh here. This is the first moment the dependency tree is
+    # settled, so it is the first moment the question can be answered at all;
+    # rule 1 guarantees no earlier failure was cached to short-circuit it.
     reason = node_oracle_skip_reason(oracle_dir)
     if reason is not None:
         raise NodeOracleUnavailable(reason)

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -7,8 +7,6 @@ import time
 from functools import lru_cache
 from pathlib import Path, PurePosixPath
 
-import pytest
-
 from codebase_rag import constants as cs
 
 from .. import constants as ec
@@ -28,6 +26,25 @@ from ..types_defs import (
 
 # The node-backed oracles (Lua, PHP, Ruby, TypeScript/JavaScript) all shell
 # out to the same toolchain, so they share one availability probe.
+class NodeOracleUnavailable(RuntimeError):
+    """This node toolchain cannot run the oracle, learned after installing.
+
+    A real exception rather than `pytest.skip`, which the oracle runner used
+    to raise directly. That made every caller a pytest caller: the four
+    standalone eval scripts (`evals/ts_l1.py`, `php_l1.py`, `lua_l1.py`,
+    `inheritance.py`) would have died on pytest's private control-flow
+    exception instead of reporting an unavailable toolchain.
+
+    `__test__ = False` and the `outcome` attribute let pytest translate this
+    into a SKIP at the call sites, so the test-suite behaviour is unchanged:
+    an unavailable toolchain must not surface as an ERROR (a misdiagnosis) or
+    as an empty payload (which grades every node as missing), which is the
+    defect issue #1639 is about.
+    """
+
+    __test__ = False
+
+
 def node_oracle_skip_reason(oracle_dir: Path | None = None) -> str | None:
     """Why the node oracle cannot run here, or None when it can (issue #1639).
 
@@ -217,12 +234,7 @@ def run_node_oracle_payload(
     # FAILURE, which is the whole defect issue #1639 is about.
     reason = node_oracle_skip_reason(oracle_dir)
     if reason is not None:
-        # `pytest.skip` rather than a raise or an empty payload. An empty
-        # payload grades every node as missing, which reads as a real
-        # regression; a bare raise reaches the report as an ERROR, which is
-        # the same misdiagnosis #1639 is about. Skipping here needs no change
-        # at the ~24 call sites and cannot be forgotten at a new one.
-        pytest.skip(reason)
+        raise NodeOracleUnavailable(reason)
     proc = subprocess.run(
         [node, str(script), *args],
         capture_output=True,

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -4,6 +4,7 @@ import json
 import shutil
 import subprocess
 import time
+from functools import lru_cache
 from pathlib import Path, PurePosixPath
 
 from codebase_rag import constants as cs
@@ -25,10 +26,39 @@ from ..types_defs import (
 
 # The node-backed oracles (Lua, PHP, Ruby, TypeScript/JavaScript) all shell
 # out to the same toolchain, so they share one availability probe.
+@lru_cache(maxsize=1)
 def node_oracle_available() -> bool:
-    return (
-        shutil.which(ec.NODE_BIN) is not None and shutil.which(ec.NPM_BIN) is not None
-    )
+    """Whether the node toolchain can RUN an oracle, not merely whether it exists.
+
+    `shutil.which` answers "is this binary on PATH", which is not the question a
+    skip guard needs (issue #1639). Node 18 satisfies it and then cannot
+    `require()` the ESM-only `@ruby/prism` these oracles load, so every
+    node-backed oracle test hard-FAILED on an under-provisioned machine instead
+    of skipping -- 24 failures and 4 errors on a clean main, in tests named as
+    though they were real regressions, which cost a full revert-and-compare run
+    to attribute.
+
+    So the probe runs node once and asks it to do the thing that breaks. The
+    check is the ESM/CJS interop boundary rather than a parsed version number:
+    it is the CAPABILITY that matters, and a version comparison would need
+    updating for every future incompatibility. Cached because four oracles
+    consult it and the answer cannot change within a run.
+    """
+    node = shutil.which(ec.NODE_BIN)
+    if node is None or shutil.which(ec.NPM_BIN) is None:
+        return False
+    try:
+        probe = subprocess.run(
+            [node, ec.NODE_EVAL_FLAG, ec.NODE_ESM_PROBE],
+            capture_output=True,
+            text=True,
+            encoding=cs.ENCODING_UTF8,
+            check=False,
+            timeout=ec.NODE_PROBE_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return probe.returncode == 0
 
 
 def _node_deps_ready(oracle_dir: Path) -> bool:

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -26,39 +26,81 @@ from ..types_defs import (
 
 # The node-backed oracles (Lua, PHP, Ruby, TypeScript/JavaScript) all shell
 # out to the same toolchain, so they share one availability probe.
-@lru_cache(maxsize=1)
-def node_oracle_available() -> bool:
-    """Whether the node toolchain can RUN an oracle, not merely whether it exists.
+@lru_cache(maxsize=8)
+def node_oracle_available(oracle_dir: Path | None = None) -> bool:
+    """Whether the node toolchain can RUN this oracle, not merely whether it exists.
 
-    `shutil.which` answers "is this binary on PATH", which is not the question a
-    skip guard needs (issue #1639). Node 18 satisfies it and then cannot
-    `require()` the ESM-only `@ruby/prism` these oracles load, so every
-    node-backed oracle test hard-FAILED on an under-provisioned machine instead
-    of skipping -- 24 failures and 4 errors on a clean main, in tests named as
-    though they were real regressions, which cost a full revert-and-compare run
-    to attribute.
+    `shutil.which` answers "is this binary on PATH", which is not the question
+    a skip guard needs (issue #1639). Node 18 satisfies it and then cannot
+    `require()` the ESM-only `@ruby/prism` that `ruby_ast.js` loads, so the
+    node-backed oracle tests hard-FAILED on an under-provisioned machine
+    instead of skipping: 24 failures and 4 errors on a clean main, in tests
+    named as though they were real regressions.
 
-    So the probe runs node once and asks it to do the thing that breaks. The
-    check is the ESM/CJS interop boundary rather than a parsed version number:
-    it is the CAPABILITY that matters, and a version comparison would need
-    updating for every future incompatibility. Cached because four oracles
-    consult it and the answer cannot change within a run.
+    The probe therefore does the thing that breaks -- `require()` of the
+    oracle's own entry script's dependency, from a CommonJS context, which is
+    exactly the failing call. A dynamic `import()` would NOT do: it has worked
+    since Node 12, so a Node that fails the real oracle passes that probe and
+    the guard is worse than none. Measured against a Node-18-shaped shim
+    (dynamic import fine, `require()` of an ES module refused), an
+    `import()`-based probe reported the toolchain as available.
+
+    `oracle_dir` is required to reach that dependency, because the oracles do
+    not share one: ruby loads `@ruby/prism`, lua `luaparse`, php `php-parser`,
+    ts `typescript`, and only the first is ESM-only. Called with no directory
+    the check degrades to node+npm presence, which is all it can honestly
+    assert without knowing which package to load.
     """
     node = shutil.which(ec.NODE_BIN)
     if node is None or shutil.which(ec.NPM_BIN) is None:
         return False
+    if oracle_dir is None:
+        return True
+    package = _oracle_dependency(oracle_dir)
+    if package is None:
+        return True
     try:
         probe = subprocess.run(
-            [node, ec.NODE_EVAL_FLAG, ec.NODE_ESM_PROBE],
+            [node, ec.NODE_EVAL_FLAG, ec.NODE_REQUIRE_PROBE.format(package=package)],
             capture_output=True,
             text=True,
             encoding=cs.ENCODING_UTF8,
             check=False,
+            cwd=oracle_dir,
             timeout=ec.NODE_PROBE_TIMEOUT_S,
         )
     except (subprocess.TimeoutExpired, OSError):
         return False
     return probe.returncode == 0
+
+
+def _oracle_dependency(oracle_dir: Path) -> str | None:
+    """The package this oracle loads, read from its own `package.json`.
+
+    Read rather than hard-coded so the probe cannot drift from what the oracle
+    actually requires, and per-oracle because they do not share a dependency:
+    ruby loads `@ruby/prism`, lua `luaparse`, php `php-parser`, ts
+    `typescript`, and only the first is ESM-only.
+
+    The DEPENDENCY is the right subject, not the entry script: requiring
+    `ruby_ast.js` runs its main, which prints a usage line and exits non-zero
+    with no arguments, so a working toolchain would be reported broken.
+
+    None when the manifest is missing or deps are not installed yet, so the
+    guard cannot mistake "not fetched" for "toolchain broken" -- that is
+    `ensure_node_deps`'s job and it runs later.
+    """
+    if not (oracle_dir / ec.NODE_MODULES_DIRNAME).is_dir():
+        return None
+    manifest = oracle_dir / ec.NODE_PACKAGE_MANIFEST
+    try:
+        deps = json.loads(manifest.read_text(encoding=cs.ENCODING_UTF8)).get(
+            ec.NODE_PACKAGE_DEPS_KEY, {}
+        )
+    except (OSError, ValueError, AttributeError):
+        return None
+    names = sorted(deps) if isinstance(deps, dict) else []
+    return names[0] if names else None
 
 
 def _node_deps_ready(oracle_dir: Path) -> bool:

--- a/evals/oracles/csharp_oracle.py
+++ b/evals/oracles/csharp_oracle.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import time
+from functools import lru_cache
 from pathlib import Path
 
 from codebase_rag import constants as cs
@@ -28,8 +29,54 @@ _CALLABLE_KINDS = frozenset(
 _DOTNET_ENV = {ec.DOTNET_TELEMETRY_ENV: "1", ec.DOTNET_NOLOGO_ENV: "1"}
 
 
+@lru_cache(maxsize=1)
 def csharp_oracle_available() -> bool:
-    return shutil.which(ec.DOTNET_BIN) is not None
+    """Whether a dotnet SDK that can BUILD this oracle is installed (issue #1639).
+
+    `which("dotnet")` answers "is the launcher present", which a runtime-only
+    install and an SDK too old for the csproj both satisfy. `Oracle.csproj`
+    targets `net10.0`, so an SDK 8 machine sailed past the guard and the build
+    then failed with NETSDK1045 -- 15 failures and 4 setup errors that read as
+    real regressions rather than as a missing toolchain.
+
+    The probe asks the SDK to list itself and requires a major version at least
+    the csproj's. Comparing majors (not attempting the build) keeps the guard
+    cheap and side-effect free; the build's own failure path still skips for
+    anything this cannot foresee, such as an unreachable NuGet feed.
+    """
+    dotnet = shutil.which(ec.DOTNET_BIN)
+    if dotnet is None:
+        return False
+    try:
+        probe = subprocess.run(
+            [dotnet, ec.DOTNET_LIST_SDKS_FLAG],
+            capture_output=True,
+            text=True,
+            encoding=cs.ENCODING_UTF8,
+            check=False,
+            timeout=ec.DOTNET_PROBE_TIMEOUT_S,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    if probe.returncode != 0:
+        return False
+    return any(
+        _sdk_major(line) >= ec.CSHARP_ORACLE_MIN_SDK_MAJOR
+        for line in probe.stdout.splitlines()
+    )
+
+
+def _sdk_major(sdk_line: str) -> int:
+    """Major version from a `dotnet --list-sdks` line, or 0 if unreadable.
+
+    Lines look like `10.0.400 [/usr/share/dotnet/sdk]`. A line this cannot
+    parse must not count as a usable SDK, hence 0 rather than a raise: the
+    caller is a skip guard, and failing it closed costs a skip while failing
+    it open costs the hard failure this exists to prevent.
+    """
+    head = sdk_line.strip().split(ec.DOTNET_SDK_LINE_SEP, 1)[0]
+    major = head.split(".", 1)[0]
+    return int(major) if major.isdigit() else 0
 
 
 def _dll_fresh() -> bool:

--- a/evals/oracles/csharp_oracle.py
+++ b/evals/oracles/csharp_oracle.py
@@ -67,6 +67,8 @@ def csharp_oracle_skip_reason() -> str | None:
         return ec.DOTNET_SKIP_BUILD_FAILED.format(
             stderr=((e.stderr or e.stdout or "").strip())[: ec.SKIP_REASON_STDERR_CHARS]
         )
+    except subprocess.TimeoutExpired as e:
+        return ec.DOTNET_SKIP_BUILD_TIMEOUT.format(seconds=e.timeout)
     except (OSError, subprocess.SubprocessError) as e:
         return ec.DOTNET_SKIP_BUILD_FAILED.format(stderr=str(e))
     return None
@@ -134,6 +136,10 @@ def _ensure_built(dotnet: str) -> bool:
                 text=True,
                 encoding=cs.ENCODING_UTF8,
                 check=True,
+                # Bounded: an unreachable NuGet feed makes `dotnet build`
+                # block indefinitely, and the guard calls this, so a stalled
+                # restore would hang the whole run instead of skipping it.
+                timeout=ec.DOTNET_BUILD_TIMEOUT_S,
                 env={**os.environ, **_DOTNET_ENV},
             )
     finally:

--- a/evals/oracles/csharp_oracle.py
+++ b/evals/oracles/csharp_oracle.py
@@ -30,23 +30,17 @@ _DOTNET_ENV = {ec.DOTNET_TELEMETRY_ENV: "1", ec.DOTNET_NOLOGO_ENV: "1"}
 
 
 @lru_cache(maxsize=1)
-def csharp_oracle_available() -> bool:
-    """Whether a dotnet SDK that can BUILD this oracle is installed (issue #1639).
+def csharp_oracle_skip_reason() -> str | None:
+    """Why the C# oracle cannot run here, or None when it can (issue #1639).
 
-    `which("dotnet")` answers "is the launcher present", which a runtime-only
-    install and an SDK too old for the csproj both satisfy. `Oracle.csproj`
-    targets `net10.0`, so an SDK 8 machine sailed past the guard and the build
-    then failed with NETSDK1045 -- 15 failures and 4 setup errors that read as
-    real regressions rather than as a missing toolchain.
-
-    The probe asks the SDK to list itself and requires a major version at least
-    the csproj's. Comparing majors (not attempting the build) keeps the guard
-    cheap and side-effect free; the build's own failure path still skips for
-    anything this cannot foresee, such as an unreachable NuGet feed.
+    "dotnet toolchain not installed" is FALSE on the reporting machine: dotnet
+    IS installed there and the build fails with NETSDK1045 because the SDK is
+    too old for the csproj. The issue asks for the captured stderr so the skip
+    line names the real obstacle.
     """
     dotnet = shutil.which(ec.DOTNET_BIN)
     if dotnet is None:
-        return False
+        return ec.DOTNET_SKIP_NO_BINARY.format(binary=ec.DOTNET_BIN)
     try:
         probe = subprocess.run(
             [dotnet, ec.DOTNET_LIST_SDKS_FLAG],
@@ -56,14 +50,36 @@ def csharp_oracle_available() -> bool:
             check=False,
             timeout=ec.DOTNET_PROBE_TIMEOUT_S,
         )
-    except (subprocess.TimeoutExpired, OSError):
-        return False
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return str(e)
     if probe.returncode != 0:
-        return False
-    return any(
-        _sdk_major(line) >= ec.CSHARP_ORACLE_MIN_SDK_MAJOR
-        for line in probe.stdout.splitlines()
-    )
+        return ec.DOTNET_SKIP_NO_SDKS.format(stderr=(probe.stderr or "").strip())
+    listed = [line for line in probe.stdout.splitlines() if line.strip()]
+    if not any(_sdk_major(line) >= ec.CSHARP_ORACLE_MIN_SDK_MAJOR for line in listed):
+        return ec.DOTNET_SKIP_SDK_TOO_OLD.format(
+            needed=ec.CSHARP_ORACLE_MIN_SDK_MAJOR,
+            found=", ".join(listed) or "none",
+        )
+    try:
+        if not _ensure_built(dotnet):
+            return ec.DOTNET_SKIP_BUILD_INCOMPLETE
+    except subprocess.CalledProcessError as e:
+        return ec.DOTNET_SKIP_BUILD_FAILED.format(
+            stderr=((e.stderr or e.stdout or "").strip())[: ec.SKIP_REASON_STDERR_CHARS]
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        return ec.DOTNET_SKIP_BUILD_FAILED.format(stderr=str(e))
+    return None
+
+
+def csharp_oracle_available() -> bool:
+    """Whether the C# oracle can run here (issue #1639).
+
+    Thin wrapper over `csharp_oracle_skip_reason`, which holds the reasoning
+    and the caching, so the two can never disagree about availability and the
+    build is probed once rather than once per caller.
+    """
+    return csharp_oracle_skip_reason() is None
 
 
 def _sdk_major(sdk_line: str) -> int:

--- a/evals/oracles/lua_oracle.py
+++ b/evals/oracles/lua_oracle.py
@@ -25,7 +25,13 @@ def lua_oracle_available() -> bool:
 
 
 def lua_oracle_skip_reason() -> str | None:
-    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    """Why this oracle cannot run here, or None when it can (issue #1639).
+
+    On a clean checkout this answers None because the deps are not installed
+    yet and the probe cannot run; `run_node_oracle_payload` re-checks once
+    `ensure_node_deps` has fetched them and raises `NodeOracleUnavailable`,
+    which the test guards below turn into a skip carrying the real reason.
+    """
     return node_oracle_skip_reason(_ORACLE_DIR)
 
 

--- a/evals/oracles/lua_oracle.py
+++ b/evals/oracles/lua_oracle.py
@@ -20,7 +20,7 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value})
 
 
 def lua_oracle_available() -> bool:
-    return node_oracle_available()
+    return node_oracle_available(_ORACLE_DIR)
 
 
 def _run_lua_oracle_payload(target: Path) -> OraclePayload:

--- a/evals/oracles/lua_oracle.py
+++ b/evals/oracles/lua_oracle.py
@@ -9,6 +9,7 @@ from ..types_defs import GraphData, OraclePayload
 from ._common import (
     is_ignored,
     node_oracle_available,
+    node_oracle_skip_reason,
     payload_to_graph,
     run_node_oracle_payload,
 )
@@ -21,6 +22,11 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value})
 
 def lua_oracle_available() -> bool:
     return node_oracle_available(_ORACLE_DIR)
+
+
+def lua_oracle_skip_reason() -> str | None:
+    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    return node_oracle_skip_reason(_ORACLE_DIR)
 
 
 def _run_lua_oracle_payload(target: Path) -> OraclePayload:

--- a/evals/oracles/php_oracle.py
+++ b/evals/oracles/php_oracle.py
@@ -20,7 +20,7 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.va
 
 
 def php_oracle_available() -> bool:
-    return node_oracle_available()
+    return node_oracle_available(_ORACLE_DIR)
 
 
 def _run_php_oracle_payload(target: Path) -> OraclePayload:

--- a/evals/oracles/php_oracle.py
+++ b/evals/oracles/php_oracle.py
@@ -25,7 +25,13 @@ def php_oracle_available() -> bool:
 
 
 def php_oracle_skip_reason() -> str | None:
-    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    """Why this oracle cannot run here, or None when it can (issue #1639).
+
+    On a clean checkout this answers None because the deps are not installed
+    yet and the probe cannot run; `run_node_oracle_payload` re-checks once
+    `ensure_node_deps` has fetched them and raises `NodeOracleUnavailable`,
+    which the test guards below turn into a skip carrying the real reason.
+    """
     return node_oracle_skip_reason(_ORACLE_DIR)
 
 

--- a/evals/oracles/php_oracle.py
+++ b/evals/oracles/php_oracle.py
@@ -9,6 +9,7 @@ from ..types_defs import GraphData, OraclePayload
 from ._common import (
     is_ignored,
     node_oracle_available,
+    node_oracle_skip_reason,
     payload_to_graph,
     run_node_oracle_payload,
 )
@@ -21,6 +22,11 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.va
 
 def php_oracle_available() -> bool:
     return node_oracle_available(_ORACLE_DIR)
+
+
+def php_oracle_skip_reason() -> str | None:
+    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    return node_oracle_skip_reason(_ORACLE_DIR)
 
 
 def _run_php_oracle_payload(target: Path) -> OraclePayload:

--- a/evals/oracles/ruby_oracle.py
+++ b/evals/oracles/ruby_oracle.py
@@ -25,7 +25,13 @@ def ruby_oracle_available() -> bool:
 
 
 def ruby_oracle_skip_reason() -> str | None:
-    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    """Why this oracle cannot run here, or None when it can (issue #1639).
+
+    On a clean checkout this answers None because the deps are not installed
+    yet and the probe cannot run; `run_node_oracle_payload` re-checks once
+    `ensure_node_deps` has fetched them and raises `NodeOracleUnavailable`,
+    which the test guards below turn into a skip carrying the real reason.
+    """
     return node_oracle_skip_reason(_ORACLE_DIR)
 
 

--- a/evals/oracles/ruby_oracle.py
+++ b/evals/oracles/ruby_oracle.py
@@ -9,6 +9,7 @@ from ..types_defs import GraphData, OraclePayload
 from ._common import (
     is_ignored,
     node_oracle_available,
+    node_oracle_skip_reason,
     payload_to_graph,
     run_node_oracle_payload,
 )
@@ -21,6 +22,11 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.va
 
 def ruby_oracle_available() -> bool:
     return node_oracle_available(_ORACLE_DIR)
+
+
+def ruby_oracle_skip_reason() -> str | None:
+    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    return node_oracle_skip_reason(_ORACLE_DIR)
 
 
 def _run_ruby_oracle_payload(target: Path) -> OraclePayload:

--- a/evals/oracles/ruby_oracle.py
+++ b/evals/oracles/ruby_oracle.py
@@ -20,7 +20,7 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.va
 
 
 def ruby_oracle_available() -> bool:
-    return node_oracle_available()
+    return node_oracle_available(_ORACLE_DIR)
 
 
 def _run_ruby_oracle_payload(target: Path) -> OraclePayload:

--- a/evals/oracles/typescript_oracle.py
+++ b/evals/oracles/typescript_oracle.py
@@ -9,6 +9,7 @@ from ..types_defs import GraphData, OraclePayload
 from ._common import (
     is_ignored,
     node_oracle_available,
+    node_oracle_skip_reason,
     payload_to_graph,
     run_node_oracle_payload,
 )
@@ -21,6 +22,11 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.va
 
 def typescript_available() -> bool:
     return node_oracle_available(_ORACLE_DIR)
+
+
+def typescript_skip_reason() -> str | None:
+    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    return node_oracle_skip_reason(_ORACLE_DIR)
 
 
 def _run_payload(target: Path, suffixes: tuple[str, ...]) -> OraclePayload:

--- a/evals/oracles/typescript_oracle.py
+++ b/evals/oracles/typescript_oracle.py
@@ -20,7 +20,7 @@ _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.va
 
 
 def typescript_available() -> bool:
-    return node_oracle_available()
+    return node_oracle_available(_ORACLE_DIR)
 
 
 def _run_payload(target: Path, suffixes: tuple[str, ...]) -> OraclePayload:

--- a/evals/oracles/typescript_oracle.py
+++ b/evals/oracles/typescript_oracle.py
@@ -25,7 +25,13 @@ def typescript_available() -> bool:
 
 
 def typescript_skip_reason() -> str | None:
-    """Why this oracle cannot run here, or None when it can (issue #1639)."""
+    """Why this oracle cannot run here, or None when it can (issue #1639).
+
+    On a clean checkout this answers None because the deps are not installed
+    yet and the probe cannot run; `run_node_oracle_payload` re-checks once
+    `ensure_node_deps` has fetched them and raises `NodeOracleUnavailable`,
+    which the test guards below turn into a skip carrying the real reason.
+    """
     return node_oracle_skip_reason(_ORACLE_DIR)
 
 

--- a/evals/php_l1.py
+++ b/evals/php_l1.py
@@ -7,7 +7,7 @@ from . import constants as ec
 from . import logs as ls
 from .cgr_graph import extract_cgr_php_graph
 from .l1_eval import run_l1_eval
-from .oracles import php_oracle_available, run_php_oracle
+from .oracles import php_oracle_available, php_oracle_skip_reason, run_php_oracle
 
 _TITLE = "cgr L1 structure eval (PHP vs php-parser)"
 
@@ -28,6 +28,7 @@ def main(
         project_name,
         out_dir,
         available=php_oracle_available,
+        skip_reason=php_oracle_skip_reason,
         oracle_missing=ls.PHP_ORACLE_MISSING,
         extract_cgr=extract_cgr_php_graph,
         run_oracle=run_php_oracle,

--- a/evals/ts_l1.py
+++ b/evals/ts_l1.py
@@ -7,7 +7,7 @@ from . import constants as ec
 from . import logs as ls
 from .cgr_graph import extract_cgr_ts_graph
 from .l1_eval import run_l1_eval
-from .oracles import run_typescript_oracle, typescript_available
+from .oracles import run_typescript_oracle, typescript_available, typescript_skip_reason
 
 _TITLE = "cgr L1 structure eval (TypeScript vs tsc)"
 
@@ -28,6 +28,7 @@ def main(
         project_name,
         out_dir,
         available=typescript_available,
+        skip_reason=typescript_skip_reason,
         oracle_missing=ls.TS_ORACLE_MISSING,
         extract_cgr=extract_cgr_ts_graph,
         run_oracle=run_typescript_oracle,


### PR DESCRIPTION
Closes #1639.

Stacked on #1697, which fixes the formatter half. Merge that one first.

## The defect

The oracle skip guards were `shutil.which(...)`, which answers "is this binary
on PATH" rather than "can this toolchain do the job". A toolchain that is
present but too old sails past and the test **hard-fails instead of skipping**:
on the reported machine (Node 18, .NET SDK 8) that was 24 failures and 4 errors
on a clean `main`, in tests named as though they were real regressions. The
cost is not just noise — a genuine regression landing in one of those 28 is
invisible, because it is already red.

## Node: probe the call that actually breaks

The oracles load their parser through CommonJS `require()`. `@ruby/prism` is
ESM-only, so Node 18 satisfies `which` and then dies with `ERR_REQUIRE_ESM`.

The probe therefore does exactly that: `require()` the oracle's own dependency
from the oracle directory. **A dynamic `import()` probe would not work**, and
this is worth stating because it was my first attempt: dynamic import has
worked since Node 12, so it passes on the very Node that fails the oracle.
Three designs against the same Node-18-shaped shim:

| Probe | Verdict | Outcome |
|---|---|---|
| `which node && which npm` (today) | `True` | hard failure |
| dynamic `import('node:path')` | `True` | **hard failure — probe useless** |
| `require(<the oracle's dependency>)` | `False` | correct skip |

The package name is read from that oracle's own `package.json` rather than
hard-coded, because the four node oracles do **not** share a dependency —
ruby `@ruby/prism`, lua `luaparse`, php `php-parser`, ts `typescript`, and only
the first is ESM-only. A single shared probe cannot speak for all four, and a
hard-coded name would be a second copy of a fact free to drift.

Probing the *dependency* rather than the entry script also matters: requiring
`ruby_ast.js` runs its main, which prints a usage line and exits non-zero with
no arguments, so a working Node 22 was reported broken. That was caught by
running it, not by reading it.

When `node_modules` is absent the guard returns available: "deps not fetched
yet" must not read as "toolchain broken", since `ensure_node_deps` fixes the
former and runs later.

## C#: require an SDK that can build the csproj

`Oracle.csproj` targets `net10.0`, so SDK 8 passes `which dotnet` and the build
dies with NETSDK1045. The guard now parses `dotnet --list-sdks` and requires a
major at least the csproj's. Comparing majors rather than the exact TFM is
deliberate: SDK 11 builds `net10.0`, and an exact match would wrongly skip on
newer SDKs. `_sdk_major` returns 0 for an unparseable line — a skip guard must
fail closed, since failing open costs the hard failure this exists to prevent.

## Evidence

Neither failure can be reproduced on this machine (Node 22, SDK 10, both
working), so the negative cases are **constructed** with shell stubs. Stating
that plainly: a green run on a well-provisioned host says nothing about the
case these guards were written for.

| Toolchain | Old guard | New guard |
|---|---|---|
| `dotnet` listing only `8.0.130` | `True` → NETSDK1045 | `False` → skip |
| `node` refusing `require()` of an ES module | `True` → ERR_REQUIRE_ESM | `False` → skip |
| Real host (Node 22, SDK 10) | `True` | `True` |

The reviewer independently confirmed the ESM finding using a **real** Node
18.19.1 binary rather than a stub, and confirmed this fix resolves it: ruby
`False`, lua `True` on that Node — the per-oracle split working as intended.

## Tests

There were none for these guards, which is why the useless `import()` probe
survived a green run. `test_oracle_toolchain_guards.py` adds 19, driving stub
toolchains on `PATH`, plus a drift gate that reads `TargetFramework` out of
`Oracle.csproj` and asserts it against `CSHARP_ORACLE_MIN_SDK_MAJOR` — the
forcing function a comment cannot provide.

Deletion check: stubbing `node_oracle_available` entirely turns 2 tests red,
including the Node-18 case. Mutations: reverting the probe to dynamic
`import()` fails the Node-18 test; reverting the node guard to `which`-only
fails it too.

One of those tests initially did **not** discriminate — swapping `require()`
back to `import()` left it green, because the stub node ignored its arguments.
The stub now branches on the argument. Worth recording, because it is the same
defect twice: first in the probe, then in the test for the probe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - C# oracle checks now validate the installed SDK version and build readiness.
  - Node-based oracle checks now probe each oracle’s required packages directly.
  - Availability checks safely handle missing dependencies, unreadable configuration, command failures, timeouts, and module-format errors.
  - Checks are scoped to the correct oracle and can re-evaluate after dependencies are installed.
  - Test skips now identify the specific unavailable toolchain, dependency, or SDK requirement.

- **Tests**
  - Added coverage for SDK validation, dependency probing, configuration drift, failure handling, post-install rechecking, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->