### PR TITLE
fix: parse a C file's #include directives so it emits the same IMPORTS edge a header does

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -939,7 +939,11 @@ class ImportProcessor:
                     self._parse_rust_imports(captures, module_qn)
                 case cs.SupportedLanguage.GO:
                     self._parse_go_imports(captures, module_qn)
-                case cs.SupportedLanguage.CPP:
+                # C shares the include grammar and the resolver: without its
+                # own arm here a `.c` file's `#include "foo.h"` never reached
+                # the import map, so it emitted no IMPORTS edge while a `.h`
+                # including the same header (parsed as C++) did (issue #1654).
+                case cs.SupportedLanguage.CPP | cs.SupportedLanguage.C:
                     self._parse_cpp_imports(captures, module_qn)
                 case cs.SupportedLanguage.LUA:
                     self._parse_lua_imports(captures, module_qn)

--- a/codebase_rag/parsers/stdlib_extractor.py
+++ b/codebase_rag/parsers/stdlib_extractor.py
@@ -167,7 +167,10 @@ class StdlibExtractor:
                 return self._extract_go_stdlib_path(full_qualified_name)
             case cs.SupportedLanguage.RUST:
                 return self._extract_rust_stdlib_path(full_qualified_name)
-            case cs.SupportedLanguage.CPP:
+            # C shares the include grammar: the same CPP-only arm that hid a
+            # `.c` file's includes upstream (issue #1654) would send its system
+            # includes through the generic extractor here instead.
+            case cs.SupportedLanguage.CPP | cs.SupportedLanguage.C:
                 return self._extract_cpp_stdlib_path(full_qualified_name)
             case cs.SupportedLanguage.JAVA:
                 return self._extract_java_stdlib_path(full_qualified_name)

--- a/codebase_rag/tests/test_c_include_imports.py
+++ b/codebase_rag/tests/test_c_include_imports.py
@@ -1,0 +1,108 @@
+"""A `.c` file's `#include` must emit the same IMPORTS edge a `.h` file's does.
+
+`ImportProcessor.parse_imports` dispatches on language, and the arm that
+parses `preproc_include` nodes was keyed on C++ alone. Headers are registered
+as C++ (`.h` is in `CPP_EXTENSIONS`), so `bar.h` including `foo.h` produced
+`(Module bar) -[IMPORTS]-> (Module foo)`, while `bar.c` with the identical
+directive reached no arm and emitted nothing (issue #1654). A C translation
+unit's includes were therefore invisible to every consumer of IMPORTS edges:
+dependents queries, importer lists, the incremental re-parse set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+HEADER = "#ifndef FOO_H\n#define FOO_H\nint foo(void);\n#endif\n"
+
+
+def _imports(root: Path, includer: str) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    for language in (cs.SupportedLanguage.C, cs.SupportedLanguage.CPP):
+        if language not in parsers:
+            pytest.skip(f"{language} parser not available")
+    (root / "foo.h").write_text(HEADER, encoding="utf-8")
+    (root / includer).write_text('#include "foo.h"\n', encoding="utf-8")
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    return {
+        (str(src), str(dst))
+        for (_sl, src, rel, _tl, dst) in store.edges
+        if rel == cs.RelationshipType.IMPORTS.value
+    }
+
+
+def test_a_c_files_include_emits_the_same_imports_edge_as_a_headers(
+    tmp_path: Path,
+) -> None:
+    c_root = tmp_path / "c"
+    h_root = tmp_path / "h"
+    c_root.mkdir()
+    h_root.mkdir()
+
+    from_c = _imports(c_root, "bar.c")
+    from_h = _imports(h_root, "bar.h")
+
+    expected = {("proj.bar", "proj.foo")}
+    assert from_h == expected, f"fixture guard: the .h includer lost its edge: {from_h}"
+    assert from_c == expected, (
+        f"a .c file's #include emitted no IMPORTS edge while a .h file's did: {from_c}"
+    )
+    assert from_c == from_h
+
+
+def _system_import_targets(root: Path, includer: str) -> set[str]:
+    parsers, queries = load_parsers()
+    for language in (cs.SupportedLanguage.C, cs.SupportedLanguage.CPP):
+        if language not in parsers:
+            pytest.skip(f"{language} parser not available")
+    (root / includer).write_text("#include <Foo>\nint x;\n", encoding="utf-8")
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    return {
+        str(dst)
+        for (_sl, _src, rel, _tl, dst) in store.edges
+        if rel == cs.RelationshipType.IMPORTS.value
+    }
+
+
+def test_a_c_files_system_include_names_the_same_external_module_as_cpps(
+    tmp_path: Path,
+) -> None:
+    # One dispatch further down the path this fix opens to C: the stdlib
+    # extractor also keyed its C++ arm on CPP alone, so a C entry fell to the
+    # generic extractor, which strips a capitalised last segment as an
+    # "entity". `<Foo>` is the extension-less shape where the two diverge; the
+    # common `<stdio.h>` forms happen to agree (found in local review).
+    c_root = tmp_path / "c"
+    cpp_root = tmp_path / "cpp"
+    c_root.mkdir()
+    cpp_root.mkdir()
+    from_c = _system_import_targets(c_root, "a.c")
+    from_cpp = _system_import_targets(cpp_root, "a.cpp")
+    assert from_cpp, "fixture guard: the .cpp includer emitted no IMPORTS edge"
+    assert from_c == from_cpp, (
+        f"a .c system include named {from_c} where the same include from .cpp "
+        f"named {from_cpp}"
+    )

--- a/codebase_rag/tests/test_incremental_stem_siblings.py
+++ b/codebase_rag/tests/test_incremental_stem_siblings.py
@@ -37,8 +37,9 @@ C: dict[str, str] = {
         "int add(int a, int b);\nstatic inline int twice(int a) { return a * 2; }\n"
     ),
     "util.c": '#include "util.h"\nint add(int a, int b) { return a + b; }\n',
-    # A `.c` includer emits no IMPORTS edge, so only a CALLS edge into the
-    # header's inline function ties this file to the survivor's changing qn.
+    # A `.c` includer carries both an IMPORTS edge to the header (since
+    # #1654) and a CALLS edge into its inline function; both must follow the
+    # survivor's changing qn.
     "main.c": '#include "util.h"\nint main(void) { return twice(1); }\n',
 }
 _ABSOLUTE = {cs.NodeLabel.FOLDER.value, cs.NodeLabel.PACKAGE.value}


### PR DESCRIPTION
Closes #1654.

## The defect

`bar.h` with `#include "foo.h"` produced `(Module bar) -[IMPORTS]-> (Module foo)`; `bar.c` with the identical directive produced nothing. `ImportProcessor.parse_imports` dispatches on language, and the arm that parses `preproc_include` captures was keyed on C++ alone. Headers are registered as C++ (`.h` is in `CPP_EXTENSIONS`), so only a C translation unit fell through, and its includes were invisible to every consumer of IMPORTS edges: dependents queries, importer lists, the incremental re-parse set.

Measured on `main`: the `.c` includer yields an empty edge set; with the fix, the same edge as the header.

## The fix

The arm is now `CPP | C`. The same CPP-only shape existed one dispatch further down the path this opens to C: `StdlibExtractor.extract_module_path` sent a C entry through the generic extractor, which strips a capitalised last segment as an "entity", so `#include <Foo>` from `.c` named `std` where `.cpp` named `std.Foo` (found in local review). That arm is widened too. C's import query captures only `preproc_include`, so the module-import and module-declaration branches stay unreachable for C, and include resolution from a `.c` module qn was verified for same-stem pairs and `-I` style paths.

## Tests

`test_c_include_imports.py`: both includer variants on the stateful store must produce identical edge sets, and a system include from `.c` and `.cpp` must name the same ExternalModule. Red on `main`. The fixture comment in `test_incremental_stem_siblings.py` that stated the old behaviour is corrected.

Found in review and filed separately: `startswith("std")` on the include path is a substring match, so `<stdio.h>` is named without the `std.` prefix while `<signal.h>` gets it (#1744).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - C source files now recognize `#include` directives and populate import relationships consistently with C++ files.
  - System and project header imports from C files now resolve to the corresponding modules.

- **Bug Fixes**
  - Updated incremental relationship tracking so C include-based import and call links remain aligned when qualified names change.

- **Tests**
  - Added coverage for project and system includes in C files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->