### PR TITLE
fix: rebuild the C++ interface set instead of accumulating it (#1692)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1163,6 +1163,10 @@ class GraphUpdater:
         # Reset per-run parse tracking so a reused updater does not reprocess
         # a previous run's files in Pass 3.
         self._parsed_files.clear()
+        # Per-run for the same reason: the set records what THIS run parsed,
+        # so a reused updater must not treat a previous run's interfaces as
+        # unflushed writes that rehydration has to preserve.
+        self.factory.definition_processor.cpp_interfaces_parsed_this_run.clear()
         # Per-run for the same reason: set on the in-sync early return below
         # and previously cleared only in `__init__`, so a reused instance kept
         # reporting a previous run's skip. `cli.py` reads it to decide what to
@@ -1840,6 +1844,20 @@ class GraphUpdater:
         # verification as a live target. Cleared only now that the rows are
         # in hand, so a failed query above leaves the previous set intact.
         self._rehydrated_module_qns.clear()
+        # Same rebuild for the interface set the loop below fills from these
+        # same rows. A stale entry defeats the membership check in
+        # resolve_deferred_cpp_module_impls, which is what stops an IMPLEMENTS
+        # edge being minted to a ModuleInterface the graph no longer holds.
+        #
+        # Interfaces THIS run parsed are put back: their node writes may still
+        # be in the ingestor's buffer and so absent from the rows just
+        # fetched, and dropping one loses the IMPLEMENTS edge for an interface
+        # and implementation added together. That is not hypothetical -- an
+        # earlier attempt at this cleared the set outright and did exactly
+        # that.
+        dp = self.factory.definition_processor
+        dp.cpp_module_interfaces.clear()
+        dp.cpp_module_interfaces |= dp.cpp_interfaces_parsed_this_run
         for row in module_rows:
             qn = row.get(cs.KEY_QUALIFIED_NAME)
             label = row.get(cs.KEY_LABEL)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -190,6 +190,7 @@ class ClassIngestMixin:
     rust_impl_method_traits: dict[str, str]
     rust_inherent_impl_methods: set[str]
     cpp_module_interfaces: set[str]
+    cpp_interfaces_parsed_this_run: set[str]
     _deferred_cpp_module_impls: list[tuple[str, str]]
     declared_module_qns: set[str]
     rust_function_modules: dict[str, str]
@@ -313,6 +314,7 @@ class ClassIngestMixin:
         module_qn: str,
         file_path: Path,
     ) -> None:
+        before = set(self.cpp_module_interfaces)
         cpp_modules.ingest_cpp_module_declarations(
             root_node,
             module_qn,
@@ -323,6 +325,10 @@ class ClassIngestMixin:
             self.cpp_module_interfaces,
             self._deferred_cpp_module_impls,
         )
+        # Remember what this parse added, so rehydration can rebuild the
+        # graph-derived entries without dropping an interface whose node
+        # write has not been flushed yet.
+        self.cpp_interfaces_parsed_this_run |= self.cpp_module_interfaces - before
 
     def resolve_deferred_cpp_module_impls(self) -> int:
         """Emit ModuleImplementation IMPLEMENTS edges for interfaces that exist.

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -278,6 +278,12 @@ class DefinitionProcessor(
         # implementation units whose IMPLEMENTS edge waits for its
         # interface to be known.
         self.cpp_module_interfaces: set[str] = set()
+        # The subset of the above that THIS run's parsing registered, as
+        # opposed to entries read back from the graph. Rehydration rebuilds
+        # the graph-derived part and must not drop these: a just-parsed
+        # interface's node write is still in the ingestor's buffer, so it is
+        # absent from the rows rehydration fetches.
+        self.cpp_interfaces_parsed_this_run: set[str] = set()
         self._deferred_cpp_module_impls: list[tuple[str, str]] = []
         # Inline (non-file) module qns, e.g. Rust `mod x {}`; deferred
         # import verification counts them as real internal targets.

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -448,6 +448,43 @@ def test_a_cpp_interface_the_graph_lost_is_forgotten(temp_repo: Path) -> None:
     assert "proj.M" not in updater.factory.definition_processor.cpp_module_interfaces
 
 
+def test_a_parsed_interface_is_not_revived_on_a_later_run(temp_repo: Path) -> None:
+    # cpp_interfaces_parsed_this_run exempts an interface from the rebuild
+    # because its write may be unflushed. That exemption is scoped to ONE
+    # run: without the per-run reset the qn stays in the companion set
+    # forever and every later rebuild puts it back, which is the stale entry
+    # this fix removes.
+    #
+    # The interface must be parsed by THIS updater, not a previous one --
+    # with a fresh updater the companion set is empty and the reset cannot
+    # be what saves it.
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "iface.cppm": "export module M;\nexport int f();\n",
+            "other.cpp": "int x() { return 1; }\n",
+        },
+    )
+    store = _StatefulIngestor()
+    updater = _updater(store, root, cs.SupportedLanguage.CPP)
+    if cs.SupportedLanguage.CPP not in updater.parsers:
+        pytest.skip("cpp parser not available")
+    updater.run(force=True)
+    assert "proj.M" in updater.factory.definition_processor.cpp_module_interfaces
+
+    removed = [key for key in store.nodes if key[0] == "ModuleInterface"]
+    assert removed, "expected a ModuleInterface node to delete"
+    for key in removed:
+        del store.nodes[key]
+
+    (root / "other.cpp").write_text("int x() { return 2; }\n", encoding="utf-8")
+    _bump(root, "other.cpp")
+    updater.run(force=False)
+
+    assert "proj.M" not in updater.factory.definition_processor.cpp_module_interfaces
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -359,6 +359,95 @@ def test_a_failed_module_query_leaves_the_rehydrated_set_intact(
     assert "proj.stale" in updater._rehydrated_module_qns
 
 
+class _BufferingIngestor(_StatefulIngestor):
+    # Production batches node writes and flushes at batch_size, so a module
+    # parsed in the current run is NOT visible to a query issued mid-run. A
+    # write-through fake hides every bug that depends on that.
+    def __init__(self) -> None:
+        super().__init__()
+        self._pending: list[tuple[str, dict[str, object]]] = []
+
+    def ensure_node_batch(self, label: str, properties: dict[str, object]) -> None:
+        self._pending.append((label, properties))
+
+    def flush_all(self) -> None:
+        for label, properties in self._pending:
+            super().ensure_node_batch(label, properties)
+        self._pending = []
+
+
+def test_a_cpp_interface_parsed_this_run_survives_rehydration(
+    temp_repo: Path,
+) -> None:
+    # cpp_module_interfaces is rebuilt from the graph, but an interface this
+    # run parsed is still unflushed when rehydration reads, so rebuilding
+    # without it drops the IMPLEMENTS edge for an interface and an
+    # implementation added together. An earlier attempt at this fix did
+    # exactly that.
+    root = temp_repo / "proj"
+    _materialise(root, {"other.cpp": "int x() { return 1; }\n"})
+    store = _BufferingIngestor()
+    first = _updater(store, root, cs.SupportedLanguage.CPP)
+    if cs.SupportedLanguage.CPP not in first.parsers:
+        pytest.skip("cpp parser not available")
+    first.run(force=True)
+    store.flush_all()
+
+    (root / "iface.cppm").write_text(
+        "export module M;\nexport int f();\n", encoding="utf-8"
+    )
+    (root / "impl.cpp").write_text(
+        "module M;\nint f() { return 1; }\n", encoding="utf-8"
+    )
+    _bump(root, "iface.cppm")
+    _bump(root, "impl.cpp")
+
+    _updater(store, root, cs.SupportedLanguage.CPP).run(force=False)
+    store.flush_all()
+
+    implements = [
+        edge for edge in store.edges if edge[2] == cs.RelationshipType.IMPLEMENTS.value
+    ]
+    assert implements, "the interface was dropped before its impl resolved"
+
+
+def test_a_cpp_interface_the_graph_lost_is_forgotten(temp_repo: Path) -> None:
+    # The mirror case: an interface another writer deleted must not linger,
+    # or resolve_deferred_cpp_module_impls mints an IMPLEMENTS edge to a
+    # ModuleInterface the graph no longer holds.
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "iface.cppm": "export module M;\nexport int f();\n",
+            "other.cpp": "int x() { return 1; }\n",
+        },
+    )
+    store = _StatefulIngestor()
+    first = _updater(store, root, cs.SupportedLanguage.CPP)
+    if cs.SupportedLanguage.CPP not in first.parsers:
+        pytest.skip("cpp parser not available")
+    first.run(force=True)
+
+    updater = _updater(store, root, cs.SupportedLanguage.CPP)
+    (root / "other.cpp").write_text("int x() { return 2; }\n", encoding="utf-8")
+    _bump(root, "other.cpp")
+    updater.run(force=False)
+    interfaces = updater.factory.definition_processor.cpp_module_interfaces
+    assert "proj.M" in interfaces, "the shape did not rehydrate"
+
+    removed = [key for key in store.nodes if key[0] == "ModuleInterface"]
+    assert removed, "expected a ModuleInterface node to delete"
+    for key in removed:
+        del store.nodes[key]
+
+    (root / "other.cpp").write_text("int x() { return 3; }\n", encoding="utf-8")
+    _bump(root, "other.cpp")
+    updater.run(force=False)
+
+    assert "proj.M" not in updater.factory.definition_processor.cpp_module_interfaces
+
+
 JEDI_CORE = (
     "class Base:\n    def run(self):\n        return 1\n\n\ndef build():\n"
     "    return Base()\n"


### PR DESCRIPTION
Closes #1692.

## What

`_rehydrate_registry_from_graph` fills `definition_processor.cpp_module_interfaces` from the module rows and nothing ever cleared it, so on a reused updater (the watcher, the MCP server) an interface another writer deleted stays for the life of the process.

A stale entry defeats the membership check in `resolve_deferred_cpp_module_impls`, which exists precisely to stop an `IMPLEMENTS` edge being minted to a `ModuleInterface` the graph no longer holds — "a phantom the database drops", in its own docstring.

## Why the two obvious fixes are wrong

**A bare `clear()` is a regression, not a fix.** Production batches node writes, so an interface parsed in the current run is still in the ingestor's buffer when rehydration reads and is absent from the rows it fetches. Clearing outright drops it and loses the `IMPLEMENTS` edge for an interface and implementation added together. That is what an earlier attempt shipped and withdrew, and this branch carries the test that proves it.

**Snapshot-and-restore fails too.** The set survives across runs on a reused updater, so restoring "whatever was there" carries the previous run's stale entries straight back in.

## The fix

Three parts, each pinned by its own test:

1. **Capture** — the parse records what it registered into a companion set, `cpp_interfaces_parsed_this_run`.
2. **Per-run reset** — `run()` clears that set where it clears `_parsed_files`, so a previous run's entries are never mistaken for unflushed writes.
3. **Rebuild with restore** — rehydration clears the interface set, refills the graph-derived part from its rows, then puts this run's parsed entries back.

Stale entries go; unflushed ones stay.

## Verification

| variant | result |
|---|---|
| baseline | **17 passed** |
| bare `clear()` (the withdrawn regression) | 1 failed — `…parsed_this_run_survives_rehydration` |
| rebuild removed | 2 failed — `…graph_lost_is_forgotten`, `…not_revived_on_a_later_run` |
| per-run reset removed | 1 failed — `…not_revived_on_a_later_run` |

The last row was a real gap found in review: before that test, deleting the reset left all 16 tests green while reintroducing this very bug. `…graph_lost_is_forgotten` cannot catch it, because its interface is parsed by a *first* updater, so the second updater's companion set is empty and the reset is never what saves it. The new test parses with the same updater that runs again.

Tests use a `_BufferingIngestor` that holds node writes until `flush_all`, because a write-through fake hides every bug that depends on batching — the fixture lesson from #1688.

Full suite on this branch: **10513 passed, 40 skipped, 1 xfailed, 0 failed.** C++ tests confirmed to run rather than skip (the interpreter with all 15 grammars; the Python-only venv skips them silently).

## Scope

`cpp_interfaces_parsed_this_run` grows unbounded on an updater that only ever calls `reingest()`, since `run()` is the sole reset point. No correctness effect — `reingest` rehydrates at most once (`_hydrate_for_reingest` sets `_reingest_hydrated` on every path) so the set is never consulted there — but it is a slow leak in a long-lived watcher or MCP updater. Measured across three successive `reingest()` calls: rehydration count stays at 1 while the set grows. Noted rather than fixed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved incremental processing of C++20 module interfaces so newly parsed interfaces remain available during the current run.
  - Prevented stale interface records from being incorrectly restored after graph updates or subsequent runs.
  - Correctly recognizes interfaces removed by another update, keeping implementation relationships in sync with the latest graph state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->