### PR TITLE
fix: parse .mxx C++ module interfaces and derive the module set from the parsed set

### DIFF
--- a/codebase_rag/constants/ast_cpp.py
+++ b/codebase_rag/constants/ast_cpp.py
@@ -51,7 +51,6 @@ class CppNodeType(StrEnum):
     TYPE_DESCRIPTOR = "type_descriptor"
 
 
-CPP_MODULE_EXTENSIONS = (".ixx", ".cppm", ".ccm", ".mxx")
 CPP_MODULE_PATH_MARKERS = frozenset({"interfaces", "modules"})
 
 # C++ module declaration prefixes

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -43,6 +43,7 @@ EXT_HH = ".hh"
 EXT_IXX = ".ixx"
 EXT_CPPM = ".cppm"
 EXT_CCM = ".ccm"
+EXT_MXX = ".mxx"
 EXT_C = ".c"
 EXT_PHP = ".php"
 EXT_LUA = ".lua"
@@ -81,7 +82,15 @@ CPP_EXTENSIONS = (
     EXT_IXX,
     EXT_CPPM,
     EXT_CCM,
+    EXT_MXX,
 )
+# C++ module interface units, a subset of CPP_EXTENSIONS by construction. This
+# used to be a second literal list in constants/ast_cpp.py and it drifted:
+# `.mxx` was named there and parsed by nothing, so a `.mxx` interface produced
+# no Module and no ModuleInterface and its implementation units resolved
+# against nothing (issue #1727). Spelled from the named constants so the two
+# sets cannot disagree again; test_cpp_module_extension_parity pins it.
+CPP_MODULE_EXTENSIONS = (EXT_IXX, EXT_CPPM, EXT_CCM, EXT_MXX)
 # Translation-unit sources: only these can define a linkable OS entry point;
 # headers and C++ module interface files never are the entry unit.
 C_CPP_SOURCE_EXTENSIONS = (EXT_C, EXT_CPP, EXT_CC, EXT_CXX)

--- a/codebase_rag/tests/test_cpp_module_extension_parity.py
+++ b/codebase_rag/tests/test_cpp_module_extension_parity.py
@@ -1,0 +1,95 @@
+"""Every C++ module-interface extension must also be a parsed C++ extension.
+
+`CPP_MODULE_EXTENSIONS` says which suffixes mark a C++ module interface unit;
+`CPP_EXTENSIONS` is what `language_spec.py` registers as C++ and therefore
+decides which files are parsed at all. They were two separate literal lists,
+and they disagreed: `.mxx` was a module extension parsed by nothing, so a
+`.mxx` interface produced no `Module`, no `ModuleInterface`, and any
+`module X;` implementation unit pointing at it had nothing to resolve against
+(issue #1727).
+
+Same shape as the JS/TS restatement in #1720: a language extension set spelled
+out a second time drifts from the first without anything noticing. The fix
+defines the module set FROM the parsed set's named constants, and this file
+pins both halves: that the sets agree, and that every module extension really
+is indexed end to end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.language_spec import get_language_for_extension
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+
+def test_every_module_extension_is_a_parsed_cpp_extension() -> None:
+    missing = [ext for ext in cs.CPP_MODULE_EXTENSIONS if ext not in cs.CPP_EXTENSIONS]
+    assert not missing, (
+        f"{missing} are C++ module extensions that no language spec parses, so "
+        "a module interface with that suffix is invisible to the graph"
+    )
+    # The control: the set is not empty and each member is a suffix, so an
+    # empty tuple or a stray bare name could not pass the check above.
+    assert len(cs.CPP_MODULE_EXTENSIONS) >= 4
+    assert all(ext.startswith(".") for ext in cs.CPP_MODULE_EXTENSIONS)
+
+
+@pytest.mark.parametrize("ext", cs.CPP_MODULE_EXTENSIONS)
+def test_every_module_extension_resolves_to_cpp(ext: str) -> None:
+    assert get_language_for_extension(ext) == cs.SupportedLanguage.CPP, (
+        f"{ext} is a C++ module extension claimed by "
+        f"{get_language_for_extension(ext)!r}, not C++"
+    )
+
+
+@pytest.mark.parametrize("ext", cs.CPP_MODULE_EXTENSIONS)
+def test_a_module_interface_with_every_extension_is_indexed(
+    tmp_path: Path, ext: str
+) -> None:
+    """End to end: the interface exists in the graph and its impl resolves to it.
+
+    Asserting the `IMPLEMENTS` edge and not just the `ModuleInterface` node:
+    the edge is what a `module M;` implementation unit needs, and it is the
+    symptom the issue was found by. Parametrised over the whole set rather
+    than `.mxx` alone, so the next extension added to one list and not the
+    other fails here instead of in a user's graph.
+    """
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.CPP not in parsers:
+        pytest.skip("cpp parser not available")
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / f"iface{ext}").write_text(
+        "export module M;\nexport int f();\n", encoding="utf-8"
+    )
+    (root / "impl.cpp").write_text(
+        "module M;\nint f() { return 1; }\n", encoding="utf-8"
+    )
+
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+
+    interfaces = [
+        key for key in store.nodes if key[0] == cs.NodeLabel.MODULE_INTERFACE.value
+    ]
+    assert interfaces, f"no ModuleInterface node for iface{ext}: {sorted(store.nodes)}"
+    implements = [
+        edge for edge in store.edges if edge[2] == cs.RelationshipType.IMPLEMENTS.value
+    ]
+    assert implements, (
+        f"impl.cpp's `module M;` resolved to nothing when the interface is "
+        f"iface{ext}: {sorted(store.edges)}"
+    )

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -13,7 +13,7 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 |--------|------|----------|---------|---------------|-------|-----------------|-------------------|
 | C | Fully Supported | .c | ✓ | ✓ | ✓ | ✓ | Functions, structs, unions, enums, preprocessor includes |
 | C# | Fully Supported | .cs | ✓ | ✓ | ✓ | - | Namespaces (block and file-scoped), classes/structs/records/interfaces/enums, generics, inheritance/interfaces/overrides, typed call resolution with overloads, using directives |
-| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
+| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm, .mxx | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
 | Dart | Fully Supported | .dart | ✓ | ✓ | ✓ | - | Classes, mixins, extensions, enhanced enums, factory/named constructors, Flutter widgets, package/relative/dart: imports, part directives, pubspec dependencies |
 | Go | Fully Supported | .go | ✓ | ✓ | ✓ | - | Receiver methods with cross-file binding, structs, interfaces, type declarations, function-local types |
 | Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |


### PR DESCRIPTION
Closes #1727.

## The defect

The set of C++ module-interface extensions existed twice and the two copies disagreed. `CPP_MODULE_EXTENSIONS` in `constants/ast_cpp.py` was a literal tuple naming `.ixx`, `.cppm`, `.ccm` and `.mxx`; `CPP_EXTENSIONS` in `constants/languages.py`, which `language_spec.py` registers as C++ and which therefore decides what is parsed at all, listed the first three and not `.mxx`. A `.mxx` interface unit was invisible: no `Module`, no `ModuleInterface`, and a `module X;` implementation unit pointing at it had nothing to resolve against.

Measured on `main` before the change: `get_language_for_extension(".mxx")` is `None`.

## The fix

`EXT_MXX` joins the named extension constants, `CPP_EXTENSIONS` gains it, and `CPP_MODULE_EXTENSIONS` moves to `constants/languages.py` spelled from those same constants, so the module set is a subset of the parsed set by construction. The literal tuple in `ast_cpp.py` is gone. The only production consumer (`parsers/cpp/utils.py`) reads it through the constants package and is unchanged. The pre-commit README hook regenerated `docs/architecture/language-support.md` to list the new extension.

## The test

`test_cpp_module_extension_parity.py` pins both halves: every member of `CPP_MODULE_EXTENSIONS` is in `CPP_EXTENSIONS` and resolves to C++, and a module interface with each extension is indexed end to end, asserting the `IMPLEMENTS` edge an implementation unit needs, not just the `ModuleInterface` node. Parametrised over the whole set rather than `.mxx` alone, so the next extension added to one list and not the other fails here rather than in a user's graph. All three assertions fail on `main` for `.mxx`.

Same defect shape as #1720 and #1714: a language extension set restated at a second site and drifting from the first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `.mxx` C++ module interface files.
  - C++ modules using `.mxx` now resolve correctly, including module implementation relationships.

- **Documentation**
  - Updated the language support matrix to list `.mxx` as a supported C++ extension.

- **Tests**
  - Added coverage to verify consistent handling and parsing of all supported C++ module extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->