### PR TITLE
fix: a run rooted at a path that is neither a file nor a directory raises instead of indexing nothing

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1219,7 +1219,21 @@ class GraphUpdater:
         return known_module_paths
 
     def run(self, force: bool = False) -> None:
-        """Ingest the repository; ``force`` rebuilds instead of updating incrementally."""
+        """Ingest the repository; ``force`` rebuilds instead of updating incrementally.
+
+        Raises `FileNotFoundError` when `self.repo_path` -- the target
+        directory, or the parent of a single-file target -- is not a
+        directory. The constructor recognises a single-file target only
+        while the file exists, so a deleted or mistyped path fell through as
+        a directory run rooted at a non-directory: the walk yielded nothing
+        and the run reported success having indexed nothing (issue #1651).
+        Raising here rather than in the constructor keeps construction cheap
+        and side-effect free for callers that never run. A single-file
+        target deleted AFTER construction passes this check (its parent
+        exists) and is a separate decision (#1737).
+        """
+        if not self.repo_path.is_dir():
+            raise FileNotFoundError(ls.REPO_PATH_MISSING.format(path=self.repo_path))
         py_engine = self.factory.type_inference._python_type_inference
         if py_engine is not None:
             py_engine._available_classes_cache.clear()

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -98,6 +98,13 @@ GO_FRONTEND_NO_FACTS = (
     "Go frontend produced no facts; every join falls back to tree-sitter. "
     "Tool diagnostics:\n{stderr}"
 )
+# A run rooted at a path that is neither a file nor a directory used to walk
+# nothing and report success (issue #1651): a deleted or mistyped target was
+# indistinguishable from one that was indexed.
+REPO_PATH_MISSING = (
+    "Repository path {path} does not exist as a file or a directory; nothing "
+    "was indexed"
+)
 GRAPH_ALREADY_IN_SYNC = (
     "Knowledge graph already in sync (hash cache matches every file). Skipping passes."
 )

--- a/codebase_rag/tests/test_missing_repo_path.py
+++ b/codebase_rag/tests/test_missing_repo_path.py
@@ -1,0 +1,89 @@
+"""A run rooted at a path that does not exist must fail, not succeed at nothing.
+
+`GraphUpdater.__init__` recognises a single-file target only while the file
+exists (`repo_path.is_file()`), so a path that was deleted or mistyped fell
+through as an ordinary directory run rooted at a non-directory. The walk found
+no files and `run()` returned normally: a caller asking to re-index one file
+got the same success signal whether the path was indexed, deleted or
+misspelled (issue #1651).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+@pytest.fixture
+def py_project(temp_repo: Path) -> Path:
+    (temp_repo / "module_a.py").write_text("def func_a():\n    pass\n")
+    return temp_repo
+
+
+def _updater(target: Path, ingestor: MagicMock) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=ingestor, repo_path=target, parsers=parsers, queries=queries
+    )
+
+
+def test_a_run_rooted_at_a_deleted_file_raises(
+    py_project: Path, mock_ingestor: MagicMock
+) -> None:
+    """The issue's own reproduction: full build, delete a module, run on it.
+
+    Before the fix the second run completed without raising and rewrote
+    nothing; the caller could not tell that from a successful re-index.
+    """
+    _updater(py_project, mock_ingestor).run()
+    before = (py_project / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8")
+    target = py_project / "module_a.py"
+    target.unlink()
+    assert not target.exists(), "fixture guard: the target must be gone"
+
+    with pytest.raises(FileNotFoundError, match="module_a.py"):
+        _updater(target, mock_ingestor).run()
+
+    # Nothing was published for the run that never happened.
+    after = (py_project / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8")
+    assert after == before, "a run that indexed nothing rewrote the cache"
+
+
+def test_a_run_rooted_at_a_missing_directory_raises(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    missing = tmp_path / "no_such_project"
+    with pytest.raises(FileNotFoundError, match="no_such_project"):
+        _updater(missing, mock_ingestor).run()
+    assert not mock_ingestor.ensure_node_batch.called, (
+        "a run rooted at a missing directory wrote to the graph"
+    )
+
+
+def test_construction_alone_does_not_require_the_path(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    """The check lives in `run`, not the constructor.
+
+    Unit tests across the suite build updaters on paths such as `/test` to
+    exercise parsers and registries without ever running; the constructor
+    stays cheap and side-effect free for them.
+    """
+    _updater(tmp_path / "never_run", mock_ingestor)
+
+
+def test_the_controls_still_run(py_project: Path, mock_ingestor: MagicMock) -> None:
+    """A directory and an existing single file both run as before."""
+    _updater(py_project, mock_ingestor).run()
+    assert mock_ingestor.ensure_node_batch.called
+    mock_ingestor.reset_mock()
+    single = _updater(py_project / "module_a.py", mock_ingestor)
+    assert single._single_file is not None, "fixture guard: not a single-file run"
+    single.run()
+    assert mock_ingestor.ensure_node_batch.called

--- a/codebase_rag/tests/test_missing_repo_path.py
+++ b/codebase_rag/tests/test_missing_repo_path.py
@@ -47,8 +47,9 @@ def test_a_run_rooted_at_a_deleted_file_raises(
     target.unlink()
     assert not target.exists(), "fixture guard: the target must be gone"
 
+    updater = _updater(target, mock_ingestor)
     with pytest.raises(FileNotFoundError, match="module_a.py"):
-        _updater(target, mock_ingestor).run()
+        updater.run()
 
     # Nothing was published for the run that never happened.
     after = (py_project / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8")
@@ -59,8 +60,9 @@ def test_a_run_rooted_at_a_missing_directory_raises(
     tmp_path: Path, mock_ingestor: MagicMock
 ) -> None:
     missing = tmp_path / "no_such_project"
+    updater = _updater(missing, mock_ingestor)
     with pytest.raises(FileNotFoundError, match="no_such_project"):
-        _updater(missing, mock_ingestor).run()
+        updater.run()
     assert not mock_ingestor.ensure_node_batch.called, (
         "a run rooted at a missing directory wrote to the graph"
     )

--- a/codebase_rag/tests/test_missing_repo_path.py
+++ b/codebase_rag/tests/test_missing_repo_path.py
@@ -26,7 +26,7 @@ def py_project(temp_repo: Path) -> Path:
     return temp_repo
 
 
-def _updater(target: Path, ingestor: MagicMock) -> GraphUpdater:
+def _create_graph_updater(target: Path, ingestor: MagicMock) -> GraphUpdater:
     parsers, queries = load_parsers()
     return GraphUpdater(
         ingestor=ingestor, repo_path=target, parsers=parsers, queries=queries
@@ -41,13 +41,13 @@ def test_a_run_rooted_at_a_deleted_file_raises(
     Before the fix the second run completed without raising and rewrote
     nothing; the caller could not tell that from a successful re-index.
     """
-    _updater(py_project, mock_ingestor).run()
+    _create_graph_updater(py_project, mock_ingestor).run()
     before = (py_project / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8")
     target = py_project / "module_a.py"
     target.unlink()
     assert not target.exists(), "fixture guard: the target must be gone"
 
-    updater = _updater(target, mock_ingestor)
+    updater = _create_graph_updater(target, mock_ingestor)
     with pytest.raises(FileNotFoundError, match="module_a.py"):
         updater.run()
 
@@ -60,7 +60,7 @@ def test_a_run_rooted_at_a_missing_directory_raises(
     tmp_path: Path, mock_ingestor: MagicMock
 ) -> None:
     missing = tmp_path / "no_such_project"
-    updater = _updater(missing, mock_ingestor)
+    updater = _create_graph_updater(missing, mock_ingestor)
     with pytest.raises(FileNotFoundError, match="no_such_project"):
         updater.run()
     assert not mock_ingestor.ensure_node_batch.called, (
@@ -77,15 +77,15 @@ def test_construction_alone_does_not_require_the_path(
     exercise parsers and registries without ever running; the constructor
     stays cheap and side-effect free for them.
     """
-    _updater(tmp_path / "never_run", mock_ingestor)
+    _create_graph_updater(tmp_path / "never_run", mock_ingestor)
 
 
 def test_the_controls_still_run(py_project: Path, mock_ingestor: MagicMock) -> None:
     """A directory and an existing single file both run as before."""
-    _updater(py_project, mock_ingestor).run()
+    _create_graph_updater(py_project, mock_ingestor).run()
     assert mock_ingestor.ensure_node_batch.called
     mock_ingestor.reset_mock()
-    single = _updater(py_project / "module_a.py", mock_ingestor)
+    single = _create_graph_updater(py_project / "module_a.py", mock_ingestor)
     assert single._single_file is not None, "fixture guard: not a single-file run"
     single.run()
     assert mock_ingestor.ensure_node_batch.called


### PR DESCRIPTION
Closes #1651.

## The defect

`GraphUpdater.__init__` recognises a single-file target only while the file exists (`repo_path.is_file()`). A path that had been deleted or was mistyped fell through as an ordinary directory run rooted at a non-directory: the walk yielded nothing and `run()` returned normally. A caller asking to re-index one file got the same success signal whether the path was indexed, deleted or misspelled.

## The fix

`run()` raises `FileNotFoundError` (message `REPO_PATH_MISSING` in `logs.py`) when `self.repo_path` is not a directory. In `run()` rather than the constructor: a dozen unit tests build updaters on paths such as `/test` to exercise parsers and registries without ever running, and construction stays cheap and side-effect free for them; the issue offered the constructor as a direction rather than a requirement, and a test pins the choice.

Every production caller already validates its root (`cli.py` through `_resolve_and_validate_repo`, MCP through `project_root`, the watcher through its resolved watch root), so nothing that works today changes. `reingest` does not need the guard: it already refuses out-of-repo and directory paths and treats vanished files as gone.

## Tests

`test_missing_repo_path.py`: the issue's own reproduction (full build, delete a module, run rooted at it: raises, cache untouched), a missing directory (raises, nothing written), construction-only (no raise), and controls for a directory run and an existing single-file run. Red on `main` (2 failed), green with the fix alongside the incremental and import-parsing suites.

A single-file target deleted between construction and `run()` passes the guard (its parent exists) and today completes as a no-op that republishes a cache still listing the file; the issue defers that decision and it is filed as #1737.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Repository indexing now reports a clear `FileNotFoundError` when the configured path does not exist.
  - Failed indexing runs no longer update cached data or create partial index content.
  - Valid file and directory indexing behavior remains unchanged.

- **Tests**
  - Added coverage for missing files and directories, cache preservation after failures, and successful indexing of valid paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->