### PR TITLE
test: require the rehydration pass to rebuild the C++ interface set, not merely keep the edge

### DIFF
--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -402,9 +403,35 @@ def test_a_cpp_interface_parsed_this_run_survives_rehydration(
     _bump(root, "iface.cppm")
     _bump(root, "impl.cpp")
 
-    _updater(store, root, cs.SupportedLanguage.CPP).run(force=False)
+    second = _updater(store, root, cs.SupportedLanguage.CPP)
+    dp = second.factory.definition_processor
+    # The edge assertion below is true of a system where rehydration does
+    # nothing: with the rebuild deleted the set is never cleared, so the
+    # interface stays and the edge is minted anyway (issue #1725, measured).
+    # A planted entry the graph does not hold separates the two: a real
+    # rebuild drops it and keeps `proj.M`; a neutered pass keeps both; the
+    # bare `clear()` this test was written against drops both.
+    dp.cpp_module_interfaces.add("proj.STALE")
+    rebuilt: list[frozenset[str]] = []
+    real_rehydrate = second._rehydrate_registry_from_graph
+
+    def _observe() -> None:
+        real_rehydrate()
+        rebuilt.append(frozenset(dp.cpp_module_interfaces))
+
+    with patch.object(second, "_rehydrate_registry_from_graph", side_effect=_observe):
+        second.run(force=False)
     store.flush_all()
 
+    assert rebuilt, "rehydration never ran, so this test is not about it"
+    assert "proj.STALE" not in rebuilt[-1], (
+        "rehydration kept an interface the graph does not hold, so it did not "
+        f"rebuild the set: {sorted(rebuilt[-1])}"
+    )
+    assert "proj.M" in rebuilt[-1], (
+        "rehydration dropped the interface this run parsed but had not yet "
+        f"flushed: {sorted(rebuilt[-1])}"
+    )
     implements = [
         edge for edge in store.edges if edge[2] == cs.RelationshipType.IMPLEMENTS.value
     ]


### PR DESCRIPTION
Closes #1725.

## The defect

`test_a_cpp_interface_parsed_this_run_survives_rehydration` passed with `_rehydrate_registry_from_graph` replaced by an immediate `return`. It asserted only that an `IMPLEMENTS` edge exists after an interface and its implementation are added together; with the rebuild deleted nothing ever clears `cpp_module_interfaces`, so the interface stays and the edge is minted anyway. The assertion was true of a system where the component the test names does nothing.

The fix the test guards is correct and the test did catch the regression it was written for (the bare `clear()` that dropped an unflushed interface). What was wrong is that its name and comment claimed to cover rehydration and it did not.

## The change

Before the second run the test plants `proj.STALE` in `cpp_module_interfaces`, an interface the graph does not hold, and wraps the instance's `_rehydrate_registry_from_graph` to snapshot the set immediately after it returns. It then asserts that rehydration ran, that the plant is gone, and that `proj.M` (parsed this run, still unflushed) survived. The three mutants now separate:

| Rehydration | `proj.STALE` | `proj.M` | Result |
|---|---|---|---|
| real rebuild | dropped | kept | passes |
| neutered (`return`) | kept | kept | fails on the plant |
| bare `clear()` | dropped | dropped | fails on `proj.M` |

Measured: the neutered pass fails at the plant assertion, the bare `clear()` at the `proj.M` assertion. Nothing outside `_rehydrate_registry_from_graph` mutates the set except the parser's own `.add`, so only the pass under test can remove the plant. The original edge assertion stays.

Found in review: no test anywhere covers the positive graph re-add path (an interface held only in the graph, only its implementation re-parsed, edge still emitted); filed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded incremental update coverage to verify that interface state is correctly rebuilt during rehydration.
  * Confirmed stale interface entries are removed while newly parsed, unflushed interfaces remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->