### PR TITLE
fix: strip the whole compound suffix from a declaration file's module qn (#1720)

### DIFF
--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -211,6 +211,12 @@ PARSER_FINGERPRINT_SOURCE_FILES: tuple[str, ...] = (
     "ast_cache.py",
     "language_spec.py",
     "parser_loader.py",
+    # `base_module_qn` lives here, and the whole graph keys on the names it
+    # derives: change the rule and every module node should be re-keyed. It
+    # was absent, so a change touching ONLY this file left existing indexes on
+    # the old identities with no staleness warning, and `utils/` is in neither
+    # of the directory globs above (issue #1720 review).
+    "utils/path_utils.py",
 )
 PY_SOURCE_GLOB = "*.py"
 # The bundled Roslyn C# frontend tool is parser code too, though .cs/.csproj

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -159,6 +159,8 @@ JS_TS_MODULE_EXTENSIONS: tuple[str, ...] = (
     ".d.mts",
     ".d.cts",
     ".d.ts",
+    # (declaration forms above; JS_TS_DECLARATION_EXTENSIONS is derived from
+    # this tuple below, so adding one here cannot leave the qn rule behind)
     ".tsx",
     ".mts",
     ".cts",
@@ -167,6 +169,16 @@ JS_TS_MODULE_EXTENSIONS: tuple[str, ...] = (
     ".mjs",
     ".cjs",
     ".js",
+)
+# TypeScript declaration suffixes, DERIVED from the set above rather than
+# retyped: `.d.ts` is one extension, not `.ts` preceded by a `.d` segment, so
+# the module qn must lose the whole thing. Stripping only the final suffix
+# stored `pkg/index.d.ts` as `proj.pkg.index.d` while the resolver looked for
+# `proj.pkg`, and the IMPORTS edge was dropped for want of a matching node
+# (issue #1720). Derived so a `.d.*` added above cannot leave the qn rule
+# behind -- a second hand-written list is exactly how the two drifted apart.
+JS_TS_DECLARATION_EXTENSIONS: tuple[str, ...] = tuple(
+    ext for ext in JS_TS_MODULE_EXTENSIONS if ext.startswith(".d.")
 )
 TSCONFIG_FILENAMES: tuple[str, ...] = (
     "tsconfig.json",

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -4,6 +4,7 @@
 # unchanged files. These tests pin the parser-fingerprint safeguard: full
 # syncs stamp the fingerprint of the parser that built the graph, and any
 # later sync against a different parser warns loudly until a clean rebuild.
+import inspect
 from collections.abc import Iterator
 from pathlib import Path
 from typing import IO
@@ -19,6 +20,7 @@ from codebase_rag.cli import _delete_hash_cache
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_fingerprint import compute_parser_fingerprint
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.utils.path_utils import base_module_qn
 
 STALE_FINGERPRINT = "0" * 32
 
@@ -92,6 +94,41 @@ class TestComputeParserFingerprint:
         before = compute_parser_fingerprint(pkg)
         source.write_text("A = 2\n")
         assert compute_parser_fingerprint(pkg) != before
+
+    def test_changes_when_the_module_qn_rule_changes(self, tmp_path: Path) -> None:
+        """`base_module_qn` decides every module's identity, so a change to it
+        must re-key the graph.
+
+        It lives in `utils/path_utils.py`, which was in NEITHER the directory
+        globs (`parsers`, `constants`) nor the file list, so a change touching
+        only that file left existing indexes on their old module names with no
+        staleness warning — the graph silently disagreeing with the code that
+        built it (issue #1720 review).
+        """
+        assert "utils/path_utils.py" in cs.PARSER_FINGERPRINT_SOURCE_FILES
+        pkg = tmp_path / "pkg"
+        (pkg / "utils").mkdir(parents=True)
+        source = pkg / "utils" / "path_utils.py"
+        source.write_text("A = 1\n")
+        before = compute_parser_fingerprint(pkg)
+        source.write_text("A = 2\n")
+        assert compute_parser_fingerprint(pkg) != before
+
+    def test_every_module_qn_deriving_source_is_a_fingerprint_input(self) -> None:
+        """The forcing function the case above cannot provide.
+
+        That test names the file I already know about. This one asks the
+        question from the other end: whoever defines `base_module_qn` must be
+        a fingerprint input, so moving or splitting it cannot silently drop
+        the graph's identity rule out of the staleness check.
+        """
+        module = Path(inspect.getsourcefile(base_module_qn) or "")
+        package_root = Path(cs.__file__).resolve().parent.parent
+        rel = module.resolve().relative_to(package_root).as_posix()
+        covered = rel in cs.PARSER_FINGERPRINT_SOURCE_FILES or rel.startswith(
+            tuple(f"{d}/" for d in cs.PARSER_FINGERPRINT_SOURCE_DIRS)
+        )
+        assert covered, f"{rel} defines base_module_qn but is not a fingerprint input"
 
     def test_unchanged_tree_same_fingerprint(self, tmp_path: Path) -> None:
         pkg = tmp_path / "pkg"

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from codebase_rag import constants as cs
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parsers.cpp_frontend.qn import build_module_qn_map
 from codebase_rag.utils.path_utils import (
@@ -148,6 +149,45 @@ class TestTheBaseModuleQnIsSharedNotMirrored:
             base_module_qn(Path("dir.with.dots/f.py"), PROJECT)
             == f"{PROJECT}.dir.with.dots.f"
         )
+
+    def test_a_declaration_file_loses_its_whole_compound_suffix(self) -> None:
+        """`.d.ts` is ONE extension, not `.ts` after a `.d` segment.
+
+        The single-suffix rule indexed `pkg/index.d.ts` as `proj.pkg.index.d`,
+        while `JS_TS_MODULE_EXTENSIONS` lists `.d.ts` and the JS/TS resolver
+        treats that file as the `./pkg` entry point and looks for `proj.pkg`.
+        The file was therefore stored under a name nothing ever asks for, and
+        deferred verification dropped its IMPORTS edge (issue #1720).
+
+        Every `.d.*` in the language set is covered, not just `.d.ts`: the
+        parametrisation below enumerates what I thought of, and the set-driven
+        test after it is what catches the one I did not.
+        """
+        assert base_module_qn(Path("pkg/index.d.ts"), PROJECT) == f"{PROJECT}.pkg.index"
+        assert base_module_qn(Path("t/util.d.mts"), PROJECT) == f"{PROJECT}.t.util"
+        assert base_module_qn(Path("t/util.d.cts"), PROJECT) == f"{PROJECT}.t.util"
+
+    def test_every_declaration_extension_is_stripped_whole(self) -> None:
+        """The forcing function: a `.d.*` added to the language set later must
+        not quietly fall back to the single-suffix rule and reintroduce #1720.
+        """
+        leftovers = {
+            ext: base_module_qn(Path(f"pkg/m{ext}"), PROJECT)
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+            if ext.startswith(".d.")
+        }
+        assert leftovers, "no declaration extensions in the language set to check"
+        assert all(qn == f"{PROJECT}.pkg.m" for qn in leftovers.values()), leftovers
+
+    def test_a_non_module_dotted_name_still_keeps_its_stem(self) -> None:
+        """The control. Stripping compound suffixes generally would cut
+        `archive.tar.gz` to `archive`, which the rule above deliberately does
+        not do -- only extensions the language set names are compound.
+        """
+        assert (
+            base_module_qn(Path("archive.tar.gz"), PROJECT) == f"{PROJECT}.archive.tar"
+        )
+        assert base_module_qn(Path("a.b.py"), PROJECT) == f"{PROJECT}.a.b"
 
 
 class TestOneUnignorePatternIsEnoughToRescue:

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -282,11 +282,29 @@ def base_module_qn(rel_path: Path, project_name: str) -> str:
 
     ``__init__.py`` and ``mod.rs`` name their PACKAGE rather than themselves,
     so they drop their own filename segment.
+
+    A TypeScript declaration file loses its COMPOUND suffix: ``.d.ts`` is one
+    extension, not ``.ts`` after a ``.d`` segment. Stripping only the final one
+    stored ``pkg/index.d.ts`` as ``proj.pkg.index.d`` while the JS/TS resolver
+    treated it as the ``./pkg`` entry point and asked for ``proj.pkg``, so the
+    module was keyed under a name nothing looked up and its IMPORTS edge was
+    dropped (issue #1720). The narrower rule is deliberate: only extensions the
+    language set NAMES are compound, so ``archive.tar.gz`` still keeps
+    ``archive.tar``.
     """
     if rel_path.name in (cs.INIT_PY, cs.MOD_RS):
         parts = rel_path.parent.parts
     else:
-        parts = rel_path.with_suffix("").parts
+        name = rel_path.name
+        declaration = next(
+            (ext for ext in cs.JS_TS_DECLARATION_EXTENSIONS if name.endswith(ext)),
+            None,
+        )
+        parts = (
+            (*rel_path.parent.parts, name[: -len(declaration)])
+            if declaration
+            else rel_path.with_suffix("").parts
+        )
     return cs.SEPARATOR_DOT.join([project_name, *parts])
 
 


### PR DESCRIPTION
Closes #1720.

`base_module_qn` stripped one suffix, so a TypeScript declaration file was indexed under a name the resolver never asks for:

```
pkg/index.d.ts   ->  proj.pkg.index.d      (before)
pkg/index.ts     ->  proj.pkg.index
```

`JS_TS_MODULE_EXTENSIONS` lists `.d.ts`, `.d.mts` and `.d.cts`, and the JS/TS directory-index lookup treats `pkg/index.d.ts` as the entry point for `./pkg`. So the indexer and the resolver disagreed about the same file's key.

## The fix

`.d.ts` is ONE extension, not `.ts` after a `.d` segment, so the whole compound suffix goes. The declaration set is **derived** from `JS_TS_MODULE_EXTENSIONS` rather than retyped:

```python
JS_TS_DECLARATION_EXTENSIONS: tuple[str, ...] = tuple(
    ext for ext in JS_TS_MODULE_EXTENSIONS if ext.startswith(".d.")
)
```

A second hand-written list is precisely how these two drifted apart in the first place, so a `.d.*` added later cannot leave the qn rule behind.

The rule stays narrow on purpose: only extensions the language set *names* are compound. `archive.tar.gz` still yields `archive.tar`, and the existing `test_only_the_final_suffix_is_stripped` is unchanged and still passing.

## Verification

Red first — all three declaration extensions produced `proj.pkg.m.d` before the change. After:

```
pkg/index.d.ts   ->  proj.pkg.index
t/util.d.mts     ->  proj.t.util
archive.tar.gz   ->  proj.archive.tar     (control, unchanged)
a.b.py           ->  proj.a.b             (control, unchanged)
```

Mutation-tested: removing the compound-suffix branch turns exactly the two new tests red and leaves both controls green.

`test_every_declaration_extension_is_stripped_whole` is driven by the language set rather than by a list I typed, because the enumerated cases only cover the extensions I thought of — which is how this defect existed at all.

## What this does NOT fix

Measured, not assumed: after this change `pkg/index.d.ts` is correctly keyed `proj.pkg.index` and its `go` is registered as `proj.pkg.index.go`, but the importer's `IMPORTS` edge **still does not land**. A plain `pkg/index.ts` control does land. The importer binds `go` to `proj.pkg.go` and verification finds no such target, which is a separate defect in how a declaration module's exports bind — beyond the naming issue this PR fixes. #1720 is updated with that evidence so the residue is tracked rather than implied away by a green test.

The local reviewer agent is not available in this session, so this PR's own Greptile review is the first review of the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and TypeScript module name handling for compound declaration extensions such as `.d.ts`, `.d.mts`, and `.d.cts`.
  * Preserved correct filename suffix behavior for unrelated dotted filenames.
  * Ensured changes affecting module name derivation are detected, preventing stale indexes from being used.

* **Tests**
  * Added coverage for registered declaration extensions, compound suffixes, and parser fingerprint updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->