### PR TITLE
fix: record unresolved relative specifiers so dropped-edge importers stay findable (#1714)

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -62,6 +62,11 @@ KEY_IMPORTED_NAME = "imported_name"
 # `imported_name` of a wildcard import (`from x import *`, `export * from`).
 IMPORTED_NAME_WILDCARD = "*"
 KEY_PATH = "path"
+# Literal relative specifiers this module imported that named no file on disk
+# when it was parsed ("./index"). A dropped IMPORTS edge leaves no row for the
+# target-side lookup to match, so the waiting importer is recorded here and
+# stays findable from the created file's path alone (issue #1714).
+KEY_UNRESOLVED_SPECIFIERS = "unresolved_specifiers"
 KEY_ABSOLUTE_PATH = "absolute_path"
 # Whether flow analysis covered a Module: its language is in the source/sink
 # registry AND the FLOWS_TO capture group was enabled at indexing. Read by
@@ -618,6 +623,21 @@ CYPHER_UNRESOLVED_IMPORTER_PATHS = (
     "OR target.qualified_name STARTS WITH name + '.') "
     "RETURN DISTINCT importer.path AS caller_path"
 )
+# Modules carrying at least one unresolved relative specifier, with the
+# specifiers themselves. The specifier is relative to the IMPORTING module's
+# directory, so the match against a created file is resolved in Python rather
+# than attempted as path arithmetic in Cypher; the row count is small because
+# only modules with a dropped relative import carry the property (issue #1714).
+CYPHER_UNRESOLVED_SPECIFIER_IMPORTERS = (
+    "MATCH (importer) "
+    "WHERE importer.path IS NOT NULL "
+    "AND importer.qualified_name STARTS WITH $project_prefix "
+    "AND importer.unresolved_specifiers IS NOT NULL "
+    "AND size(importer.unresolved_specifiers) > 0 "
+    "RETURN importer.path AS caller_path, "
+    "importer.unresolved_specifiers AS specifiers"
+)
+CYPHER_KEY_SPECIFIERS = "specifiers"
 CYPHER_ALL_INHERITS = (
     "MATCH (child)-[r:INHERITS]->(base) "
     "WHERE child.qualified_name IS NOT NULL AND base.qualified_name IS NOT NULL "

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2341,6 +2341,7 @@ class GraphUpdater:
             for module in definers
             if (key := key_for_module.get(module)) is not None and key not in gone
         }
+
     def _specifier_waiter_keys(self, present_keys: list[str]) -> set[str]:
         """Importers whose recorded relative specifier names one of these files.
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import os
+import posixpath
 import sys
 import time
 from collections import defaultdict
@@ -2231,6 +2232,7 @@ class GraphUpdater:
                 for row in rows
                 if isinstance(path := row.get(cs.KEY_CALLER_PATH), str) and path
             }
+            | self._specifier_waiter_keys(present_keys)
         )
 
     def _foreign_definer_keys(self, gone_keys: Iterable[str]) -> set[str]:
@@ -2278,6 +2280,55 @@ class GraphUpdater:
             for module in definers
             if (key := key_for_module.get(module)) is not None and key not in gone
         }
+    def _specifier_waiter_keys(self, present_keys: list[str]) -> set[str]:
+        """Importers whose recorded relative specifier names one of these files.
+
+        The row-based lookup above reads persisted IMPORTS edges, and a
+        relative JS/TS import of a path that does not exist yet has no such
+        row: the edge is dropped at flush as an unverifiable internal target.
+        Those importers record the literal specifier on their Module node
+        instead, so they stay findable from the created file's path alone
+        (issue #1714).
+
+        The specifier is relative to the IMPORTER's own directory, so it is
+        resolved here rather than in Cypher, where the arithmetic against
+        `importer.path` would be far harder to read and to test.
+        """
+        if not isinstance(self.ingestor, QueryProtocol):
+            return set()
+        try:
+            rows = self.ingestor.fetch_all(
+                cs.CYPHER_UNRESOLVED_SPECIFIER_IMPORTERS,
+                {cs.KEY_PROJECT_PREFIX: self.project_name + cs.SEPARATOR_DOT},
+            )
+        except Exception:
+            logger.warning(ls.PRUNE_QUERY_FAILED, label="unresolved specifiers")
+            return set()
+        wanted = {PurePosixPath(key).with_suffix("").as_posix() for key in present_keys}
+        # A created `pkg/index.ts` also satisfies `./pkg`, the directory form.
+        wanted |= {
+            parent
+            for key in present_keys
+            if (p := PurePosixPath(key)).stem == cs.JS_INDEX_STEM
+            and (parent := p.parent.as_posix()) not in (cs.PATH_CURRENT_DIR, "")
+        }
+        waiters: set[str] = set()
+        for row in rows:
+            caller = row.get(cs.KEY_CALLER_PATH)
+            specifiers = row.get(cs.CYPHER_KEY_SPECIFIERS)
+            if not isinstance(caller, str) or not caller:
+                continue
+            if not isinstance(specifiers, list):
+                continue
+            base = PurePosixPath(caller).parent
+            for specifier in specifiers:
+                if not isinstance(specifier, str):
+                    continue
+                target = posixpath.normpath((base / specifier).as_posix())
+                if target in wanted:
+                    waiters.add(caller)
+                    break
+        return waiters
 
     def _package_paths(self) -> set[str] | None:
         """Relative paths of this project's Package nodes, None if unreadable."""

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -374,11 +374,17 @@ def _module_key(path: str) -> str:
 
     `PurePosixPath.with_suffix("")` is not enough on its own -- it strips one
     suffix, turning `index.d.ts` into `index.d` rather than `index`.
+
+    A path with no MODULE extension is returned unchanged. Stripping whatever
+    suffix it happens to carry cuts a dotted basename in half: `./foo.test`
+    became `foo` while the created `foo.test.ts` became `foo.test`, so the two
+    forms of the same module missed each other again -- the very asymmetry
+    this function exists to remove (raised on #1717).
     """
     for ext in _MODULE_EXTS_LONGEST_FIRST:
         if path.endswith(ext):
             return path[: -len(ext)]
-    return PurePosixPath(path).with_suffix("").as_posix()
+    return path
 
 
 def _specifier_wanted_keys(present_keys: Iterable[str]) -> set[str]:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -353,6 +353,61 @@ def _stem_key(file_key: str) -> str:
     return Path(file_key).with_suffix("").as_posix()
 
 
+# Longest first, so `index.d.ts` loses `.d.ts` whole rather than being cut back
+# to `index.d` the way a single-suffix strip does.
+_MODULE_EXTS_LONGEST_FIRST: tuple[str, ...] = tuple(
+    # `str.__len__` rather than `len`: the bare builtin makes the inferred
+    # element type `Sized`, which does not satisfy `tuple[str, ...]`, while a
+    # lambda trips PLW0108. This spelling passes both gates.
+    sorted(cs.JS_TS_MODULE_EXTENSIONS, key=str.__len__, reverse=True)
+)
+
+
+def _module_key(path: str) -> str:
+    """A path with any JS/TS module extension removed.
+
+    Applied to BOTH sides of the waiter match, which is the point: a source
+    writing `./foo.js` records the extension, while the created file arrives
+    as the key `foo.js`. Normalising only one side left them as `foo.js` and
+    `foo` and they never met, so an importer using an explicit extension was
+    never re-parsed (raised on #1717).
+
+    `PurePosixPath.with_suffix("")` is not enough on its own -- it strips one
+    suffix, turning `index.d.ts` into `index.d` rather than `index`.
+    """
+    for ext in _MODULE_EXTS_LONGEST_FIRST:
+        if path.endswith(ext):
+            return path[: -len(ext)]
+    return PurePosixPath(path).with_suffix("").as_posix()
+
+
+def _specifier_wanted_keys(present_keys: Iterable[str]) -> set[str]:
+    """Extension-free names a created file can be imported by."""
+    wanted: set[str] = set()
+    for key in present_keys:
+        module_key = _module_key(key)
+        wanted.add(module_key)
+        # A created `pkg/index.ts` also satisfies `./pkg`, the directory form.
+        as_path = PurePosixPath(module_key)
+        parent = as_path.parent.as_posix()
+        if as_path.name == cs.JS_INDEX_STEM and parent not in (
+            cs.PATH_CURRENT_DIR,
+            "",
+        ):
+            wanted.add(parent)
+    return wanted
+
+
+def _specifier_targets(caller: str, specifiers: Iterable[object]) -> set[str]:
+    """What each recorded specifier names, relative to its importer."""
+    base = PurePosixPath(caller).parent
+    return {
+        _module_key(posixpath.normpath((base / specifier).as_posix()))
+        for specifier in specifiers
+        if isinstance(specifier, str)
+    }
+
+
 def _load_dir_mtimes(cache_path: Path) -> DirMtimesCache:
     if not cache_path.is_file():
         return {}
@@ -2304,14 +2359,7 @@ class GraphUpdater:
         except Exception:
             logger.warning(ls.PRUNE_QUERY_FAILED, label="unresolved specifiers")
             return set()
-        wanted = {PurePosixPath(key).with_suffix("").as_posix() for key in present_keys}
-        # A created `pkg/index.ts` also satisfies `./pkg`, the directory form.
-        wanted |= {
-            parent
-            for key in present_keys
-            if (p := PurePosixPath(key)).stem == cs.JS_INDEX_STEM
-            and (parent := p.parent.as_posix()) not in (cs.PATH_CURRENT_DIR, "")
-        }
+        wanted = _specifier_wanted_keys(present_keys)
         waiters: set[str] = set()
         for row in rows:
             caller = row.get(cs.KEY_CALLER_PATH)
@@ -2320,14 +2368,8 @@ class GraphUpdater:
                 continue
             if not isinstance(specifiers, list):
                 continue
-            base = PurePosixPath(caller).parent
-            for specifier in specifiers:
-                if not isinstance(specifier, str):
-                    continue
-                target = posixpath.normpath((base / specifier).as_posix())
-                if target in wanted:
-                    waiters.add(caller)
-                    break
+            if not wanted.isdisjoint(_specifier_targets(caller, specifiers)):
+                waiters.add(caller)
         return waiters
 
     def _package_paths(self) -> set[str] | None:

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -465,6 +465,24 @@ class DefinitionProcessor(
                 self._ingest_missing_import_patterns(
                     root_node, module_qn, language, queries
                 )
+                # Written AFTER parse_imports, which is what fills the set, and
+                # unconditionally rather than only when non-empty: the node
+                # already exists from the batch above, so the flush MERGEs and
+                # `SET n += props`, which updates a property but never removes
+                # one. Writing the empty list is therefore the only way a
+                # re-parse can CLEAR specifiers whose target now exists
+                # (issue #1714).
+                self.ingestor.ensure_node_batch(
+                    cs.NodeLabel.MODULE,
+                    {
+                        cs.KEY_QUALIFIED_NAME: module_qn,
+                        cs.KEY_UNRESOLVED_SPECIFIERS: sorted(
+                            self.import_processor.unresolved_specifiers.get(
+                                module_qn, ()
+                            )
+                        ),
+                    },
+                )
             if language == cs.SupportedLanguage.CPP:
                 self._ingest_cpp_module_declarations(root_node, module_qn, file_path)
                 CppTypeInferenceEngine().collect_type_aliases(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -3322,9 +3322,11 @@ class ImportProcessor:
                 continue
             # A CommonJS `require()` reads a dual-package exports map from
             # the require side.
+            require_text = safe_decode_with_fallback(arg).strip("'\"")
             resolved_module = self._resolve_js_module_path(
-                safe_decode_with_fallback(arg).strip("'\""), current_module, True
+                require_text, current_module, True
             )
+            self._note_unresolved_js_specifier(current_module, require_text)
             if name_node.type == cs.TS_IDENTIFIER:
                 # `const fs = require('fs')`: bind the whole module.
                 var_name = safe_decode_with_fallback(name_node)
@@ -3348,6 +3350,7 @@ class ImportProcessor:
                 source_module = self._resolve_js_module_path(
                     source_text, current_module
                 )
+                self._note_unresolved_js_specifier(current_module, source_text)
                 break
 
         if not source_module:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -493,6 +493,7 @@ class ImportProcessor:
         "_cpp_module_qn_map",
         "_cpp_qn_to_rel",
         "_deferred_import_edges",
+        "unresolved_specifiers",
         "_import_sites",
         "_import_site_owners",
         "_import_site_writers",
@@ -558,6 +559,14 @@ class ImportProcessor:
         # IMPORTS edges held back until every file is parsed, so internal
         # targets verify against the full module registry (issue #652).
         self._deferred_import_edges: list[DeferredImportEdge] = []
+        # Per module qn: the LITERAL relative specifiers ("./index") that named
+        # no file on disk when this module was parsed. A relative JS/TS import
+        # of a path that does not exist yet has its IMPORTS edge dropped at
+        # flush as an unverifiable internal target, so the target-side lookup
+        # that finds waiting importers has no row to match and the waiter is
+        # never re-parsed when the file is finally created (issue #1714).
+        # Recorded here so the importer stays findable from the path alone.
+        self.unresolved_specifiers: dict[str, set[str]] = {}
         # Per scope qn: the site props of each bound import name (#1522),
         # attached to the IMPORTS edge when the deferred edge flushes.
         self._import_sites: dict[str, dict[str, PropertyDict]] = {}
@@ -902,6 +911,11 @@ class ImportProcessor:
         # leave the old namespace bound to this module.
         self.php_module_namespaces.pop(module_qn, None)
         self.js_ts_bare_imports.pop(module_qn, None)
+        # A re-parse re-derives these from the current source, so the previous
+        # run's specifiers must not survive: an import the edit removed, or one
+        # whose target now exists, would otherwise keep nominating this file
+        # for ever (issue #1714).
+        self.unresolved_specifiers.pop(module_qn, None)
 
         try:
             if pre_captures is not None:
@@ -3060,6 +3074,7 @@ class ImportProcessor:
                         source_module = self._resolve_js_module_path(
                             source_text, module_qn
                         )
+                        self._note_unresolved_js_specifier(module_qn, source_text)
                         break
 
                 if not source_module:
@@ -3114,17 +3129,7 @@ class ImportProcessor:
                 cs.PATH_PARENT_DIR
             ):
                 continue
-            module_rel: str | None = None
-            if any(
-                (self.repo_path / f"{normalized}{ext}").is_file()
-                for ext in cs.JS_TS_MODULE_EXTENSIONS
-            ):
-                module_rel = normalized
-            elif (self.repo_path / normalized).is_dir() and any(
-                (self.repo_path / normalized / f"{cs.JS_INDEX_STEM}{ext}").is_file()
-                for ext in cs.JS_TS_MODULE_EXTENSIONS
-            ):
-                module_rel = f"{normalized}{cs.SEPARATOR_SLASH}{cs.JS_INDEX_STEM}"
+            module_rel = self._js_module_rel_on_disk(normalized)
             if module_rel is None:
                 continue
             dotted = module_rel.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
@@ -3142,6 +3147,52 @@ class ImportProcessor:
             if import_path.endswith(ext) and len(import_path) > len(ext):
                 return import_path[: -len(ext)]
         return import_path
+
+    def _js_module_rel_on_disk(self, normalized: str) -> str | None:
+        """The repo-relative module this path names on disk, or None.
+
+        A JS/TS specifier names either the file itself (with any of the module
+        extensions) or a directory holding an `index` entry point. Shared by
+        the tsconfig-alias resolver and the unresolved-specifier probe so the
+        two cannot disagree about what "exists" means.
+        """
+        if any(
+            (self.repo_path / f"{normalized}{ext}").is_file()
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+        ):
+            return normalized
+        directory = self.repo_path / normalized
+        if directory.is_dir() and any(
+            (directory / f"{cs.JS_INDEX_STEM}{ext}").is_file()
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+        ):
+            return f"{normalized}{cs.SEPARATOR_SLASH}{cs.JS_INDEX_STEM}"
+        return None
+
+    def _note_unresolved_js_specifier(self, module_qn: str, specifier: str) -> None:
+        """Record a RELATIVE specifier that names nothing on disk (issue #1714).
+
+        Only relative ones: a bare specifier (`lodash`) is an external package
+        and becomes a real IMPORTS edge to an ExternalModule, which the
+        target-side lookup can already find. A relative path that resolves
+        nowhere is the case with no persisted row at all.
+
+        The literal text is stored, not the derived qn: the qn is what the
+        dropped edge would have used, while the specifier is what the source
+        wrote and what a later-created file must be matched against.
+        """
+        if not specifier.startswith(cs.PATH_CURRENT_DIR):
+            return
+        resolved = self._resolve_js_module_path(specifier, module_qn)
+        prefix = f"{self.project_name}{cs.SEPARATOR_DOT}"
+        if not resolved.startswith(prefix):
+            # Escapes the project (`../../outside`), so no file this repo can
+            # create would ever satisfy it.
+            return
+        rel = resolved[len(prefix) :].replace(cs.SEPARATOR_DOT, cs.SEPARATOR_SLASH)
+        if self._js_module_rel_on_disk(rel) is not None:
+            return
+        self.unresolved_specifiers.setdefault(module_qn, set()).add(specifier)
 
     def _resolve_js_module_path(
         self, import_path: str, current_module: str, require: bool = False

--- a/codebase_rag/tests/test_protobuf_node_property_parity.py
+++ b/codebase_rag/tests/test_protobuf_node_property_parity.py
@@ -41,7 +41,23 @@ _NOT_EXPORTED: dict[str, frozenset[str]] = {
     "Package": frozenset({"absolute_path"}),
     "Folder": frozenset({"absolute_path"}),
     "File": frozenset({"absolute_path"}),
-    "Module": frozenset({"absolute_path", "end_line", "start_line"}),
+    # `unresolved_specifiers` (issue #1714) is the second entry added with a
+    # known cost rather than as a record of the past. It records the literal
+    # relative specifiers an importer is waiting on, so a file created later at
+    # that path can nominate it for re-parsing. A graph round-tripped through
+    # protobuf loses them, so a scoped re-ingest against an IMPORTED graph does
+    # not re-parse those waiters and diverges from a clean index exactly as
+    # #1714 describes -- for imported graphs only.
+    #
+    # The degradation is safe by construction and self-healing: an absent
+    # property reads as "no specifiers", which yields no nomination rather than
+    # a wrong one, and the next parse of the importing module rewrites the list.
+    # Exporting it needs a proto field plus regenerated bindings, which needs
+    # protoc; neither protoc nor grpc_tools is available in this environment,
+    # and #1490 carries that question for the whole set.
+    "Module": frozenset(
+        {"absolute_path", "end_line", "start_line", "unresolved_specifiers"}
+    ),
     "Class": frozenset({"absolute_path", "modifiers", "path", "start_col"}),
     # `positional_params` (issue #227) is the one entry here added with a
     # known cost rather than as a record of the past: a graph round-tripped

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -11,22 +11,24 @@ for exactly the create-then-import order an agent commonly uses.
 waiting importer's IMPORTS edge points at an unresolved target named after the
 new module, which is findable even with no inbound edge.
 
-SCOPE OF THESE TESTS. The `#1682` classes drive the query layer with a stubbed
-`fetch_all`, which is what can be verified without a live graph: that the right
-question is asked, that the answer is wired into the dependent set, and that a
-failure degrades rather than raising. The end-to-end claim for THAT path -- that
-a real create-then-reingest matches a clean index -- needs the integration suite
-against Memgraph and is NOT asserted here. A mock ingestor answers no dependents
-query at all, so an end-to-end assertion written against one passes or fails for
-reasons unrelated to this change.
+SCOPE OF THESE TESTS. `TestUnresolvedImporterLookup` drives the query layer with
+a stubbed `fetch_all`: that the right question is asked, that the answer is
+wired into the dependent set, and that a failure degrades rather than raising.
+A MagicMock cannot show more, so an end-to-end assertion written against one
+passes or fails for reasons unrelated to the code.
 
-`TestUnresolvedSpecifierWaiters` (#1714) is different and does run end to end,
-against the stateful in-memory double rather than a stub, because its claim is
-that a property is WRITTEN during an ordinary parse and READ back by the lookup
--- neither of which a stub can show. The double had to learn the new query for
-that to mean anything: an unanswered query returns `[]` there, which is
-indistinguishable from "no waiters" and would have let these pass against a
-lookup that never ran.
+`TestUnresolvedSpecifierWaiters` runs end to end against the stateful in-memory
+double, covering BOTH halves of the mechanism: the persisted-row path (#1682,
+`import util` records the external-looking target `util`) and the recorded-
+specifier path (#1714, a relative `./index` records no row at all). That became
+possible only once the double answered these two queries. It previously fell
+through to `case _: return []` for both, which reads as "no waiters" and is
+indistinguishable from a lookup that never ran -- which is why this file could
+originally cover the query layer alone.
+
+Still NOT asserted here: that a real scoped re-ingest against Memgraph produces
+the same graph as a clean index. The double is faithful to the queries cgr
+issues, not to the database.
 """
 
 from __future__ import annotations
@@ -378,6 +380,55 @@ class TestUnresolvedSpecifierWaiters:
 
         assert updater._unresolved_importer_keys(["index.js"]) == []
         assert updater._unresolved_importer_keys(["sub/index.js"]) == ["sub/main.js"]
+
+    def test_a_python_waiter_is_found_through_its_persisted_unresolved_edge(
+        self, tmp_path: Path
+    ) -> None:
+        """The #1682 row path, driven end to end rather than through a stub.
+
+        This was previously unassertable: the stateful double did not answer
+        `CYPHER_UNRESOLVED_IMPORTER_PATHS` and fell through to `[]`, so the
+        lookup reported no waiters for reasons unrelated to the code. With the
+        double answering it, the two halves of the mechanism can be told
+        apart -- this one keeps a persisted IMPORTS row (`import util` records
+        the external-looking target `util`), where the JS/TS cases above keep
+        none at all.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.py": "import util\n\ndef run():\n    return util.helper()\n"}
+        )
+        # The premise: an unresolved row exists here, unlike the JS/TS case.
+        assert [edge for edge in store.edges if edge[2] == "IMPORTS"]
+
+        (root / "util.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["util.py"])
+
+        assert keys == ["main.py"]
+
+    def test_a_resolved_import_is_not_reported_as_a_waiter(
+        self, tmp_path: Path
+    ) -> None:
+        """The control for the row path: only UNRESOLVED targets count.
+
+        Without it, a double that returned every importer of anything would
+        satisfy the test above.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root,
+            {
+                "main.py": "import util\n\ndef run():\n    return util.helper()\n",
+                "util.py": "def helper():\n    return 1\n",
+            },
+        )
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["util.py"])
+
+        assert keys == []
 
     def test_a_reused_updater_clears_a_specifier_whose_target_now_exists(
         self, tmp_path: Path

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -379,22 +379,29 @@ class TestUnresolvedSpecifierWaiters:
         assert updater._unresolved_importer_keys(["index.js"]) == []
         assert updater._unresolved_importer_keys(["sub/index.js"]) == ["sub/main.js"]
 
-    def test_a_re_parse_clears_a_specifier_whose_target_now_exists(
+    def test_a_reused_updater_clears_a_specifier_whose_target_now_exists(
         self, tmp_path: Path
     ) -> None:
         """Recording is only half of it; a stale specifier nominates for ever.
 
-        The fresh-index control above never exercises this, because there the
-        specifier is never recorded in the first place. This one records it,
-        creates the target, re-parses, and requires the property to go EMPTY
-        rather than merely to stop matching -- `SET n += props` cannot remove
-        a property, so the empty list has to be written explicitly.
+        The updater is REUSED across both runs, which is the watcher's shape
+        and the only one that exercises the clearing at all: a fresh updater
+        builds a fresh ImportProcessor whose specifier map starts empty, so it
+        writes `[]` whether or not the previous entry is ever retracted.
+        Measured -- with a fresh updater here, deleting the retraction leaves
+        every test in this file green.
+
+        The property must go EMPTY rather than merely stop matching, because
+        `SET n += props` can update a property but never remove one.
         """
         root = tmp_path / "proj"
         root.mkdir()
-        store = self._index(
-            root, {"main.js": "import { go } from './index';\nexport const r = go;\n"}
+        (root / "main.js").write_text(
+            "import { go } from './index';\nexport const r = go;\n", encoding="utf-8"
         )
+        store = _StatefulIngestor()
+        updater = self._updater_on(root, store)
+        updater.run(force=True)
         assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == [
             "./index"
         ]
@@ -402,9 +409,7 @@ class TestUnresolvedSpecifierWaiters:
         (root / "index.js").write_text(
             "export function go() { return 1; }\n", encoding="utf-8"
         )
-        self._updater_on(root, store).run(force=True)
+        updater.run(force=True)
 
         assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == []
-        assert (
-            self._updater_on(root, store)._unresolved_importer_keys(["index.js"]) == []
-        )
+        assert updater._unresolved_importer_keys(["index.js"]) == []

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -430,6 +430,54 @@ class TestUnresolvedSpecifierWaiters:
 
         assert keys == []
 
+    def test_a_specifier_written_with_an_explicit_extension_still_matches(
+        self, tmp_path: Path
+    ) -> None:
+        """`./foo.js` records the extension; the created file arrives as
+        `foo.js`. Normalising only one side left them as `foo` and `foo.js`,
+        which never met, so the importer was never re-parsed (raised on the
+        #1717 review and reproduced before fixing)."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.js": "import { go } from './foo.js';\nexport const r = go;\n"}
+        )
+        assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == [
+            "./foo.js"
+        ]
+        (root / "foo.js").write_text(
+            "export function go() { return 1; }\n", encoding="utf-8"
+        )
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["foo.js"])
+
+        assert keys == ["main.js"]
+
+    def test_a_declaration_file_normalises_past_both_of_its_suffixes(
+        self, tmp_path: Path
+    ) -> None:
+        """`index.d.ts` must reduce to `index`, not `index.d`.
+
+        A single-suffix strip leaves `index.d`, so a created declaration entry
+        point would not satisfy `./pkg` either. Found while fixing the
+        explicit-extension case rather than reported.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.ts": "import { go } from './pkg';\nexport const r = go;\n"}
+        )
+        (root / "pkg").mkdir()
+        (root / "pkg" / "index.d.ts").write_text(
+            "export declare function go(): number;\n", encoding="utf-8"
+        )
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(
+            ["pkg/index.d.ts"]
+        )
+
+        assert keys == ["main.ts"]
+
     def test_a_reused_updater_clears_a_specifier_whose_target_now_exists(
         self, tmp_path: Path
     ) -> None:

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -461,6 +461,16 @@ class TestUnresolvedSpecifierWaiters:
         A single-suffix strip leaves `index.d`, so a created declaration entry
         point would not satisfy `./pkg` either. Found while fixing the
         explicit-extension case rather than reported.
+
+        SCOPE. This asserts NOMINATION -- that the waiting importer is selected
+        for re-parsing -- which is the mechanism this file covers. It does not
+        assert that the resulting IMPORTS edge lands, and for a declaration
+        file today it does not: `base_module_qn` indexes `pkg/index.d.ts` as
+        `proj.pkg.index.d` while the resolver looks for `proj.pkg`, so the edge
+        is dropped downstream. That is issue #1720, pre-existing and far wider
+        than this file (it affects every `.d.ts` in every project). Stated here
+        because a reader would otherwise take a green test as proof that
+        declaration entry points work end to end.
         """
         root = tmp_path / "proj"
         root.mkdir()

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -478,6 +478,94 @@ class TestUnresolvedSpecifierWaiters:
 
         assert keys == ["main.ts"]
 
+    def test_a_dotted_basename_is_not_cut_in_half(self, tmp_path: Path) -> None:
+        """`./foo.test` must not lose `.test`, which is not a module extension.
+
+        The fallback used to strip whatever suffix a path carried, so the
+        specifier became `foo` while the created `foo.test.ts` became
+        `foo.test` -- the same asymmetry the normalisation exists to remove,
+        reintroduced by the branch that handles everything else (raised on
+        #1717).
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root,
+            {"main.ts": "import { go } from './foo.test';\nexport const r = go;\n"},
+        )
+        (root / "foo.test.ts").write_text(
+            "export function go() { return 1; }\n", encoding="utf-8"
+        )
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["foo.test.ts"])
+
+        assert keys == ["main.ts"]
+
+    def test_a_commonjs_require_of_a_missing_target_is_recorded(
+        self, tmp_path: Path
+    ) -> None:
+        """`require('./util')` drops its edge exactly as `import` does.
+
+        The recording hung off the import-statement branch alone, so CommonJS
+        importers were never nominated -- and `require` is the older half of
+        the JS corpus, not an edge case (raised on #1717).
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root,
+            {
+                "main.js": "const { go } = require('./util');\nmodule.exports = { go };\n"
+            },
+        )
+
+        assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == [
+            "./util"
+        ]
+
+        (root / "util.js").write_text(
+            "function go() { return 1; }\nmodule.exports = { go };\n",
+            encoding="utf-8",
+        )
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["util.js"])
+
+        assert keys == ["main.js"]
+
+    def test_a_re_export_from_a_missing_target_is_recorded(
+        self, tmp_path: Path
+    ) -> None:
+        """`export ... from './util'` takes its own parse branch."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(root, {"main.ts": "export { go } from './util';\n"})
+
+        assert self._module(store, "main.ts")[cs.KEY_UNRESOLVED_SPECIFIERS] == [
+            "./util"
+        ]
+
+        (root / "util.ts").write_text(
+            "export function go(): number { return 1; }\n", encoding="utf-8"
+        )
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["util.ts"])
+
+        assert keys == ["main.ts"]
+
+    def test_a_bare_require_of_a_package_is_not_recorded(self, tmp_path: Path) -> None:
+        """The control for the two above: only RELATIVE specifiers qualify.
+
+        A bare `require('lodash')` becomes a real edge to an ExternalModule,
+        which the row-based lookup already finds; recording it here would
+        nominate the importer on every unrelated creation.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root,
+            {"main.js": "const _ = require('lodash');\nmodule.exports = { _ };\n"},
+        )
+
+        assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == []
+
     def test_a_reused_updater_clears_a_specifier_whose_target_now_exists(
         self, tmp_path: Path
     ) -> None:

--- a/codebase_rag/tests/test_reingest_new_file_importers.py
+++ b/codebase_rag/tests/test_reingest_new_file_importers.py
@@ -11,14 +11,22 @@ for exactly the create-then-import order an agent commonly uses.
 waiting importer's IMPORTS edge points at an unresolved target named after the
 new module, which is findable even with no inbound edge.
 
-SCOPE OF THESE TESTS. They drive the query layer with a stubbed `fetch_all`,
-which is what can be verified without a live graph: that the right question is
-asked, that the answer is wired into the dependent set, and that a failure
-degrades rather than raising. The end-to-end claim -- that a real create-then-
-reingest now matches a clean index -- needs the integration suite against
-Memgraph and is NOT asserted here. A mock ingestor answers no dependents query
-at all, so an end-to-end assertion written against one passes or fails for
+SCOPE OF THESE TESTS. The `#1682` classes drive the query layer with a stubbed
+`fetch_all`, which is what can be verified without a live graph: that the right
+question is asked, that the answer is wired into the dependent set, and that a
+failure degrades rather than raising. The end-to-end claim for THAT path -- that
+a real create-then-reingest matches a clean index -- needs the integration suite
+against Memgraph and is NOT asserted here. A mock ingestor answers no dependents
+query at all, so an end-to-end assertion written against one passes or fails for
 reasons unrelated to this change.
+
+`TestUnresolvedSpecifierWaiters` (#1714) is different and does run end to end,
+against the stateful in-memory double rather than a stub, because its claim is
+that a property is WRITTEN during an ordinary parse and READ back by the lookup
+-- neither of which a stub can show. The double had to learn the new query for
+that to mean anything: an unanswered query returns `[]` there, which is
+indistinguishable from "no waiters" and would have let these pass against a
+lookup that never ran.
 """
 
 from __future__ import annotations
@@ -32,6 +40,7 @@ import pytest
 from codebase_rag import constants as cs
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
 
 
 class _QueryingIngestor:
@@ -155,8 +164,12 @@ class TestUnresolvedImporterLookup:
 
         assert updater._unresolved_importer_keys(["util.py"]) == ["main.py"]
 
-        query, params = ingestor.queries[-1]
-        assert query == cs.CYPHER_UNRESOLVED_IMPORTER_PATHS
+        # Selected by identity rather than by position: the lookup now issues
+        # a second query for specifier-recorded waiters (issue #1714), so
+        # `queries[-1]` names that one and would assert nothing about this.
+        params = next(
+            p for q, p in ingestor.queries if q == cs.CYPHER_UNRESOLVED_IMPORTER_PATHS
+        )
         assert params[cs.CYPHER_PARAM_MODULE_NAMES] == ["util"]
         assert params[cs.KEY_PROJECT_PREFIX] == "proj."
 
@@ -200,3 +213,198 @@ class TestWiredIntoTheDependentSet:
             present={"util.py": tmp_path / "util.py"}, gone={}
         )
         assert dependents == {}
+
+
+class TestUnresolvedSpecifierWaiters:
+    """The relative JS/TS case the row-based lookup cannot see (issue #1714).
+
+    `main.js` importing a missing `./index` persists NO IMPORTS edge -- it is
+    dropped at flush as an unverifiable internal target -- so the target-side
+    query has no row to match. Measured on the parent branch:
+
+        main.js  import { go } from './index'  ->  IMPORTS edges: []
+        main.py  import util                   ->  [('proj.main', 'util')]
+
+    The importer records the literal specifier on its Module node instead.
+    Driven through a real index against the stateful double rather than a
+    stubbed `fetch_all`, because the claim is that the property is WRITTEN
+    during a normal parse, which a stub cannot show.
+    """
+
+    @staticmethod
+    def _index(root: Path, files: dict[str, str]) -> _StatefulIngestor:
+        for rel, text in files.items():
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+        store = _StatefulIngestor()
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=store,
+            repo_path=root,
+            parsers=parsers,
+            queries=queries,
+            project_name="proj",
+        ).run(force=True)
+        return store
+
+    @staticmethod
+    def _module(store: _StatefulIngestor, path: str) -> dict[str, Any]:
+        return next(
+            dict(props)
+            for (label, _uid), props in store.nodes.items()
+            if label == cs.NodeLabel.MODULE.value and props.get(cs.KEY_PATH) == path
+        )
+
+    @staticmethod
+    def _updater_on(root: Path, store: _StatefulIngestor) -> GraphUpdater:
+        parsers, queries = load_parsers()
+        return GraphUpdater(
+            ingestor=store,
+            repo_path=root,
+            parsers=parsers,
+            queries=queries,
+            project_name="proj",
+        )
+
+    def test_the_dropped_specifier_is_recorded_on_the_importer(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.js": "import { go } from './index';\nexport const r = go;\n"}
+        )
+
+        assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == [
+            "./index"
+        ]
+        # The premise, asserted rather than assumed: there is genuinely no
+        # IMPORTS row for the existing lookup to find.
+        assert not [edge for edge in store.edges if edge[2] == "IMPORTS"]
+
+    def test_a_specifier_whose_target_exists_is_not_recorded(
+        self, tmp_path: Path
+    ) -> None:
+        """The control that stops this from nominating everything for ever.
+
+        A probe that recorded every relative specifier would pass the test
+        above and still be useless, so this drives the same import with the
+        target present.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root,
+            {
+                "main.js": "import { go } from './index';\nexport const r = go;\n",
+                "index.js": "export function go() { return 1; }\n",
+            },
+        )
+
+        assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == []
+
+    def test_the_waiter_is_nominated_when_the_file_is_created(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.js": "import { go } from './index';\nexport const r = go;\n"}
+        )
+        (root / "index.js").write_text(
+            "export function go() { return 1; }\n", encoding="utf-8"
+        )
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["index.js"])
+
+        assert keys == ["main.js"]
+
+    def test_a_directory_entry_point_satisfies_the_directory_specifier(
+        self, tmp_path: Path
+    ) -> None:
+        # `./pkg` is satisfied by creating `pkg/index.js`, which is the form a
+        # bare directory import resolves to.
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.js": "import { go } from './pkg';\nexport const r = go;\n"}
+        )
+        (root / "pkg").mkdir()
+        (root / "pkg" / "index.js").write_text(
+            "export function go() { return 1; }\n", encoding="utf-8"
+        )
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["pkg/index.js"])
+
+        assert keys == ["main.js"]
+
+    def test_an_unrelated_creation_does_not_nominate_the_waiter(
+        self, tmp_path: Path
+    ) -> None:
+        """The specifier must be MATCHED, not merely present.
+
+        Without this, a lookup that returned every module carrying any
+        unresolved specifier would pass every test above.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.js": "import { go } from './index';\nexport const r = go;\n"}
+        )
+        (root / "other.js").write_text("export const x = 1;\n", encoding="utf-8")
+
+        keys = self._updater_on(root, store)._unresolved_importer_keys(["other.js"])
+
+        assert keys == []
+
+    def test_a_specifier_is_resolved_against_the_importers_own_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """`./index` in `sub/main.js` means `sub/index.js`, not `index.js`.
+
+        A match on the specifier text alone would bind the root file, which is
+        why the resolution happens against `importer.path` rather than in the
+        query.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root,
+            {"sub/main.js": ("import { go } from './index';\nexport const r = go;\n")},
+        )
+        (root / "index.js").write_text("export const x = 1;\n", encoding="utf-8")
+        updater = self._updater_on(root, store)
+
+        assert updater._unresolved_importer_keys(["index.js"]) == []
+        assert updater._unresolved_importer_keys(["sub/index.js"]) == ["sub/main.js"]
+
+    def test_a_re_parse_clears_a_specifier_whose_target_now_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """Recording is only half of it; a stale specifier nominates for ever.
+
+        The fresh-index control above never exercises this, because there the
+        specifier is never recorded in the first place. This one records it,
+        creates the target, re-parses, and requires the property to go EMPTY
+        rather than merely to stop matching -- `SET n += props` cannot remove
+        a property, so the empty list has to be written explicitly.
+        """
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = self._index(
+            root, {"main.js": "import { go } from './index';\nexport const r = go;\n"}
+        )
+        assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == [
+            "./index"
+        ]
+
+        (root / "index.js").write_text(
+            "export function go() { return 1; }\n", encoding="utf-8"
+        )
+        self._updater_on(root, store).run(force=True)
+
+        assert self._module(store, "main.js")[cs.KEY_UNRESOLVED_SPECIFIERS] == []
+        assert (
+            self._updater_on(root, store)._unresolved_importer_keys(["index.js"]) == []
+        )

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -881,7 +881,7 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     ),
     NodeSchema(
         NodeLabel.MODULE,
-        "{qualified_name: string, name: string, path: string, absolute_path: string, flow_covered: boolean?, generated: boolean?, generator: string?, start_line: int?, end_line: int?, decorators: list[string]?, rust_cfg_test_mods: list[string]?, rust_ungated_mods: list[string]?, front_matter: list[string]?}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, flow_covered: boolean?, generated: boolean?, generator: string?, start_line: int?, end_line: int?, decorators: list[string]?, rust_cfg_test_mods: list[string]?, rust_ungated_mods: list[string]?, front_matter: list[string]?, unresolved_specifiers: list[string]?}",
     ),
     NodeSchema(
         NodeLabel.CLASS,

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -323,6 +323,48 @@ class _StatefulIngestor:
                     }
                     rows.append(row)
                 return rows
+            case cs.CYPHER_UNRESOLVED_IMPORTER_PATHS:
+                # Importers whose IMPORTS edge points at an UNRESOLVED target
+                # named after one of the given modules (issue #1682). Emulated
+                # for the same reason as the specifier query below: falling
+                # through returned [], which reads as "no waiters" and is why
+                # that issue's tests could only cover the query layer.
+                names = params.get(cs.CYPHER_PARAM_MODULE_NAMES) if params else None
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                wanted_names = (
+                    [n for n in names if isinstance(n, str)]
+                    if isinstance(names, list)
+                    else []
+                )
+                importer_rows: list[ResultRow] = []
+                if not wanted_names or not prefix:
+                    return importer_rows
+                seen_paths: set[str] = set()
+                for from_label, from_val, rel_type, _to_label, to_val in self.edges:
+                    if rel_type != cs.RelationshipType.IMPORTS.value:
+                        continue
+                    importer = self.nodes.get((from_label, from_val))
+                    if importer is None:
+                        continue
+                    importer_path = _text(importer.get(cs.KEY_PATH))
+                    importer_qn = _text(importer.get(cs.KEY_QUALIFIED_NAME)) or ""
+                    if not importer_path or not importer_qn.startswith(prefix):
+                        continue
+                    target_qn = _text(to_val) or ""
+                    # The target must be UNRESOLVED: a first-party one is a
+                    # real module and its importer is found by the inbound
+                    # edge lookup instead.
+                    if target_qn.startswith(prefix):
+                        continue
+                    if any(
+                        target_qn == name
+                        or target_qn.startswith(f"{name}{cs.SEPARATOR_DOT}")
+                        for name in wanted_names
+                    ):
+                        if importer_path not in seen_paths:
+                            seen_paths.add(importer_path)
+                            importer_rows.append({cs.KEY_CALLER_PATH: importer_path})
+                return importer_rows
             case cs.CYPHER_UNRESOLVED_SPECIFIER_IMPORTERS:
                 # Modules carrying a dropped relative specifier (issue #1714).
                 # Emulated rather than left to fall through: an unanswered

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -323,6 +323,31 @@ class _StatefulIngestor:
                     }
                     rows.append(row)
                 return rows
+            case cs.CYPHER_UNRESOLVED_SPECIFIER_IMPORTERS:
+                # Modules carrying a dropped relative specifier (issue #1714).
+                # Emulated rather than left to fall through: an unanswered
+                # query returns [] here, which is indistinguishable from "no
+                # waiters" and would let an end-to-end test pass against a
+                # lookup that never ran.
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                waiter_rows: list[ResultRow] = []
+                for (label, _uid), props in self.nodes.items():
+                    if label != _MODULE_LABEL:
+                        continue
+                    path = _text(props.get(cs.KEY_PATH))
+                    qn = _text(props.get(cs.KEY_QUALIFIED_NAME)) or ""
+                    specifiers = props.get(cs.KEY_UNRESOLVED_SPECIFIERS)
+                    if not path or not (prefix and qn.startswith(prefix)):
+                        continue
+                    if not isinstance(specifiers, list) or not specifiers:
+                        continue
+                    waiter_rows.append(
+                        {
+                            cs.KEY_CALLER_PATH: path,
+                            cs.CYPHER_KEY_SPECIFIERS: list(specifiers),
+                        }
+                    )
+                return waiter_rows
             case _:
                 return []
 


### PR DESCRIPTION
Closes #1714.

`_unresolved_importer_keys` (#1682) finds a waiting importer by looking for a persisted `IMPORTS` edge whose target sits outside the project prefix. That works only if such an edge exists. For a JS/TS **relative** import of a path that does not exist yet, the edge is dropped at flush as an unverifiable internal target, so there is nothing to match and the waiter is never re-parsed when the file is finally created.

Measured, indexing a project whose only import target is missing:

| importer | import | persisted `IMPORTS` edge |
|---|---|---|
| `main.js` | `import { go } from './index'` | **none** |
| `main.py` | `import util` | `('proj.main', 'util')` |
| `main.py` | `from util import helper` | `('proj.main', 'util.helper')` |

The Python rows carry an external-looking target, which is exactly what the existing query matches. The JS/TS row carries nothing.

## The fix

The importer records the **literal specifier as written** (`"./index"`) on its own Module node, so it stays findable from the created file's path alone.

- Written at parse time, when a relative JS/TS specifier names no file on disk. Only relative ones: a bare specifier (`lodash`) becomes a real edge to an ExternalModule, which the existing lookup already finds.
- Retracted when the module is re-parsed, so an import the edit removed — or one whose target now exists — stops nominating the file.
- Read by `_unresolved_importer_keys` alongside the existing row match.

Two choices worth calling out:

**The match is resolved in Python, not Cypher.** A specifier is relative to the *importer's* directory, so `./index` in `sub/main.js` means `sub/index.js`, not `index.js`. The query returns `(caller_path, specifiers)` for modules carrying a non-empty list and the resolution happens against `importer.path`. Path arithmetic in Cypher would be markedly harder to read and to test; the stored form is still the literal specifier.

**The empty list is written unconditionally.** Node writes flush as `MERGE (n) SET n += row.props`, which can update a property but never remove one, so writing `[]` is the only way a re-parse can clear a specifier whose target now exists.

`unresolved_specifiers` is declared on the Module `NodeSchema`. The repo audits node properties against that schema and failed four import-verification tests until it was — a good gate that caught this immediately.

## Verification

Both halves of the mechanism are now driven end to end against the stateful in-memory double, not a stub: the persisted-row path (#1682) and the recorded-specifier path (this issue). That became possible only by teaching the double two queries it did not answer — it fell through to `case _: return []` for both, which reads as "no waiters" and is indistinguishable from a lookup that never ran. That is why #1682's tests could only cover the query layer, and the wider version of the problem is filed as #1716.

Every claim has its control: a specifier whose target exists is not recorded; an unrelated creation does not nominate the waiter; a resolved import is not reported; and `./index` in `sub/main.js` binds `sub/index.js` rather than the root file.

Mutation-tested in three parts — dropping the recording, the lookup, or the retraction each turns the relevant tests red. The first pass found a defect in **my own test**: removing the retraction left everything green, because the clearing test built a *fresh* updater for the second run, and a fresh updater gets a fresh `ImportProcessor` whose map starts empty — so it wrote `[]` whether or not the retraction ran. It now reuses the updater, which is the watcher's shape and the only one that exercises it.

Not asserted here: that a real scoped re-ingest against Memgraph produces the same graph as a clean index. The double is faithful to the queries cgr issues, not to the database.

The configured local reviewer agent is not available in this session, so the pre-push local round could not be run; this PR's own Greptile review is the first review of the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Merged on a documented exception

Greptile sits at 4/5 on this branch and will not clear, because its finding is about `codebase_rag/utils/path_utils.py`, which this PR does not touch. Recording the reasoning rather than leaving a red check unexplained:

- **Pre-existing.** `path_utils.py` is untouched here; it was last changed by #1637. The behaviour predates this branch.
- **Greptile's own words.** Its summary calls it "a separate limitation rather than a waiter reingestion failure".
- **Attempted and withdrawn.** I fixed it in #1721 and closed that PR after measuring the result: the naming change made a `.d.ts` sidecar steal the bare qn from its implementation (`./foo` bound to the type stub instead of the real module, verified against a worktree at `origin/main`), and delivered no end-to-end benefit — the IMPORTS edge still did not land. A regression for no gain.
- **Fully specified.** #1720 stays open with all three constraints any real fix must satisfy together: strip the compound suffix, make a declaration file yield the bare qn to its implementation order-independently, and fix the export binding.
- **One piece did land.** #1722 (merged) makes `utils/path_utils.py` a parser-fingerprint input, so whenever that rule does change, existing graphs are re-keyed rather than silently kept on stale identities.

Everything else on this PR is clear: 0 unresolved threads, all CI checks green including the full unit suite on six platform/version combinations and the Memgraph integration suite, and all three lint gates verified locally.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of files created after an initial scan, allowing referencing modules to be reprocessed.
  * Added support for unresolved relative JavaScript and TypeScript imports, including directory entry points and explicit extensions.
  * Improved matching for declaration files and dotted filenames in import paths.
  * Added support for unresolved CommonJS `require` and re-export paths.
  * Prevented package imports and unrelated file creations from triggering unnecessary updates.
  * Cleared previously unresolved import references once their target files become available.
  * Improved handling of existing unresolved imports across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
