### PR TITLE
fix: a Delombok-forced re-parse deletes the file's old subtree instead of stacking a second parse

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3073,6 +3073,16 @@ class GraphUpdater:
             if self._single_file is not None and not cache_is_dead
             else {}
         )
+        # Remembered BEFORE the pop: a key forced through re-parse by a
+        # Delombok overlay change was indexed by the previous run, and
+        # popping it from `old_hashes` is what forces the re-hash. It must
+        # not also make the file look NEW to the classification below --
+        # `is_new` skips the delete-before-reingest, so the file's previous
+        # subtree stayed in the graph beside the fresh parse whenever the
+        # graph-backed `preexisting_paths` had nothing to say (issue #1657).
+        forced_reparse_keys = {
+            key for key in self._delombok_stale_keys if key in old_hashes
+        }
         for stale_key in self._delombok_stale_keys:
             old_hashes.pop(stale_key, None)
         is_full_build = (force or not old_hashes) and self._single_file is None
@@ -3209,6 +3219,7 @@ class GraphUpdater:
 
             is_new = (
                 file_key not in old_hashes
+                and file_key not in forced_reparse_keys
                 and preexisting_paths is not None
                 and file_key not in preexisting_paths
             )

--- a/codebase_rag/tests/test_delombok_overlay.py
+++ b/codebase_rag/tests/test_delombok_overlay.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from codebase_rag import constants as cs
 from codebase_rag.capture import ALL_ENABLED
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
@@ -213,13 +214,70 @@ def test_jar_appearing_after_a_raw_index_forces_the_reparse(
     _fake_delombok(monkeypatch)
     mock.reset_mock()
     updater.run()
-    # The reused updater re-registers the class under a duplicate-name
-    # suffix (Widget@N), so the assertion matches the METHOD name only.
-    assert any(".getName(" in qn for qn in _method_qns(mock))
+    # Under the bare class qn: the forced re-parse drops the raw parse's
+    # registry entries first (issue #1657), so the class is not re-registered
+    # as a `Widget@N` duplicate. The graph-side delete is covered by
+    # `test_a_forced_reparse_deletes_the_files_old_subtree_first`, which a
+    # MagicMock cannot observe.
+    assert "proj.src.main.java.com.app.Widget.Widget.getName()" in _method_qns(mock)
     monkeypatch.setattr(java_lombok, "find_lombok_jar", lambda: None)
     mock.reset_mock()
     updater.run()
     assert not any(".getName(" in qn for qn in _method_qns(mock))
+
+
+def test_a_forced_reparse_deletes_the_files_old_subtree_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A file forced through re-parse by an overlay change is a RE-INDEX, not
+    # an addition: its previous subtree must be deleted before the parse, or
+    # the old parse's entities linger beside the fresh ones. Popping the
+    # forced key from `old_hashes` made `is_new` read it as new whenever the
+    # graph-backed path set was empty, so the delete AND the in-memory state
+    # drop were both skipped: the store kept the raw parse's Widget beside a
+    # second, `@N`-suffixed Widget from the expanded parse (issue #1657).
+    #
+    # The stateful evals store rather than a MagicMock: `_delete_module_entities`
+    # runs only for a `QueryProtocol` ingestor, which a MagicMock is not, so a
+    # mock cannot observe the delete in either state.
+    from evals.cgr_graph import _StatefulIngestor
+
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    _fake_java(monkeypatch)
+    monkeypatch.setattr(java_lombok, "find_lombok_jar", lambda: None)
+    parsers, queries = load_parsers()
+    # Default capture: the store models the graph, not the optional network
+    # resource pass ALL_ENABLED would switch on, and the Widget nodes this
+    # asserts on are in the default set.
+    store = _StatefulIngestor()
+    updater = GraphUpdater(
+        ingestor=store, repo_path=repo, parsers=parsers, queries=queries
+    )
+    updater.run()
+    widget_class = "proj.src.main.java.com.app.Widget.Widget"
+    assert (cs.NodeLabel.CLASS.value, widget_class) in store.nodes, (
+        "fixture guard: the raw parse did not register Widget"
+    )
+
+    # The jar appears: the checked-in bytes are unchanged, so only the overlay
+    # identity forces Widget.java back through the parser.
+    _fake_delombok(monkeypatch)
+    updater.run()
+
+    classes = sorted(
+        str(uid) for (label, uid) in store.nodes if label == cs.NodeLabel.CLASS.value
+    )
+    assert classes == [widget_class], (
+        "the forced re-parse did not delete the previous subtree first, so the "
+        f"old Widget survives beside the new parse's: {classes}"
+    )
+    methods = sorted(
+        str(uid) for (label, uid) in store.nodes if label == cs.NodeLabel.METHOD.value
+    )
+    assert f"{widget_class}.getName()" in methods, (
+        f"the expanded member did not land under the bare class qn: {methods}"
+    )
 
 
 def test_maven_cache_prefers_the_numerically_newest_jar(


### PR DESCRIPTION
Closes #1657.

## The defect

A file forced through re-parse by a Delombok overlay change has its key popped from `old_hashes` in `_process_files`; that pop is what forces the re-hash. It also made `is_new` true whenever the graph-backed `preexisting_paths` was the literal empty set (an incremental run whose exclusions match), so the forced file was classified as an ADDITION: neither the up-front `_delete_module_entities` nor `remove_file_from_state` ran, and the previous parse's subtree stayed in the graph beside the fresh one.

Measured on `main` with the stateful store: after the jar appears, two `Class` nodes, the second `Widget@3`-suffixed, and the expanded method registered under the suffixed class.

## The fix

`forced_reparse_keys` is recorded before the pop (a stale key that was in `old_hashes` was indexed by the previous run) and `is_new` excludes it, so the forced file takes the delete-before-reingest path like any other changed file: graph subtree deleted at the pre-parse loop, in-memory state dropped, inbound edges captured and restored. A stale key that was never in `old_hashes` still classifies as new, correctly. The single-file path is unaffected: its `_delombok_stale_keys` is always empty.

## Tests

`test_a_forced_reparse_deletes_the_files_old_subtree_first` uses the stateful evals store, because `_delete_module_entities` runs only for a `QueryProtocol` ingestor and a `MagicMock` is not one, so a mock cannot observe the delete in either state (a first draft of this test passed for that reason on both trees). It asserts exactly one `Class` node after the forced re-parse and the expanded member under the bare class qn. Red on `main`, green with the fix. The sibling test's `Widget@N` comment, which documented the defect as expected behaviour, is replaced by an assertion on the bare qn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected forced re-parsing after overlay changes so outdated graph data is removed before refreshed results are ingested.
  * Prevented duplicate class and method entries from appearing after re-parsing.
  * Ensured refreshed members are associated with the correct class path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->