### PR TITLE
chore: turn off CodeRabbit's docstring-coverage pre-merge check to match the PR template

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# The docstring-coverage pre-merge check is off (issue #1617). The pull request
+# template requires "No new comments or docstrings (code should be
+# self-documenting)", and test functions here carry none by convention, so the
+# default 80% threshold warned on every PR that touched a test and could not be
+# cleared without breaking the template. One class of warning that is routinely
+# declined weakens the rule that every bot finding is cleared before merge.
+reviews:
+  pre_merge_checks:
+    docstrings:
+      mode: "off"


### PR DESCRIPTION
Closes #1617.

## The contradiction

CodeRabbit's pre-merge "Docstring Coverage" check warns whenever fewer than 80% of the functions a diff touches carry docstrings. The pull request template requires the opposite: "No new comments or docstrings (code should be self-documenting)". Test functions here carry none by convention, so any PR touching a test drew a warning it was not allowed to clear (#1614 was flagged at 30% for a prose-only edit inside an existing test), and a class of bot warning that is routinely declined weakens the rule that every finding is cleared before merge.

## The change

A root `.coderabbit.yaml` with `reviews.pre_merge_checks.docstrings.mode: "off"` and a comment stating why. Verified against the CodeRabbit v2 schema: the key path exists, `mode` is an enum of `off`/`warning`/`error`, and the value must be quoted (bare `off` is YAML 1.1 `false` and fails the schema). No other CodeRabbit configuration exists in the repository; the file at the repository root is what the docs specify, and the copy on a feature branch governs that branch's review.

The issue's narrower alternative, scoping the check to non-test code and amending the template, was not taken: the template forbids docstrings everywhere, so a threshold anywhere would still contradict it.