### PR TITLE
fix: strip inherited GIT_* routing and count only loose objects in the readonly cleanup test

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import functools
 import os
+import re
 import shutil
 import stat
 import subprocess
@@ -554,6 +555,63 @@ def _tmp_path_stays_removable(request: pytest.FixtureRequest) -> Generator[None]
     yield
     if root is not None:
         _make_tmp_path_removable(root)
+
+
+_FANOUT_DIR = re.compile(r"[0-9a-f]{2}")
+# 38 hex for sha1 object names, 62 for sha256; the leading two hex chars are
+# the fanout directory, so a basename is the remaining 38 or 62. Fixtures
+# here pin sha1, but the helper must not silently discard a sha256 repo.
+_LOOSE_OBJECT = re.compile(r"[0-9a-f]{38}|[0-9a-f]{62}")
+
+
+def collect_loose_objects(repo: Path) -> tuple[list[str], list[int]]:
+    """Return the loose objects under `repo`, and which of them are read-only.
+
+    Counts ONLY `objects/<2 hex>/<38 or 62 hex>` (sha1 or sha256 basenames).
+    Everything else under `objects/` is a different kind of file, and several
+    are mode 444: `pack/*.pack`, `*.idx`, `*.rev`, `commit-graph`. Walking all
+    of `objects/` would let those satisfy a "git wrote read-only loose
+    objects" assertion with zero loose objects present -- the exact state such
+    an assertion exists to reject. Git only packs at `gc.auto` (6700) loose
+    objects, so the fixture cannot reach that today, but the guard must not
+    depend on that staying true.
+    Shared by every test that asserts on git's loose objects (issue #1652):
+    a scan of all of `objects/` in test_temp_repo_readonly_cleanup passed on
+    pack files alone.
+    `test_the_loose_object_filter_rejects_a_packed_repo` pins the packed
+    difference; `test_the_loose_object_filter_accepts_a_sha256_repo` pins the
+    62-hex branch, which the sha1 pins in every other fixture would otherwise
+    leave uncovered.
+
+    Modes are read AT LISTING TIME, one `lstat` per entry, never a second
+    pass. `git commit` spawns `git maintenance run --auto --quiet --detach`,
+    which deletes its own `.git/objects/maintenance.lock` asynchronously, so a
+    list-then-stat pair races it: the entry is listed and gone by the time the
+    stat runs. That is the TOCTOU `_clear_readonly` documents, and it failed
+    exactly once, on macos/3.13 under xdist (#1622). A vanished entry is
+    skipped rather than tolerated after the fact: it cannot be the read-only
+    loose object callers assert on, because a loose object is permanent for
+    the life of the repo while the lock is transient.
+    """
+    listed: list[str] = []
+    readonly_modes: list[int] = []
+    for dirpath, _dirs, _files in os.walk(repo / ".git" / "objects"):
+        if not _FANOUT_DIR.fullmatch(os.path.basename(dirpath)):
+            continue
+        with os.scandir(dirpath) as entries:
+            for entry in entries:
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if not _LOOSE_OBJECT.fullmatch(entry.name):
+                    continue
+                try:
+                    mode = entry.stat(follow_symlinks=False).st_mode
+                except FileNotFoundError:
+                    continue
+                listed.append(entry.name)
+                if not mode & stat.S_IWUSR:
+                    readonly_modes.append(mode)
+    return listed, readonly_modes
 
 
 def git_env(**overrides: str) -> dict[str, str]:

--- a/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
+++ b/codebase_rag/tests/test_temp_repo_readonly_cleanup.py
@@ -26,7 +26,11 @@ from typing import Any
 
 import pytest
 
-from codebase_rag.tests.conftest import _clear_readonly
+from codebase_rag.tests.conftest import (
+    _clear_readonly,
+    collect_loose_objects,
+    git_env,
+)
 
 
 def _windows_unlink(real_unlink: Any) -> Any:
@@ -144,25 +148,35 @@ def test_a_real_git_repo_is_removable_by_the_temp_repo_teardown(
     """
     repo = tmp_path / "repo"
     repo.mkdir()
-    env = {
-        **os.environ,
-        "GIT_AUTHOR_NAME": "t",
-        "GIT_AUTHOR_EMAIL": "t@e",
-        "GIT_COMMITTER_NAME": "t",
-        "GIT_COMMITTER_EMAIL": "t@e",
-    }
+    # `git_env`, not `{**os.environ, ...}`: an inherited GIT_DIR,
+    # GIT_WORK_TREE, GIT_INDEX_FILE or GIT_OBJECT_DIRECTORY sends `git init`
+    # somewhere else, exits 0, and leaves this test scanning a repo that was
+    # never built here (issue #1673).
+    # The config files are neutralised too, as the `git_repo` fixture does: a
+    # global `commit.gpgsign=true` or a hook path would otherwise reach the
+    # commit below and fail it for reasons that have nothing to do with
+    # read-only objects (#1673 local review).
+    env = git_env(
+        GIT_AUTHOR_NAME="t",
+        GIT_AUTHOR_EMAIL="t@e",
+        GIT_COMMITTER_NAME="t",
+        GIT_COMMITTER_EMAIL="t@e",
+        GIT_CONFIG_GLOBAL=str(tmp_path / "gitconfig-absent"),
+        GIT_CONFIG_SYSTEM=str(tmp_path / "gitconfig-absent"),
+    )
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=env)
+    assert (repo / ".git").is_dir(), "git init built its repository elsewhere"
     (repo / "a.py").write_text("x = 1\n", encoding="utf-8")
     subprocess.run(["git", "add", "a.py"], cwd=repo, check=True, env=env)
     subprocess.run(["git", "commit", "-qm", "c"], cwd=repo, check=True, env=env)
 
-    objects = repo / ".git" / "objects"
-    readonly = [
-        p
-        for p in objects.rglob("*")
-        if p.is_file() and not (p.stat().st_mode & stat.S_IWRITE)
-    ]
-    assert readonly, "git wrote no read-only loose objects; nothing to test"
+    # Loose objects ONLY. A scan of all of `objects/` counts `pack/*.pack`,
+    # `*.idx`, `*.rev` and `commit-graph`, which git also writes mode 444, so
+    # it was satisfied by a packed repo holding zero loose objects -- the
+    # state this guard exists to reject (issue #1652).
+    listed, readonly_modes = collect_loose_objects(repo)
+    assert listed, "git wrote no loose objects; nothing to test"
+    assert readonly_modes, "git wrote no read-only loose objects; nothing to test"
 
     shutil.rmtree(repo, onexc=_clear_readonly)
     assert not repo.exists()

--- a/codebase_rag/tests/test_tmp_path_readonly_default.py
+++ b/codebase_rag/tests/test_tmp_path_readonly_default.py
@@ -38,7 +38,6 @@ reason above.
 from __future__ import annotations
 
 import os
-import re
 import stat
 import subprocess
 import sys
@@ -47,6 +46,7 @@ from pathlib import Path
 import pytest
 
 from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import collect_loose_objects
 
 # Planted by the inner session so the outer test can find the tree afterwards.
 _INNER_TEST = """
@@ -606,60 +606,6 @@ def test_non_removal_funcs_lists_every_callable_rmtree_passes() -> None:
     assert os.rmdir not in _NON_REMOVAL_FUNCS
 
 
-_FANOUT_DIR = re.compile(r"[0-9a-f]{2}")
-# 38 hex for sha1 object names, 62 for sha256; the leading two hex chars are
-# the fanout directory, so a basename is the remaining 38 or 62. Fixtures
-# here pin sha1, but the helper must not silently discard a sha256 repo.
-_LOOSE_OBJECT = re.compile(r"[0-9a-f]{38}|[0-9a-f]{62}")
-
-
-def _collect_loose_objects(repo: Path) -> tuple[list[str], list[int]]:
-    """Return the loose objects under `repo`, and which of them are read-only.
-
-    Counts ONLY `objects/<2 hex>/<38 or 62 hex>` (sha1 or sha256 basenames).
-    Everything else under `objects/` is a different kind of file, and several
-    are mode 444: `pack/*.pack`, `*.idx`, `*.rev`, `commit-graph`. Walking all
-    of `objects/` would let those satisfy a "git wrote read-only loose
-    objects" assertion with zero loose objects present -- the exact state such
-    an assertion exists to reject. Git only packs at `gc.auto` (6700) loose
-    objects, so the fixture cannot reach that today, but the guard must not
-    depend on that staying true.
-    `test_the_loose_object_filter_rejects_a_packed_repo` pins the packed
-    difference; `test_the_loose_object_filter_accepts_a_sha256_repo` pins the
-    62-hex branch, which the sha1 pins in every other fixture would otherwise
-    leave uncovered.
-
-    Modes are read AT LISTING TIME, one `lstat` per entry, never a second
-    pass. `git commit` spawns `git maintenance run --auto --quiet --detach`,
-    which deletes its own `.git/objects/maintenance.lock` asynchronously, so a
-    list-then-stat pair races it: the entry is listed and gone by the time the
-    stat runs. That is the TOCTOU `_clear_readonly` documents, and it failed
-    exactly once, on macos/3.13 under xdist (#1622). A vanished entry is
-    skipped rather than tolerated after the fact: it cannot be the read-only
-    loose object callers assert on, because a loose object is permanent for
-    the life of the repo while the lock is transient.
-    """
-    listed: list[str] = []
-    readonly_modes: list[int] = []
-    for dirpath, _dirs, _files in os.walk(repo / ".git" / "objects"):
-        if not _FANOUT_DIR.fullmatch(os.path.basename(dirpath)):
-            continue
-        with os.scandir(dirpath) as entries:
-            for entry in entries:
-                if not entry.is_file(follow_symlinks=False):
-                    continue
-                if not _LOOSE_OBJECT.fullmatch(entry.name):
-                    continue
-                try:
-                    mode = entry.stat(follow_symlinks=False).st_mode
-                except FileNotFoundError:
-                    continue
-                listed.append(entry.name)
-                if not mode & stat.S_IWUSR:
-                    readonly_modes.append(mode)
-    return listed, readonly_modes
-
-
 def test_git_repo_fixture_survives_an_inherited_git_dir(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -749,7 +695,7 @@ def test_git_repo_fixture_tears_down_its_own_readonly_objects(
     # is skipped rather than tolerated after the fact: it cannot be the
     # read-only loose object this asserts on, because a loose object is
     # permanent for the life of the repo while the lock is transient.
-    listed, readonly_modes = _collect_loose_objects(git_repo)
+    listed, readonly_modes = collect_loose_objects(git_repo)
 
     assert listed, "git wrote no loose objects, so the fixture proves nothing"
     assert readonly_modes, (
@@ -763,7 +709,7 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
 ) -> None:
     """A repo with no loose objects must fail the guard, not pass it on packs.
 
-    This is the control for `_collect_loose_objects`. Widening it back to all
+    This is the control for `collect_loose_objects`. Widening it back to all
     of `objects/` leaves every other test in this file green, because the
     fixture never packs -- so without this test the filter can regress
     silently. `git gc` here creates the state the fixture cannot reach on its
@@ -799,7 +745,7 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
         check=True,
         env=env,
     )
-    assert _collect_loose_objects(repo)[0], "no loose objects before gc: bad control"
+    assert collect_loose_objects(repo)[0], "no loose objects before gc: bad control"
 
     subprocess.run(
         ["git", "gc", "-q", "--prune=now"],
@@ -831,7 +777,7 @@ def test_the_loose_object_filter_rejects_a_packed_repo(
     decoy.write_bytes(b"not an object")
     decoy.chmod(0o444)
 
-    listed, readonly_modes = _collect_loose_objects(repo)
+    listed, readonly_modes = collect_loose_objects(repo)
     assert listed == [], (
         f"packed artefacts or temp files counted as loose objects: {listed} "
         "-- the filter no longer discriminates and the fixture guard is "
@@ -890,7 +836,7 @@ def test_the_loose_object_filter_accepts_a_sha256_repo(
         env=env,
     )
 
-    listed, _readonly_modes = _collect_loose_objects(repo)
+    listed, _readonly_modes = collect_loose_objects(repo)
     assert listed, (
         "a sha256 repo's loose objects were all discarded: the 62-hex half of "
         "`_LOOSE_OBJECT` no longer matches, so the helper silently reports an "


### PR DESCRIPTION
Closes #1673. Closes #1652.

## The two defects, one test

`test_a_real_git_repo_is_removable_by_the_temp_repo_teardown` in `test_temp_repo_readonly_cleanup.py` ran `git init` with `{**os.environ, ...}`. An inherited `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` or `GIT_OBJECT_DIRECTORY` sends the command somewhere else; `git init` still exits 0, so `check=True` does not catch it and the test scans a repository that was never built where it looks (#1673). The `git_repo` fixture in `conftest.py` already went through `git_env`, which strips the whole `GIT_*` prefix; this was the remaining site.

The same test then asserted that git wrote read-only loose objects with `objects.rglob("*")`. That walk covers `pack/` and `info/`, and git writes `pack-*.pack`, `*.idx`, `*.rev` and `commit-graph` as mode 444, so the assertion was satisfied by packed artefacts alone with zero loose objects present, the exact state it exists to reject (#1652). Not reachable today because one commit never triggers `gc.auto`, but it would stop discriminating silently the moment the fixture grew.

Measured during review: after `git gc` the old scan finds 4 read-only files and the loose-object scan finds 0.

## The fix

The test builds its environment with `git_env`, pinning `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to an absent file as every sibling call site does (a global `commit.gpgsign=true` would otherwise fail the commit for reasons unrelated to read-only objects, found in local review), and asserts `.git` exists where it expects it.

`_collect_loose_objects`, which #1648 wrote for `test_tmp_path_readonly_default.py`, moves verbatim into `conftest.py` as `collect_loose_objects` with its `objects/<2 hex>/<38 or 62 hex>` filter, and both test files import it. The cleanup test asserts separately that loose objects exist and that some are read-only, so a packed repo fails the first rather than passing the second.

## Verification

Both readonly test files pass (36 tests, including the sha256 62-hex case and the packed-repo control that pins the filter). Under an inherited `GIT_DIR` the new `.git` assertion fails and under `GIT_OBJECT_DIRECTORY` the loose-object assertion fails, so neither is vacuous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage for read-only repository cleanup scenarios.
  - Added validation that temporary Git repositories are initialized in the expected location.
  - Tests now reliably isolate inherited Git configuration and environment settings.
  - Refined object-file checks to focus on relevant loose objects and handle files that disappear during inspection.

- **Refactor**
  - Consolidated shared test utilities to reduce duplication and improve consistency across repository cleanup tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->