### PR TITLE
fix: give the deletion ownership set the same path-derived fallback as the sweep (#1719)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2570,7 +2570,18 @@ class GraphUpdater:
         # they are never re-registered because it is not re-parsed. The span
         # records key by the REGISTERING file's module qn, so a qn recorded
         # under a module this event does not touch survives (issue #1025).
-        touched_modules = recorded_qns
+        # Uses the same set the prefix sweep uses, INCLUDING its path-derived
+        # fallback. `recorded_qns` is filled only when a file is parsed
+        # (`DefinitionProcessor.process_file`), so on a FRESH updater doing a
+        # scoped re-ingest it is empty -- and an empty `touched_modules` makes
+        # every rehydrated span foreign, which protects the whole graph from a
+        # sweep that then removes nothing. The re-parse re-registers a qn the
+        # rehydrated registry still holds and lands on a `@1` DUP_QN variant
+        # instead of the clean name (issue #1719). The prefix sweep already
+        # falls back to the path-derived qn for exactly this case; ownership
+        # has to fall back with it, or the two disagree about which modules
+        # this event touches.
+        touched_modules = module_qn_prefixes
         foreign_qns = set()
         # The mirror of foreign_qns, and the reason the prefix sweep is not
         # sufficient on its own: a definition's qn does not have to sit under

--- a/codebase_rag/tests/test_reingest.py
+++ b/codebase_rag/tests/test_reingest.py
@@ -304,7 +304,6 @@ def test_reingest_gives_same_stem_siblings_their_clean_index_qns(
     changed: list[str],
     deleted: list[str],
     fresh_updater: bool,
-    request: pytest.FixtureRequest,
 ) -> None:
     # The first same-stem sibling in walk order owns the bare module qn
     # (issue #1569). Adding the sibling that wins that order, or deleting
@@ -312,32 +311,13 @@ def test_reingest_gives_same_stem_siblings_their_clean_index_qns(
     # must re-parse the survivor unseeded, as the batch path does, and a
     # fresh updater must see the taken qns before it parses anything.
     #
-    # ONE combination is a known production defect (#1719): a FRESH updater
-    # rehydrates function locations at graph_updater:3952 before deleting the
-    # re-parsed subtree at :3996, so the re-parse finds the qn taken and
-    # registers `sib.util.helper@1`. Marked here rather than in a
-    # `pytest.param`, because the two stacked parametrize decorators cannot
-    # express the intersection: a mark on the `add_loser` row would also
-    # exempt `warm`, which passes and must keep passing.
-    #
-    # strict=True on purpose. When #1719 is fixed this test starts passing and
-    # a non-strict marker would let it sit here for ever; strict turns that
-    # into a failure that says "remove me". The xfail comes off in that PR.
-    #
-    # This passed until #1716 taught the eval double to answer
-    # CYPHER_ALL_FUNCTION_LOCATIONS. Before that it returned [], rehydration
-    # silently no-opped, and the equality asserted below was never exercised
-    # on this path.
-    if request.node.callspec.id == "add_loser-fresh":
-        request.applymarker(
-            pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "issue #1719: fresh-updater re-ingest rehydrates locations "
-                    "before the delete, so the re-parse registers a DUP_QN variant"
-                ),
-            )
-        )
+    # The FRESH case is the one that regressed: a fresh updater has parsed
+    # nothing, so `module_qn_to_file_path` is empty and the deleted file's
+    # ownership set fell back to nothing, protecting every rehydrated span
+    # from the sweep. The re-parse then found its own qn still held by the
+    # rehydrated registry and landed on `sib.util.helper@1` (issue #1719).
+    # It was xfail(strict=True) here until that fix; the marker is gone
+    # because the strict marker is what forced its removal.
     root = temp_repo / "sib"
     root.mkdir()
     for rel, text in before.items():


### PR DESCRIPTION
Closes #1719.

A **fresh** `GraphUpdater` (the shape the MCP tool builds per project) doing a scoped `reingest` registered a re-parsed file's definitions under a `DUP_QN` variant instead of the clean name:

```
extra node:   ('Function', 'sib.util.helper@1')
missing node: ('Function', 'sib.util.helper')
```

## Cause

Not the hydrate/delete ordering the issue first guessed. `remove_file_from_state` computes two sets from the same question — which modules does this file own?

```python
recorded_qns      = {qn for qn, path in module_qn_to_file_path.items() if path == file_path}
module_qn_prefixes = recorded_qns or {path_derived_qn}     # sweep: HAS a fallback
touched_modules    = recorded_qns                          # ownership: had NONE
```

`module_qn_to_file_path` is filled only when a file is parsed (`DefinitionProcessor.process_file`), so on a fresh updater it is **empty**. The sweep survives that through its path-derived fallback; the ownership set did not. An empty `touched_modules` makes *every* rehydrated span "foreign", and `foreign_qns` then protects the entire graph from a sweep that consequently removes nothing.

The re-parse then finds its own qualified name still held by the rehydrated registry and disambiguates to `@1`.

## The fix

One line: ownership uses the same set as the sweep, fallback included.

```python
touched_modules = module_qn_prefixes
```

The two were answering the same question from different data. Where the sweep says "these are the prefixes this file owns", ownership must agree, or they disagree about which modules the event touches — which is precisely what happened.

## Verification

The regression test already existed, marked `xfail(strict=True)` by #1716 when the eval double started answering `CYPHER_ALL_FUNCTION_LOCATIONS` and the assertion became real. **That marker is removed here** — which is what `strict=True` was for: once fixed, the test passes and strict turns a lingering marker into a failure saying "remove me".

- `test_reingest_gives_same_stem_siblings_their_clean_index_qns` — all 8 parametrisations pass, `warm` and `fresh` alike.
- Mutation: reverting to `recorded_qns` reproduces exactly the original failure on exactly the original case, `[add_loser-fresh]`, and nothing else.
- 236 tests pass across the reingest, incremental, watcher-ownership, cross-language-collision and eval-double files.

The `#1025` ownership guard this touches still holds: `test_watch_registry_ownership.py` and the inline-mod cases pass unchanged. That guard exists so a sweep by prefix alone cannot deregister another file's definitions, and widening `touched_modules` only ever narrows `foreign_qns` for the file being removed — a file that is about to be re-parsed and re-register whatever it still defines.

## Provenance

Surfaced by #1716, which made the eval double answer queries it had been silently returning `[]` for. The test had been passing only because rehydration no-opped, so the equality it asserts was never exercised on this path. An honest double showing a red test is what made this findable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed scoped re-ingestion so re-parsed files no longer receive unnecessary duplicate-qualified-name variants.
  - Ensured existing code relationships are correctly removed and rebuilt during fresh re-ingestion.

- **Tests**
  - Re-enabled coverage for re-ingestion scenarios that previously expected the defect.
  - Updated test descriptions to reflect the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->