### PR TITLE
fix: prune seeded module qns the graph no longer holds (#1687)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1358,10 +1358,16 @@ class GraphUpdater:
 
         # Before known_module_paths is built from the map: the seed pass only
         # ever adds, so a reused updater carries qns whose Module another
-        # writer has since deleted. A full build re-parses everything and
-        # rebuilds the map from scratch, so it needs no prune.
-        if not force:
-            self._prune_stale_seeded_module_qns()
+        # writer has since deleted.
+        #
+        # A forced run prunes too. It re-parses every file but does NOT clear
+        # the map, so on a reused updater a qn whose Module and file are both
+        # gone survives a full rebuild -- measured, and the reason this is not
+        # gated on `not force`. Nothing this run parsed can be dropped
+        # (`_parsed_files` exempts it) and an unreadable or empty read is
+        # already a no-op, so the first full build of an empty graph is
+        # unaffected.
+        self._prune_stale_seeded_module_qns()
 
         known_module_paths = self._resolve_deferred_definitions(rehydrate=not force)
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2001,6 +2001,12 @@ class GraphUpdater:
         Not folded into the seed helper: `reingest` calls that twice with
         different path sets, the second covering only the gone files, so a
         prune running inside it would delete what the first call seeded.
+
+        `reingest` therefore never prunes, since it does not go through
+        `run()`: a retained updater that indexes once and then only makes
+        scoped re-ingest calls (the MCP server's `_live_updater`) still
+        accumulates. That is the same class of bug in a path this fix does
+        not reach, not something it closes.
         """
         if not isinstance(self.ingestor, QueryProtocol):
             return

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1356,6 +1356,13 @@ class GraphUpdater:
         # method name-token locations Pass 2 registered.
         self._run_java_frontend()
 
+        # Before known_module_paths is built from the map: the seed pass only
+        # ever adds, so a reused updater carries qns whose Module another
+        # writer has since deleted. A full build re-parses everything and
+        # rebuilds the map from scratch, so it needs no prune.
+        if not force:
+            self._prune_stale_seeded_module_qns()
+
         known_module_paths = self._resolve_deferred_definitions(rehydrate=not force)
 
         logger.info(ls.FOUND_FUNCTIONS, count=len(self.function_registry))
@@ -1975,6 +1982,43 @@ class GraphUpdater:
             if _stem_key(path) in flux_stems:
                 continue
             module_map.setdefault(qn, self.repo_path / path)
+
+    def _prune_stale_seeded_module_qns(self) -> None:
+        """Drop map entries for modules the graph no longer holds.
+
+        `_seed_module_qns_from_graph` only ever adds, so on a reused updater
+        (the watcher, the MCP server) a qn whose Module was deleted by another
+        writer -- a second updater, `delete_project` then a re-index, a run in
+        another clone -- stays in the map for the life of the process and keeps
+        being offered by `known_module_paths`, where it carries a real path and
+        so wins the Rust sub-scope arbitration outright.
+
+        An entry absent from the graph is dropped unless this run parsed its
+        file: a re-parsed file writes its own entry directly and its Module
+        node may not be flushed yet, so the graph read cannot see it. Anything
+        else the next run that parses the file re-adds.
+
+        Not folded into the seed helper: `reingest` calls that twice with
+        different path sets, the second covering only the gone files, so a
+        prune running inside it would delete what the first call seeded.
+        """
+        if not isinstance(self.ingestor, QueryProtocol):
+            return
+        dp = self.factory.definition_processor
+        module_map = dp.module_qn_to_file_path
+        if not module_map:
+            return
+        in_graph: set[str] = set()
+        for row in self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL):
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            if isinstance(qn, str):
+                in_graph.add(qn)
+        parsed_this_run = {path for path, _lang in self._parsed_files}
+        for qn in [qn for qn in module_map if qn not in in_graph]:
+            # A file this run parsed writes its own entry and its Module node
+            # may still be unflushed, so the read above cannot see it.
+            if module_map[qn] not in parsed_this_run:
+                del module_map[qn]
 
     def _rehydrate_class_inheritance_from_graph(self) -> None:
         # Incremental runs rebuild class_inheritance only from re-parsed files.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2008,11 +2008,24 @@ class GraphUpdater:
         module_map = dp.module_qn_to_file_path
         if not module_map:
             return
-        in_graph: set[str] = set()
-        for row in self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL):
-            qn = row.get(cs.KEY_QUALIFIED_NAME)
-            if isinstance(qn, str):
-                in_graph.add(qn)
+        # No rows is "no verdict", never "the graph is empty". A read that
+        # fails or comes back empty against a populated map is the unflushed
+        # or transient case, and pruning on it would drop every entry except
+        # the handful this run re-parsed -- on a one-file incremental run over
+        # a large repo, almost the whole map. Same posture as
+        # _rehydrate_registry_from_graph, where a failed query leaves the
+        # previous state intact.
+        try:
+            rows = self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL)
+        except Exception:
+            logger.warning(ls.SEED_PRUNE_NO_VERDICT)
+            return
+        in_graph = {
+            qn for row in rows if isinstance(qn := row.get(cs.KEY_QUALIFIED_NAME), str)
+        }
+        if not in_graph:
+            logger.warning(ls.SEED_PRUNE_NO_VERDICT)
+            return
         parsed_this_run = {path for path, _lang in self._parsed_files}
         for qn in [qn for qn in module_map if qn not in in_graph]:
             # A file this run parsed writes its own entry and its Module node

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -945,6 +945,10 @@ REHYDRATE_QUERY_FAILED = (
     "Could not read persisted definitions from the graph; continuing with "
     "only this run's freshly parsed registry."
 )
+SEED_PRUNE_NO_VERDICT = (
+    "Could not read module paths from the graph; keeping every seeded module "
+    "qn rather than treating an unreadable graph as an empty one."
+)
 CSHARP_TYPE_LOCATIONS_REHYDRATED = (
     "Rehydrated {count} C# type location(s) from the graph for the partial join"
 )

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -670,6 +670,43 @@ def test_a_forced_run_also_prunes_the_seeded_map(temp_repo: Path) -> None:
     assert "proj.other" in pruned
 
 
+def test_a_stale_qn_is_pruned_even_though_its_file_still_exists(
+    temp_repo: Path,
+) -> None:
+    # The issue's own scenario: another writer deletes the Module while the
+    # FILE stays on disk and this run does not re-parse it. The exemption is
+    # "this run parsed it", not "the file exists" -- exempting on existence
+    # is a plausible-looking fix that leaves exactly this entry behind, and
+    # every other test here uses a ghost whose file is absent, so none of
+    # them can tell the two apart.
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "util.py": "def helper():\n    return 1\n",
+            "other.py": "def x():\n    return 1\n",
+        },
+    )
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    updater.run(force=True)
+    assert "proj.util" in updater.factory.definition_processor.module_qn_to_file_path
+
+    removed = [key for key in store.nodes if key[1] == "proj.util"]
+    assert removed, "expected a proj.util node to delete"
+    for key in removed:
+        del store.nodes[key]
+    assert (root / "util.py").exists(), "the file must survive for this shape"
+
+    (root / "other.py").write_text("def x():\n    return 2\n", encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+
+    pruned = updater.factory.definition_processor.module_qn_to_file_path
+    assert "proj.util" not in pruned
+    assert "proj.other" in pruned
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -485,6 +485,48 @@ def test_a_parsed_interface_is_not_revived_on_a_later_run(temp_repo: Path) -> No
     assert "proj.M" not in updater.factory.definition_processor.cpp_module_interfaces
 
 
+def test_seeded_module_qns_are_pruned_when_the_graph_loses_them(
+    temp_repo: Path,
+) -> None:
+    # `_seed_module_qns_from_graph` only ever adds, so on a reused updater a
+    # qn whose Module another writer deleted -- a second updater, a
+    # delete_project then re-index, a run in another clone -- stayed in
+    # module_qn_to_file_path for the life of the process. Unlike a rehydrated
+    # qn it carries a real path, so it wins the Rust sub-scope arbitration.
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "util.py": "def helper():\n    return 1\n",
+            "other.py": "def x():\n    return 1\n",
+        },
+    )
+    store = _StatefulIngestor()
+    _updater(store, root, cs.SupportedLanguage.PYTHON).run(force=True)
+
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    (root / "other.py").write_text("def x():\n    return 2\n", encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+    qn_to_path = updater.factory.definition_processor.module_qn_to_file_path
+    assert "proj.util" in qn_to_path, "the shape did not seed"
+
+    # A qn the graph does not hold and whose file was never parsed here: what
+    # an entry left over from an earlier project state looks like.
+    qn_to_path["proj.ghost"] = root / "ghost.py"
+
+    (root / "other.py").write_text("def x():\n    return 3\n", encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+
+    pruned = updater.factory.definition_processor.module_qn_to_file_path
+    assert "proj.ghost" not in pruned
+    assert "proj.ghost" not in updater.known_module_paths()
+    # Entries the graph still holds survive.
+    assert "proj.util" in pruned
+    assert "proj.other" in pruned
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -594,6 +594,50 @@ def test_a_failed_module_read_does_not_prune_the_seeded_map(
     assert updater.factory.definition_processor.module_qn_to_file_path == before
 
 
+def test_a_file_parsed_this_run_survives_a_read_that_cannot_see_it(
+    temp_repo: Path,
+) -> None:
+    # Production buffers node writes until a flush, so a file added this run
+    # has no Module in the graph when the prune reads. Its entry must survive
+    # on the strength of having been parsed, and keep its real PATH: the
+    # pathless form loses the Rust sub-scope arbitration.
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "util.py": "def helper():\n    return 1\n",
+            "other.py": "def x():\n    return 1\n",
+        },
+    )
+    store = _StatefulIngestor()
+    _updater(store, root, cs.SupportedLanguage.PYTHON).run(force=True)
+
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    (root / "fresh.py").write_text("def z():\n    return 1\n", encoding="utf-8")
+    _bump(root, "fresh.py")
+
+    original = store.fetch_all
+
+    def _hide_fresh(
+        query: str, *args: object, **kwargs: object
+    ) -> list[dict[str, object]]:
+        rows = original(query, *args, **kwargs)
+        if query is cs.CYPHER_ALL_MODULE_PATHS_INTERNAL:
+            # What an unflushed write looks like from the prune's read.
+            return [r for r in rows if r.get(cs.KEY_QUALIFIED_NAME) != "proj.fresh"]
+        return rows
+
+    store.fetch_all = _hide_fresh  # type: ignore[method-assign]
+    try:
+        updater.run(force=False)
+    finally:
+        store.fetch_all = original  # type: ignore[method-assign]
+
+    qn_to_path = updater.factory.definition_processor.module_qn_to_file_path
+    assert "proj.fresh" in qn_to_path, "a file parsed this run was pruned"
+    assert updater.known_module_paths()["proj.fresh"].endswith("fresh.py")
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -638,6 +638,38 @@ def test_a_file_parsed_this_run_survives_a_read_that_cannot_see_it(
     assert updater.known_module_paths()["proj.fresh"].endswith("fresh.py")
 
 
+def test_a_forced_run_also_prunes_the_seeded_map(temp_repo: Path) -> None:
+    # A forced run re-parses every file but does NOT clear
+    # module_qn_to_file_path, so on a reused updater a qn whose Module and
+    # file are both gone survives the full rebuild. Gating the prune on
+    # `not force` left exactly that hole.
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "util.py": "def helper():\n    return 1\n",
+            "other.py": "def x():\n    return 1\n",
+        },
+    )
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    updater.run(force=True)
+    assert "proj.util" in updater.factory.definition_processor.module_qn_to_file_path
+
+    removed = [key for key in store.nodes if key[1] == "proj.util"]
+    assert removed, "expected a proj.util node to delete"
+    for key in removed:
+        del store.nodes[key]
+    (root / "util.py").unlink()
+
+    updater.run(force=True)
+
+    pruned = updater.factory.definition_processor.module_qn_to_file_path
+    assert "proj.util" not in pruned
+    assert "proj.util" not in updater.known_module_paths()
+    assert "proj.other" in pruned
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -527,6 +527,73 @@ def test_seeded_module_qns_are_pruned_when_the_graph_loses_them(
     assert "proj.other" in pruned
 
 
+def _seeded_updater(temp_repo: Path) -> tuple[GraphUpdater, _StatefulIngestor]:
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "util.py": "def helper():\n    return 1\n",
+            "other.py": "def x():\n    return 1\n",
+        },
+    )
+    store = _StatefulIngestor()
+    _updater(store, root, cs.SupportedLanguage.PYTHON).run(force=True)
+    updater = _updater(store, root, cs.SupportedLanguage.PYTHON)
+    (root / "other.py").write_text("def x():\n    return 2\n", encoding="utf-8")
+    _bump(root, "other.py")
+    updater.run(force=False)
+    return updater, store
+
+
+def test_an_empty_module_read_does_not_prune_the_seeded_map(
+    temp_repo: Path,
+) -> None:
+    # No rows is "no verdict", not "the graph is empty". Pruning on an empty
+    # read would drop every entry except the few this run re-parsed, which on
+    # a one-file incremental run over a large repo is nearly the whole map.
+    updater, store = _seeded_updater(temp_repo)
+    before = dict(updater.factory.definition_processor.module_qn_to_file_path)
+    assert len(before) > 1, before
+
+    original = store.fetch_all
+
+    def _empty(query: str, *args: object, **kwargs: object) -> list[dict[str, object]]:
+        if query is cs.CYPHER_ALL_MODULE_PATHS_INTERNAL:
+            return []
+        return original(query, *args, **kwargs)
+
+    store.fetch_all = _empty  # type: ignore[method-assign]
+    try:
+        updater._prune_stale_seeded_module_qns()
+    finally:
+        store.fetch_all = original  # type: ignore[method-assign]
+
+    assert updater.factory.definition_processor.module_qn_to_file_path == before
+
+
+def test_a_failed_module_read_does_not_prune_the_seeded_map(
+    temp_repo: Path,
+) -> None:
+    # Same posture for a raising read, matching _rehydrate_registry_from_graph.
+    updater, store = _seeded_updater(temp_repo)
+    before = dict(updater.factory.definition_processor.module_qn_to_file_path)
+
+    original = store.fetch_all
+
+    def _boom(query: str, *args: object, **kwargs: object) -> list[dict[str, object]]:
+        if query is cs.CYPHER_ALL_MODULE_PATHS_INTERNAL:
+            raise RuntimeError("module path read failed")
+        return original(query, *args, **kwargs)
+
+    store.fetch_all = _boom  # type: ignore[method-assign]
+    try:
+        updater._prune_stale_seeded_module_qns()
+    finally:
+        store.fetch_all = original  # type: ignore[method-assign]
+
+    assert updater.factory.definition_processor.module_qn_to_file_path == before
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"


### PR DESCRIPTION
Closes #1687.

## What

`_seed_module_qns_from_graph` fills `module_qn_to_file_path` with `setdefault` and nothing ever removes an entry. On a reused updater (the watcher, the MCP server) a qn whose `Module` another writer deleted — a second updater, `delete_project` then a re-index, a run in another clone — stays for the life of the process.

`known_module_paths()` unions that map, and unlike a rehydrated qn these entries carry a **real path**, so a stale one wins the Rust sub-scope ownership arbitration outright.

`_prune_stale_seeded_module_qns()` reads the module paths back once and drops any entry the graph no longer holds, exempting files this run parsed.

## Three constraints shaped it

**It is not folded into `_seed_module_qns_from_graph`**, the obvious home. `reingest` calls that helper *twice* with different path sets — the second covering only the gone files, so their entries exist for the state drop to key on — and a prune keyed on that call's `eligible_paths` would delete everything the first call seeded.

**It runs on forced runs too.** An earlier revision gated this on `not force`, justified by "a full build rebuilds the map from scratch". That is **not true for a reused updater**: measured, `run(force=True)` after deleting a module's node *and* its file left the qn in the map and `known_module_paths()` still offered it. Removing the gate is safe — nothing this run parsed can be dropped (`_parsed_files` exempts it) and an unreadable or empty read is already a no-op, so the first full build of an empty graph is unaffected. Both measured. (Reported by CodeRabbit.)

**It fails closed.** An earlier revision deleted every entry absent from its read, so a read that failed or came back empty against a populated map wiped everything except the files just re-parsed — on a one-file incremental run over a large repo, nearly the whole map, silently. That revision also **failed an existing test**, `test_fully_unreadable_graph_still_completes_the_rebuild`. No rows is now "no verdict", never "the graph is empty", matching `_rehydrate_registry_from_graph` whose comment already says a failed query leaves the previous state intact.

## Verification

Four tests, each pinning a distinct behaviour, verified by mutation:

| mutant | result |
|---|---|
| baseline | **24 passed** |
| prune removed | 2 failed — `…pruned_when_the_graph_loses_them`, `…forced_run_also_prunes` |
| `not force` guard restored | 1 failed — `…forced_run_also_prunes` |
| both read guards stripped | 2 failed — `…empty_module_read`, `…failed_module_read` |
| `parsed_this_run` exemption stripped | 1 failed — `…file_parsed_this_run_survives` |

The last one was a real gap: before that test the exemption was load-bearing but unguarded, and stripping it left all 15 tests green. Without it an added file loses its **path**, becoming the pathless form that loses the Rust arbitration.

Also verified with an ingestor that buffers node writes until `flush_all` — the fixture that matters here, since production batches: a file added this run keeps its entry despite its `Module` being unflushed at prune time.

Full suite on this branch: **10502 passed, 40 skipped, 1 xfailed, 0 failed**.

## Scope: two things this does not close

**`reingest` never prunes.** It does not go through `run()`, so a retained updater that indexes once and then only makes scoped re-ingest calls — the MCP server's `_live_updater` — still accumulates. Measured: after a graph-side delete, five further `reingest` calls leave the qn in the map with a real path and `known_module_paths()` still offers it. Same class of bug, in a path this fix does not reach; filed separately and stated in the docstring so it does not read as handled.

**This is half of one defect.** With the file still on disk, the qn also reaches `known_module_paths()` through `_rehydrated_module_qns`, which is #1688. Measured after this prune: `module_qn_to_file_path` no longer has the qn, `_rehydrated_module_qns` still does. Neither PR closes that path alone — #1688 should merge first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental updates by removing stale module references and definitions after files or modules are deleted.
  * Preserved current-run results when graph data is unavailable or incomplete.
  * Improved import and module-path resolution for newly created JavaScript and TypeScript files.
  * Corrected handling of C++ module interfaces and Go methods after updates or file renames.
  * Improved recovery after update failures, including automatic full re-indexing when needed.
  * Improved resilience when cached data cannot be removed.

* **Tests**
  * Added regression coverage for reused update sessions, deleted state, unavailable graph data, and renamed files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
