### PR TITLE
fix: stamp the parser fingerprint at the post-flush commit point, not inside _process_files

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -550,6 +550,12 @@ class GraphUpdater:
         self._pending_hash_cache: tuple[Path, FileHashCache] | None = None
         self._pending_dir_mtimes: tuple[Path, DirMtimesCache] | None = None
         self._pending_cache_observed_at: float | None = None
+        # The parser fingerprint a full build will stamp, also deferred to the
+        # commit point (issue #1634): stamped inside `_process_files` it
+        # outlived a build that died before its final flush, and the next run
+        # then found the stamp equal to its own and never warned that the
+        # graph was built by different parser code.
+        self._pending_parser_fingerprint: str | None = None
         # Package paths read from the graph before Pass 1 of an incremental
         # run; None on a full build or when the graph could not be read.
         self._packages_before_run: set[str] | None = None
@@ -1281,6 +1287,7 @@ class GraphUpdater:
         self._pending_hash_cache = None
         self._pending_dir_mtimes = None
         self._pending_cache_observed_at = None
+        self._pending_parser_fingerprint = None
         if not force and self._is_already_in_sync():
             logger.info(ls.GRAPH_ALREADY_IN_SYNC)
             self.skipped_because_in_sync = True
@@ -1423,6 +1430,22 @@ class GraphUpdater:
                 self.repo_path / cs.DELOMBOK_STATE_FILENAME,
                 self._delombok_state_candidate,
             )
+
+        # The parser fingerprint commits here too, for the same reason
+        # (issue #1634). `_warn_if_parser_changed` compares the stored stamp
+        # with the current fingerprint to tell the user the graph was built by
+        # different parser code; a stamp written inside `_process_files`, before
+        # the flushes above, survived a full build that died in between and
+        # claimed this parser's edges were in a graph that held none of them,
+        # so the very run that failed was the one the warning stayed silent
+        # for. Set only by a full build (`_process_files`), so incremental runs
+        # keep the stale stamp and the warning with it.
+        if self._pending_parser_fingerprint is not None:
+            _save_parser_fingerprint(
+                self.repo_path / cs.PARSER_FINGERPRINT_FILENAME,
+                self._pending_parser_fingerprint,
+            )
+            self._pending_parser_fingerprint = None
 
         # Same commit point, for the same reason. The module deletions a newly
         # excluded file triggers are execute_write calls that only become
@@ -3521,13 +3544,13 @@ class GraphUpdater:
             self._pending_cache_observed_at = cache_mtime or None
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry
-        # the old parser's edges.
+        # the old parser's edges. Stashed here and WRITTEN at the commit point
+        # in `run`, after the final flush (issue #1634): a build that dies
+        # between here and that flush must leave no stamp, or its successor
+        # reads its own fingerprint back and never warns.
         if is_full_build:
-            _save_parser_fingerprint(
-                self.repo_path / cs.PARSER_FINGERPRINT_FILENAME,
-                compute_parser_fingerprint(
-                    repo_path=self.repo_path, capture=self.capture
-                ),
+            self._pending_parser_fingerprint = compute_parser_fingerprint(
+                repo_path=self.repo_path, capture=self.capture
             )
 
     def _pre_parse_changed_files(

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -10,7 +10,7 @@ import textwrap
 from collections.abc import Iterator
 from pathlib import Path
 from typing import IO
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from loguru import logger
@@ -297,6 +297,45 @@ class TestFingerprintStamping:
         assert stamp.read_text(encoding="utf-8").strip() == (
             compute_parser_fingerprint(repo_path=py_project)
         )
+
+    def test_a_full_build_that_dies_before_the_flush_leaves_no_stamp(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The stamp must not outlive a build whose writes never became durable.
+
+        Stamped inside `_process_files`, before the final flush, a full build
+        that died in between left a fingerprint claiming this parser's edges
+        were in the graph while the graph held none of them; the next run
+        compared equal and `_warn_if_parser_changed` stayed silent for exactly
+        the run that failed (issue #1634). The exclusion stamp, the hash cache
+        and the directory mtimes already commit after the flush; this pins the
+        fingerprint to the same point.
+
+        `_prune_orphan_nodes` sits between the old stamp site and the final
+        flush, so raising from it is a death in that window.
+        """
+        updater = _make_updater(py_project, mock_ingestor)
+        with (
+            patch.object(
+                updater,
+                "_prune_orphan_nodes",
+                side_effect=RuntimeError("died before the final flush"),
+            ),
+            pytest.raises(RuntimeError, match="died before the final flush"),
+        ):
+            updater.run()
+
+        assert not _fingerprint_path(py_project).exists(), (
+            "a full build that died before its final flush left a parser "
+            "fingerprint, so the next run will not warn that the graph was "
+            "built by different parser code"
+        )
+
+        # The control: the same build, allowed to reach its commit point,
+        # does stamp -- so the absence above is the deferral and not a stamp
+        # that never happens.
+        _make_updater(py_project, mock_ingestor).run()
+        assert _fingerprint_path(py_project).is_file()
 
     def test_incremental_sync_does_not_overwrite_stale_stamp(
         self, py_project: Path, mock_ingestor: MagicMock


### PR DESCRIPTION
Closes #1634.

## The defect

`_save_parser_fingerprint` ran inside `_process_files`, in the `if is_full_build:` block after the hash-cache save, before the final `flush_all` in `run()`. A full build that died between that stamp and the flush left a fingerprint on disk claiming this parser's edges were in the graph while the graph held none of them, or a previous parser's. The next run compared the stored fingerprint with its own, found them equal, and `_warn_if_parser_changed` stayed silent for exactly the run that failed.

The exclusion stamp (#1606, #1621), the hash cache and the directory mtimes (#1615) already commit after the final flush for this reason. The fingerprint was the remaining artefact with pre-flush crash semantics.

## The fix

`_process_files` now stashes the fingerprint on `self._pending_parser_fingerprint` (full builds only, as before) and `run()` writes it at the commit point beside the delombok stamp, after both final flushes. The field is reset per run with the other pending caches, so a reused instance whose previous run died cannot stamp a stale value on a later incremental run or on the in-sync fast path.

Ordering at the commit point is fingerprint before hash cache, deliberately: a stop after the fingerprint but before the cache leaves an empty cache, so the successor is a silent full build; the reverse would leave a cache with no stamp and a spurious mismatch warning. The stamp is still written when `_graph_state_unknown` is set: withholding it would make the successor warn with a remedy (delete caches, full rebuild) that has just run, and the stale-leftover risk from an unreadable graph is carried by the withheld exclusion stamp, which already forces reconciliation.

## The test

`test_a_full_build_that_dies_before_the_flush_leaves_no_stamp` raises from `_prune_orphan_nodes`, which sits between the old stamp site and the final flush, and asserts no stamp; a control runs the same build to completion and asserts it stamps. Red on `main` (the base stamps before the patched raise), green with the fix, alongside the existing stamping tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented incomplete full builds from recording a parser fingerprint.
  - Subsequent runs now correctly warn when the graph may have been built with different parser code after an interrupted build.

- **Tests**
  - Added coverage verifying that failed builds leave no misleading parser fingerprint stamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->