### PR TITLE
fix: distrust a hash-cache stamp from the future so edits are not skipped (#1665)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -321,6 +321,36 @@ def _publish_hash_cache(
         return False
 
 
+def _trustworthy_cache_mtime(cache_path: Path) -> float:
+    """The cache mtime to compare files against, or 0.0 if it cannot be trusted.
+
+    Both readers use this instant as a watermark: "every file at or below it is
+    already accounted for". A stamp AHEAD of the wall clock makes that true of
+    EVERY file on disk however recently edited, so nothing is re-hashed, the
+    edit never reaches the graph, and no later run corrects it because the
+    stamp stays ahead (issue #1665). The causes are ordinary -- an NTP step
+    backwards, VM suspend and resume, `cp -p` or `rsync -t` from a host whose
+    clock ran ahead, a restored backup or a copied container image.
+
+    Returning 0.0 rather than clamping to `time.time()`: clamping is not
+    enough, because "now" is never older than an edit made now, so a file
+    written in the same instant still satisfies `mtime <= now` and is skipped
+    for the wrong reason. 0.0 disables the shortcut entirely and defers to the
+    HASH comparison, which is the authority the watermark is only an
+    optimisation over. The cost is one re-hash pass on a tree whose cache is
+    misstamped; the alternative is losing edits silently and permanently.
+
+    Shared by both readers on purpose. They answer the same question, and a
+    guard applied to one of two predicates is the shape that let the indexer
+    and the watcher disagree in issue #1636.
+    """
+    try:
+        stamped = cache_path.stat().st_mtime
+    except OSError:
+        return 0.0
+    return 0.0 if stamped > time.time() else stamped
+
+
 def _load_parser_fingerprint(stamp_path: Path) -> str | None:
     try:
         return stamp_path.read_text(encoding="utf-8").strip() or None
@@ -2907,7 +2937,7 @@ class GraphUpdater:
         # incidentally, by being an indexed and hashed file itself.
         if not self._exclusions_match_last_run():
             return False
-        cache_mtime = cache_path.stat().st_mtime
+        cache_mtime = _trustworthy_cache_mtime(cache_path)
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
         old_hashes = (
             {} if self._cache_discarded_in_memory else _load_hash_cache(cache_path)
@@ -3075,7 +3105,9 @@ class GraphUpdater:
             old_hashes.pop(stale_key, None)
         is_full_build = (force or not old_hashes) and self._single_file is None
         self._is_full_build = is_full_build
-        cache_mtime = cache_path.stat().st_mtime if cache_path.is_file() else 0.0
+        cache_mtime = (
+            _trustworthy_cache_mtime(cache_path) if cache_path.is_file() else 0.0
+        )
         if force:
             logger.info(ls.INCREMENTAL_FORCE)
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3548,7 +3548,15 @@ class GraphUpdater:
             # write time -- LATER than this run's instant, so it makes the
             # trap worse rather than closing it. `cache_mtime` was read at the
             # top of this method, before anything wrote to the cache.
-            self._pending_cache_observed_at = cache_mtime or None
+            #
+            # `or 0.0`, never `or None`: `cache_mtime` is 0.0 when the previous
+            # stamp was distrusted for being in the future (issue #1665), and
+            # 0.0 is falsy, so `or None` would take exactly the branch the
+            # paragraph above warns against. The epoch vouches for nothing,
+            # which is the honest claim for a run whose predecessor's stamp
+            # could not be trusted; None vouches for now, and loses a sibling
+            # edited before this run, permanently.
+            self._pending_cache_observed_at = cache_mtime or 0.0
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry
         # the old parser's edges.

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1246,13 +1246,35 @@ class TestFastPathInSync:
             f"{sorted(indexed_functions)}"
         )
 
-        # And the edit must actually REACH the graph. The assertion above is
-        # satisfied by any reason for declining the fast path, including a
-        # rescan that finds nothing wrong: it pins "did not take the shortcut",
-        # not "did not lose the edit", and those are different claims. Skipping
-        # silently is the dangerous direction here; a redundant re-hash is the
-        # safe error, so the outcome is what has to be asserted. Measured
-        # against the unfixed helper, where the new symbol never appears.
+    def test_a_stamp_that_cannot_be_read_is_not_trusted(self, tmp_path: Path) -> None:
+        """The third answer `_trustworthy_cache_mtime` gives: unreadable.
+
+        Both readers only reach it once `cache_path.is_file()` or the fast
+        path's own checks said the cache exists, so a failing `stat` here is a
+        race with a concurrent publish or a permissions change underneath the
+        run. The honest watermark for a stamp that cannot be read is the same
+        as for one that cannot be trusted: 0.0, so nothing is skipped on its
+        account and the hash comparison decides.
+
+        A file in the path where a directory should be makes `stat` raise
+        `NotADirectoryError`, an `OSError`, without touching permissions,
+        which behave differently for root and on Windows.
+        """
+        not_a_dir = tmp_path / "file.txt"
+        not_a_dir.write_text("x", encoding="utf-8")
+        unreadable = not_a_dir / "cache.json"
+        with pytest.raises(OSError):
+            unreadable.stat()  # fixture guard: the stat must actually fail
+
+        assert graph_updater_module._trustworthy_cache_mtime(unreadable) == 0.0
+
+        # The control: a readable, sane stamp is returned as it is, so the
+        # 0.0 above is the OSError branch and not a helper that always
+        # answers 0.0.
+        readable = tmp_path / "cache.json"
+        readable.write_text("{}", encoding="utf-8")
+        os.utime(readable, (1_000_000.0, 1_000_000.0))
+        assert graph_updater_module._trustworthy_cache_mtime(readable) == 1_000_000.0
 
     def test_a_future_stamp_does_not_skip_an_edit_in_the_hashing_loop(
         self, py_project: Path, mock_ingestor: MagicMock

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1175,6 +1175,65 @@ class TestFastPathInSync:
         )
         assert updater._is_already_in_sync() is False
 
+    def test_a_cache_stamped_in_the_future_does_not_skip_an_edit(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """Issue #1665: a future mtime makes every file look unchanged.
+
+        `_is_already_in_sync` and the hashing loop both fast-path a file whose
+        mtime is at or below the cache's. A cache stamped ahead of the wall
+        clock satisfies that for EVERY file on disk, however recently edited,
+        so nothing is re-indexed and the graph silently stops tracking the
+        tree. It does not self-correct: the stamp stays ahead, so every later
+        run skips too.
+
+        The causes are ordinary rather than exotic -- an NTP correction
+        backwards, VM suspend/resume, `cp -p` or `rsync -t` from a host whose
+        clock ran ahead, a restored backup or copied image.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        cache = py_project / cs.HASH_CACHE_FILENAME
+        assert cache.is_file(), "fixture guard: run 1 wrote no cache to stamp"
+        ahead = time.time() + 3600
+        os.utime(cache, (ahead, ahead))
+
+        # Edited AFTER the stamp, so its mtime is older than the cache's while
+        # being newer than the content the cache describes -- the exact shape
+        # the comparison cannot distinguish.
+        (py_project / "module_a.py").write_text(
+            "def edited_after_the_stamp():\n    return 2\n", encoding="utf-8"
+        )
+
+        successor = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        assert successor._is_already_in_sync() is False, (
+            "a cache stamped in the future reported the tree as in sync, so "
+            "the edit is never indexed and no later run corrects it"
+        )
+
+        # Only `_is_already_in_sync` is pinned here, deliberately. The hashing
+        # loop reads the same stamp for the same shortcut, and is guarded the
+        # same way, but reverting ONLY that reader leaves the suite green and
+        # the edit still indexed: once the sync check declines, the loop's
+        # `old_hashes` comparison catches the changed content whatever the
+        # mtime says, because the hash is the authority and the mtime is only
+        # an optimisation over it. Measured, not assumed -- with that reader
+        # reverted the run still re-indexed the edited file and rewrote the
+        # cache with a sane stamp. The guard stays on both readers so they
+        # cannot diverge (issue #1636's shape), but the second one has no
+        # failing case to pin.
+
     def test_changed_cli_exclusion_disables_fast_path(
         self, py_project: Path, mock_ingestor: MagicMock
     ) -> None:

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1222,17 +1222,151 @@ class TestFastPathInSync:
             "the edit is never indexed and no later run corrects it"
         )
 
-        # Only `_is_already_in_sync` is pinned here, deliberately. The hashing
-        # loop reads the same stamp for the same shortcut, and is guarded the
-        # same way, but reverting ONLY that reader leaves the suite green and
-        # the edit still indexed: once the sync check declines, the loop's
-        # `old_hashes` comparison catches the changed content whatever the
-        # mtime says, because the hash is the authority and the mtime is only
-        # an optimisation over it. Measured, not assumed -- with that reader
-        # reverted the run still re-indexed the edited file and rewrote the
-        # cache with a sane stamp. The guard stays on both readers so they
-        # cannot diverge (issue #1636's shape), but the second one has no
-        # failing case to pin.
+        # And the edit must actually REACH the graph. The assertion above is
+        # satisfied by any reason for declining the fast path, including a
+        # rescan that finds nothing wrong: it pins "did not take the shortcut",
+        # not "did not lose the edit", and those are different claims. Skipping
+        # silently is the dangerous direction here; a redundant re-hash is the
+        # safe error, so the outcome is what has to be asserted. Measured
+        # against the unfixed helper, where the new symbol never appears.
+        mock_ingestor.reset_mock()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+        indexed_functions = {
+            str(call.args[1].get(cs.KEY_QUALIFIED_NAME))
+            for call in mock_ingestor.ensure_node_batch.call_args_list
+            if call.args[0] == cs.NodeLabel.FUNCTION
+        }
+        assert any("edited_after_the_stamp" in qn for qn in indexed_functions), (
+            "the edit never reached the graph against a future stamp: "
+            f"{sorted(indexed_functions)}"
+        )
+
+        # And the edit must actually REACH the graph. The assertion above is
+        # satisfied by any reason for declining the fast path, including a
+        # rescan that finds nothing wrong: it pins "did not take the shortcut",
+        # not "did not lose the edit", and those are different claims. Skipping
+        # silently is the dangerous direction here; a redundant re-hash is the
+        # safe error, so the outcome is what has to be asserted. Measured
+        # against the unfixed helper, where the new symbol never appears.
+
+    def test_a_future_stamp_does_not_skip_an_edit_in_the_hashing_loop(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The SECOND reader of the stamp, at the loop that actually indexes.
+
+        `_is_already_in_sync` is only the fast path. When it declines, the run
+        reaches the hashing loop, which applies the same `mtime <=
+        cache_mtime` shortcut against the same stamp -- and that shortcut
+        `continue`s BEFORE the hash comparison, so the hash is not the
+        authority here the way it is for the sync check. The stale hash is
+        then copied into the new cache and the stamp rewritten sanely, so the
+        lie becomes indistinguishable from truth and no later run corrects it.
+
+        The unrelated addition is what makes this test about the LOOP: it
+        makes the sync check decline for a reason other than the edit itself,
+        which is the only way the poisoned stamp reaches the loop at all.
+        Without it the sync check answers first and this re-tests the reader
+        above.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        cache = py_project / cs.HASH_CACHE_FILENAME
+        assert cache.is_file(), "fixture guard: run 1 wrote no cache to stamp"
+        ahead = time.time() + 3600
+        os.utime(cache, (ahead, ahead))
+
+        (py_project / "module_a.py").write_text(
+            "def edited_under_a_future_stamp():\n    return 2\n", encoding="utf-8"
+        )
+        (py_project / "module_new.py").write_text(
+            "def unrelated():\n    return 3\n", encoding="utf-8"
+        )
+
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        # The cache must carry the file's REAL hash. Asserting on the graph
+        # would not do: the edited file is re-parsed either way once the run
+        # proceeds, and it is the persisted stale hash that loses the edit for
+        # every later run.
+        cached = json.loads(cache.read_text(encoding="utf-8")).get("module_a.py")
+        assert cached == _hash_file(py_project / "module_a.py"), (
+            "the hashing loop skipped the edited file against a future stamp "
+            "and persisted its stale hash, so no later run sees the edit"
+        )
+
+    def test_a_single_file_run_over_a_distrusted_cache_keeps_sibling_edits(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The stamp WRITER, which the two readers above do not reach.
+
+        A single-file run carries the previous cache mtime forward so the
+        siblings it never looked at keep their meaning. When that previous
+        stamp was distrusted for being in the future it reads as 0.0, and
+        `cache_mtime or None` -- falsy 0.0 -- takes the `None` branch the
+        comment beside it explicitly warns against: `None` skips the
+        `os.utime`, the cache keeps its own write time (NOW), and a sibling
+        edited before the run is then older than the stamp, so every later
+        project run reports "already in sync" and the edit is lost for good.
+
+        So the read guard alone made the write worse. The epoch vouches for
+        nothing, which is the honest claim after an untrustworthy stamp;
+        `None` vouches for now.
+        """
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        cache = py_project / cs.HASH_CACHE_FILENAME
+        assert cache.is_file(), "fixture guard: run 1 wrote no cache to stamp"
+        ahead = time.time() + 3600
+        os.utime(cache, (ahead, ahead))
+
+        # Edited BEFORE the single-file run, and never looked at by it: this
+        # is the sibling whose edit the stamp has to keep visible.
+        (py_project / "module_b.py").write_text(
+            "def b_edited_before_the_single_file_run():\n    return 2\n",
+            encoding="utf-8",
+        )
+
+        single = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        single._single_file = py_project / "module_a.py"
+        single.run()
+
+        successor = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        assert successor._is_already_in_sync() is False, (
+            "the single-file run stamped the cache with its own write time, "
+            "so the sibling edited before it is never indexed again"
+        )
 
     def test_changed_cli_exclusion_disables_fast_path(
         self, py_project: Path, mock_ingestor: MagicMock


### PR DESCRIPTION
Closes #1665.

## The defect

`_is_already_in_sync` and the incremental hashing loop both fast-path a file
when `stat.st_mtime <= cache_mtime`, where `cache_mtime` is the mtime of
`.cgr-hash-cache.json`. A cache stamped **ahead of the wall clock** satisfies
that for every file on disk however recently edited, so nothing is re-indexed.

It does not self-correct: the stamp stays ahead, so every later run skips too.
Reproduced before fixing — index, `os.utime(cache, (time.time()+3600,)*2)`,
edit a file, re-run: runs 2 and 3 both index nothing.

The causes are ordinary rather than exotic: an NTP step backwards, VM
suspend/resume, `cp -p` or `rsync -t` from a host whose clock ran ahead, a
restored backup or a copied container image.

## The fix

`_trustworthy_cache_mtime` returns the stamp, or `0.0` when it is in the
future, and both readers use it.

**`0.0` rather than clamping to `time.time()`.** Clamping was my first attempt
and it does not work: "now" is never older than an edit made *now*, so a file
written in the same instant still satisfies `mtime <= now` and is skipped. `0.0`
disables the watermark and defers to the hash comparison. Cost is one re-hash
pass, after which the run rewrites the cache with a sane stamp — verified to
self-correct in exactly one pass.

## Three sites, three failure modes

The read guard alone was not enough, and the two extra findings both came from
review rather than from me.

| Site | Failure if unguarded |
|---|---|
| `_is_already_in_sync` (2929) | the fast path reports "in sync"; the edit is never indexed |
| the hashing loop (3097) | the shortcut `continue`s **before** the hash comparison, persists the stale hash, and re-stamps sanely — so the lie becomes permanent |
| the stamp **writer** (3540) | `cache_mtime or None` — `0.0` is falsy, so this took the `None` branch the comment beside it warns against, skipping `os.utime` and losing a sibling edit forever |

That third one is the one worth reading twice: **the read guard made the write
path worse.** A single-file run carries the previous stamp forward for the
siblings it never looked at; with `None` it instead keeps its own write time,
which is *later* than a sibling edited before the run. Reproduced: after one
single-file run over a poisoned cache, every subsequent project run reports
`in_sync=True` and the sibling's edit is gone. Fixed with `or 0.0` — the epoch
vouches for nothing, which is the honest claim; `None` vouches for now.

## A comment I shipped that was wrong

I originally guarded both readers, could not make a test discriminate the
second, investigated, and concluded in a comment that it had no failing case
because "the hash is the authority". **That was false**, and the reviewer
disproved it by construction: make the sync check decline for an *unrelated*
addition, and the poisoned stamp reaches the loop, whose shortcut skips the
edited file *before any hash comparison*. Measured under that mutation: cached
hash `77736f65…` vs actual `c8e27920…`, still diverged three runs later.

The comment is gone and there is a test in its place.

## Discrimination

| Mutation | Result |
|---|---|
| Stub the helper to return the raw stat | 2 red |
| Clamp to `time.time()` instead of `0.0` | red |
| Revert only the sync-check reader | red (that test only) |
| Revert only the hashing-loop reader | red (that test only) |
| Revert the stamp writer to `or None` | red (that test only) |

Each mutation fails its own test and nothing else. 131 passed across
`test_graph_updater_incremental.py`, `test_reingest.py` and
`test_hash_cache_guard.py`.

The first version of the main assertion was `_is_already_in_sync() is False`,
which is satisfied by *any* reason for declining — including a rescan that
finds nothing wrong. It pins "did not take the shortcut", not "did not lose the
edit". It now asserts the edited symbol reaches the graph, which fails against
the unfixed helper.

## Known gap, not fixed here

`_reingest_update_hashes` (4027, 4050) reads the raw stamp and writes it
straight back, so the watcher/MCP path can re-poison a cache. No edit is lost
today — reingest works from an explicit file list, and both batch readers are
now guarded — so this is robustness rather than a live defect, and it is a
different call path from the three above. Worth its own issue if you would
rather it were separate; happy to fold it in if you would rather it were not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection when cache timestamps are unreadable or incorrectly set in the future.
  * Ensured edited files are reprocessed and indexed instead of being hidden by stale cache metadata.
  * Preserved detection of edits to files not processed during single-file updates.

* **Tests**
  * Added regression coverage for future-dated cache timestamps, rehashing, indexing, and incremental update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->