### PR TITLE
fix: re-parse files that define into a departing module (#1660)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2215,6 +2215,52 @@ class GraphUpdater:
             }
         )
 
+    def _foreign_definer_keys(self, gone_keys: Iterable[str]) -> set[str]:
+        """Files that registered definitions keyed under a module going away.
+
+        A definition's qn need not sit under the qn of the file that defines
+        it. A Go method keys by its RECEIVER TYPE's module, so
+        `func (t T) M()` in pkg/methods.go registers `proj.pkg.types.T.M`
+        when `T` is declared in pkg/types.go.
+
+        Renaming types.go deletes that Module subtree, and the method node
+        and its outgoing CALLS go with it because they hang off the type.
+        methods.go holds no edge INTO types.go, so the caller query cannot
+        find it, nothing re-parses it, and the method is never recreated:
+        the reused updater ends with no CALLS at all where a clean index has
+        them (issue #1660).
+
+        The span records already name the registering module, so the files
+        to re-parse are exactly those that recorded a qn under a departing
+        module without being that module themselves. Read before
+        `remove_file_from_state` runs, while the run's records still stand.
+        """
+        gone = set(gone_keys)
+        if not gone:
+            return set()
+        dp = self.factory.definition_processor
+        key_for_module = {
+            qn: cached_relative_path(path, self.repo_path).as_posix()
+            for qn, path in dp.module_qn_to_file_path.items()
+        }
+        gone_modules = {qn for qn, key in key_for_module.items() if key in gone}
+        if not gone_modules:
+            return set()
+        definers = set()
+        for (span_module, _line, _col), location in dp.function_locations.items():
+            if span_module in gone_modules:
+                continue
+            qn = location.qualified_name
+            if any(
+                qn.startswith(f"{module}{cs.SEPARATOR_DOT}") for module in gone_modules
+            ):
+                definers.add(span_module)
+        return {
+            key
+            for module in definers
+            if (key := key_for_module.get(module)) is not None and key not in gone
+        }
+
     def _package_paths(self) -> set[str] | None:
         """Relative paths of this project's Package nodes, None if unreadable."""
         if not isinstance(self.ingestor, QueryProtocol):
@@ -3116,6 +3162,13 @@ class GraphUpdater:
         # module qn changes on this run, so a file that includes or calls it
         # must re-parse too, or its captured inbound edges are restored
         # against the old qn (a wrong IMPORTS edge, a dropped CALLS edge).
+        # A file that DEFINES into a departing module joins for a different
+        # reason than a caller does: its definitions live in the subtree
+        # about to be deleted, and no edge points from it into that file for
+        # the caller query to follow (issue #1660).
+        foreign_definers = self._foreign_definer_keys(
+            {*reindexed_keys, *deleted_before_parse}
+        )
         affected = 0
         for caller_key in sorted(
             {
@@ -3123,6 +3176,7 @@ class GraphUpdater:
                     sorted({*reindexed_keys, *deleted_before_parse, *siblings})
                 ),
                 *siblings,
+                *foreign_definers,
             }
         ):
             if caller_key in present:

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -692,3 +692,45 @@ def test_re_parsing_a_go_file_does_not_duplicate_a_sibling_keyed_method(
     clean = _clean(temp_repo, GO_AFTER, cs.SupportedLanguage.GO)
     assert _methods(after) == _methods(clean)
     assert _methods(after) == {"proj.pkg.types.T.M"}
+
+
+GO_TYPE_RENAMED = {
+    "pkg/kinds.go": GO_BEFORE["pkg/types.go"],
+    "pkg/methods.go": GO_BEFORE["pkg/methods.go"],
+    "pkg/util.go": GO_BEFORE["pkg/util.go"],
+}
+
+
+def test_renaming_the_go_file_holding_a_receiver_type_keeps_the_method_calls(
+    temp_repo: Path,
+) -> None:
+    """Renaming types.go must not strand the methods bound to the type it held.
+
+    `func (t T) M()` lives in methods.go but keys under the module that
+    declares `T`. Renaming types.go to kinds.go moves that module, and on a
+    reused updater the method's CALLS edge disappeared entirely rather than
+    rebinding under the new module (issue #1660).
+
+    Compared against a clean index of the renamed tree rather than a hardcoded
+    qn: whether the method should now key under `proj.pkg.kinds` is the clean
+    index's answer to give, and pinning my own guess would make this test
+    agree with whatever I happened to build.
+
+    Sits beside the #1659 test deliberately: both start from the same fixture
+    and rename one file, and the pair is what shows the two defects are
+    distinct -- that one removes stale state, this one nominates a file to
+    re-parse.
+    """
+    root = temp_repo / "proj"
+    _materialise(root, GO_BEFORE)
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.GO)
+    updater.run(force=True)
+    (root / "pkg" / "types.go").rename(root / "pkg" / "kinds.go")
+    _bump(root, "pkg/kinds.go")
+    updater.run(force=False)
+    after = _snapshot(store, root)
+
+    clean = _clean(temp_repo, GO_TYPE_RENAMED, cs.SupportedLanguage.GO)
+    assert _calls(after) == _calls(clean)
+    assert after == clean


### PR DESCRIPTION
Closes #1660.

Renaming `pkg/types.go` to `pkg/kinds.go` on a reused updater left **no CALLS edge from `T.M` at all**, where a clean index of the renamed tree has `proj.pkg.kinds.T.M -> proj.pkg.util.helper`.

## What actually happens

Instrumenting the second run shows it re-indexes one file:

```
Re-indexing 1 changed files
parsed files run2: ['kinds.go']
calls: set()
registry .T.: ['proj.pkg.types.T.M']
```

A Go method keys by its **receiver type's** module, so `func (t T) M()` in `methods.go` registers as `proj.pkg.types.T.M` and its Method node hangs off the type declared in `types.go`. Renaming that file deletes its Module subtree, and the method node — plus its outgoing CALLS — goes with it.

`methods.go` should therefore be re-parsed to recreate them. It never is. The dependents query finds files whose edges point **into** the changed file, and `methods.go` holds no such edge: its relationship to `types.go` is that it *defines into* it. Nothing else nominates it, so the method is deleted and never rebuilt, while the in-memory registry still lists `proj.pkg.types.T.M` — graph and registry disagree until a forced rebuild.

## The fix

`_foreign_definer_keys` nominates the missing files: those that recorded a qn under a departing module without being that module themselves. The `function_locations` span records already name the registering module, so this needs no new bookkeeping — the first run records

```
('proj.pkg.methods', 3, 11) -> proj.pkg.types.T.M
```

and `proj.pkg.methods` is exactly the module to re-parse when `proj.pkg.types` departs. It is read before `remove_file_from_state` runs, while those records still stand.

They join the same re-parse set as siblings and affected callers, for a different reason than either: not "my bindings moved" but "my definitions live in the subtree about to be deleted".

## Verification

```
before:  calls == set()
after:   calls == {('proj.pkg.kinds.T.M', 'proj.pkg.util.helper')}
```

The test asserts the **whole snapshot** equals a clean index of the renamed tree, which is the issue's stated expectation, and compares against that clean index rather than a hardcoded qn — whether the method should now key under `proj.pkg.kinds` is the clean index's answer to give, not mine to guess.

Mutation-tested: dropping `foreign_definers` from the re-parse set leaves exactly one test red, the new one. 192 tests pass across every incremental, watcher, registry, reingest and Go file.

## Relationship to #1659

Separate defects, checked rather than assumed. This reproduces on plain `main` **and** with #1659's fix applied, and #1659's reproduction fails with this fix alone. They are two sides of the same underlying fact — a definition's qn need not sit under the qn of the file that defines it — but one is about sweeping stale state and this one is about nominating a file to re-parse. #1659 is PR #1710; this branches from `main` and does not depend on it.

## Suite

Full unit suite on this commit: **10454 passed**, 23 failed, 4 errors. The failure set is byte-identical to a run of the same suite on an unrelated branch, and every entry is the pre-existing #1639 oracle-toolchain issue on this machine (Node 18 / .NET SDK 8) confined to `test_csharp_retrieval_eval.py`, `test_csharp_structure_oracle.py` and `test_ruby_structure_oracle.py`. None are in the graph, incremental, watcher or registry paths.

The configured local reviewer agent is not available in this session, so the pre-push local round could not be run; the PR's own Greptile review is the first review of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Incremental indexing now preserves method relationships and call references when a Go file defining a receiver type is renamed or removed.
  - Updated codebase graphs more reliably reflect renamed or deleted modules without losing related definitions or outgoing call information.
  - Newly created files and previously unresolved imports are now detected more consistently, including directory and root-level modules.
  - Failed stale-cache cleanup no longer causes invalid cached data to be reused during rebuilding.

- **Tests**
  - Added coverage for incremental updates involving renamed Go type declaration files, including comparison with a clean rebuild.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->