### PR TITLE
fix: make the module-qn rule a parser fingerprint input (#1720)

### DIFF
--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -211,6 +211,12 @@ PARSER_FINGERPRINT_SOURCE_FILES: tuple[str, ...] = (
     "ast_cache.py",
     "language_spec.py",
     "parser_loader.py",
+    # `base_module_qn` lives here, and the whole graph keys on the names it
+    # derives: change the rule and every module node should be re-keyed. It
+    # was absent, so a change touching ONLY this file left existing indexes on
+    # the old identities with no staleness warning, and `utils/` is in neither
+    # of the directory globs above (issue #1720 review).
+    "utils/path_utils.py",
 )
 PY_SOURCE_GLOB = "*.py"
 # The bundled Roslyn C# frontend tool is parser code too, though .cs/.csproj

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -4,7 +4,9 @@
 # unchanged files. These tests pin the parser-fingerprint safeguard: full
 # syncs stamp the fingerprint of the parser that built the graph, and any
 # later sync against a different parser warns loudly until a clean rebuild.
+import ast
 import inspect
+import textwrap
 from collections.abc import Iterator
 from pathlib import Path
 from typing import IO
@@ -118,17 +120,55 @@ class TestComputeParserFingerprint:
         """The forcing function the case above cannot provide.
 
         That test names the file I already know about. This one asks the
-        question from the other end: whoever defines `base_module_qn` must be
-        a fingerprint input, so moving or splitting it cannot silently drop
-        the graph's identity rule out of the staleness check.
+        question from the other end, and follows the rule rather than one
+        file: `base_module_qn` AND every package-internal module or callable
+        it references must be a fingerprint input.
+
+        Checking only the defining file would pass a SPLIT refactor -- the
+        wrapper stays in `utils/path_utils.py` while the arithmetic moves to
+        an unlisted helper, and edits to the helper then leave existing graphs
+        on stale identities with the guard still green (raised on #1722). The
+        property is "everything the identity rule depends on", not "the file
+        it currently lives in".
         """
-        module = Path(inspect.getsourcefile(base_module_qn) or "")
         package_root = Path(cs.__file__).resolve().parent.parent
-        rel = module.resolve().relative_to(package_root).as_posix()
-        covered = rel in cs.PARSER_FINGERPRINT_SOURCE_FILES or rel.startswith(
-            tuple(f"{d}/" for d in cs.PARSER_FINGERPRINT_SOURCE_DIRS)
+
+        def _rel(obj: object) -> str | None:
+            try:
+                source = inspect.getsourcefile(obj)  # type: ignore[arg-type]
+            except TypeError:
+                return None
+            if not source:
+                return None
+            path = Path(source).resolve()
+            if not path.is_relative_to(package_root):
+                return None  # stdlib and third-party are not ours to fingerprint
+            return path.relative_to(package_root).as_posix()
+
+        def _covered(rel: str) -> bool:
+            return rel in cs.PARSER_FINGERPRINT_SOURCE_FILES or rel.startswith(
+                tuple(f"{d}/" for d in cs.PARSER_FINGERPRINT_SOURCE_DIRS)
+            )
+
+        defining_module = inspect.getmodule(base_module_qn)
+        assert defining_module is not None
+        tree = ast.parse(textwrap.dedent(inspect.getsource(base_module_qn)))
+        referenced = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+        # The definition itself, plus every package-internal name its body
+        # actually reaches for (`cs` resolves to the constants package, which
+        # the directory glob already covers).
+        subjects = {base_module_qn} | {
+            obj
+            for name in referenced
+            if (obj := getattr(defining_module, name, None)) is not None
+        }
+        uncovered = sorted(
+            rel for obj in subjects if (rel := _rel(obj)) and not _covered(rel)
         )
-        assert covered, f"{rel} defines base_module_qn but is not a fingerprint input"
+        assert not uncovered, (
+            "the module-qn rule depends on these files, and a change to any of "
+            f"them would not refresh the parser fingerprint: {uncovered}"
+        )
 
     def test_unchanged_tree_same_fingerprint(self, tmp_path: Path) -> None:
         pkg = tmp_path / "pkg"

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -4,6 +4,7 @@
 # unchanged files. These tests pin the parser-fingerprint safeguard: full
 # syncs stamp the fingerprint of the parser that built the graph, and any
 # later sync against a different parser warns loudly until a clean rebuild.
+import inspect
 from collections.abc import Iterator
 from pathlib import Path
 from typing import IO
@@ -19,6 +20,7 @@ from codebase_rag.cli import _delete_hash_cache
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_fingerprint import compute_parser_fingerprint
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.utils.path_utils import base_module_qn
 
 STALE_FINGERPRINT = "0" * 32
 
@@ -92,6 +94,41 @@ class TestComputeParserFingerprint:
         before = compute_parser_fingerprint(pkg)
         source.write_text("A = 2\n")
         assert compute_parser_fingerprint(pkg) != before
+
+    def test_changes_when_the_module_qn_rule_changes(self, tmp_path: Path) -> None:
+        """`base_module_qn` decides every module's identity, so a change to it
+        must re-key the graph.
+
+        It lives in `utils/path_utils.py`, which was in NEITHER the directory
+        globs (`parsers`, `constants`) nor the file list, so a change touching
+        only that file left existing indexes on their old module names with no
+        staleness warning — the graph silently disagreeing with the code that
+        built it (issue #1720 review).
+        """
+        assert "utils/path_utils.py" in cs.PARSER_FINGERPRINT_SOURCE_FILES
+        pkg = tmp_path / "pkg"
+        (pkg / "utils").mkdir(parents=True)
+        source = pkg / "utils" / "path_utils.py"
+        source.write_text("A = 1\n")
+        before = compute_parser_fingerprint(pkg)
+        source.write_text("A = 2\n")
+        assert compute_parser_fingerprint(pkg) != before
+
+    def test_every_module_qn_deriving_source_is_a_fingerprint_input(self) -> None:
+        """The forcing function the case above cannot provide.
+
+        That test names the file I already know about. This one asks the
+        question from the other end: whoever defines `base_module_qn` must be
+        a fingerprint input, so moving or splitting it cannot silently drop
+        the graph's identity rule out of the staleness check.
+        """
+        module = Path(inspect.getsourcefile(base_module_qn) or "")
+        package_root = Path(cs.__file__).resolve().parent.parent
+        rel = module.resolve().relative_to(package_root).as_posix()
+        covered = rel in cs.PARSER_FINGERPRINT_SOURCE_FILES or rel.startswith(
+            tuple(f"{d}/" for d in cs.PARSER_FINGERPRINT_SOURCE_DIRS)
+        )
+        assert covered, f"{rel} defines base_module_qn but is not a fingerprint input"
 
     def test_unchanged_tree_same_fingerprint(self, tmp_path: Path) -> None:
         pkg = tmp_path / "pkg"


### PR DESCRIPTION
`base_module_qn` decides the qualified name of every module, and the whole graph keys on those names. It lives in `codebase_rag/utils/path_utils.py`, which was in **neither** of the parser-fingerprint inputs: not the directory globs (`parsers`, `constants`), not the file list.

So a change touching only that file re-keys every module node while the fingerprint stays identical — an incremental sync sees no staleness, keeps the old identities, and the graph silently disagrees with the code that built it. No error, no warning.

## The fix

`utils/path_utils.py` joins `PARSER_FINGERPRINT_SOURCE_FILES`, with two tests:

- `test_changes_when_the_module_qn_rule_changes` — editing that file changes the fingerprint.
- `test_every_module_qn_deriving_source_is_a_fingerprint_input` — resolves `base_module_qn` through `inspect.getsourcefile` and asserts whatever file defines it is covered.

The second is the one that matters. The first names the file I already know about; the second keeps holding if the function is moved or split, which is exactly how it escaped coverage in the first place. An inventory of "files to fingerprint" cannot fail for the file nobody remembered to list.

Mutation-tested: removing the entry turns both red.

## Provenance

Raised by Greptile on #1721 as "existing indexes retain the old identity after upgrade". Its specific claim about that PR was wrong — the fingerprint did change there, because the PR also edited `constants/languages.py`, and I verified both digests against a real worktree at `origin/main`:

```
origin/main   d0fb7757f60a58bf...
that branch   d5e16de88877cc2e...
```

But the underlying gap was real and independent of that PR, so it is fixed here on its own. #1721 itself is closed: its naming change made a `.d.ts` sidecar steal the bare qn from its implementation, and delivered no end-to-end benefit. #1720 carries that.

No separate index-identity version is added. The fingerprint IS that mechanism; a second one keyed on the same question would be one more thing to drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index freshness detection when module path resolution and naming logic changes.
  * Existing indexes are now re-keyed when relevant parser behavior becomes outdated, helping keep indexed results consistent.

* **Tests**
  * Expanded coverage to verify that parser fingerprints include all internal sources that influence module names.
  * Added validation for changes across referenced path-resolution logic, ensuring stale indexes are detected reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->