### PR TITLE
fix: preserve nested-class construction for optional receivers

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -491,7 +491,7 @@ class CallResolver:
         var_type = local_var_types.get(head)
         if not var_type:
             return False
-        typed_qn = self._resolve_class_name(var_type, module_qn)
+        typed_qn = self._resolve_class_name(self._strip_optional(var_type), module_qn)
         return bool(
             typed_qn
             and self.function_registry.get(typed_qn) == cs.NodeLabel.CLASS

--- a/codebase_rag/tests/test_self_nested_class_construction.py
+++ b/codebase_rag/tests/test_self_nested_class_construction.py
@@ -59,7 +59,7 @@ class Outer:
     def make(self):
         return self.Inner(1)
 
-
+    def make_optional(o: Outer | None): return o.Inner(1)
 class Base:
     def render(self):
         return "base"
@@ -95,7 +95,7 @@ class TestSelfNestedClassConstruction:
         # The other half: removing the bad edge must not remove the good ones.
         create_and_run_updater(nested_project, mock_ingestor)
         assert (
-            "selfnested.m.Outer.make",
+            "selfnested.m.Outer.make_optional",
             "selfnested.m.Outer.Inner",
         ) in _source_target_pairs(mock_ingestor, RelationshipType.INSTANTIATES)
         assert (

--- a/codebase_rag/tests/test_self_nested_class_construction.py
+++ b/codebase_rag/tests/test_self_nested_class_construction.py
@@ -95,9 +95,11 @@ class TestSelfNestedClassConstruction:
         # The other half: removing the bad edge must not remove the good ones.
         create_and_run_updater(nested_project, mock_ingestor)
         assert (
-            "selfnested.m.Outer.make_optional",
+            "selfnested.m.Outer.make",
             "selfnested.m.Outer.Inner",
         ) in _source_target_pairs(mock_ingestor, RelationshipType.INSTANTIATES)
+        edges = _source_target_pairs(mock_ingestor, RelationshipType.INSTANTIATES)
+        assert ("selfnested.m.Outer.make_optional", "selfnested.m.Outer.Inner") in edges
         assert (
             "selfnested.m.Outer.make",
             "selfnested.m.Outer.Inner.__init__",


### PR DESCRIPTION
## Summary

- Normalize optional Python receiver annotations before deciding whether a nested class is constructed.
- Cover `o: Outer | None` constructing `Outer.Inner`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Fixes #1680

## Test Plan

- [x] Unit tests pass (`uv run pytest -q codebase_rag/tests/test_self_nested_class_construction.py codebase_rag/tests/test_call_resolver.py`)
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [ ] Manual testing (describe below)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nested-class construction now resolves correctly when the receiver type is optional, such as `X | None`.

* **Tests**
  * Added coverage confirming that nested-class construction from an optional receiver is represented correctly in the graph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->