### PR TITLE
test: emulate the unanswered queries and make the eval double fail closed (#1716)

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -689,6 +689,12 @@ CYPHER_ALL_METHOD_LOCATIONS = (
 KEY_CHILD_QN = "child_qn"
 KEY_BASE_QN = "base_qn"
 KEY_BASE_INDEX = "base_index"
+# Result columns of the location-rehydration and module-count queries. Named
+# so the readers and the eval double cannot drift apart on the spelling, which
+# is the failure these queries were already prone to (issue #1716).
+KEY_MODULE_QN = "module_qn"
+KEY_CONTAINER_QN = "container_qn"
+KEY_COUNT = "count"
 
 CYPHER_PARAM_PATHS = "paths"
 CYPHER_PARAM_MODULE_NAMES = "module_names"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2156,10 +2156,10 @@ class GraphUpdater:
     ) -> int:
         restored = 0
         for row in rows:
-            module_qn = row.get("module_qn")
+            module_qn = row.get(cs.KEY_MODULE_QN)
             qn = row.get(cs.KEY_QUALIFIED_NAME)
             label = row.get(cs.KEY_LABEL)
-            container = row.get("container_qn")
+            container = row.get(cs.KEY_CONTAINER_QN)
             start_line = _persisted_int(row.get(cs.KEY_START_LINE))
             start_col = _persisted_int(row.get(cs.KEY_START_COL))
             name_line = _persisted_int(row.get(cs.KEY_NAME_START_LINE))
@@ -2812,7 +2812,7 @@ class GraphUpdater:
         try:
             # count() always yields exactly one row; anything else means the
             # sink did not really answer and cannot invalidate the cache.
-            count = int(rows[0]["count"])
+            count = int(rows[0][cs.KEY_COUNT])
         except (KeyError, IndexError, TypeError, ValueError):
             return
         if count:

--- a/codebase_rag/tests/test_eval_double_query_coverage.py
+++ b/codebase_rag/tests/test_eval_double_query_coverage.py
@@ -1,0 +1,198 @@
+"""The eval double must answer every query cgr issues, or refuse (issue #1716).
+
+`_StatefulIngestor` stands in for the graph in the incremental and re-ingest
+tests. It matched queries by identity and answered anything unrecognised with
+`[]`, which is a valid result for most of them -- so an unemulated query was
+indistinguishable from a genuinely empty graph, and a test could pass because
+a lookup silently returned nothing.
+
+That was not hypothetical. `CYPHER_UNRESOLVED_IMPORTER_PATHS` (#1682) went
+unemulated, its waiting-importer lookup answered `[]` for every scenario, and
+that issue's tests could only ever cover the query layer. Measured over five
+files at the time of writing: 136 tests passed while SIX distinct queries were
+being answered `[]`.
+
+These tests pin the two halves of the fix.
+
+READING, not merely non-emptiness. Each emulation is checked by asserting the
+CONTENT of the rows it returns -- the qualified names, the module a definition
+hangs off, the container of a method, the count. "No longer `[]`" would pass
+against an emulation that returned one garbage row, which is the same fail-open
+shape one level up.
+
+REFUSING. `case _` raises, so a query added to the updater and forgotten here
+fails loudly instead of quietly answering nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+PREFIX = {cs.KEY_PROJECT_PREFIX: "proj."}
+
+PY_SRC = {
+    "util.py": "def helper():\n    return 1\n",
+    "app.py": "class Widget:\n    def draw(self):\n        return 2\n",
+}
+CS_SRC = {"Shapes.cs": "namespace Demo;\npublic class Circle { }\n"}
+GO_SRC = {"pkg/types.go": "package pkg\n\ntype T struct{}\n"}
+
+
+def _indexed(root: Path, files: dict[str, str]) -> _StatefulIngestor:
+    for rel, text in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    store = _StatefulIngestor()
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run(force=True)
+    return store
+
+
+@pytest.fixture
+def python_store(tmp_path: Path) -> _StatefulIngestor:
+    root = tmp_path / "proj"
+    root.mkdir()
+    return _indexed(root, PY_SRC)
+
+
+class TestTheDoubleAnswersWithRealRows:
+    def test_function_locations_carry_their_module_and_qualified_name(
+        self, python_store: _StatefulIngestor
+    ) -> None:
+        rows = python_store.fetch_all(cs.CYPHER_ALL_FUNCTION_LOCATIONS, PREFIX)
+
+        by_qn = {row[cs.KEY_QUALIFIED_NAME]: row for row in rows}
+        assert "proj.util.helper" in by_qn, sorted(by_qn)
+        helper = by_qn["proj.util.helper"]
+        assert helper[cs.KEY_MODULE_QN] == "proj.util"
+        assert helper[cs.KEY_LABEL] == cs.NodeLabel.FUNCTION.value
+        # A location with no line is useless to the rehydration it feeds.
+        assert isinstance(helper[cs.KEY_START_LINE], int)
+
+    def test_method_locations_carry_their_container(
+        self, python_store: _StatefulIngestor
+    ) -> None:
+        rows = python_store.fetch_all(cs.CYPHER_ALL_METHOD_LOCATIONS, PREFIX)
+
+        by_qn = {row[cs.KEY_QUALIFIED_NAME]: row for row in rows}
+        assert "proj.app.Widget.draw" in by_qn, sorted(by_qn)
+        draw = by_qn["proj.app.Widget.draw"]
+        assert draw[cs.KEY_CONTAINER_QN] == "proj.app.Widget"
+        assert draw[cs.KEY_MODULE_QN] == "proj.app"
+        assert draw[cs.KEY_LABEL] == cs.NodeLabel.METHOD.value
+
+    def test_a_method_is_not_returned_as_a_function(
+        self, python_store: _StatefulIngestor
+    ) -> None:
+        """The two queries select different labels, and conflating them would
+        rehydrate a method under its module instead of its class."""
+        functions = {
+            row[cs.KEY_QUALIFIED_NAME]
+            for row in python_store.fetch_all(cs.CYPHER_ALL_FUNCTION_LOCATIONS, PREFIX)
+        }
+
+        assert "proj.util.helper" in functions
+        assert "proj.app.Widget.draw" not in functions
+
+    def test_the_module_count_is_the_number_of_project_modules(
+        self, python_store: _StatefulIngestor
+    ) -> None:
+        """A COUNT query returns exactly one row, and its caller reads
+        `rows[0]["count"]`. Answering `[]` raised IndexError there, the handler
+        returned, and the orphaned-cache check never ran."""
+        rows = python_store.fetch_all(
+            cs.CYPHER_COUNT_PROJECT_MODULES,
+            {cs.KEY_PROJECT_NAME: "proj", cs.KEY_PROJECT_PREFIX: "proj."},
+        )
+
+        assert len(rows) == 1
+        assert rows[0][cs.KEY_COUNT] == len(PY_SRC)
+
+    def test_the_module_count_excludes_other_projects(self, tmp_path: Path) -> None:
+        """The control. A count that ignored the prefix would still be
+        non-empty and still look right on a single-project fixture."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = _indexed(root, PY_SRC)
+        store.ensure_node_batch(
+            cs.NodeLabel.MODULE.value,
+            {cs.KEY_QUALIFIED_NAME: "other.mod", cs.KEY_PATH: "other/mod.py"},
+        )
+
+        rows = store.fetch_all(
+            cs.CYPHER_COUNT_PROJECT_MODULES,
+            {cs.KEY_PROJECT_NAME: "proj", cs.KEY_PROJECT_PREFIX: "proj."},
+        )
+
+        assert rows[0][cs.KEY_COUNT] == len(PY_SRC)
+
+    def test_csharp_type_locations_are_restricted_to_cs_files(
+        self, tmp_path: Path
+    ) -> None:
+        """The query carries `AND n.path ENDS WITH '.cs'`. A Python class must
+        not appear, or the C# partial-group join would key on it."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        parsers, _ = load_parsers()
+        if cs.SupportedLanguage.CSHARP not in parsers:
+            pytest.skip("c_sharp parser not available")
+        store = _indexed(root, {**CS_SRC, **PY_SRC})
+
+        rows = store.fetch_all(cs.CYPHER_ALL_CSHARP_TYPE_LOCATIONS, PREFIX)
+
+        paths = {row[cs.KEY_PATH] for row in rows}
+        assert paths, "no C# type locations returned at all"
+        assert all(str(path).endswith(".cs") for path in paths), paths
+        qns = {row[cs.KEY_QUALIFIED_NAME] for row in rows}
+        assert any("Circle" in str(qn) for qn in qns), qns
+        # The Python class in the same index must be absent.
+        assert not any("Widget" in str(qn) for qn in qns), qns
+
+    def test_go_type_locations_include_the_struct(self, tmp_path: Path) -> None:
+        root = tmp_path / "proj"
+        root.mkdir()
+        parsers, _ = load_parsers()
+        if cs.SupportedLanguage.GO not in parsers:
+            pytest.skip("go parser not available")
+        store = _indexed(root, GO_SRC)
+
+        rows = store.fetch_all(cs.CYPHER_ALL_GO_TYPE_LOCATIONS, PREFIX)
+
+        by_qn = {row[cs.KEY_QUALIFIED_NAME]: row for row in rows}
+        assert "proj.pkg.types.T" in by_qn, sorted(by_qn)
+        assert by_qn["proj.pkg.types.T"][cs.KEY_LABEL] in {
+            cs.NodeLabel.CLASS.value,
+            cs.NodeLabel.TYPE.value,
+        }
+
+
+class TestTheDoubleRefusesWhatItDoesNotModel:
+    def test_an_unemulated_query_raises_rather_than_answering_nothing(self) -> None:
+        store = _StatefulIngestor()
+
+        with pytest.raises(AssertionError, match="does not emulate this query"):
+            store.fetch_all("MATCH (n:Invented) RETURN n.qualified_name AS qn", {})
+
+    def test_a_deliberately_unmodelled_query_still_answers_empty(self) -> None:
+        """The embeddings pass writes vectors to Qdrant, which this double does
+        not model, and its caller already treats `[]` as "nothing to embed". It
+        is named in `_NOT_MODELLED` so the refusal above cannot swallow it."""
+        store = _StatefulIngestor()
+
+        assert (
+            store.fetch_all(cs.CYPHER_QUERY_EMBEDDINGS, {"project_name": "proj"}) == []
+        )

--- a/codebase_rag/tests/test_eval_double_query_coverage.py
+++ b/codebase_rag/tests/test_eval_double_query_coverage.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import pytest
 
 from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from evals.cgr_graph import _StatefulIngestor
@@ -76,7 +77,7 @@ class TestTheDoubleAnswersWithRealRows:
         rows = python_store.fetch_all(cs.CYPHER_ALL_FUNCTION_LOCATIONS, PREFIX)
 
         by_qn = {row[cs.KEY_QUALIFIED_NAME]: row for row in rows}
-        assert "proj.util.helper" in by_qn, sorted(by_qn)
+        assert "proj.util.helper" in by_qn, sorted(map(str, by_qn))
         helper = by_qn["proj.util.helper"]
         assert helper[cs.KEY_MODULE_QN] == "proj.util"
         assert helper[cs.KEY_LABEL] == cs.NodeLabel.FUNCTION.value
@@ -89,7 +90,7 @@ class TestTheDoubleAnswersWithRealRows:
         rows = python_store.fetch_all(cs.CYPHER_ALL_METHOD_LOCATIONS, PREFIX)
 
         by_qn = {row[cs.KEY_QUALIFIED_NAME]: row for row in rows}
-        assert "proj.app.Widget.draw" in by_qn, sorted(by_qn)
+        assert "proj.app.Widget.draw" in by_qn, sorted(map(str, by_qn))
         draw = by_qn["proj.app.Widget.draw"]
         assert draw[cs.KEY_CONTAINER_QN] == "proj.app.Widget"
         assert draw[cs.KEY_MODULE_QN] == "proj.app"
@@ -173,11 +174,98 @@ class TestTheDoubleAnswersWithRealRows:
         rows = store.fetch_all(cs.CYPHER_ALL_GO_TYPE_LOCATIONS, PREFIX)
 
         by_qn = {row[cs.KEY_QUALIFIED_NAME]: row for row in rows}
-        assert "proj.pkg.types.T" in by_qn, sorted(by_qn)
+        assert "proj.pkg.types.T" in by_qn, sorted(map(str, by_qn))
         assert by_qn["proj.pkg.types.T"][cs.KEY_LABEL] in {
             cs.NodeLabel.CLASS.value,
             cs.NodeLabel.TYPE.value,
         }
+
+
+class TestQueriesWhoseCallersSwallowExceptions:
+    """Some readers catch the refusal, so for them emulation is not optional.
+
+    `case _` raising only helps when the exception reaches the test. The three
+    route-rehydration queries are read inside `except Exception: return []`
+    (`graph_updater.py`), so a raise is caught and turned straight back into an
+    empty result — the fail-closed default defeated one layer down, invisibly.
+    Emulating them is the only thing that works for these (raised on #1716).
+
+    Asserted by CONTENT, not by "did not raise": a refusal converted to `[]` by
+    the caller and a faithful empty answer are indistinguishable from the
+    outside, which is the whole problem.
+    """
+
+    def test_project_modules_returns_the_matching_modules(
+        self, python_store: _StatefulIngestor
+    ) -> None:
+        rows = python_store.fetch_all(
+            gu.CYPHER_PROJECT_MODULES,
+            {cs.KEY_PROJECT_PREFIX: "proj.", "extensions": [".py"]},
+        )
+
+        assert {row[cs.KEY_QUALIFIED_NAME] for row in rows} == {
+            "proj.util",
+            "proj.app",
+        }
+
+    def test_project_modules_honours_the_extension_filter(
+        self, python_store: _StatefulIngestor
+    ) -> None:
+        """The control. Ignoring `$extensions` would still look right above,
+        because every module in that fixture is Python."""
+        rows = python_store.fetch_all(
+            gu.CYPHER_PROJECT_MODULES,
+            {cs.KEY_PROJECT_PREFIX: "proj.", "extensions": [".ts"]},
+        )
+
+        assert rows == []
+
+    def test_project_py_modules_returns_python_modules(
+        self, python_store: _StatefulIngestor
+    ) -> None:
+        rows = python_store.fetch_all(
+            gu.CYPHER_PROJECT_PY_MODULES, {cs.KEY_PROJECT_PREFIX: "proj."}
+        )
+
+        assert {row[cs.KEY_QUALIFIED_NAME] for row in rows} == {
+            "proj.util",
+            "proj.app",
+        }
+
+    def test_route_handlers_returns_only_decorated_definitions(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "proj"
+        root.mkdir()
+        store = _indexed(
+            root,
+            {
+                "api.py": (
+                    "def route(path):\n"
+                    "    def deco(fn):\n"
+                    "        return fn\n"
+                    "    return deco\n"
+                    "\n"
+                    "@route('/x')\n"
+                    "def handler():\n"
+                    "    return 1\n"
+                    "\n"
+                    "def plain():\n"
+                    "    return 2\n"
+                ),
+            },
+        )
+
+        rows = store.fetch_all(
+            gu.CYPHER_PROJECT_ROUTE_HANDLERS, {cs.KEY_PROJECT_PREFIX: "proj."}
+        )
+
+        qns = {row[cs.KEY_QUALIFIED_NAME] for row in rows}
+        assert "proj.api.handler" in qns, qns
+        # The undecorated sibling must be absent: the query selects on
+        # `f.decorators IS NOT NULL`, and returning every function would make
+        # a stale-route sweep touch definitions that never exposed a route.
+        assert "proj.api.plain" not in qns, qns
 
 
 class TestTheDoubleRefusesWhatItDoesNotModel:

--- a/codebase_rag/tests/test_reingest.py
+++ b/codebase_rag/tests/test_reingest.py
@@ -304,12 +304,40 @@ def test_reingest_gives_same_stem_siblings_their_clean_index_qns(
     changed: list[str],
     deleted: list[str],
     fresh_updater: bool,
+    request: pytest.FixtureRequest,
 ) -> None:
     # The first same-stem sibling in walk order owns the bare module qn
     # (issue #1569). Adding the sibling that wins that order, or deleting
     # the one that held it, changes the survivor's qn, so the scoped path
     # must re-parse the survivor unseeded, as the batch path does, and a
     # fresh updater must see the taken qns before it parses anything.
+    #
+    # ONE combination is a known production defect (#1719): a FRESH updater
+    # rehydrates function locations at graph_updater:3952 before deleting the
+    # re-parsed subtree at :3996, so the re-parse finds the qn taken and
+    # registers `sib.util.helper@1`. Marked here rather than in a
+    # `pytest.param`, because the two stacked parametrize decorators cannot
+    # express the intersection: a mark on the `add_loser` row would also
+    # exempt `warm`, which passes and must keep passing.
+    #
+    # strict=True on purpose. When #1719 is fixed this test starts passing and
+    # a non-strict marker would let it sit here for ever; strict turns that
+    # into a failure that says "remove me". The xfail comes off in that PR.
+    #
+    # This passed until #1716 taught the eval double to answer
+    # CYPHER_ALL_FUNCTION_LOCATIONS. Before that it returned [], rehydration
+    # silently no-opped, and the equality asserted below was never exercised
+    # on this path.
+    if request.node.callspec.id == "add_loser-fresh":
+        request.applymarker(
+            pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "issue #1719: fresh-updater re-ingest rehydrates locations "
+                    "before the delete, so the re-parse registers a DUP_QN variant"
+                ),
+            )
+        )
     root = temp_repo / "sib"
     root.mkdir()
     for rel, text in before.items():

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
@@ -127,6 +128,10 @@ _AFFECTED_CALLER_RELS = frozenset(
         cs.RelationshipType.INHERITS.value,
         cs.RelationshipType.IMPLEMENTS.value,
     }
+)
+# Labels CYPHER_PROJECT_ROUTE_HANDLERS selects on.
+_ROUTE_HANDLER_LABELS = frozenset(
+    {cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value}
 )
 _INHERITS_REL = cs.RelationshipType.INHERITS.value
 
@@ -344,6 +349,46 @@ class _StatefulIngestor:
                     }
                     rows.append(row)
                 return rows
+            case gu.CYPHER_PROJECT_MODULES | gu.CYPHER_PROJECT_PY_MODULES:
+                # Route rehydration. These MUST be emulated rather than left to
+                # the refusal below: their readers wrap the call in
+                # `except Exception: return []`, so a raise is caught and
+                # turned straight back into an empty result -- the fail-closed
+                # default defeated one layer down, invisibly (raised on #1716).
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                raw_exts = params.get("extensions") if params else None
+                # CYPHER_PROJECT_MODULES filters on a passed extension list;
+                # the PY variant hardcodes `.py` in its Cypher.
+                suffixes = (
+                    tuple(e for e in raw_exts if isinstance(e, str))
+                    if isinstance(raw_exts, list)
+                    else (".py",)
+                )
+                return [
+                    {cs.KEY_QUALIFIED_NAME: qn, cs.KEY_PATH: path}
+                    for (label, _uid), props in self.nodes.items()
+                    if label == _MODULE_LABEL
+                    and (qn := _text(props.get(cs.KEY_QUALIFIED_NAME)) or "")
+                    and prefix
+                    and qn.startswith(prefix)
+                    and (path := _text(props.get(cs.KEY_PATH)) or "").endswith(suffixes)
+                ]
+            case gu.CYPHER_PROJECT_ROUTE_HANDLERS:
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                return [
+                    {
+                        cs.KEY_LABELS: [label],
+                        cs.KEY_QUALIFIED_NAME: qn,
+                        "decorators": [d for d in decorators if isinstance(d, str)],
+                    }
+                    for (label, _uid), props in self.nodes.items()
+                    if label in _ROUTE_HANDLER_LABELS
+                    and (qn := _text(props.get(cs.KEY_QUALIFIED_NAME)) or "")
+                    and prefix
+                    and qn.startswith(prefix)
+                    and isinstance(decorators := props.get("decorators"), list)
+                    and decorators
+                ]
             case cs.CYPHER_UNRESOLVED_IMPORTER_PATHS:
                 # Importers whose IMPORTS edge points at an UNRESOLVED target
                 # named after one of the given modules (issue #1682). Emulated

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -63,6 +63,27 @@ _DEFINES_RELS = frozenset(
         cs.RelationshipType.DEFINES_METHOD.value,
     }
 )
+# Labels the C# partial-join and Go col-keyed rehydration queries select on.
+_CSHARP_TYPE_LABELS = frozenset(
+    {
+        cs.NodeLabel.CLASS.value,
+        cs.NodeLabel.INTERFACE.value,
+        cs.NodeLabel.ENUM.value,
+    }
+)
+_GO_TYPE_LABELS = _CSHARP_TYPE_LABELS | {
+    cs.NodeLabel.TYPE.value,
+    cs.NodeLabel.UNION.value,
+}
+# Queries this double deliberately does NOT model, so `case _` can raise for
+# everything else without pretending these are graph reads (issue #1716).
+#
+# `CYPHER_QUERY_EMBEDDINGS` drives Pass 4, which reads function bodies and
+# writes vectors to Qdrant. The double models the graph, not the vector store,
+# and its caller already treats an empty result as "no functions to embed" and
+# returns -- verified at graph_updater's embeddings pass, not assumed. An
+# emulation would invite the double into work it cannot represent.
+_NOT_MODELLED: frozenset[str] = frozenset({cs.CYPHER_QUERY_EMBEDDINGS})
 _MODULE_QN_LABELS = frozenset(
     {
         _MODULE_LABEL,
@@ -390,8 +411,132 @@ class _StatefulIngestor:
                         }
                     )
                 return waiter_rows
+            case cs.CYPHER_COUNT_PROJECT_MODULES:
+                # A COUNT query yields exactly ONE row. Falling through to []
+                # was the sharpest of the gaps: its caller reads `rows[0]
+                # ["count"]`, so an empty list raises IndexError, the handler
+                # returns, and the orphaned-hash-cache check never runs at all
+                # (issue #1716).
+                project_name = (
+                    _text(params.get(cs.KEY_PROJECT_NAME)) if params else None
+                )
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                total = sum(
+                    1
+                    for (label, _uid), props in self.nodes.items()
+                    if label == _MODULE_LABEL
+                    and (
+                        (qn := _text(props.get(cs.KEY_QUALIFIED_NAME)) or "")
+                        == project_name
+                        or (prefix and qn.startswith(prefix))
+                    )
+                )
+                return [{cs.KEY_COUNT: total}]
+            case cs.CYPHER_ALL_CSHARP_TYPE_LOCATIONS:
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                return [
+                    {
+                        cs.KEY_QUALIFIED_NAME: qn,
+                        cs.KEY_PATH: path,
+                        cs.KEY_START_LINE: _int(props.get(cs.KEY_START_LINE)),
+                    }
+                    for (label, _uid), props in self.nodes.items()
+                    if label in _CSHARP_TYPE_LABELS
+                    and (qn := _text(props.get(cs.KEY_QUALIFIED_NAME)) or "")
+                    and prefix
+                    and qn.startswith(prefix)
+                    and (path := _text(props.get(cs.KEY_PATH)) or "").endswith(
+                        cs.EXT_CS
+                    )
+                ]
+            case cs.CYPHER_ALL_GO_TYPE_LOCATIONS:
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                return [
+                    {
+                        cs.KEY_LABEL: label,
+                        cs.KEY_QUALIFIED_NAME: qn,
+                        cs.KEY_PATH: _text(props.get(cs.KEY_PATH)),
+                        cs.KEY_START_LINE: _int(props.get(cs.KEY_START_LINE)),
+                        cs.KEY_START_COL: _int(props.get(cs.KEY_START_COL)),
+                    }
+                    for (label, _uid), props in self.nodes.items()
+                    if label in _GO_TYPE_LABELS
+                    and (qn := _text(props.get(cs.KEY_QUALIFIED_NAME)) or "")
+                    and prefix
+                    and qn.startswith(prefix)
+                ]
+            case cs.CYPHER_ALL_FUNCTION_LOCATIONS:
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                return self._definition_location_rows(
+                    prefix, cs.NodeLabel.FUNCTION.value
+                )
+            case cs.CYPHER_ALL_METHOD_LOCATIONS:
+                prefix = _text(params.get(cs.KEY_PROJECT_PREFIX)) if params else None
+                return self._definition_location_rows(prefix, cs.NodeLabel.METHOD.value)
             case _:
-                return []
+                if query in _NOT_MODELLED:
+                    return []
+                # Fail CLOSED. An unemulated query answered [] is
+                # indistinguishable from a genuinely empty result, so a test
+                # can pass because a lookup silently returned nothing -- which
+                # is how #1682's waiting-importer path went uncovered for a
+                # whole release (issue #1716). A new query must be emulated
+                # here, or named in _NOT_MODELLED with a reason.
+                raise AssertionError(
+                    f"{type(self).__name__} does not emulate this query, and it "
+                    f"is not in _NOT_MODELLED. Add a case or a reason:\n{query}"
+                )
+
+    def _definition_location_rows(
+        self, prefix: str | None, target_label: str
+    ) -> list[ResultRow]:
+        """Rows for the Function/Method location rehydration queries.
+
+        Both walk Module -[:DEFINES]-> ... to the definition; the Method form
+        has one more hop through its container and returns `container_qn`.
+        Shared so the two cannot drift apart in what counts as "in project".
+        """
+        if not prefix:
+            return []
+        rows: list[ResultRow] = []
+        for from_label, from_val, rel, to_label, to_val in self.edges:
+            if rel != cs.RelationshipType.DEFINES.value:
+                continue
+            if from_label != _MODULE_LABEL:
+                continue
+            module_qn = _text(from_val) or ""
+            if not module_qn.startswith(prefix):
+                continue
+            if target_label == cs.NodeLabel.FUNCTION.value:
+                if to_label != target_label:
+                    continue
+                pairs = [(None, (to_label, to_val))]
+            else:
+                # Module -DEFINES-> container -DEFINES_METHOD-> Method.
+                pairs = [
+                    (to_val, (m_label, m_val))
+                    for (c_label, c_val, m_rel, m_label, m_val) in self.edges
+                    if m_rel == cs.RelationshipType.DEFINES_METHOD.value
+                    and (c_label, c_val) == (to_label, to_val)
+                    and m_label == target_label
+                ]
+            for container_qn, node_id in pairs:
+                props = self.nodes.get(node_id)
+                if props is None:
+                    continue
+                row: ResultRow = {
+                    cs.KEY_LABEL: node_id[0],
+                    cs.KEY_QUALIFIED_NAME: _text(props.get(cs.KEY_QUALIFIED_NAME)),
+                    cs.KEY_MODULE_QN: module_qn,
+                    cs.KEY_START_LINE: _int(props.get(cs.KEY_START_LINE)),
+                    cs.KEY_START_COL: _int(props.get(cs.KEY_START_COL)),
+                    cs.KEY_NAME_START_LINE: _int(props.get(cs.KEY_NAME_START_LINE)),
+                    cs.KEY_NAME_START_COL: _int(props.get(cs.KEY_NAME_START_COL)),
+                }
+                if container_qn is not None:
+                    row[cs.KEY_CONTAINER_QN] = _text(container_qn)
+                rows.append(row)
+        return rows
 
     def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
         path = params.get(cs.KEY_PATH) if params else None


### PR DESCRIPTION
Closes #1716.

`_StatefulIngestor` stands in for the graph in the incremental and re-ingest tests. It matched queries by identity and answered anything unrecognised with `[]` — a valid result for most of them, so an unemulated query was indistinguishable from a genuinely empty graph. A test could pass because a lookup silently returned nothing.

Not hypothetical. `CYPHER_UNRESOLVED_IMPORTER_PATHS` went unemulated, so #1682's waiting-importer lookup answered `[]` for every scenario and that issue's tests could only ever cover the query layer — its own module docstring records the limitation. Measured over five files: **136 tests passed while six distinct queries were being answered `[]`**.

## The fix, in the order that makes it cheap

**Emulate the six**, then flip the default. Doing it the other way round is what makes the change look expensive: with a bare `case _: raise`, the suite showed **80 failed / 113 passed**. With the six emulated first, the same flip costs nothing.

| constant | why it matters |
|---|---|
| `CYPHER_COUNT_PROJECT_MODULES` | its caller reads `rows[0]["count"]`, so `[]` raised `IndexError` and the orphaned-cache check never ran at all |
| `CYPHER_ALL_FUNCTION_LOCATIONS` | location rehydration |
| `CYPHER_ALL_METHOD_LOCATIONS` | location rehydration |
| `CYPHER_ALL_GO_TYPE_LOCATIONS` | col-keyed rehydration |
| `CYPHER_ALL_CSHARP_TYPE_LOCATIONS` | C# partial-group joining |
| `CYPHER_QUERY_EMBEDDINGS` | **not** emulated — named in `_NOT_MODELLED` with its reason |

The two location queries share one walker so they cannot drift on what "in project" means. `CYPHER_QUERY_EMBEDDINGS` is allow-listed rather than emulated because the double models graph structure and that pass writes vectors to Qdrant; I verified against its caller that it already treats `[]` as "no functions to embed" and returns.

`case _` now **raises**, naming the query and telling you to add a case or a reason.

Also adds `KEY_MODULE_QN`, `KEY_CONTAINER_QN` and `KEY_COUNT`, and points the three `graph_updater` readers at them. Those columns were raw strings on both the reader and the double — precisely the drift this issue is about.

## Tests read the rows

Each emulation is checked by asserting row CONTENT — the qualified names, the module a definition hangs off, the container of a method, the count. "No longer `[]`" would pass against an emulation returning one garbage row, which is the same fail-open shape one level up.

Mutation-tested for exactly that property: rather than deleting an emulation (which only proves a test reaches the query), two emulations were made to return **wrong** rows — `container_qn` hardcoded, and the C# query dropping its `.cs` filter. Both were caught, by the two right tests.

Three further tests earn their place: a method must not come back from the function query; a count that ignores the project prefix (which would still be non-empty and still look right on a single-project fixture); and both halves of the refusal.

## One test is now xfail, and that is the point

`test_reingest_gives_same_stem_siblings_their_clean_index_qns[add_loser-fresh]` asserted that a scoped re-ingest equals a clean index, and passed only because rehydration silently no-opped. With `CYPHER_ALL_FUNCTION_LOCATIONS` emulated it fails, exposing a real defect: a fresh updater rehydrates locations at `graph_updater.py` before deleting the re-parsed subtree, so the re-parse finds the qn taken and registers `sib.util.helper@1`.

Filed as **#1719**. Marked `xfail(strict=True)` so it cannot rot — when #1719 lands the test starts passing and strict turns that into a failure saying "remove me".

Marked in-body via `request.applymarker` rather than on a `pytest.param`, because the two stacked `parametrize` decorators cannot express the intersection: a mark on the `add_loser` row would also exempt `add_loser-warm`, which passes and must keep passing.

An honest double that shows a red test is the point of this change; hiding it again would defeat it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved validation of indexing, re-ingestion, and route rehydration workflows, including function, method, C#, Go, and module location data.
  * Unsupported query scenarios are now detected explicitly instead of being silently treated as empty results.
  * Route handling now validates project filtering, file extensions, qualified names, and decorated definitions.

* **Tests**
  * Expanded automated coverage for module counts, project filtering, qualified names, and language-specific type locations.
  * Documented a known fresh re-ingestion issue as an expected test failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->