### PR TITLE
test: state the rewrite-after-run mtime precondition in the remaining incremental tests

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -632,8 +632,19 @@ def force_mtime_after_cache(repo: Path, source: Path) -> None:
     otherwise is whatever the preceding run happened to cost.
     """
     cache_mtime = (repo / rag_cs.HASH_CACHE_FILENAME).stat().st_mtime
+    # Read back and advance until the STORED stamp is strictly later: a
+    # filesystem with coarse mtime resolution can round the requested value
+    # onto the cache's own tick, which is the collision this exists to
+    # remove (CodeRabbit, #1743).
     stamp = cache_mtime + 1.0
-    os.utime(source, (stamp, stamp))
+    for _ in range(8):
+        os.utime(source, (stamp, stamp))
+        if source.stat().st_mtime > cache_mtime:
+            return
+        stamp += 1.0
+    raise AssertionError(
+        f"could not stamp {source} later than the hash cache ({cache_mtime})"
+    )
 
 
 def git_env(**overrides: str) -> dict[str, str]:

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -614,6 +614,28 @@ def collect_loose_objects(repo: Path) -> tuple[list[str], list[int]]:
     return listed, readonly_modes
 
 
+def force_mtime_after_cache(repo: Path, source: Path) -> None:
+    """Put `source` on a strictly later tick than the hash cache file.
+
+    An incremental run only re-hashes a cached file whose mtime is strictly
+    greater than the cache file's own (`if file_mtime <= cache_mtime`), so a
+    rewrite that lands on the same filesystem tick as the cache written by the
+    preceding run is SKIPPED and the run under test never reaches the code the
+    test is about. Since #1615 the cache file is restamped back to the instant
+    observed before the previous run's hashing loop, so on a fine-grained clock
+    the two differ by that run's own hashing and later passes; on a coarse one
+    they can still collide, which is why this failed on Windows py3.12.
+    Stating the precondition removes the dependency on clock resolution.
+
+    Shared by every test that rewrites a cached source right after a run and
+    needs the rewrite re-hashed (issue #1640); the margin such a test gets
+    otherwise is whatever the preceding run happened to cost.
+    """
+    cache_mtime = (repo / rag_cs.HASH_CACHE_FILENAME).stat().st_mtime
+    stamp = cache_mtime + 1.0
+    os.utime(source, (stamp, stamp))
+
+
 def git_env(**overrides: str) -> dict[str, str]:
     """A Git environment with every inherited `GIT_*` routing variable gone.
 

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -6,32 +6,16 @@
 # reingest every current file (deleting an absent module is a no-op).
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from codebase_rag import constants as cs
-from codebase_rag.tests.conftest import create_and_run_updater
-
-
-def _force_mtime_after_cache(repo: Path, source: Path) -> None:
-    """Put `source` on a strictly later tick than the hash cache file.
-
-    An incremental run only re-hashes a cached file whose mtime is strictly
-    greater than the cache file's own (`if file_mtime <= cache_mtime`), so a
-    rewrite that lands on the same filesystem tick as the cache written by the
-    preceding run is SKIPPED and the run under test never reaches the code the
-    test is about. Since #1615 the cache file is restamped back to the instant
-    observed before the previous run's hashing loop, so on a fine-grained clock
-    the two differ by that run's own hashing and later passes; on a coarse one
-    they can still collide, which is why this failed on Windows py3.12.
-    Stating the precondition removes the dependency on clock resolution.
-    """
-    cache_mtime = (repo / cs.HASH_CACHE_FILENAME).stat().st_mtime
-    stamp = cache_mtime + 1.0
-    os.utime(source, (stamp, stamp))
+from codebase_rag.tests.conftest import (
+    create_and_run_updater,
+    force_mtime_after_cache,
+)
 
 
 def test_module_path_lookup_failure_forces_delete_before_reingest(
@@ -98,7 +82,7 @@ def test_incremental_rehydration_failure_aborts(
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
 
     source.write_text("def f():\n    return 2\n", encoding="utf-8")
-    _force_mtime_after_cache(temp_repo, source)
+    force_mtime_after_cache(temp_repo, source)
 
     def unavailable(query: str, params: dict | None = None) -> list:
         if query == cs.CYPHER_ALL_DEFINITION_QNS:
@@ -203,7 +187,7 @@ def test_incremental_run_aborts_when_inbound_capture_fails(
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
 
     source.write_text("def f():\n    return 2\n", encoding="utf-8")
-    _force_mtime_after_cache(temp_repo, source)
+    force_mtime_after_cache(temp_repo, source)
 
     def unavailable(query: str, params: dict | None = None) -> list:
         if query == cs.CYPHER_INBOUND_EDGES:

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -21,6 +21,7 @@ from codebase_rag.graph_updater import (
     _save_hash_cache,
 )
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import force_mtime_after_cache
 
 
 @pytest.fixture
@@ -251,6 +252,10 @@ class TestIncrementalUpdates:
         updater.run()
 
         (py_project / "module_a.py").write_text("def func_a_updated():\n    pass\n")
+        # The rewrite must land on a later tick than the cache the run just
+        # wrote, or the hashing loop skips it; the margin otherwise is only
+        # the run's own duration (issue #1640).
+        force_mtime_after_cache(py_project, py_project / "module_a.py")
 
         updater2 = GraphUpdater(
             ingestor=mock_ingestor,
@@ -1110,6 +1115,9 @@ class TestFastPathInSync:
         updater.run()
 
         (py_project / "module_a.py").write_text("def func_a():\n    return 1\n")
+        # Same precondition as above: the fast path compares this mtime with
+        # the cache's, and equal ticks read as unchanged (issue #1640).
+        force_mtime_after_cache(py_project, py_project / "module_a.py")
 
         updater2 = GraphUpdater(
             ingestor=mock_ingestor,

--- a/codebase_rag/tests/test_markdown_front_matter.py
+++ b/codebase_rag/tests/test_markdown_front_matter.py
@@ -456,7 +456,10 @@ class TestIngestion:
         differing from the first -- "changed" would also be satisfied by
         writing some other wrong value.
         """
-        from codebase_rag.tests.conftest import run_updater
+        from codebase_rag.tests.conftest import (
+            force_mtime_after_cache,
+            run_updater,
+        )
         from codebase_rag.types_defs import NodeType
 
         def module_props(ingestor: MagicMock) -> list[dict]:
@@ -482,6 +485,11 @@ class TestIngestion:
 
         mock_ingestor.reset_mock()
         target.write_text("# Doc\n\nBody.\n", encoding="utf-8")
+        # The rewrite must land on a later tick than the cache the first run
+        # wrote, or the second run skips the file and "no Module node emitted
+        # on re-index" fires for a reason that has nothing to do with
+        # front-matter (issue #1640; found by the sweep's own review).
+        force_mtime_after_cache(project, target)
         run_updater(project, mock_ingestor)
         second = module_props(mock_ingestor)
 


### PR DESCRIPTION
Closes #1640.

## The assumption

An incremental run re-hashes a cached file only when its mtime is strictly greater than the hash cache's own. A test that rewrites a cached source immediately after a completed run therefore depends on that write landing on a later filesystem tick than the cache the run just wrote; the margin is whatever the run happened to cost, and on a coarse clock the two collide, the file is skipped, and the test fails somewhere unrelated to its subject. #1635 fixed the two sites where this was observed on Windows and the two it introduced; this closes the rest.

## The change

`_force_mtime_after_cache` moves from `test_cacheless_lookup_failure.py` into `conftest.py` as `force_mtime_after_cache`, body unchanged, and is called after the rewrite in:

- `test_changed_file_is_reparsed` and `test_changed_file_disables_fast_path` (`test_graph_updater_incremental.py`), the two the issue names;
- `test_removing_front_matter_clears_the_stored_value` (`test_markdown_front_matter.py`), a third of the same shape that the issue's sweep missed because it runs the updater through `run_updater` rather than `run()`; found in local review, which reproduced its failure by pinning the rewrite to the cache's tick.

The helper only states the precondition; it cannot make a test pass vacuously. With the rewrite pinned to the cache tick and no helper, all three tests fail; with the helper and unchanged content, they still fail, so the assertions continue to discriminate on content. The cache itself is never stamped ahead of the wall clock, only the source is placed one second past the cache, and no production code compares a source mtime to the current time.

## Verification

`test_graph_updater_incremental.py`, `test_cacheless_lookup_failure.py` and `test_markdown_front_matter.py` pass on this branch. The other rewrite-after-run sites in the suite already stamp inline or edit inside the run by design, per the review's sweep of all test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability for incremental updates by ensuring rewritten files are recognized as changed, including on filesystems with coarse timestamp resolution.
  - Updated cache, graph, and Markdown front-matter tests to consistently validate re-indexing after file modifications.
  - Added verification that file timestamps are successfully advanced before dependent checks run, preventing intermittent failures caused by timestamp collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->