### PR TITLE
fix: give a declaration file the module identity importers resolve to

### DIFF
--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -168,6 +168,11 @@ JS_TS_MODULE_EXTENSIONS: tuple[str, ...] = (
     ".cjs",
     ".js",
 )
+# What marks a member of the set above as TYPE-ONLY. A declaration file and its
+# implementation strip to the same module qn, and the implementation is the one
+# holding the callable definitions, so it must own the name importers resolve
+# to (issue #1720). Kept here so the two are read from one place.
+DECLARATION_EXT_PREFIX = ".d."
 TSCONFIG_FILENAMES: tuple[str, ...] = (
     "tsconfig.json",
     "tsconfig.base.json",

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2955,10 +2955,12 @@ class GraphUpdater:
         resolved = combined if combined else None
         self.unignore_paths = resolved
         # The factory-owned processors hold their own copies for structure
-        # traversal and import-time walks; they must prune identically or a
-        # sweep could read files the indexer skipped (issue #1088 invariant).
-        self.factory.import_processor.unignore_paths = resolved
-        self.factory.structure_processor.unignore_paths = resolved
+        # traversal, import-time walks and the declaration tie-break; they must
+        # prune identically or a sweep could read files the indexer skipped
+        # (issue #1088 invariant). The factory derives that set from its own
+        # slots rather than taking a list from here, because a list here failed
+        # open when a third consumer was added (#1720).
+        self.factory.propagate_unignore_paths(resolved)
         if roots:
             logger.info(ls.GENERATED_SOURCES_REGISTERED, count=len(roots))
         # Delombok overlay (issue #1140 tier 1): rebuilt per run so a jar or

--- a/codebase_rag/parsers/cpp_frontend/qn.py
+++ b/codebase_rag/parsers/cpp_frontend/qn.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import constants as cs
-from ...utils.path_utils import base_module_qn, walk_eligible_files
+from ...utils.path_utils import (
+    base_module_qn,
+    declaration_extension,
+    has_implementation_sibling,
+    walk_eligible_files,
+)
 from ..cpp.utils import convert_operator_symbol_to_name
 from . import constants as fc
 
@@ -40,10 +45,23 @@ def build_module_qn_map(
     # Mirror DefinitionProcessor._disambiguate_module_qn: a base qn is claimed
     # by the first file (in walk order); a later file colliding on that base qn
     # gets its extension appended (foo.cpp -> proj.foo, foo.h -> proj.foo.h).
+    #
+    # The one tie NOT broken by walk order is a TypeScript declaration beside
+    # its implementation (#1720): the declaration yields, decided on the
+    # filesystem. This walk covers every eligible file rather than only C++
+    # ones, so a `.d.ts` is in this map and would otherwise claim `proj.foo`
+    # here while the indexer gave it to `foo.ts` -- one module under two names,
+    # which is the #1025 failure the mirror exists to prevent.
     claimed: dict[str, str] = {}
     result: dict[str, str] = {}
     for rel in _eligible_rel_files(repo_path, exclude_paths, unignore_paths):
         base = base_module_qn(Path(rel), project_name)
+        if (declaration := declaration_extension(Path(rel).name)) and (
+            has_implementation_sibling(
+                repo_path / rel, repo_path, exclude_paths, unignore_paths
+            )
+        ):
+            base = f"{base}{cs.SEPARATOR_DOT}{declaration.lstrip(cs.SEPARATOR_DOT)}"
         existing = claimed.get(base)
         if existing is None or existing == rel:
             final = base

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -70,6 +70,8 @@ class DefinitionProcessor(
         func_class_captures_cache: dict[Path, dict] | None = None,
         *,
         flow_capture_enabled: bool = False,
+        exclude_paths: frozenset[str] | None = None,
+        unignore_paths: frozenset[str] | None = None,
     ):
         super().__init__()
         self.ingestor = ingestor
@@ -80,6 +82,11 @@ class DefinitionProcessor(
         self.import_processor = import_processor
         self.module_qn_to_file_path = module_qn_to_file_path
         self.flow_capture_enabled = flow_capture_enabled
+        # The indexer's eligibility policy, needed by the declaration
+        # tie-break: a declaration must yield only to an implementation that
+        # will actually be indexed, not merely one that exists on disk.
+        self.exclude_paths = exclude_paths
+        self.unignore_paths = unignore_paths
         # {go module qn: its `package` clause name}; Go package membership is
         # (directory, clause), so receiver binding needs both.
         self.go_package_names: dict[str, str] = {}
@@ -336,7 +343,12 @@ class DefinitionProcessor(
         # real module (`foo/d/ts.py` derives `proj.foo.d.ts`), so it still has
         # to go through the check below rather than skip it.
         if (declaration := declaration_extension(file_path.name)) and (
-            has_implementation_sibling(file_path)
+            has_implementation_sibling(
+                file_path,
+                self.repo_path,
+                exclude_paths=self.exclude_paths,
+                unignore_paths=self.unignore_paths,
+            )
         ):
             suffix = declaration.lstrip(cs.SEPARATOR_DOT)
             module_qn = f"{module_qn}{cs.SEPARATOR_DOT}{suffix}"

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -331,11 +331,15 @@ class DefinitionProcessor(
         # `@types/*` packages and for a compiled library shipped beside its
         # types, that file IS the module, and an unconditional yield would put
         # it back under a name nothing resolves to.
+        # Note this REWRITES the candidate rather than returning it: the
+        # yielded name is itself a qn like any other and can collide with a
+        # real module (`foo/d/ts.py` derives `proj.foo.d.ts`), so it still has
+        # to go through the check below rather than skip it.
         if (declaration := declaration_extension(file_path.name)) and (
             has_implementation_sibling(file_path)
         ):
             suffix = declaration.lstrip(cs.SEPARATOR_DOT)
-            return f"{module_qn}{cs.SEPARATOR_DOT}{suffix}"
+            module_qn = f"{module_qn}{cs.SEPARATOR_DOT}{suffix}"
 
         # Two files that share a basename but differ by extension (foo.py /
         # foo.cpp) strip to the same module qn. Append the extension to the

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -27,6 +27,8 @@ from ..utils.path_utils import (
     base_module_qn,
     cached_relative_path,
     cached_resolve_posix,
+    declaration_extension,
+    has_implementation_sibling,
 )
 from .class_ingest import ClassIngestMixin
 from .cpp import CppTypeInferenceEngine
@@ -315,6 +317,26 @@ class DefinitionProcessor(
         self._func_class_captures_cache = func_class_captures_cache
 
     def _disambiguate_module_qn(self, module_qn: str, file_path: Path) -> str:
+        # A TypeScript declaration file and its implementation strip to the
+        # SAME module qn once `.d.ts` is treated as one extension (#1720), and
+        # the rule below would award it to whichever is walked first. That is
+        # the stub: `"foo.d.ts" < "foo.ts"` in the ascending within-directory
+        # walk. The type-only file would own the name every importer resolves
+        # to while the callable definitions sat under `proj.foo.ts`, which
+        # nothing asks for -- the regression that closed PR #1721.
+        #
+        # So a declaration yields whenever an implementation EXISTS ON DISK,
+        # which is a fact about the repository rather than about parse order.
+        # A declaration with no implementation still takes the bare name: for
+        # `@types/*` packages and for a compiled library shipped beside its
+        # types, that file IS the module, and an unconditional yield would put
+        # it back under a name nothing resolves to.
+        if (declaration := declaration_extension(file_path.name)) and (
+            has_implementation_sibling(file_path)
+        ):
+            suffix = declaration.lstrip(cs.SEPARATOR_DOT)
+            return f"{module_qn}{cs.SEPARATOR_DOT}{suffix}"
+
         # Two files that share a basename but differ by extension (foo.py /
         # foo.cpp) strip to the same module qn. Append the extension to the
         # later one so their module nodes and all derived class/method qns stay

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -71,6 +71,38 @@ class ProcessorFactory:
         self._type_inference: TypeInferenceEngine | None = None
         self._call_processor: CallProcessor | None = None
 
+    def propagate_unignore_paths(
+        self, resolved: frozenset[str] | None
+    ) -> tuple[str, ...]:
+        """Push a re-resolved unignore policy to every ALREADY-BUILT processor.
+
+        Generated-source discovery re-resolves this policy per run, and every
+        processor that prunes must prune identically or a sweep reads files the
+        indexer skipped (issue #1088). That propagation used to be two named
+        assignments at the call site, which is an inventory that fails open: a
+        processor added later keeps a stale policy and nothing says so. The
+        declaration tie-break (#1720) became the third consumer and was missed
+        exactly that way (Greptile P1, PR #1728).
+
+        So the consumers are DERIVED from ``__slots__`` rather than listed. A
+        processor built later picks the policy up at construction, because it
+        reads the value updated here.
+
+        Returns the slots updated, so a caller can assert coverage rather than
+        assume it.
+        """
+        self.unignore_paths = resolved
+        updated: list[str] = []
+        for slot in self.__slots__:
+            if not slot.startswith("_"):
+                continue
+            built = getattr(self, slot, None)
+            if built is None or not hasattr(built, "unignore_paths"):
+                continue
+            built.unignore_paths = resolved
+            updated.append(slot)
+        return tuple(updated)
+
     @property
     def import_processor(self) -> ImportProcessor:
         if self._import_processor is None:

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -112,6 +112,8 @@ class ProcessorFactory:
                 flow_capture_enabled=(
                     RelationshipType.FLOWS_TO in self.capture.enabled_rels
                 ),
+                exclude_paths=self.exclude_paths,
+                unignore_paths=self.unignore_paths,
             )
         return self._definition_processor
 

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1626,12 +1626,23 @@ class ImportProcessor:
         potential_module = cs.SEPARATOR_DOT.join(parts[:-1])
         relative_path = cs.SEPARATOR_SLASH.join(parts[1:-1])
 
-        for ext in (cs.EXT_JS, cs.EXT_TS, cs.EXT_JSX, cs.EXT_TSX):
-            if (self.repo_path / f"{relative_path}{ext}").is_file():
-                return potential_module
-            index_path = self.repo_path / relative_path / f"{cs.INDEX_INDEX}{ext}"
-            if index_path.is_file():
-                return potential_module
+        # Where the module ends and the imported symbol begins is decided by
+        # asking whether the shorter path names a module ON DISK. That question
+        # already has an owner, and this site used to answer it again with a
+        # restated `(.js, .ts, .jsx, .tsx)` -- a four-element subset of the ten
+        # in `JS_TS_MODULE_EXTENSIONS`. For a module written in any of the
+        # other six the probe found nothing, the symbol segment was never
+        # stripped, and the unstripped `proj.pkg.go` reached verification,
+        # matched no Module node and was dropped: the IMPORTS edge vanished
+        # silently. `.d.ts` is how it was found (#1720), but `.mjs`, `.cjs`,
+        # `.mts` and `.cts` were broken by the same omission and have nothing
+        # to do with declarations.
+        #
+        # Same shape as the `.mts`/`.cts` gap in `DIRECTORY_MODULE_STEM_BY_EXT`
+        # from the #1682 review: a canonical set restated at a second site and
+        # drifting from it. Delegating is what stops it recurring here.
+        if self._js_module_rel_on_disk(relative_path) is not None:
+            return potential_module
 
         return full_name
 

--- a/codebase_rag/tests/test_js_ts_module_extension_parity.py
+++ b/codebase_rag/tests/test_js_ts_module_extension_parity.py
@@ -45,7 +45,9 @@ IMPL = "export function go() { return 1; }\n"
 DECL = "export declare function go(): number;\n"
 
 
-def _index(files: dict[str, str]) -> _StatefulIngestor:
+def _index(
+    files: dict[str, str], exclude_paths: frozenset[str] | None = None
+) -> _StatefulIngestor:
     root = Path(tempfile.mkdtemp()) / "proj"
     root.mkdir(parents=True)
     for rel, text in files.items():
@@ -60,6 +62,7 @@ def _index(files: dict[str, str]) -> _StatefulIngestor:
         parsers=parsers,
         queries=queries,
         project_name="proj",
+        exclude_paths=exclude_paths,
     ).run(force=True)
     return store
 
@@ -116,6 +119,59 @@ class TestEveryModuleExtensionBindsANamedImport:
         assert _imports(store) == [
             ("Module", "proj.main", "IMPORTS", "Module", "proj.util")
         ], f"{ext}: {_imports(store)}"
+
+    def test_a_declaration_does_not_yield_to_an_excluded_implementation(self) -> None:
+        """A declaration yields only to an implementation that WILL be indexed.
+
+        Greptile P1 on this PR, and correct. `has_implementation_sibling` asked
+        the disk "does a same-stem implementation exist", but the question the
+        tie-break needs answered is "will one be INDEXED". Those differ exactly
+        when the indexer's exclude/unignore policy removes the implementation:
+        `foo.ts` excluded, `foo.d.ts` still eligible, and the declaration
+        yielded `proj.foo` to a file that never enters the graph. Nothing then
+        owns the name imports of `./foo` resolve to -- which is #1720 again,
+        reintroduced by the fix for it under a configuration I had not tested.
+
+        Driven end-to-end through `GraphUpdater(exclude_paths=...)` rather than
+        against the predicate directly, so it also pins the WIRING: the policy
+        has to reach `_disambiguate_module_qn`, and a correct predicate that
+        nothing passes the exclude set to would still fail here.
+        """
+        store = _index(
+            {
+                "main.ts": "import { go } from './foo';\nexport const r = go;\n",
+                "foo.ts": IMPL,
+                "foo.d.ts": DECL,
+            },
+            exclude_paths=frozenset({"foo.ts"}),
+        )
+
+        modules = _modules(store)
+        # The precondition: the exclude really took, so a green result below
+        # cannot come from the implementation having been indexed after all.
+        assert "proj.foo.ts" not in modules, modules
+        assert "proj.foo" in modules, modules
+
+    def test_a_declaration_still_yields_when_the_implementation_is_indexed(
+        self,
+    ) -> None:
+        """The control for the test above: same fixture, no exclude.
+
+        Without this, "declarations never yield" would satisfy the exclusion
+        test, and the walk-order fix in `test_qn_walk_order_parity.py` would be
+        the only thing holding the other direction.
+        """
+        store = _index(
+            {
+                "main.ts": "import { go } from './foo';\nexport const r = go;\n",
+                "foo.ts": IMPL,
+                "foo.d.ts": DECL,
+            }
+        )
+
+        modules = _modules(store)
+        assert "proj.foo" in modules, modules
+        assert "proj.foo.d.ts" in modules, modules
 
     def test_an_import_of_a_directory_with_no_entry_point_binds_nothing(self) -> None:
         store = _index({"main.ts": MAIN, "pkg/other.ts": IMPL})

--- a/codebase_rag/tests/test_js_ts_module_extension_parity.py
+++ b/codebase_rag/tests/test_js_ts_module_extension_parity.py
@@ -94,15 +94,62 @@ class TestEveryModuleExtensionBindsANamedImport:
             ("Module", "proj.main", "IMPORTS", "Module", "proj.pkg.index")
         ], f"{ext}: {_imports(store)}"
 
-    def test_an_import_of_a_directory_with_no_entry_point_binds_nothing(self) -> None:
-        """The control that stops the rule collapsing into "always strip".
+    @pytest.mark.parametrize("ext", cs.JS_TS_MODULE_EXTENSIONS)
+    def test_a_flat_file_module_resolves(self, ext: str) -> None:
+        """`import { go } from './util'` with a FLAT `util<ext>`, no directory.
 
-        If the module/symbol split stopped consulting the filesystem and simply
-        dropped the last segment, every parametrisation above would pass and
-        the resolver would invent module targets for directories that hold no
-        entry point at all. Here `pkg/` exists but has no `index.*`, so there
-        is no module to bind to and no edge may be emitted.
+        Added after a surviving mutant, not by foresight. Every case above
+        routes through a directory entry point, so neutering the file branch of
+        `_js_module_rel_on_disk` -- the other half of the helper this fix
+        delegates to -- left all 12 tests green. The suite was one-dimensional
+        on "directory entry point vs flat file" and could not see half the
+        component it depends on.
         """
+        body = DECL if ext.startswith(".d.") else IMPL
+        store = _index(
+            {
+                "main.ts": "import { go } from './util';\nexport const r = go;\n",
+                f"util{ext}": body,
+            }
+        )
+
+        assert _imports(store) == [
+            ("Module", "proj.main", "IMPORTS", "Module", "proj.util")
+        ], f"{ext}: {_imports(store)}"
+
+    def test_an_import_of_a_directory_with_no_entry_point_binds_nothing(self) -> None:
         store = _index({"main.ts": MAIN, "pkg/other.ts": IMPL})
 
+        assert _imports(store) == [], _imports(store)
+
+    def test_the_split_still_asks_the_filesystem(self) -> None:
+        """The control with teeth: over-stripping must bind the WRONG module.
+
+        The previous control asserted only that an unresolvable import produces
+        no edge, and a resolver that dropped the last segment unconditionally
+        satisfied that too -- `proj.pkg.missing` is no more bindable than
+        `proj.pkg.missing.go`, so both readings emit nothing and the test could
+        not tell them apart. It passed against the over-stripping mutant.
+
+        This fixture makes the two readings disagree about a real target. A
+        Python package `pkg/__init__.py` registers the module qn `proj.pkg`,
+        while `pkg/` holds no JS/TS entry point at all. So:
+
+          asking the disk  `pkg` names no JS module -> keep `proj.pkg.go`
+                           -> matches nothing -> no edge, correctly
+          over-stripping   -> `proj.pkg` -> IS a known module -> emits an
+                           IMPORTS edge from a TypeScript file to a Python
+                           package
+
+        The failure the split exists to prevent is a wrong edge, not a missing
+        one, so the assertion has to be able to see a wrong edge.
+        """
+        store = _index(
+            {
+                "main.ts": MAIN,
+                "pkg/__init__.py": "def go():\n    return 1\n",
+            }
+        )
+
+        assert "proj.pkg" in _modules(store), _modules(store)
         assert _imports(store) == [], _imports(store)

--- a/codebase_rag/tests/test_js_ts_module_extension_parity.py
+++ b/codebase_rag/tests/test_js_ts_module_extension_parity.py
@@ -48,22 +48,28 @@ DECL = "export declare function go(): number;\n"
 def _index(
     files: dict[str, str], exclude_paths: frozenset[str] | None = None
 ) -> _StatefulIngestor:
-    root = Path(tempfile.mkdtemp()) / "proj"
-    root.mkdir(parents=True)
-    for rel, text in files.items():
-        path = root / rel
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(text, encoding="utf-8")
-    store = _StatefulIngestor()
-    parsers, queries = load_parsers()
-    GraphUpdater(
-        ingestor=store,
-        repo_path=root,
-        parsers=parsers,
-        queries=queries,
-        project_name="proj",
-        exclude_paths=exclude_paths,
-    ).run(force=True)
+    # `TemporaryDirectory`, not `mkdtemp`: this helper runs once per
+    # parametrisation and there are twenty-odd of them, so an unremoved tree
+    # per case accumulates in the system temp directory (CodeRabbit, #1728).
+    # The graph is asserted against the in-memory store, which outlives the
+    # directory, so tearing it down at the end of indexing is safe.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "proj"
+        root.mkdir(parents=True)
+        for rel, text in files.items():
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(text, encoding="utf-8")
+        store = _StatefulIngestor()
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=store,
+            repo_path=root,
+            parsers=parsers,
+            queries=queries,
+            project_name="proj",
+            exclude_paths=exclude_paths,
+        ).run(force=True)
     return store
 
 

--- a/codebase_rag/tests/test_js_ts_module_extension_parity.py
+++ b/codebase_rag/tests/test_js_ts_module_extension_parity.py
@@ -1,0 +1,108 @@
+"""A named import must bind through EVERY JS/TS module extension (#1720).
+
+`_resolve_js_internal_module` decides where a named import's module ends and
+its symbol begins: given the deferred target `proj.pkg.go` it must return
+`proj.pkg` so the alias map can redirect that to the real `proj.pkg.index`
+Module node. It made that decision by probing the filesystem against a
+RESTATED list of four extensions -- `.js`, `.ts`, `.jsx`, `.tsx` -- rather than
+against `JS_TS_MODULE_EXTENSIONS`, which is the set every other part of the
+JS/TS path already uses.
+
+So for a module written in any of the other six forms the probe found nothing,
+the symbol segment was never stripped, and `proj.pkg.go` was carried forward to
+verification, where it matches no Module node and is dropped as an unverifiable
+internal target. The import edge simply vanishes.
+
+This is the same defect shape as the `.mts`/`.cts` omission from
+`DIRECTORY_MODULE_STEM_BY_EXT` found in the #1682 review: a subset of a
+canonical set, restated at a second site, silently drifting from it. The fix
+there and here is the same -- ask the one helper that owns the question.
+
+Scope note, because #1720 framed this as a `.d.ts` problem: declarations are
+how it was FOUND, not the extent of it. `.mjs`, `.cjs`, `.mts` and `.cts` are
+ordinary implementation files with no declaration involvement and they were
+equally broken, which is why the parametrisation below covers the whole set
+rather than the three `.d.*` forms.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+# A named import through a directory entry point: the shape that needs the
+# module/symbol split to be made correctly.
+MAIN = "import { go } from './pkg';\nexport const r = go;\n"
+IMPL = "export function go() { return 1; }\n"
+DECL = "export declare function go(): number;\n"
+
+
+def _index(files: dict[str, str]) -> _StatefulIngestor:
+    root = Path(tempfile.mkdtemp()) / "proj"
+    root.mkdir(parents=True)
+    for rel, text in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+    store = _StatefulIngestor()
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run(force=True)
+    return store
+
+
+def _imports(store: _StatefulIngestor) -> list[tuple[Any, ...]]:
+    return [edge for edge in store.edges if edge[2] == "IMPORTS"]
+
+
+def _modules(store: _StatefulIngestor) -> list[str]:
+    return sorted(
+        props[cs.KEY_QUALIFIED_NAME]
+        for (label, _uid), props in store.nodes.items()
+        if label == cs.NodeLabel.MODULE.value
+    )
+
+
+class TestEveryModuleExtensionBindsANamedImport:
+    @pytest.mark.parametrize("ext", cs.JS_TS_MODULE_EXTENSIONS)
+    def test_a_directory_entry_point_resolves(self, ext: str) -> None:
+        """`import { go } from './pkg'` with `pkg/index<ext>` as the entry point.
+
+        Asserts the edge's TARGET, not merely that some edge exists: carrying
+        the unstripped `proj.pkg.go` forward produces no edge at all, but a
+        different wrong split could produce an edge to the wrong node, and
+        "an edge exists" cannot tell those apart.
+        """
+        body = DECL if ext.startswith(".d.") else IMPL
+        store = _index({"main.ts": MAIN, f"pkg/index{ext}": body})
+
+        assert "proj.pkg.index" in _modules(store), _modules(store)
+        assert _imports(store) == [
+            ("Module", "proj.main", "IMPORTS", "Module", "proj.pkg.index")
+        ], f"{ext}: {_imports(store)}"
+
+    def test_an_import_of_a_directory_with_no_entry_point_binds_nothing(self) -> None:
+        """The control that stops the rule collapsing into "always strip".
+
+        If the module/symbol split stopped consulting the filesystem and simply
+        dropped the last segment, every parametrisation above would pass and
+        the resolver would invent module targets for directories that hold no
+        entry point at all. Here `pkg/` exists but has no `index.*`, so there
+        is no module to bind to and no edge may be emitted.
+        """
+        store = _index({"main.ts": MAIN, "pkg/other.ts": IMPL})
+
+        assert _imports(store) == [], _imports(store)

--- a/codebase_rag/tests/test_processor_factory.py
+++ b/codebase_rag/tests/test_processor_factory.py
@@ -390,3 +390,77 @@ class TestSharedState:
         assert "test.module.func" in definition_proc.function_registry
         assert "test.module.func" in type_inf.function_registry
         assert "test.module.func" in call_proc._resolver.function_registry
+
+
+class TestTheUnignorePolicyReachesEveryProcessor:
+    """Generated-source discovery re-resolves the unignore policy per run.
+
+    Every processor that prunes must prune identically, or a sweep reads files
+    the indexer skipped (issue #1088). That propagation used to be two named
+    assignments in ``_register_generated_sources``, which is an inventory that
+    FAILS OPEN: a processor added later silently keeps the stale policy and no
+    assertion anywhere notices. The declaration tie-break (#1720) became the
+    third consumer and was missed exactly that way -- under a stale policy it
+    rejects an implementation inside a rescued generated-source tree, so the
+    declaration claims the qualified name importers resolve to and displaces
+    the file holding the callable definitions (Greptile P1, PR #1728).
+
+    Written against the DERIVED set rather than a named list, so a fourth
+    consumer is covered without editing these tests.
+    """
+
+    def test_every_built_processor_carrying_the_policy_is_updated(
+        self, factory: ProcessorFactory
+    ) -> None:
+        # Build them all, so none escapes the check by never existing.
+        factory.import_processor
+        factory.structure_processor
+        factory.definition_processor
+        factory.type_inference
+        factory.call_processor
+        resolved = frozenset({"target/generated-sources/annotations/**"})
+
+        updated = factory.propagate_unignore_paths(resolved)
+
+        carriers = [
+            slot
+            for slot in factory.__slots__
+            if slot.startswith("_")
+            and getattr(factory, slot, None) is not None
+            and hasattr(getattr(factory, slot), "unignore_paths")
+        ]
+        # The precondition: something carries the policy at all, so a green
+        # result cannot come from an empty set of carriers on both sides.
+        assert carriers, factory.__slots__
+        assert sorted(updated) == sorted(carriers)
+        for slot in carriers:
+            assert getattr(factory, slot).unignore_paths == resolved, slot
+
+    def test_the_definition_processor_is_one_of_them(
+        self, factory: ProcessorFactory
+    ) -> None:
+        """Named explicitly because it is the consumer that was missed.
+
+        The enumeration above stays green if ``DefinitionProcessor`` simply
+        stops carrying ``unignore_paths`` -- it drops out of ``carriers`` on
+        both sides of the comparison. This pins that it IS a carrier, which is
+        what the #1720 tie-break depends on.
+        """
+        proc = factory.definition_processor
+        resolved = frozenset({"build/generated/sources/**"})
+
+        factory.propagate_unignore_paths(resolved)
+
+        assert proc.unignore_paths == resolved
+
+    def test_a_processor_built_after_the_update_sees_the_new_policy(
+        self, factory: ProcessorFactory
+    ) -> None:
+        """The other half: a lazily-built processor must not resurrect the old
+        policy from a stale factory field."""
+        resolved = frozenset({"target/generated-sources/annotations/**"})
+
+        factory.propagate_unignore_paths(resolved)
+
+        assert factory._definition_processor is None
+        assert factory.definition_processor.unignore_paths == resolved

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -222,9 +222,14 @@ class TestADeclarationNeverStealsTheImplementationsName:
     order, which is why both parametrisations below must pass.
     """
 
-    def _processor(self) -> DefinitionProcessor:
+    def _processor(self, repo: Path) -> DefinitionProcessor:
         proc = DefinitionProcessor.__new__(DefinitionProcessor)
         proc.module_qn_to_file_path = {}
+        # The declaration tie-break consults the indexer's eligibility policy,
+        # so the processor needs the repo root and the (here empty) filters.
+        proc.repo_path = repo
+        proc.exclude_paths = None
+        proc.unignore_paths = None
         return proc
 
     def _assign(self, proc: DefinitionProcessor, repo: Path, path: Path) -> str:
@@ -244,7 +249,7 @@ class TestADeclarationNeverStealsTheImplementationsName:
         impl.write_text("export const a = 1;\n", encoding="utf-8")
         order = [decl, impl] if declaration_first else [impl, decl]
 
-        proc = self._processor()
+        proc = self._processor(tmp_path)
         qns = {path.name: self._assign(proc, tmp_path, path) for path in order}
 
         assert qns["foo.ts"] == f"{PROJECT}.foo", qns
@@ -264,7 +269,7 @@ class TestADeclarationNeverStealsTheImplementationsName:
         decl = tmp_path / "foo.d.ts"
         decl.write_text("export declare const a: number;\n", encoding="utf-8")
 
-        proc = self._processor()
+        proc = self._processor(tmp_path)
 
         assert self._assign(proc, tmp_path, decl) == f"{PROJECT}.foo"
 
@@ -277,7 +282,7 @@ class TestADeclarationNeverStealsTheImplementationsName:
         decl.write_text("export declare const a: number;\n", encoding="utf-8")
         other.write_text("export const b = 2;\n", encoding="utf-8")
 
-        proc = self._processor()
+        proc = self._processor(tmp_path)
 
         assert self._assign(proc, tmp_path, decl) == f"{PROJECT}.foo"
 
@@ -295,7 +300,7 @@ class TestADeclarationNeverStealsTheImplementationsName:
         first.write_text("int x;\n", encoding="utf-8")
         second.write_text("x = 1\n", encoding="utf-8")
 
-        proc = self._processor()
+        proc = self._processor(tmp_path)
         qns = {p.name: self._assign(proc, tmp_path, p) for p in (first, second)}
 
         assert qns["foo.cpp"] == f"{PROJECT}.foo", qns

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -23,11 +23,16 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from codebase_rag.graph_updater import GraphUpdater
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater, _module_key
 from codebase_rag.parsers.cpp_frontend.qn import build_module_qn_map
+from codebase_rag.parsers.definition_processor import DefinitionProcessor
 from codebase_rag.utils.path_utils import (
     _walk_dir_keys,
     base_module_qn,
+    module_stem,
     walk_eligible_files,
 )
 
@@ -141,6 +146,55 @@ class TestTheBaseModuleQnIsSharedNotMirrored:
         assert base_module_qn(Path("pkg/__init__.py"), PROJECT) == f"{PROJECT}.pkg"
         assert base_module_qn(Path("x/mod.rs"), PROJECT) == f"{PROJECT}.x"
 
+    def test_a_declaration_file_loses_its_whole_compound_suffix(self) -> None:
+        """`.d.ts` is ONE extension, not `.ts` after a `.d` segment.
+
+        The single-suffix rule indexed `pkg/index.d.ts` as `proj.pkg.index.d`,
+        while `JS_TS_MODULE_EXTENSIONS` lists `.d.ts` and the JS/TS resolver
+        treats that file as the `./pkg` entry point and looks for
+        `proj.pkg.index`. The file was stored under a name nothing asks for
+        (issue #1720).
+        """
+        assert base_module_qn(Path("pkg/index.d.ts"), PROJECT) == f"{PROJECT}.pkg.index"
+        assert base_module_qn(Path("t/util.d.mts"), PROJECT) == f"{PROJECT}.t.util"
+        assert base_module_qn(Path("t/util.d.cts"), PROJECT) == f"{PROJECT}.t.util"
+
+    def test_every_declaration_extension_is_stripped_whole(self) -> None:
+        """The forcing function: a `.d.*` added to the language set later must
+        not fall back to the single-suffix rule and reintroduce #1720.
+
+        The `".d."` here is deliberately a literal rather than
+        ``cs.DECLARATION_EXT_PREFIX``. The production code partitions the
+        extension set with that constant, so selecting the cases with it too
+        would make this test agree with the code by construction: a wrong
+        constant would select a wrong set and still pass. The literal is the
+        independent statement of which extensions are declarations.
+        """
+        leftovers = {
+            ext: base_module_qn(Path(f"pkg/m{ext}"), PROJECT)
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+            if ext.startswith(".d.")
+        }
+        assert leftovers, "no declaration extensions in the language set to check"
+        assert all(qn == f"{PROJECT}.pkg.m" for qn in leftovers.values()), leftovers
+
+    def test_the_two_extension_strippers_agree(self) -> None:
+        """``graph_updater._module_key`` strips the same set, separately.
+
+        It was written for the specifier-waiter lookup (#1714) before this
+        helper existed, so the rule now has two implementations. They must
+        agree on every module extension: `_module_key` decides what an
+        importer's specifier resolves to and `module_stem` decides what the
+        file is stored as, so a divergence is #1720 again in the other
+        direction -- a waiter asking for a name the file was never given.
+        """
+        divergent = {
+            ext: (_module_key(f"pkg/m{ext}"), f"pkg/{module_stem(f'm{ext}')}")
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+            if _module_key(f"pkg/m{ext}") != f"pkg/{module_stem(f'm{ext}')}"
+        }
+        assert not divergent, divergent
+
     def test_only_the_final_suffix_is_stripped(self) -> None:
         # `.tar.gz` loses only `.gz`; a dotted DIRECTORY keeps its dots.
         assert base_module_qn(Path("weird.tar.gz"), PROJECT) == f"{PROJECT}.weird.tar"
@@ -148,6 +202,104 @@ class TestTheBaseModuleQnIsSharedNotMirrored:
             base_module_qn(Path("dir.with.dots/f.py"), PROJECT)
             == f"{PROJECT}.dir.with.dots.f"
         )
+
+
+class TestADeclarationNeverStealsTheImplementationsName:
+    """Stripping `.d.ts` whole is not safe on its own -- it CAUSES a collision.
+
+    Before #1720, `foo.d.ts` derived `proj.foo.d` and `foo.ts` derived
+    `proj.foo`, so they never met. Making the declaration strip to `proj.foo`
+    puts both files on one name, and the pre-existing rule awards it to
+    whichever is walked FIRST. Within a directory the walk is ascending, and
+    `"foo.d.ts" < "foo.ts"`, so the stub would win every time: the type-only
+    file would own the name every importer resolves to, and the implementation
+    -- the file that actually holds the callable definitions -- would be
+    displaced to `proj.foo.ts`, which nothing asks for.
+
+    That is exactly the regression that closed PR #1721, caught only because
+    the partial fix was tried and measured. So the tie is broken on the
+    FILESYSTEM (does an implementation sibling exist?) rather than on walk
+    order, which is why both parametrisations below must pass.
+    """
+
+    def _processor(self) -> DefinitionProcessor:
+        proc = DefinitionProcessor.__new__(DefinitionProcessor)
+        proc.module_qn_to_file_path = {}
+        return proc
+
+    def _assign(self, proc: DefinitionProcessor, repo: Path, path: Path) -> str:
+        qn = proc._disambiguate_module_qn(
+            base_module_qn(path.relative_to(repo), PROJECT), path
+        )
+        proc.module_qn_to_file_path[qn] = path
+        return qn
+
+    @pytest.mark.parametrize("declaration_first", [True, False])
+    def test_the_implementation_wins_in_either_walk_order(
+        self, tmp_path: Path, declaration_first: bool
+    ) -> None:
+        decl = tmp_path / "foo.d.ts"
+        impl = tmp_path / "foo.ts"
+        decl.write_text("export declare const a: number;\n", encoding="utf-8")
+        impl.write_text("export const a = 1;\n", encoding="utf-8")
+        order = [decl, impl] if declaration_first else [impl, decl]
+
+        proc = self._processor()
+        qns = {path.name: self._assign(proc, tmp_path, path) for path in order}
+
+        assert qns["foo.ts"] == f"{PROJECT}.foo", qns
+        assert qns["foo.d.ts"] != f"{PROJECT}.foo", qns
+        # ...and the loser still gets a name of its own rather than colliding.
+        assert len(set(qns.values())) == 2, qns
+
+    def test_a_lone_declaration_still_takes_the_bare_qn(self, tmp_path: Path) -> None:
+        """The control, and the reason the rule is not "declarations always lose".
+
+        A published package whose only entry point is a `.d.ts` is the ordinary
+        case for `@types/*` and for a compiled library shipped beside its
+        types. If the yield were unconditional, that file would be stored under
+        a name no importer resolves to and #1720 would be reintroduced for
+        every repo that has no matching implementation on disk.
+        """
+        decl = tmp_path / "foo.d.ts"
+        decl.write_text("export declare const a: number;\n", encoding="utf-8")
+
+        proc = self._processor()
+
+        assert self._assign(proc, tmp_path, decl) == f"{PROJECT}.foo"
+
+    def test_an_unrelated_neighbour_is_not_an_implementation_sibling(
+        self, tmp_path: Path
+    ) -> None:
+        """The yield keys on the STEM, not on "some .ts exists nearby"."""
+        decl = tmp_path / "foo.d.ts"
+        other = tmp_path / "bar.ts"
+        decl.write_text("export declare const a: number;\n", encoding="utf-8")
+        other.write_text("export const b = 2;\n", encoding="utf-8")
+
+        proc = self._processor()
+
+        assert self._assign(proc, tmp_path, decl) == f"{PROJECT}.foo"
+
+    def test_a_plain_same_stem_collision_still_goes_to_the_first_seen(
+        self, tmp_path: Path
+    ) -> None:
+        """The declaration rule must not disturb the general case (#1025).
+
+        `foo.py` and `foo.cpp` still collide, and the first walked still wins.
+        Without this, narrowing the change to declarations would be untested
+        and a broader rewrite of the tie-break would look equally green.
+        """
+        first = tmp_path / "foo.cpp"
+        second = tmp_path / "foo.py"
+        first.write_text("int x;\n", encoding="utf-8")
+        second.write_text("x = 1\n", encoding="utf-8")
+
+        proc = self._processor()
+        qns = {p.name: self._assign(proc, tmp_path, p) for p in (first, second)}
+
+        assert qns["foo.cpp"] == f"{PROJECT}.foo", qns
+        assert qns["foo.py"] == f"{PROJECT}.foo.py", qns
 
 
 class TestOneUnignorePatternIsEnoughToRescue:

--- a/codebase_rag/tests/test_qn_walk_order_parity.py
+++ b/codebase_rag/tests/test_qn_walk_order_parity.py
@@ -131,6 +131,68 @@ class TestTheQnMapWalksInIndexerOrder:
         assert list(qn_map) == _indexer_order(tmp_path, unignore_paths=rescues)
 
 
+class TestTheQnMapAssignsTheSAMEQnsNotJustTheSameOrder:
+    """Order parity is not qn parity once the tie-break stops being order.
+
+    ``build_module_qn_map`` says it mirrors ``_disambiguate_module_qn``, and
+    every existing check of that claim compares WALK ORDER or the SET of file
+    keys. Both are satisfied by two implementations that hand the same files
+    different qualified names, which is the #1025 failure exactly: one module,
+    two nodes, no error.
+
+    That gap was latent while both sides broke ties on "first walked". The
+    declaration rule (#1720) makes the indexer break one tie on the filesystem
+    instead, so the mirror is now a claim about behaviour that nothing checked.
+    This compares the assignments themselves.
+
+    The map walks EVERY eligible file, not only C++ ones -- it shares the
+    indexer's walk by construction -- so a `.d.ts` is in it and can claim a
+    base qn out from under another file.
+    """
+
+    @staticmethod
+    def _indexer_qns(repo: Path) -> dict[str, str]:
+        """What the tree-sitter pass would name each file, in walk order."""
+        proc = DefinitionProcessor.__new__(DefinitionProcessor)
+        proc.module_qn_to_file_path = {}
+        proc.repo_path = repo
+        proc.exclude_paths = None
+        proc.unignore_paths = None
+        assigned: dict[str, str] = {}
+        for _dirpath, _fname, rel in walk_eligible_files(repo):
+            path = repo / rel
+            qn = proc._disambiguate_module_qn(base_module_qn(Path(rel), PROJECT), path)
+            proc.module_qn_to_file_path[qn] = path
+            assigned[rel] = qn
+        return assigned
+
+    def test_a_declaration_beside_its_implementation_agrees(
+        self, tmp_path: Path
+    ) -> None:
+        # `"foo.d.ts" < "foo.ts"`, so a first-walked-wins map gives the stub
+        # `proj.foo` while the indexer now gives it to the implementation.
+        _write(tmp_path, "foo.d.ts", "export declare const a: number;\n")
+        _write(tmp_path, "foo.ts", "export const a = 1;\n")
+
+        assert build_module_qn_map(tmp_path, PROJECT) == self._indexer_qns(tmp_path)
+
+    def test_a_lone_declaration_agrees(self, tmp_path: Path) -> None:
+        # The control: with no implementation the declaration keeps the bare
+        # qn on BOTH sides, so a map that simply never yielded would pass the
+        # test above by matching a rule the indexer does not have.
+        _write(tmp_path, "foo.d.ts", "export declare const a: number;\n")
+
+        assert build_module_qn_map(tmp_path, PROJECT) == self._indexer_qns(tmp_path)
+
+    def test_a_plain_extension_collision_agrees(self, tmp_path: Path) -> None:
+        # And the pre-existing rule is unaffected: foo.cpp/foo.h still go to
+        # the first walked, on both sides.
+        _write(tmp_path, "foo.cpp")
+        _write(tmp_path, "foo.h")
+
+        assert build_module_qn_map(tmp_path, PROJECT) == self._indexer_qns(tmp_path)
+
+
 class TestTheBaseModuleQnIsSharedNotMirrored:
     """``__init__.py``/``mod.rs`` name their package, not themselves.
 

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -324,8 +324,13 @@ def declaration_extension(filename: str) -> str | None:
     return None
 
 
-def has_implementation_sibling(path: Path) -> bool:
-    """Does a same-stem file with a NON-declaration module extension exist?
+def has_implementation_sibling(
+    path: Path,
+    repo_path: Path,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> bool:
+    """Will a same-stem NON-declaration module actually be INDEXED?
 
     Asked of the filesystem rather than of the parse registry deliberately.
     The registry answers "has one been seen yet", which depends on walk order;
@@ -333,9 +338,33 @@ def has_implementation_sibling(path: Path) -> bool:
     whole point -- a `.d.ts` sorts before its `.ts` in an ascending walk, so a
     registry-based tie-break hands the shared name to the stub every time
     (issue #1720, and the regression that closed PR #1721).
+
+    But existence alone is too permissive, and the gap is not hypothetical: an
+    excluded `foo.ts` is on disk and will never be a node, so yielding
+    `proj.foo` to it leaves NOTHING owning the name imports of `./foo` resolve
+    to -- #1720 reintroduced by its own fix, under a configuration the first
+    version of this predicate could not see (Greptile P1 on PR #1728).
+
+    So candidates are filtered through `should_skip_path`, the same predicate
+    the repository walk prunes with. Sharing it is what stops this from
+    disagreeing with the indexer about which files exist (issue #1088); asking
+    the question a second way here is how the two would drift apart.
     """
     stem = module_stem(path.name)
-    return any((path.parent / f"{stem}{ext}").is_file() for ext in _IMPLEMENTATION_EXTS)
+    for ext in _IMPLEMENTATION_EXTS:
+        candidate = path.parent / f"{stem}{ext}"
+        if not candidate.is_file():
+            continue
+        if should_skip_path(
+            candidate,
+            repo_path,
+            exclude_paths=exclude_paths,
+            unignore_paths=unignore_paths,
+            is_file=True,
+        ):
+            continue
+        return True
+    return False
 
 
 def base_module_qn(rel_path: Path, project_name: str) -> str:

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -272,6 +272,72 @@ def should_skip_rel_file(
     return has_ignored_dir_part(dir_parts)
 
 
+# Longest first, so `.d.ts` is tried before the `.ts` it ends with. Derived
+# from the language set rather than restated, so an extension added there
+# cannot silently fall through to the single-suffix rule below (issue #1720).
+_MODULE_EXTS_LONGEST_FIRST: tuple[str, ...] = tuple(
+    sorted(cs.JS_TS_MODULE_EXTENSIONS, key=str.__len__, reverse=True)
+)
+
+
+def module_stem(filename: str) -> str:
+    """The filename with its MODULE extension removed, compound ones included.
+
+    ``Path.with_suffix("")`` strips one dot-segment, which is right for `.py`
+    and wrong for `.d.ts`: TypeScript declaration files carry a two-segment
+    extension that the language treats as a unit, and every other part of cgr
+    already does too -- ``JS_TS_MODULE_EXTENSIONS`` lists `.d.ts`, and the
+    JS/TS resolver looks up `pkg/index.d.ts` as the `pkg` entry point. Only the
+    qn derivation disagreed, storing it as `proj.pkg.index.d`, a name no
+    importer ever asks for, so its definitions were unreachable (issue #1720).
+
+    Extensions outside the language set keep the single-suffix behaviour:
+    `archive.tar.gz` is not a module named `archive`, and a `.d` in some other
+    language is not a declaration marker.
+    """
+    for ext in _MODULE_EXTS_LONGEST_FIRST:
+        if filename.endswith(ext) and len(filename) > len(ext):
+            return filename[: -len(ext)]
+    return Path(filename).stem
+
+
+_DECLARATION_EXTS: tuple[str, ...] = tuple(
+    ext
+    for ext in _MODULE_EXTS_LONGEST_FIRST
+    if ext.startswith(cs.DECLARATION_EXT_PREFIX)
+)
+_IMPLEMENTATION_EXTS: tuple[str, ...] = tuple(
+    ext for ext in _MODULE_EXTS_LONGEST_FIRST if ext not in _DECLARATION_EXTS
+)
+
+
+def declaration_extension(filename: str) -> str | None:
+    """The TYPE-ONLY module extension this file carries, if any.
+
+    Partitioned from the one language set rather than listed again, so a
+    declaration form added to ``JS_TS_MODULE_EXTENSIONS`` is classified here
+    without a second edit.
+    """
+    for ext in _DECLARATION_EXTS:
+        if filename.endswith(ext) and len(filename) > len(ext):
+            return ext
+    return None
+
+
+def has_implementation_sibling(path: Path) -> bool:
+    """Does a same-stem file with a NON-declaration module extension exist?
+
+    Asked of the filesystem rather than of the parse registry deliberately.
+    The registry answers "has one been seen yet", which depends on walk order;
+    the disk answers "does one exist", which does not. The distinction is the
+    whole point -- a `.d.ts` sorts before its `.ts` in an ascending walk, so a
+    registry-based tie-break hands the shared name to the stub every time
+    (issue #1720, and the regression that closed PR #1721).
+    """
+    stem = module_stem(path.name)
+    return any((path.parent / f"{stem}{ext}").is_file() for ext in _IMPLEMENTATION_EXTS)
+
+
 def base_module_qn(rel_path: Path, project_name: str) -> str:
     """The module qualified name for a file, BEFORE collision disambiguation.
 
@@ -286,7 +352,7 @@ def base_module_qn(rel_path: Path, project_name: str) -> str:
     if rel_path.name in (cs.INIT_PY, cs.MOD_RS):
         parts = rel_path.parent.parts
     else:
-        parts = rel_path.with_suffix("").parts
+        parts = (*rel_path.parent.parts, module_stem(rel_path.name))
     return cs.SEPARATOR_DOT.join([project_name, *parts])
 
 


### PR DESCRIPTION
Closes #1720.

A TypeScript declaration file was stored under a module qualified name nothing resolves to, so its definitions were unreachable from any importer.

Three changes. The first two are genuinely coupled — the first alone is a regression. The third turned out **not** to be coupled at all, and to be considerably wider than the issue describes.

## 1. `.d.ts` is one extension, not `.ts` after a `.d` segment

`base_module_qn` derived the stem with `Path.with_suffix("")`, which strips one dot-segment:

```
pkg/index.d.ts   ->  proj.pkg.index.d      (nothing asks for this)
t/util.d.mts     ->  proj.t.util.d
```

Everywhere else in cgr already treats `.d.ts` as a unit: `JS_TS_MODULE_EXTENSIONS` lists it, and the JS/TS resolver looks up `pkg/index.d.ts` as the `./pkg` entry point under `proj.pkg.index`. Only the qn derivation disagreed. New `module_stem` helper strips the longest matching module extension; extensions outside the language set keep the single-suffix behaviour, so `archive.tar.gz` is still `archive.tar`.

## 2. The implementation, not the stub, owns the shared name

Change 1 on its own **creates** a collision: `foo.d.ts` and `foo.ts` now derive the same qn, and the pre-existing rule awards a collision to whichever file is walked first. The within-directory walk is ascending and `"foo.d.ts" < "foo.ts"`, so the type-only stub wins every time:

```
{'foo.d.ts': 'proj.foo', 'foo.ts': 'proj.foo.ts'}
```

That is the regression that closed PR #1721, reproduced here as a test rather than asserted from memory. The tie is therefore broken on the **filesystem** — does an implementation sibling with this stem exist? — which is a fact about the repository rather than about parse order. A declaration with no implementation still takes the bare name, because for `@types/*` packages and for a library shipped beside its types that file *is* the module.

**The parametrisation is doing the work here.** Only the declaration-first order fails; implementation-first passes on the broken code, on the plausible wrong fix, and on the real fix alike. A single-order test — the one I would have written by default — would have been green throughout.

## 3. A named import must bind through every module extension, not four

Not coupled to the above, and the issue was wrong to say it was. With change 1 in place the qns for a lone `pkg/index.d.ts` are byte-identical to the working `.ts` control, and the edge still vanished:

```
CONTROL pkg/index.ts    modules ['proj.main','proj.pkg.index']  funcs ['proj.pkg.index.go']  IMPORTS 1
SUBJECT pkg/index.d.ts  modules ['proj.main','proj.pkg.index']  funcs ['proj.pkg.index.go']  IMPORTS 0
```

Same names, same deferred target. Wrapping the resolver gave up the cause in one line:

```
CONTROL  _resolve_module_path('proj.pkg.go') -> 'proj.pkg'       -> alias -> proj.pkg.index
SUBJECT  _resolve_module_path('proj.pkg.go') -> 'proj.pkg.go'    -> matches nothing, dropped
```

`_resolve_js_internal_module` decides where the module ends and the imported symbol begins by probing the disk, and it did so against a restated `(.js, .ts, .jsx, .tsx)` — a four-element subset of the ten in `JS_TS_MODULE_EXTENSIONS`. On a miss the symbol segment is never stripped, so `proj.pkg.go` reaches verification, matches no Module node, and the IMPORTS edge is dropped silently.

Measured across the whole canonical set:

```
7 failed, 5 passed
broken: .d.ts .d.mts .d.cts .mts .cts .mjs .cjs
worked: .js .ts .jsx .tsx
```

**Four of the seven have nothing to do with declarations.** `.mjs`, `.cjs`, `.mts` and `.cts` are ordinary implementation files, and every named import through one of them has been losing its IMPORTS edge. Declarations are how the defect was found, not its extent.

Fixed by delegating to `_js_module_rel_on_disk`, which already owns "does this name a module on disk" for two other callers, so the rule has one implementation instead of two.

This is the third instance of one shape: a canonical extension set restated at a second site and drifting from it — `DIRECTORY_MODULE_STEM_BY_EXT` missing `.mts`/`.cts` (#1682 review), `graph_updater._module_key` duplicating the strip rule (#1714), and this. A test now pins the two surviving strippers equal across the whole set.

## Verification

`357 passed, 1 xfailed` across 18 affected files — JS/TS imports, import resolution and edge verification, reingest, the C++ qn map, the parser fingerprint.

Every mutation below printed its own diff before the tests ran, because a mutation that silently fails to apply produces a green run indistinguishable from "the fix does nothing", and each was verified restored to a zero-line diff afterwards.

Changes 1 and 2:

```
component neutered  module_stem back to Path(filename).stem        5 failed / 16 passed
rule widened        declaration yields with or without a sibling   2 failed / 19 passed
component removed   declaration branch deleted                     1 failed / 20 passed
CONTROL             sibling lookup answers from the registry       1 failed / 20 passed
```

The last is the fix I would naturally have written — ask the parse registry whether an implementation has been seen — which is right in one walk order and wrong in the other. It is killed only by the declaration-first parametrisation.

### Two mutants survived the first pass on change 3

Reported because the fix is only as good as the tests, and these say something about them:

```
                                        first pass    after
fix reverted to the four-element list     7 failed    14 failed
component neutered (file branch)         12 PASSED    11 failed
plausible wrong fix (.d.* added)          4 failed     8 failed
over-strip (never ask the filesystem)    12 PASSED     1 failed
```

Both survivors were one-dimensional fixtures, not weak assertions.

Every case routed through a *directory* entry point, so the file branch of the helper the fix delegates to was never exercised and could be deleted outright. Fixed with a flat-file parametrisation across the whole extension set.

Worse, the control written specifically to catch over-stripping did not: it asserted no edge in a fixture where the broken reading also produces no edge, since `proj.pkg` is no more bindable than `proj.pkg.go`. **An absence assertion discriminates only where the wrong answer would produce a presence.** The replacement gives the two readings a real target to disagree about — a Python `pkg/__init__.py` registers `proj.pkg` while `pkg/` holds no JS/TS entry point — so over-stripping now emits a visible wrong edge:

```
assert [('Module','proj.main','IMPORTS','Module','proj.pkg')] == []
```

The assertion is unchanged. Only the fixture moved.

The third mutation is the competent wrong answer: fixing #1720 exactly as worded, by adding the three `.d.*` forms to the hardcoded list, is correct for every case the issue describes and still silently wrong for the four non-declaration extensions.

### Review

Reviewed inline against `origin/main` rather than by the usual local reviewer agent, which this session is not permitted to spawn. That round found one real defect, fixed in `2ec04116`: the declaration branch *returned* its yielded name, skipping the collision check below it. The yielded name is an ordinary qn and can itself collide — `foo/d/ts.py` derives the same `proj.foo.d.ts` — so it now rewrites the candidate and falls through. A fix whose own output bypassed the guard that exists for outputs of that shape.

This is one local round, not a loop to 5/5.

### Greptile P1 — eligibility, not existence (`3b63c7f9`)

`has_implementation_sibling` asked whether an implementation **exists**; the tie-break needs to know whether one will be **indexed**. Those differ exactly under the indexer's exclude/unignore policy: exclude `foo.ts`, leave `foo.d.ts` eligible, and the declaration yields `proj.foo` to a file that never becomes a node, so nothing owns the name `./foo` resolves to. #1720 reintroduced by its own fix.

Reproduced before fixing — `modules = ['proj.foo.d.ts', 'proj.main']` — then fixed by routing candidates through `should_skip_path`, the same predicate the repository walk prunes with, with the filters plumbed from the factory that already supplies them to `ImportProcessor` and `StructureProcessor`.

The test drives `GraphUpdater(exclude_paths=...)` end to end so it pins the wiring too, and opens with a precondition that the exclude actually took.

**This is the third single-valued axis this PR has produced, and the only one I did not find myself.** Every fixture I had indexed everything, so "exists" and "will be indexed" held the same value throughout and no assertion could separate them. Two were caught by mutation; this one needed a reviewer.

`423 passed, 1 xfailed` across the files touching `DefinitionProcessor` and the import/qn set.

**What this PR does not establish.** The end-to-end evidence runs against the in-memory `_StatefulIngestor` double, not a real Memgraph. Behaviour against the live database is covered only by CI, which is the authoritative instrument here; local green does not speak to it.

`path_utils.py` is a parser-fingerprint input, so this invalidates hash caches on merge. That is intended — the qns it produces have changed.

Pushed after a single local review round, not a loop to 5/5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and TypeScript module resolution across all supported extensions, including declaration, module, and CommonJS files.
  * Fixed named imports that could previously be missed or linked to incorrect modules.
  * Ensured declaration files use the correct qualified name when an indexable implementation exists, while standalone or excluded implementations remain resolvable.
  * Improved consistency when applying path inclusion and exclusion rules during indexing.

* **Tests**
  * Added coverage for extension parity, declaration handling, path filtering, qualified-name assignment, and import edge accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->