### PR TITLE
fix: forget a deleted Go file's return-type entries and rebuild the package index

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2633,6 +2633,29 @@ class GraphUpdater:
         if qns_to_remove:
             logger.debug(ls.REMOVING_QNS, count=len(qns_to_remove))
 
+        # The Go return-type map is keyed by the same function qns and was the
+        # one registry this sweep did not reach (issue #1668): a deleted Go
+        # file's entries persisted, and because the package index is filled
+        # with `setdefault`, a same-name sibling parsed later lost to the stale
+        # one. Same ownership filter as the registry sweep, so a qn another
+        # file still owns survives; the map's own keys are checked as well as
+        # `qns_to_remove` because an entry can outlive its registry row.
+        go_return_types = self.factory.type_inference.go_function_return_types
+        stale_go_qns = [
+            qn
+            for qn in go_return_types
+            if qn in qns_to_remove
+            or (
+                any(
+                    qn.startswith(f"{prefix}.") or qn == prefix
+                    for prefix in module_qn_prefixes
+                )
+                and qn not in foreign_qns
+            )
+        ]
+        if stale_go_qns:
+            self.factory.type_inference.drop_go_return_types(stale_go_qns)
+
         for simple_name, qn_set in self.simple_name_lookup.items():
             original_count = len(qn_set)
             new_qn_set = qn_set - qns_to_remove

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -597,6 +597,25 @@ class TypeInferenceEngine:
             class_qn = self._resolve_class_name(field_type, module_qn) or field_type
         method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{segments[-1]}"
         return self.method_return_types.get(method_qn)
+
+    def drop_go_return_types(self, qns: Collection[str]) -> None:
+        """Forget the Go return types recorded under `qns` and drop the index.
+
+        `GraphUpdater.remove_file_from_state` calls this for a deleted or
+        re-parsed file's definitions. The map used to keep them (issue #1668),
+        and the `(package, name)` index below is filled with `setdefault`, so a
+        surviving or new sibling defining a free function of the same name lost
+        to the stale entry and its return type was never recorded.
+
+        The index is invalidated outright rather than left to the size check:
+        one deletion followed by one addition leaves the size unchanged, and
+        the check would then serve the stale index over a map that no longer
+        holds the entry.
+        """
+        for qn in qns:
+            self.go_function_return_types.pop(qn, None)
+        self._go_free_fn_index = {}
+        self._go_free_fn_index_size = -1
 
     def _go_free_fn_return_type(self, name: str, module_qn: str) -> str | None:
         # Same module (file) first; then the enclosing package's sibling files

--- a/codebase_rag/tests/test_go_return_types_forget_deleted_file.py
+++ b/codebase_rag/tests/test_go_return_types_forget_deleted_file.py
@@ -1,0 +1,123 @@
+"""A deleted Go file's return-type entries must leave with its registry rows.
+
+`TypeInferenceEngine.go_function_return_types` records the first return type
+of every Go free function, and `_go_free_fn_return_type` answers a sibling
+file's call through a lazily rebuilt `(package, name)` index over it.
+`GraphUpdater.remove_file_from_state` pruned every other registry for a deleted
+file but never this map, so on a reused updater a deleted file's entries
+persisted; the index is filled with `setdefault`, so a surviving or new
+sibling defining a free function of the same name lost to the stale entry and
+its return type was never recorded (issue #1668).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import _MockIngestor
+
+A_GO = "package pkg\n\ntype A struct{}\n\nfunc New() *A { return &A{} }\n"
+USER_GO = "package pkg\n\nfunc Use() {\n\tx := New()\n\t_ = x\n}\n"
+
+
+def _updater(root: Path) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    if "go" not in {str(k) for k in parsers}:
+        pytest.skip("go parser not available")
+    return GraphUpdater(
+        ingestor=_MockIngestor(),
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+def test_a_deleted_go_files_return_types_are_forgotten(temp_repo: Path) -> None:
+    """Delete `a.go` on a reused updater: its `New` entry must go.
+
+    The second half is the sibling case the issue names, staged so that the
+    size check alone cannot rescue it: one entry removed and one added leaves
+    the map the same size, so an index that is only rebuilt on a size change
+    would keep serving the deleted file's type. The drop has to invalidate the
+    index itself.
+    """
+    root = temp_repo / "proj"
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "a.go").write_text(A_GO, encoding="utf-8")
+    (root / "pkg" / "user.go").write_text(USER_GO, encoding="utf-8")
+    updater = _updater(root)
+    updater.run()
+
+    engine = updater.factory.type_inference
+    assert engine.go_function_return_types.get("proj.pkg.a.New") == "A", (
+        "fixture guard: the first run did not record New's return type: "
+        f"{engine.go_function_return_types}"
+    )
+    # Prime the package index the way a call from user.go does.
+    assert engine._go_free_fn_return_type("New", "proj.pkg.user") == "A"
+
+    (root / "pkg" / "a.go").unlink()
+    updater.remove_file_from_state(root / "pkg" / "a.go")
+
+    assert "proj.pkg.a.New" not in engine.go_function_return_types, (
+        "the deleted file's return-type entry survived remove_file_from_state"
+    )
+
+    # A new sibling takes the name BEFORE any lookup: the map is back to the
+    # size the index was built at, so a drop that only popped the entry and
+    # left the size sentinel alone would serve the stale index here. No
+    # intermediate lookup, deliberately -- one would rebuild the index on the
+    # size change and hide exactly that (#1668 local review).
+    engine.go_function_return_types["proj.pkg.c.New"] = "C"
+    assert len(engine.go_function_return_types) == engine._go_free_fn_index_size or (
+        engine._go_free_fn_index_size == -1
+    ), "fixture guard: the delete-then-add must land on the indexed size"
+    assert engine._go_free_fn_return_type("New", "proj.pkg.user") == "C", (
+        "the sibling's return type lost to the deleted file's stale entry"
+    )
+
+
+def test_a_lookup_after_the_delete_no_longer_answers(temp_repo: Path) -> None:
+    """With no sibling, the package index must answer None, not the stale type."""
+    root = temp_repo / "proj"
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "a.go").write_text(A_GO, encoding="utf-8")
+    (root / "pkg" / "user.go").write_text(USER_GO, encoding="utf-8")
+    updater = _updater(root)
+    updater.run()
+    engine = updater.factory.type_inference
+    assert engine._go_free_fn_return_type("New", "proj.pkg.user") == "A"
+
+    updater.remove_file_from_state(root / "pkg" / "a.go")
+
+    assert engine._go_free_fn_return_type("New", "proj.pkg.user") is None, (
+        "the package index still answers from the deleted file's entry"
+    )
+
+
+def test_another_files_entries_survive_the_delete(temp_repo: Path) -> None:
+    """The control: only the deleted file's entries go, not the package's."""
+    root = temp_repo / "proj"
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "a.go").write_text(A_GO, encoding="utf-8")
+    (root / "pkg" / "b.go").write_text(
+        "package pkg\n\ntype B struct{}\n\nfunc Make() *B { return &B{} }\n",
+        encoding="utf-8",
+    )
+    updater = _updater(root)
+    updater.run()
+    engine = updater.factory.type_inference
+    assert engine.go_function_return_types.get("proj.pkg.b.Make") == "B"
+
+    updater.remove_file_from_state(root / "pkg" / "a.go")
+
+    assert "proj.pkg.a.New" not in engine.go_function_return_types
+    assert engine.go_function_return_types.get("proj.pkg.b.Make") == "B", (
+        "a sibling's entry was swept along with the deleted file's"
+    )
+    assert engine._go_free_fn_return_type("Make", "proj.pkg.a") == "B"


### PR DESCRIPTION
Closes #1668.

## The defect

`TypeInferenceEngine.go_function_return_types` records the first return type of every Go free function so `cm, err := getManager()` types `cm`. `_go_free_fn_return_type` answers a sibling file's call through a `(package, name)` index over that map, rebuilt only when the map's size changes and filled with `setdefault`. `GraphUpdater.remove_file_from_state` pruned every other registry for a deleted file and never this map, so on a reused updater a deleted file's entries persisted and a surviving or new sibling defining a free function of the same name lost to the stale entry: its return type was never recorded.

## The fix

`TypeInferenceEngine.drop_go_return_types(qns)` pops the entries and invalidates the index outright (size sentinel reset), and `remove_file_from_state` calls it after the function-registry sweep with the same ownership filter (`module_qn_prefixes`, `foreign_qns`, plus the qns the sweep itself removed). The map is popped in place, so `rpc_exposure`, which holds a reference to the same dict, sees the drop.

The invalidation is load-bearing on its own: one deletion followed by one addition leaves the size unchanged, and the size check would serve the stale index over a map that no longer holds the entry. The test stages exactly that (delete, add the sibling, look up with no intermediate lookup that would rebuild by accident) and a drop that only pops fails it.

## Verification

Red on `main` (2 failed), green with the fix. A modified Go file on a reused updater goes through the same `remove_file_from_state` and re-records the new type. Found in review and filed separately: `method_return_types` (C++/Rust/Dart free functions, Go receiver methods) has the same gap, #1738.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale Go function return-type information remaining after a source file is deleted.
  * Updated code analysis to correctly reflect replacement files with matching names.
  * Preserved return-type information for unaffected sibling files.
  * Improved results when analyzing projects after Go files are removed or replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->