### PR TITLE
feat: record Go struct construction as INSTANTIATES from composite literals

### DIFF
--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -82,6 +82,10 @@ TS_GO_POINTER_TYPE = "pointer_type"
 # `pkg.Type` in a signature; kept as dotted text so a binding typed to an
 # external package's type stays TYPED (and drops) instead of trie-guessed.
 TS_GO_QUALIFIED_TYPE = "qualified_type"
+TS_GO_GENERIC_TYPE = "generic_type"
+# Field names of a `qualified_type` (`pkg.Name`): the package identifier and
+# the type name; a `composite_literal` carries its constructed type in `type`.
+FIELD_GO_PACKAGE = "package"
 # Go composite types a method may return; a chained call lands on the CONTAINER,
 # not its element, so return-type inference must not unwrap these (a `[]Command`
 # return must not resolve `.Run()` to `Command.Run`).

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -5231,15 +5231,38 @@ class CallProcessor:
         resolve to nothing rather than a guess.
         """
         package_alias, _, name = type_name.rpartition(cs.SEPARATOR_DOT)
+        import_map = self._resolver.import_processor.import_mapping.get(module_qn) or {}
         if package_alias:
-            import_map = (
-                self._resolver.import_processor.import_mapping.get(module_qn) or {}
-            )
-            package_qn = import_map.get(package_alias)
+            packages = [import_map.get(package_alias)]
         else:
-            package_qn = module_qn.rpartition(cs.SEPARATOR_DOT)[0]
-        if not package_qn:
-            return None
+            # Own package first; a bare name can also be an exported type of a
+            # DOT-imported package (`import . "proj/m"`), which the import
+            # pass records under a `.`-prefixed key (#1747 review).
+            packages = [module_qn.rpartition(cs.SEPARATOR_DOT)[0]] + [
+                path
+                for key, path in import_map.items()
+                if key.startswith(cs.SEPARATOR_DOT)
+            ]
+        for package_qn in packages:
+            if not package_qn:
+                continue
+            found = self._go_class_in_package(package_qn, name, module_qn)
+            if found is not None:
+                return found
+        return None
+
+    def _go_class_in_package(
+        self, package_qn: str, name: str, module_qn: str
+    ) -> str | None:
+        """The one Class `name` declared directly under a file of `package_qn`.
+
+        Two files of the package declaring the same name is Go's own error;
+        the shape that does occur is a function-local type shadowing a
+        package-level one, which the registry also files directly under the
+        declaring module. The one declared in THIS file wins then, because a
+        local type is what a bare literal in that file names (#1747 review).
+        Anything still ambiguous resolves to nothing rather than a guess.
+        """
         registry = self._resolver.function_registry
         depth = package_qn.count(cs.SEPARATOR_DOT) + 2
         candidates = [
@@ -5248,6 +5271,13 @@ class CallProcessor:
             if registry.get(qn) == NodeType.CLASS
             and qn.count(cs.SEPARATOR_DOT) == depth
         ]
+        if len(candidates) > 1:
+            own = [
+                qn
+                for qn in candidates
+                if qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
+            ]
+            candidates = own if own else candidates
         return candidates[0] if len(candidates) == 1 else None
 
     def _ingest_go_composite_function_references(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -689,6 +689,19 @@ _GO_SCOPE_TYPES = frozenset(
         cs.TS_GO_FUNC_LITERAL,
     }
 )
+# Each is an implicit block for a declaration inside it: a `case` clause's
+# body is its own scope without braces, so a type declared under `case 0:`
+# is invisible to the `default:` arm (#1747 review).
+_GO_BLOCK_TYPES = frozenset(
+    {
+        cs.TS_GO_BLOCK,
+        cs.TS_GO_EXPRESSION_CASE,
+        cs.TS_GO_TYPE_CASE,
+        cs.TS_GO_COMMUNICATION_CASE,
+        cs.TS_GO_DEFAULT_CASE,
+    }
+)
+_Point = tuple[int, int]
 
 
 def _go_composite_type_name(type_node: Node | None) -> str | None:
@@ -5354,7 +5367,10 @@ class CallProcessor:
         if len(declarations) != len(variants):
             return variants
         by_line = {line: span for line, span in declarations}
-        row = literal.start_point.row
+        # A point, not a row: `x := Local{}; type Local struct{}` on one line
+        # puts the literal BEFORE the declaration, and rows alone attributed
+        # it to the later local type (#1747 review).
+        point: _Point = (literal.start_point.row, literal.start_point.column)
         package_level: list[str] = []
         local: list[str] = []
         for index, variant in enumerate(variants):
@@ -5371,7 +5387,7 @@ class CallProcessor:
                 span = declarations[0][1]
             if span is None:
                 package_level.append(variant)
-            elif span[0] <= row <= span[1]:
+            elif span[0] <= point <= span[1]:
                 local.append(variant)
         if len(local) == 1:
             return local
@@ -5381,39 +5397,42 @@ class CallProcessor:
 
     def _go_type_declaration_scopes(
         self, module_qn: str, name: str
-    ) -> list[tuple[int, tuple[int, int] | None]]:
-        """(1-based line, visible row span or None) per `type name` declaration.
+    ) -> list[tuple[int, tuple[_Point, _Point] | None]]:
+        """(1-based line, visible span or None) per `type name` declaration.
 
         The span of a function-local declaration runs from the declaration's
-        own row to the last row of its innermost enclosing block (a bare
-        `{ }` block, a loop or branch body, or the function body itself),
-        which is where Go makes it visible. None marks a package-level
-        declaration, visible everywhere in the file. In document order,
-        which is the order the definition pass registered them in, so the
-        first is the natural qn and the rest are variants named by their
-        line.
+        own (row, column) to the end of its innermost enclosing block: a bare
+        `{ }` block, a loop or branch body, a `case` clause's implicit body,
+        or the function body itself, which is where Go makes it visible.
+        None marks a package-level declaration, visible everywhere in the
+        file. In document order, which is the order the definition pass
+        registered them in, so the first is the natural qn and the rest are
+        variants named by their line.
         """
         type_inference = self._resolver.type_inference
         file_path = type_inference.module_qn_to_file_path.get(module_qn)
         if file_path is None or not (entry := type_inference.ast_cache.load(file_path)):
             return []
         root_node, _ = entry
-        found: list[tuple[int, tuple[int, int] | None]] = []
-        # The second item is the last row of the innermost block, or None
+        found: list[tuple[int, tuple[_Point, _Point] | None]] = []
+        # The second item is the end point of the innermost block, or None
         # above every function.
-        stack: list[tuple[Node, int | None]] = [(root_node, None)]
+        stack: list[tuple[Node, _Point | None]] = [(root_node, None)]
         while stack:
             node, block_end = stack.pop()
             if node.type in _GO_SCOPE_TYPES or (
-                block_end is not None and node.type == cs.TS_GO_BLOCK
+                block_end is not None and node.type in _GO_BLOCK_TYPES
             ):
-                block_end = node.end_point.row
+                block_end = (node.end_point.row, node.end_point.column)
             if node.type == cs.TS_GO_TYPE_SPEC:
                 spec_name = node.child_by_field_name(cs.FIELD_NAME)
                 if spec_name is not None and safe_decode_text(spec_name) == name:
-                    row = node.start_point.row
+                    start: _Point = (node.start_point.row, node.start_point.column)
                     found.append(
-                        (row + 1, None if block_end is None else (row, block_end))
+                        (
+                            start[0] + 1,
+                            None if block_end is None else (start, block_end),
+                        )
                     )
             stack.extend((child, block_end) for child in node.children)
         found.sort(key=lambda item: item[0])

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -682,6 +682,28 @@ def _site_scoped[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
+def _go_composite_type_name(type_node: Node | None) -> str | None:
+    """The type a Go composite literal constructs, as written: `Error`, `pkg.Error`.
+
+    A `generic_type` (`Box[int]{...}`) constructs its base type. Anything
+    else -- a slice, map, array or struct type literal -- is a container or
+    an anonymous type and has no class to instantiate.
+    """
+    if type_node is None:
+        return None
+    if type_node.type == cs.TS_GO_GENERIC_TYPE:
+        return _go_composite_type_name(type_node.child_by_field_name(cs.FIELD_TYPE))
+    if type_node.type == cs.TS_GO_TYPE_IDENTIFIER:
+        return safe_decode_text(type_node)
+    if type_node.type == cs.TS_GO_QUALIFIED_TYPE:
+        package = type_node.child_by_field_name(cs.FIELD_GO_PACKAGE)
+        name = type_node.child_by_field_name(cs.FIELD_NAME)
+        if package is None or name is None:
+            return None
+        return f"{safe_decode_text(package)}{cs.SEPARATOR_DOT}{safe_decode_text(name)}"
+    return None
+
+
 class _JsFileBindingCollector:
     """Whole-file binding index for the #988 receiver resolution.
 
@@ -1720,6 +1742,13 @@ class CallProcessor:
                     module_qn,
                     None,
                     None,
+                    self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                )
+                # A module-scope `var e = &Error{}` constructs too (issue #1642).
+                self._ingest_go_composite_literal_instantiations(
+                    root_node,
+                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+                    module_qn,
                     self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 )
                 # A module-scope Go var bound to a bare function value
@@ -3203,6 +3232,12 @@ class CallProcessor:
                 module_qn,
                 local_var_types,
                 class_context,
+                self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+            )
+            self._ingest_go_composite_literal_instantiations(
+                caller_node,
+                caller_spec,
+                module_qn,
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
             )
         if language == cs.SupportedLanguage.CPP:
@@ -5137,6 +5172,84 @@ class CallProcessor:
         return name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT) or None
 
     @_site_scoped
+    def _ingest_go_composite_literal_instantiations(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        module_qn: str,
+        boundary_types: frozenset[str],
+    ) -> None:
+        # `Error{...}` and `&Error{...}` are how Go constructs a struct: there
+        # is no constructor call, so the call pass never saw a construction
+        # and no Go program produced an INSTANTIATES edge (issue #1642). The
+        # composite literal is the construction site. Only a literal whose
+        # `type` names a type is one: a slice, map or array literal builds a
+        # container, and its element literals carry no type of their own.
+        # Revive-only, like the C++ braced-return pass: nothing is emitted
+        # unless the type resolves to a registered first-party Class.
+        registry = self._resolver.function_registry
+        ensure_rel = self._emit_rel
+        stack: list[Node] = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type in boundary_types:
+                continue
+            stack.extend(node.children)
+            if node.type != cs.TS_GO_COMPOSITE_LITERAL:
+                continue
+            type_name = _go_composite_type_name(node.child_by_field_name(cs.FIELD_TYPE))
+            if not type_name:
+                continue
+            class_qn = self._go_struct_class(type_name, module_qn)
+            if class_qn is None:
+                continue
+            self._site_node = node
+            for class_variant in registry.variants(class_qn):
+                if registry.get(class_variant) != NodeType.CLASS:
+                    continue
+                ensure_rel(
+                    caller_spec,
+                    cs.RelationshipType.INSTANTIATES,
+                    (cs.NodeLabel.CLASS, cs.KEY_QUALIFIED_NAME, class_variant),
+                )
+
+    def _go_struct_class(self, type_name: str, module_qn: str) -> str | None:
+        """The registered Class a Go composite literal's type names, or None.
+
+        Go types are PACKAGE-scoped: a bare `Name` can only be a type declared
+        in the literal's own package (the files beside it), and `pkg.Name` one
+        declared in the package the import map binds `pkg` to. Types are
+        registered under the FILE that declares them (`proj.m.types.Error`),
+        so the lookup crosses the file segment the source never names.
+
+        Deliberately not `_resolve_class_name`: its last step is a repo-wide
+        search by simple name, which bound `Error{}` in package `m` to a
+        same-named struct in package `a`, or to a Python `class Error`, and
+        dead-code then revived the wrong type while reporting the constructed
+        one dead (#1642 review). The one Class named `Name` directly under a
+        file of the right package is the answer; two candidates, or none,
+        resolve to nothing rather than a guess.
+        """
+        package_alias, _, name = type_name.rpartition(cs.SEPARATOR_DOT)
+        if package_alias:
+            import_map = (
+                self._resolver.import_processor.import_mapping.get(module_qn) or {}
+            )
+            package_qn = import_map.get(package_alias)
+        else:
+            package_qn = module_qn.rpartition(cs.SEPARATOR_DOT)[0]
+        if not package_qn:
+            return None
+        registry = self._resolver.function_registry
+        depth = package_qn.count(cs.SEPARATOR_DOT) + 2
+        candidates = [
+            qn
+            for qn in registry.find_with_prefix_and_suffix(package_qn, name)
+            if registry.get(qn) == NodeType.CLASS
+            and qn.count(cs.SEPARATOR_DOT) == depth
+        ]
+        return candidates[0] if len(candidates) == 1 else None
+
     def _ingest_go_composite_function_references(
         self,
         caller_node: Node,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -5337,12 +5337,12 @@ class CallProcessor:
 
         One file declaring `Local` at package level and again inside a
         function registers both under one qn, the second as a `@line`
-        variant, and a literal fanned out to both. Go scoping says a literal
-        inside the function names the local one and a literal outside it the
-        package one, so choose by position: a declaration inside a function
-        is visible only to literals inside that function, and where one is
-        visible it shadows the package-level twin (CodeRabbit, #1747). Any
-        shape this cannot settle keeps the fan-out.
+        variant, and a literal fanned out to both. Go scoping says a local
+        type is visible from its declaration to the end of its innermost
+        block and shadows the package-level twin there; a literal before the
+        declaration, or outside the nested block that holds it, names the
+        package type (CodeRabbit and #1747 review). So choose by position
+        against that span. Any shape this cannot settle keeps the fan-out.
         """
         variants = self._resolver.function_registry.variants(class_qn)
         if len(variants) < 2 or not class_qn.startswith(
@@ -5382,11 +5382,16 @@ class CallProcessor:
     def _go_type_declaration_scopes(
         self, module_qn: str, name: str
     ) -> list[tuple[int, tuple[int, int] | None]]:
-        """(1-based line, enclosing function row span or None) per `type name`.
+        """(1-based line, visible row span or None) per `type name` declaration.
 
-        In document order, which is the order the definition pass registered
-        them in, so the first is the natural qn and the rest are variants
-        named by their line.
+        The span of a function-local declaration runs from the declaration's
+        own row to the last row of its innermost enclosing block (a bare
+        `{ }` block, a loop or branch body, or the function body itself),
+        which is where Go makes it visible. None marks a package-level
+        declaration, visible everywhere in the file. In document order,
+        which is the order the definition pass registered them in, so the
+        first is the natural qn and the rest are variants named by their
+        line.
         """
         type_inference = self._resolver.type_inference
         file_path = type_inference.module_qn_to_file_path.get(module_qn)
@@ -5394,16 +5399,23 @@ class CallProcessor:
             return []
         root_node, _ = entry
         found: list[tuple[int, tuple[int, int] | None]] = []
-        stack: list[tuple[Node, tuple[int, int] | None]] = [(root_node, None)]
+        # The second item is the last row of the innermost block, or None
+        # above every function.
+        stack: list[tuple[Node, int | None]] = [(root_node, None)]
         while stack:
-            node, span = stack.pop()
-            if node.type in _GO_SCOPE_TYPES:
-                span = (node.start_point.row, node.end_point.row)
+            node, block_end = stack.pop()
+            if node.type in _GO_SCOPE_TYPES or (
+                block_end is not None and node.type == cs.TS_GO_BLOCK
+            ):
+                block_end = node.end_point.row
             if node.type == cs.TS_GO_TYPE_SPEC:
                 spec_name = node.child_by_field_name(cs.FIELD_NAME)
                 if spec_name is not None and safe_decode_text(spec_name) == name:
-                    found.append((node.start_point.row + 1, span))
-            stack.extend((child, span) for child in node.children)
+                    row = node.start_point.row
+                    found.append(
+                        (row + 1, None if block_end is None else (row, block_end))
+                    )
+            stack.extend((child, block_end) for child in node.children)
         found.sort(key=lambda item: item[0])
         return found
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -702,6 +702,55 @@ _GO_BLOCK_TYPES = frozenset(
     }
 )
 _Point = tuple[int, int]
+_Span = tuple[_Point, _Point]
+
+
+def _go_innermost_block_end(node: Node, block_end: _Point | None) -> _Point | None:
+    """The innermost block end in force below `node`: its own end for a
+    function, or for a block-like node already inside one; else inherited."""
+    if node.type in _GO_SCOPE_TYPES or (
+        block_end is not None and node.type in _GO_BLOCK_TYPES
+    ):
+        return (node.end_point.row, node.end_point.column)
+    return block_end
+
+
+def _go_type_spec_start(node: Node, name: str) -> _Point | None:
+    """The start point of `node` when it is a `type_spec` declaring `name`."""
+    if node.type != cs.TS_GO_TYPE_SPEC:
+        return None
+    spec_name = node.child_by_field_name(cs.FIELD_NAME)
+    if spec_name is None or safe_decode_text(spec_name) != name:
+        return None
+    return (node.start_point.row, node.start_point.column)
+
+
+def _go_variant_spans(
+    variants: list[str], declarations: list[tuple[int, _Span | None]]
+) -> list[_Span | None] | None:
+    """One visible span (None for package level) per registry variant.
+
+    The natural qn is the first declaration in document order; a `@line`
+    variant names its declaration by line. None when the two cannot be put
+    in correspondence, which keeps the caller's fan-out.
+    """
+    if len(declarations) != len(variants):
+        return None
+    by_line = dict(declarations)
+    spans: list[_Span | None] = []
+    for index, variant in enumerate(variants):
+        marker = variant.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        if cs.DUP_QN_MARKER not in marker:
+            if index != 0:
+                return None
+            spans.append(declarations[0][1])
+            continue
+        suffix = marker.split(cs.DUP_QN_MARKER, 1)[1]
+        line_text = suffix.split(cs.DUP_QN_COLUMN_MARKER, 1)[0]
+        if not line_text.isdigit() or int(line_text) not in by_line:
+            return None
+        spans.append(by_line[int(line_text)])
+    return spans
 
 
 def _go_composite_type_name(type_node: Node | None) -> str | None:
@@ -5364,31 +5413,23 @@ class CallProcessor:
             return variants
         name = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
         declarations = self._go_type_declaration_scopes(module_qn, name)
-        if len(declarations) != len(variants):
+        spans = _go_variant_spans(variants, declarations)
+        if spans is None:
             return variants
-        by_line = {line: span for line, span in declarations}
         # A point, not a row: `x := Local{}; type Local struct{}` on one line
         # puts the literal BEFORE the declaration, and rows alone attributed
         # it to the later local type (#1747 review).
         point: _Point = (literal.start_point.row, literal.start_point.column)
-        package_level: list[str] = []
-        local: list[str] = []
-        for index, variant in enumerate(variants):
-            marker = variant.rsplit(cs.SEPARATOR_DOT, 1)[-1]
-            if cs.DUP_QN_MARKER in marker:
-                suffix = marker.split(cs.DUP_QN_MARKER, 1)[1]
-                line_text = suffix.split(cs.DUP_QN_COLUMN_MARKER, 1)[0]
-                if not line_text.isdigit() or int(line_text) not in by_line:
-                    return variants
-                span = by_line[int(line_text)]
-            else:
-                if index != 0:
-                    return variants
-                span = declarations[0][1]
-            if span is None:
-                package_level.append(variant)
-            elif span[0] <= point <= span[1]:
-                local.append(variant)
+        local = [
+            variant
+            for variant, span in zip(variants, spans, strict=True)
+            if span is not None and span[0] <= point <= span[1]
+        ]
+        package_level = [
+            variant
+            for variant, span in zip(variants, spans, strict=True)
+            if span is None
+        ]
         if len(local) == 1:
             return local
         if not local and len(package_level) == 1:
@@ -5397,7 +5438,7 @@ class CallProcessor:
 
     def _go_type_declaration_scopes(
         self, module_qn: str, name: str
-    ) -> list[tuple[int, tuple[_Point, _Point] | None]]:
+    ) -> list[tuple[int, _Span | None]]:
         """(1-based line, visible span or None) per `type name` declaration.
 
         The span of a function-local declaration runs from the declaration's
@@ -5414,26 +5455,18 @@ class CallProcessor:
         if file_path is None or not (entry := type_inference.ast_cache.load(file_path)):
             return []
         root_node, _ = entry
-        found: list[tuple[int, tuple[_Point, _Point] | None]] = []
+        found: list[tuple[int, _Span | None]] = []
         # The second item is the end point of the innermost block, or None
         # above every function.
         stack: list[tuple[Node, _Point | None]] = [(root_node, None)]
         while stack:
             node, block_end = stack.pop()
-            if node.type in _GO_SCOPE_TYPES or (
-                block_end is not None and node.type in _GO_BLOCK_TYPES
-            ):
-                block_end = (node.end_point.row, node.end_point.column)
-            if node.type == cs.TS_GO_TYPE_SPEC:
-                spec_name = node.child_by_field_name(cs.FIELD_NAME)
-                if spec_name is not None and safe_decode_text(spec_name) == name:
-                    start: _Point = (node.start_point.row, node.start_point.column)
-                    found.append(
-                        (
-                            start[0] + 1,
-                            None if block_end is None else (start, block_end),
-                        )
-                    )
+            block_end = _go_innermost_block_end(node, block_end)
+            start = _go_type_spec_start(node, name)
+            if start is not None:
+                found.append(
+                    (start[0] + 1, None if block_end is None else (start, block_end))
+                )
             stack.extend((child, block_end) for child in node.children)
         found.sort(key=lambda item: item[0])
         return found

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -682,6 +682,15 @@ def _site_scoped[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
+_GO_SCOPE_TYPES = frozenset(
+    {
+        cs.TS_GO_FUNCTION_DECLARATION,
+        cs.TS_GO_METHOD_DECLARATION,
+        cs.TS_GO_FUNC_LITERAL,
+    }
+)
+
+
 def _go_composite_type_name(type_node: Node | None) -> str | None:
     """The type a Go composite literal constructs, as written: `Error`, `pkg.Error`.
 
@@ -5204,7 +5213,9 @@ class CallProcessor:
             if class_qn is None:
                 continue
             self._site_node = node
-            for class_variant in registry.variants(class_qn):
+            for class_variant in self._go_visible_class_variants(
+                class_qn, module_qn, node
+            ):
                 if registry.get(class_variant) != NodeType.CLASS:
                     continue
                 ensure_rel(
@@ -5270,6 +5281,9 @@ class CallProcessor:
             for qn in registry.find_with_prefix_and_suffix(package_qn, name)
             if registry.get(qn) == NodeType.CLASS
             and qn.count(cs.SEPARATOR_DOT) == depth
+            and self._go_declaration_is_visible(
+                qn.rpartition(cs.SEPARATOR_DOT)[0], package_qn, module_qn
+            )
         ]
         if len(candidates) > 1:
             own = [
@@ -5279,6 +5293,119 @@ class CallProcessor:
             ]
             candidates = own if own else candidates
         return candidates[0] if len(candidates) == 1 else None
+
+    def _go_declaration_is_visible(
+        self, declaring_qn: str, package_qn: str, module_qn: str
+    ) -> bool:
+        """Whether a type declared in `declaring_qn` is in scope for `module_qn`.
+
+        A directory is not a package: `package m_test` files sit beside
+        `package m` files and are a DIFFERENT package, and any `_test.go` is
+        compiled only under `go test`. Without this filter a production
+        `Error{}` in a third file of the package saw both `types.Error` and a
+        same-named `Error` from `m_test.go`, and the ambiguity rule emitted
+        nothing (CodeRabbit, #1747). Same rules as `_go_package_receiver_qn`:
+        a test file is visible only to a test requester of the same package,
+        and within the requester's own directory the `package` clauses must
+        agree. A lookup through an import is into ANOTHER package, whose
+        clause the requester does not share, so only the test rule applies.
+        """
+        declaring_path = self.module_qn_to_file_path.get(declaring_qn)
+        if declaring_path is None:
+            return True
+        requester = self.module_qn_to_file_path.get(module_qn)
+        requester_is_test = requester is not None and requester.stem.endswith(
+            cs.GO_TEST_FILE_SUFFIX
+        )
+        own_package = package_qn == module_qn.rpartition(cs.SEPARATOR_DOT)[0]
+        if declaring_path.stem.endswith(cs.GO_TEST_FILE_SUFFIX) and not (
+            requester_is_test and own_package
+        ):
+            return False
+        if not own_package:
+            return True
+        requester_package = self._go_package_names.get(module_qn)
+        return (
+            requester_package is None
+            or self._go_package_names.get(declaring_qn) == requester_package
+        )
+
+    def _go_visible_class_variants(
+        self, class_qn: str, module_qn: str, literal: Node
+    ) -> list[str]:
+        """The registry variants of `class_qn` that `literal` can name.
+
+        One file declaring `Local` at package level and again inside a
+        function registers both under one qn, the second as a `@line`
+        variant, and a literal fanned out to both. Go scoping says a literal
+        inside the function names the local one and a literal outside it the
+        package one, so choose by position: a declaration inside a function
+        is visible only to literals inside that function, and where one is
+        visible it shadows the package-level twin (CodeRabbit, #1747). Any
+        shape this cannot settle keeps the fan-out.
+        """
+        variants = self._resolver.function_registry.variants(class_qn)
+        if len(variants) < 2 or not class_qn.startswith(
+            f"{module_qn}{cs.SEPARATOR_DOT}"
+        ):
+            return variants
+        name = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        declarations = self._go_type_declaration_scopes(module_qn, name)
+        if len(declarations) != len(variants):
+            return variants
+        by_line = {line: span for line, span in declarations}
+        row = literal.start_point.row
+        package_level: list[str] = []
+        local: list[str] = []
+        for index, variant in enumerate(variants):
+            marker = variant.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+            if cs.DUP_QN_MARKER in marker:
+                suffix = marker.split(cs.DUP_QN_MARKER, 1)[1]
+                line_text = suffix.split(cs.DUP_QN_COLUMN_MARKER, 1)[0]
+                if not line_text.isdigit() or int(line_text) not in by_line:
+                    return variants
+                span = by_line[int(line_text)]
+            else:
+                if index != 0:
+                    return variants
+                span = declarations[0][1]
+            if span is None:
+                package_level.append(variant)
+            elif span[0] <= row <= span[1]:
+                local.append(variant)
+        if len(local) == 1:
+            return local
+        if not local and len(package_level) == 1:
+            return package_level
+        return variants
+
+    def _go_type_declaration_scopes(
+        self, module_qn: str, name: str
+    ) -> list[tuple[int, tuple[int, int] | None]]:
+        """(1-based line, enclosing function row span or None) per `type name`.
+
+        In document order, which is the order the definition pass registered
+        them in, so the first is the natural qn and the rest are variants
+        named by their line.
+        """
+        type_inference = self._resolver.type_inference
+        file_path = type_inference.module_qn_to_file_path.get(module_qn)
+        if file_path is None or not (entry := type_inference.ast_cache.load(file_path)):
+            return []
+        root_node, _ = entry
+        found: list[tuple[int, tuple[int, int] | None]] = []
+        stack: list[tuple[Node, tuple[int, int] | None]] = [(root_node, None)]
+        while stack:
+            node, span = stack.pop()
+            if node.type in _GO_SCOPE_TYPES:
+                span = (node.start_point.row, node.end_point.row)
+            if node.type == cs.TS_GO_TYPE_SPEC:
+                spec_name = node.child_by_field_name(cs.FIELD_NAME)
+                if spec_name is not None and safe_decode_text(spec_name) == name:
+                    found.append((node.start_point.row + 1, span))
+            stack.extend((child, span) for child in node.children)
+        found.sort(key=lambda item: item[0])
+        return found
 
     def _ingest_go_composite_function_references(
         self,

--- a/codebase_rag/tests/test_go_composite_literal_instantiates.py
+++ b/codebase_rag/tests/test_go_composite_literal_instantiates.py
@@ -31,6 +31,7 @@ SVC_GO = (
     'func reassign() *Error  { var e *Error; e = &Error{Msg: "e"}; return e }\n'
     "func generic() Box[int] { return Box[int]{V: 1} }\n"
     'func container() []Error { return []Error{{Msg: "f"}} }\n\n'
+    'var moduleError = &Error{Msg: "module scope"}\n\n'
     "func callsMethod() string {\n"
     '\terr := errors.New("x")\n'
     "\treturn err.Error()\n"
@@ -84,6 +85,9 @@ def test_every_struct_construction_form_emits_instantiates(tmp_path: Path) -> No
     # emits nothing rather than guessing.
     assert "callsMethod" not in by_caller, by_caller.get("callsMethod")
     assert "container" not in by_caller, by_caller.get("container")
+    # A package-level `var e = &Error{}` constructs too; its edge hangs off
+    # the Module node (CodeRabbit, #1747).
+    assert by_caller.get("svc") == {error_qn}, by_caller.get("svc")
 
 
 def test_a_qualified_construction_resolves_through_the_import(tmp_path: Path) -> None:
@@ -132,3 +136,42 @@ def test_a_bare_name_binds_only_to_its_own_package(tmp_path: Path) -> None:
         for targets in by_caller.values()
         for dst in targets
     ), by_caller
+
+
+def test_a_dot_imported_struct_and_a_shadowing_local_type_resolve(
+    tmp_path: Path,
+) -> None:
+    # Two shapes from review (#1747): a bare `Error{}` after `import . "proj/m"`
+    # names m's struct, and a function-local `type Name struct{}` shadows the
+    # package-level one for a literal in that file.
+    root = tmp_path / "proj"
+    (root / "m").mkdir(parents=True)
+    (root / "dot").mkdir()
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "types.go").write_text(TYPES_GO, encoding="utf-8")
+    (root / "dot" / "use.go").write_text(
+        'package dot\n\nimport . "proj/m"\n\n'
+        'func viaDot() *Error { return &Error{Msg: "d"} }\n',
+        encoding="utf-8",
+    )
+    (root / "m" / "shadow.go").write_text(
+        "package m\n\ntype Local struct{}\n\nfunc pkgLevel() Local { return Local{} }\n",
+        encoding="utf-8",
+    )
+    (root / "m" / "inner.go").write_text(
+        "package m\n\nfunc withLocal() any {\n\ttype Local struct{ V int }\n"
+        "\treturn Local{V: 1}\n}\n",
+        encoding="utf-8",
+    )
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    assert by_caller.get("viaDot") == {"proj.m.types.Error"}, by_caller.get("viaDot")
+    # The package-level literal in shadow.go names shadow.go's Local; the
+    # literal inside withLocal names inner.go's local Local, not shadow.go's.
+    assert by_caller.get("pkgLevel") == {"proj.m.shadow.Local"}, by_caller.get(
+        "pkgLevel"
+    )
+    targets = by_caller.get("withLocal")
+    assert targets is not None and len(targets) == 1, targets
+    assert next(iter(targets)).startswith("proj.m.inner."), targets

--- a/codebase_rag/tests/test_go_composite_literal_instantiates.py
+++ b/codebase_rag/tests/test_go_composite_literal_instantiates.py
@@ -237,3 +237,47 @@ def test_a_test_packages_type_is_invisible_to_production_code(tmp_path: Path) ->
     assert by_caller.get("build") == {"proj.m.types.Error"}, by_caller
     assert by_caller.get("external") == {"proj.m.m_test.Error"}, by_caller
     assert by_caller.get("internal") == {"proj.m.types.Error"}, by_caller
+
+
+def test_a_local_type_is_visible_from_its_declaration_to_its_block_end(
+    tmp_path: Path,
+) -> None:
+    # Go scoping, not function scoping: a literal BEFORE the local
+    # declaration names the package type, and so does one outside the nested
+    # block that holds the declaration (CodeRabbit and #1747 review). Each
+    # function here constructs both, so its edge set must hold the package
+    # qn and its own local variant; a function-wide span would give only the
+    # local one.
+    root = tmp_path / "proj"
+    (root / "m").mkdir(parents=True)
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "one.go").write_text(
+        "package m\n\n"
+        "type Local struct{}\n\n"
+        "func before() Local {\n"
+        "\tx := Local{}\n"
+        "\ttype Local struct{ V int }\n"
+        "\t_ = Local{V: 1}\n"
+        "\treturn x\n"
+        "}\n\n"
+        "func nested() Local {\n"
+        "\t{\n"
+        "\t\ttype Local struct{ V int }\n"
+        "\t\t_ = Local{V: 1}\n"
+        "\t}\n"
+        "\treturn Local{}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    package_qn = "proj.m.one.Local"
+    assert by_caller.get("before") == {
+        package_qn,
+        f"{package_qn}{cs.DUP_QN_MARKER}7",
+    }, by_caller
+    assert by_caller.get("nested") == {
+        package_qn,
+        f"{package_qn}{cs.DUP_QN_MARKER}14",
+    }, by_caller

--- a/codebase_rag/tests/test_go_composite_literal_instantiates.py
+++ b/codebase_rag/tests/test_go_composite_literal_instantiates.py
@@ -173,5 +173,67 @@ def test_a_dot_imported_struct_and_a_shadowing_local_type_resolve(
         "pkgLevel"
     )
     targets = by_caller.get("withLocal")
-    assert targets is not None and len(targets) == 1, targets
+    assert targets is not None, by_caller
+    assert len(targets) == 1, targets
     assert next(iter(targets)).startswith("proj.m.inner."), targets
+
+
+def test_a_local_type_shadows_the_package_one_within_its_function(
+    tmp_path: Path,
+) -> None:
+    # Both declarations in ONE file register under one qn, the local one as
+    # a `@line` variant, and every literal fanned out to both. Go scoping:
+    # the literal inside `withLocal` names the local type, the one in
+    # `pkgLevel` the package-level type (CodeRabbit, #1747).
+    root = tmp_path / "proj"
+    (root / "m").mkdir(parents=True)
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "one.go").write_text(
+        "package m\n\n"
+        "type Local struct{}\n\n"
+        "func pkgLevel() Local { return Local{} }\n\n"
+        "func withLocal() any {\n"
+        "\ttype Local struct{ V int }\n"
+        "\treturn Local{V: 1}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    assert by_caller.get("pkgLevel") == {"proj.m.one.Local"}, by_caller
+    assert by_caller.get("withLocal") == {f"proj.m.one.Local{cs.DUP_QN_MARKER}8"}, (
+        by_caller
+    )
+
+
+def test_a_test_packages_type_is_invisible_to_production_code(tmp_path: Path) -> None:
+    # `package m_test` shares the directory with `package m` and is a
+    # different package; any `_test.go` is compiled only under `go test`.
+    # A production literal in a THIRD file saw both `Error` declarations and
+    # the ambiguity rule emitted nothing (CodeRabbit, #1747). The external
+    # test's own literal binds to its own `Error`; an internal test file
+    # (`package m` in `_test.go`) sees the production type.
+    root = tmp_path / "proj"
+    (root / "m").mkdir(parents=True)
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "types.go").write_text(TYPES_GO, encoding="utf-8")
+    (root / "m" / "svc.go").write_text(
+        'package m\n\nfunc build() Error { return Error{Msg: "a"} }\n',
+        encoding="utf-8",
+    )
+    (root / "m" / "m_test.go").write_text(
+        "package m_test\n\ntype Error struct{ Other int }\n\n"
+        "func external() Error { return Error{Other: 1} }\n",
+        encoding="utf-8",
+    )
+    (root / "m" / "internal_test.go").write_text(
+        'package m\n\nfunc internal() Error { return Error{Msg: "t"} }\n',
+        encoding="utf-8",
+    )
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    assert by_caller.get("build") == {"proj.m.types.Error"}, by_caller
+    assert by_caller.get("external") == {"proj.m.m_test.Error"}, by_caller
+    assert by_caller.get("internal") == {"proj.m.types.Error"}, by_caller

--- a/codebase_rag/tests/test_go_composite_literal_instantiates.py
+++ b/codebase_rag/tests/test_go_composite_literal_instantiates.py
@@ -1,0 +1,134 @@
+"""Go composite literals are struct constructions and must emit INSTANTIATES.
+
+`&Error{...}` and `Error{...}` are how a Go program constructs a struct. There
+is no constructor call, so the call pass never saw a construction, and no Go
+program produced an `INSTANTIATES` edge in any syntactic position (issue
+#1642): on gin-gonic/gin every one of the 82 such edges came from the #1641
+method-name collision rather than from a literal. The composite literal is the
+construction site, and this pins the five forms the issue enumerates plus the
+control that a method call is not one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+TYPES_GO = "package m\n\ntype Error struct {\n\tMsg string\n}\n\ntype Box[T any] struct {\n\tV T\n}\n"
+SVC_GO = (
+    "package m\n\n"
+    'import "errors"\n\n'
+    'func retPtr() *Error    { return &Error{Msg: "a"} }\n'
+    'func retVal() Error     { return Error{Msg: "b"} }\n'
+    'func assignPtr() *Error { e := &Error{Msg: "c"}; return e }\n'
+    'func assignVal() Error  { e := Error{Msg: "d"}; return e }\n'
+    'func reassign() *Error  { var e *Error; e = &Error{Msg: "e"}; return e }\n'
+    "func generic() Box[int] { return Box[int]{V: 1} }\n"
+    'func container() []Error { return []Error{{Msg: "f"}} }\n\n'
+    "func callsMethod() string {\n"
+    '\terr := errors.New("x")\n'
+    "\treturn err.Error()\n"
+    "}\n"
+)
+OTHER_GO = 'package other\n\nimport "proj/m"\n\nfunc build() *m.Error { return &m.Error{Msg: "g"} }\n'
+
+
+def _index(root: Path) -> _StatefulIngestor:
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.GO not in parsers:
+        pytest.skip("go parser not available")
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    return store
+
+
+def _instantiates(store: _StatefulIngestor) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for _sl, src, rel, _tl, dst in store.edges:
+        if rel == cs.RelationshipType.INSTANTIATES.value:
+            out.setdefault(str(src).rsplit(".", 1)[-1], set()).add(str(dst))
+    return out
+
+
+def test_every_struct_construction_form_emits_instantiates(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    (root / "m").mkdir(parents=True)
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "types.go").write_text(TYPES_GO, encoding="utf-8")
+    (root / "m" / "svc.go").write_text(SVC_GO, encoding="utf-8")
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    error_qn = "proj.m.types.Error"
+    for caller in ("retPtr", "retVal", "assignPtr", "assignVal", "reassign"):
+        assert by_caller.get(caller) == {error_qn}, (
+            f"{caller} constructs Error and emitted {by_caller.get(caller)}"
+        )
+    # A generic instantiation constructs its base type.
+    assert by_caller.get("generic") == {"proj.m.types.Box"}, by_caller.get("generic")
+    # The control: a method call is not a construction (#1641), and a slice
+    # literal's element literals carry no type of their own, so `container`
+    # emits nothing rather than guessing.
+    assert "callsMethod" not in by_caller, by_caller.get("callsMethod")
+    assert "container" not in by_caller, by_caller.get("container")
+
+
+def test_a_qualified_construction_resolves_through_the_import(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    (root / "m").mkdir(parents=True)
+    (root / "other").mkdir()
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "types.go").write_text(TYPES_GO, encoding="utf-8")
+    (root / "other" / "build.go").write_text(OTHER_GO, encoding="utf-8")
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    assert by_caller.get("build") == {"proj.m.types.Error"}, by_caller.get("build")
+
+
+def test_a_bare_name_binds_only_to_its_own_package(tmp_path: Path) -> None:
+    # Go types are package-scoped. The same struct name in another package,
+    # or a same-named class in another language, must not receive the edge:
+    # the repo-wide simple-name fallback did exactly that, so dead-code
+    # revived the wrong type and reported the constructed one dead (#1642
+    # review). `a` sorts before `m`, which is the order that fallback picked.
+    root = tmp_path / "proj"
+    for pkg in ("a", "m"):
+        (root / pkg).mkdir(parents=True)
+        (root / pkg / "types.go").write_text(
+            f"package {pkg}\n\ntype Error struct {{\n\tMsg string\n}}\n",
+            encoding="utf-8",
+        )
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "svc.go").write_text(
+        'package m\n\nfunc build() *Error { return &Error{Msg: "x"} }\n',
+        encoding="utf-8",
+    )
+    (root / "config.py").write_text("class Config:\n    pass\n", encoding="utf-8")
+    (root / "m" / "cfg.go").write_text(
+        "package m\n\ntype Config struct{}\n\nfunc cfg() Config { return Config{} }\n",
+        encoding="utf-8",
+    )
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    assert by_caller.get("build") == {"proj.m.types.Error"}, by_caller.get("build")
+    assert by_caller.get("cfg") == {"proj.m.cfg.Config"}, by_caller.get("cfg")
+    assert not any(
+        "proj.a." in dst or dst == "proj.config.Config"
+        for targets in by_caller.values()
+        for dst in targets
+    ), by_caller

--- a/codebase_rag/tests/test_go_composite_literal_instantiates.py
+++ b/codebase_rag/tests/test_go_composite_literal_instantiates.py
@@ -281,3 +281,41 @@ def test_a_local_type_is_visible_from_its_declaration_to_its_block_end(
         package_qn,
         f"{package_qn}{cs.DUP_QN_MARKER}14",
     }, by_caller
+
+
+def test_a_local_type_scope_respects_columns_and_case_clauses(tmp_path: Path) -> None:
+    # Two more shapes of the same rule (#1747 review). On one line, a literal
+    # BEFORE the declaration names the package type, which needs column
+    # order and not just rows. A `case` clause's body is an implicit block,
+    # so a type declared under `case 0:` is invisible to `default:`.
+    root = tmp_path / "proj"
+    (root / "m").mkdir(parents=True)
+    (root / "go.mod").write_text("module proj\n\ngo 1.22\n", encoding="utf-8")
+    (root / "m" / "one.go").write_text(
+        "package m\n\n"
+        "type Local struct{}\n\n"
+        "func sameLine() any { x := Local{}; type Local struct{ V int }; "
+        "y := Local{V: 1}; return []any{x, y} }\n\n"
+        "func inSwitch(n int) any {\n"
+        "\tswitch n {\n"
+        "\tcase 0:\n"
+        "\t\ttype Local struct{ V int }\n"
+        "\t\treturn Local{V: 1}\n"
+        "\tdefault:\n"
+        "\t\treturn Local{}\n"
+        "\t}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    store = _index(root)
+
+    by_caller = _instantiates(store)
+    package_qn = "proj.m.one.Local"
+    assert by_caller.get("sameLine") == {
+        package_qn,
+        f"{package_qn}{cs.DUP_QN_MARKER}5",
+    }, by_caller
+    assert by_caller.get("inSwitch") == {
+        package_qn,
+        f"{package_qn}{cs.DUP_QN_MARKER}10",
+    }, by_caller


### PR DESCRIPTION
Closes #1642.

## The gap

`&Error{...}` and `Error{...}` are how a Go program constructs a struct. There is no constructor call, so the call pass never saw a construction, and no Go program produced an INSTANTIATES edge in any position: on gin-gonic/gin every one of the 82 such edges came from the #1641 method-name collision, none from a literal.

## The change

A `_site_scoped` pass over each caller body (and the module scope, for `var e = &Error{}`) visits every `composite_literal` whose `type` is a `type_identifier`, `qualified_type` or `generic_type` and emits INSTANTIATES to the registered Class it names. Slice, map and array literals build containers and their element literals carry no type, so they emit nothing rather than guess.

Type lookup is package-scoped, which is Go's rule and the one thing the first draft got wrong (local review): a bare `Name` can only be a type declared beside the literal, and `pkg.Name` one in the package the import map binds `pkg` to. Types are registered under the file that declares them (`proj.m.types.Error`), so the lookup crosses the file segment the source never names and accepts exactly one Class at that depth. The language-agnostic `_resolve_class_name` is deliberately not used: its repo-wide simple-name fallback bound `Error{}` in package `m` to a same-named struct in package `a`, or to a Python `class Error`, and dead-code then revived the wrong type while reporting the constructed one dead.

## Tests

`test_go_composite_literal_instantiates.py`: the issue's five construction forms, a generic instantiation, a slice-literal control, the `errors.New("x").Error()` method-call control (#1641), a cross-package `m.Error{}` through the import, and the same struct name in two packages plus a same-named Python class, which must not receive the edge. Red on `main` (no Go INSTANTIATES pass), green with the change, alongside the existing Go suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go composite-literal constructions now appear as class instantiation relationships.
  * Supports pointer and value literals, generic types, qualified types, assignments, returns, and package-aware resolution.
  * Handles package-level constructions and local type shadowing while avoiding relationships for unsupported contexts such as method calls, slice element literals, or unrelated same-named types.

* **Tests**
  * Added coverage for Go composite literals, generic types, package-qualified and dot-imported constructions, assignments, returns, test-package behavior, and scope resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->