### PR TITLE
fix: sweep definitions keyed outside the re-parsed file's own module (#1659)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2313,15 +2313,26 @@ class GraphUpdater:
         # records key by the REGISTERING file's module qn, so a qn recorded
         # under a module this event does not touch survives (issue #1025).
         touched_modules = recorded_qns
-        foreign_qns = {
-            location.qualified_name
-            for (
-                span_module,
-                _line,
-                _col,
-            ), location in self.factory.definition_processor.function_locations.items()
-            if span_module not in touched_modules
-        }
+        foreign_qns = set()
+        # The mirror of foreign_qns, and the reason the prefix sweep is not
+        # sufficient on its own: a definition's qn does not have to sit under
+        # the qn of the file that registered it. A Go method is keyed by its
+        # RECEIVER TYPE's module, so `func (t T) M()` in pkg/methods.go
+        # registers `proj.pkg.types.T.M` when `T` is declared in pkg/types.go.
+        # No prefix of methods.go matches that qn, so the entry survived this
+        # cleanup and the re-parse registered a second Method beside it as
+        # `...T.M@3` (issue #1659). The span records already name the
+        # registering module, which is exactly the ownership this needs.
+        owned_qns = set()
+        for (
+            span_module,
+            _line,
+            _col,
+        ), location in self.factory.definition_processor.function_locations.items():
+            if span_module in touched_modules:
+                owned_qns.add(location.qualified_name)
+            else:
+                foreign_qns.add(location.qualified_name)
         # Frontend registrations (libclang C/C++) have no span records; their
         # ownership is tracked per rel path at registration time.
         touched_rel = relative_path.as_posix()
@@ -2345,8 +2356,8 @@ class GraphUpdater:
                     qn.startswith(f"{prefix}.") or qn == prefix
                     for prefix in module_qn_prefixes
                 )
-                and qn not in foreign_qns
-            ):
+                or qn in owned_qns
+            ) and qn not in foreign_qns:
                 qns_to_remove.add(qn)
                 del self.function_registry[qn]
 

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -582,3 +582,41 @@ def test_a_reused_updater_keeps_a_same_stem_replacements_commonjs_export(
 
     assert ("proj.main.go", "proj.util.helper") in _calls(after), _calls(after)
     assert after == _clean(temp_repo, CJS_AFTER, cs.SupportedLanguage.JS)
+
+
+def _methods(snapshot: Snapshot) -> set[str]:
+    return {uid for (label, uid) in snapshot[0] if label == cs.NodeLabel.METHOD.value}
+
+
+def test_re_parsing_a_go_file_does_not_duplicate_a_sibling_keyed_method(
+    temp_repo: Path,
+) -> None:
+    """A Go method is keyed under its RECEIVER TYPE's module, not its own file.
+
+    `func (t T) M()` in methods.go registers as `proj.pkg.types.T.M`, because
+    `T` is declared in types.go. `remove_file_from_state(methods.go)` sweeps
+    by the qn prefixes methods.go recorded (`proj.pkg.methods`), which that qn
+    does not match, so the first run's Method survives the cleanup and the
+    re-parse registers a second one beside it as `proj.pkg.types.T.M@3`.
+
+    Asserted on Method NODES rather than on CALLS edges: the rename test above
+    compares calls only, and calls alone are satisfied by a graph carrying
+    both the stale and the fresh method (issue #1659).
+    """
+    root = temp_repo / "proj"
+    _materialise(root, GO_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.GO)
+    updater.run(force=True)
+    # Renaming util.go joins methods.go to the run as a DEPENDENT, so it is
+    # re-parsed. Touching methods.go instead would not do: the hash cache sees
+    # identical content and skips the file, so nothing is re-parsed and the
+    # duplicate never forms -- a green test about a run that did not happen.
+    (root / "pkg" / "util.go").rename(root / "pkg" / "helpers.go")
+    _bump(root, "pkg/helpers.go")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    clean = _clean(temp_repo, GO_AFTER, cs.SupportedLanguage.GO)
+    assert _methods(after) == _methods(clean)
+    assert _methods(after) == {"proj.pkg.types.T.M"}


### PR DESCRIPTION
Closes #1659.

A definition's qualified name does not have to sit under the qn of the file that registered it, and `remove_file_from_state` assumed it did.

A Go method is keyed by its **receiver type's** module. With `type T struct{}` in `pkg/types.go` and `func (t T) M() int` in `pkg/methods.go`, the method registers as `proj.pkg.types.T.M`. The cleanup for `methods.go` sweeps the qn prefixes that file recorded — `proj.pkg.methods` — and nothing under that prefix matches, so the first run's registry entry survived. The re-parse then found the qn taken and registered a second Method beside it as `proj.pkg.types.T.M@3`.

## The fix

The ownership record this needs already existed and was already being computed, just only in the negative direction. `function_locations` is keyed `(registering module qn, line, col)`, so for this fixture the first run records:

```
('proj.pkg.methods', 3, 11) -> proj.pkg.types.T.M
```

`foreign_qns` was built from those entries to protect qns registered by modules this event does not touch (the #1017/#1025 inline-mod shape). The same loop now also collects the mirror set — qns whose registering module **is** touched — and a qn is swept when it matches a recorded prefix *or* is owned by this file, in both cases still subject to the existing `foreign_qns` veto. A qn registered by two modules stays protected, exactly as before.

Nothing changes for a file that was never parsed: it has no span records, so the owned set is empty and the prefix sweep is unchanged.

## Verification

The reproduction is the issue's second trigger — renaming `util.go` so `methods.go` joins the run as a dependent:

```
before:  {'proj.pkg.types.T.M', 'proj.pkg.types.T.M@3'}
after:   {'proj.pkg.types.T.M'}
```

and the snapshot now equals a clean index of the renamed tree.

The test asserts on Method **nodes**, not on CALLS edges. `test_a_reused_updater_resolves_a_go_call_after_a_same_package_rename` already covers this exact rename and compares calls only — and calls alone are satisfied by a graph carrying both the stale and the fresh method, which is why the duplicate survived alongside a passing test.

One note on the reproduction, recorded in the test because it cost me a green run: touching `methods.go` and re-running does **not** reproduce. The hash cache sees identical content and skips the file, so nothing is re-parsed and no duplicate can form. That test passed against unfixed code and was a statement about a run that never happened, not about the bug.

## Scope note

`#1660` (renaming the file that HOLDS the receiver type drops the method's CALLS) is a separate defect and is not fixed here. I checked rather than assumed: with this fix applied, that scenario still yields no CALLS at all where a clean index has `proj.pkg.kinds.T.M -> proj.pkg.util.helper`. It gets its own branch.

The full unit suite was run on this commit: 10453 passed, 23 failed, 4 errors. Every failure is the pre-existing #1639 oracle-toolchain issue on this machine (Node 18 / .NET SDK 8), which is exactly the issue's own baseline minus the rustfmt case #1697 already fixed. None are in the graph, incremental, watcher or registry paths. 175 targeted tests across every incremental/watch/registry/reingest file pass.

The configured local reviewer agent is not available in this session, so the pre-push local round could not be run; the PR's own Greptile review is the first review of this change.
