### PR TITLE
fix: hold a bold in a news bullet's body to the feature-theme rule

### DIFF
--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -141,6 +141,11 @@ class TestExtractBullets:
         assert extract_bullets(prose) == [prose]
         code = "- **Python Taint**: follows `**kwargs` through tests and `**args` too."
         assert extract_bullets(code) == [code]
+        # A double-backtick span is one span; stripping backtick pairs
+        # separately would leave `**CI**` behind as a bold (#1748 review).
+        double = "- **Web Search**: renders ``**CI**`` literally in results."
+        assert extract_bullets(double) == [double]
+        assert body_themes_are_features("``**docs**`` shown as code") is True
         assert is_feature_theme("Improvements") is True
         assert is_feature_theme("CI automation") is False
         assert body_themes_are_features("plain tests and docs in prose") is True

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -10,6 +10,7 @@ from scripts.update_news import (
     BULLET_PATTERN,
     HIGHLIGHT_BULLET,
     LATEST_RELEASE_MARKER,
+    body_themes_are_features,
     create_aggregated_bullet,
     existing_themes,
     extract_all_highlights,
@@ -109,34 +110,41 @@ class TestExtractBullets:
             "- **Web Search**: the agent searches.",
         ]
 
-    def test_the_filter_inspects_the_theme_only_which_a_later_bold_exploits(
-        self,
-    ) -> None:
-        """Pins a PRE-EXISTING limit, widened but not created by this change.
+    def test_a_non_feature_bold_in_the_body_is_rejected_like_a_theme(self) -> None:
+        """Closes the hole the previous version of this test pinned (issue #1608).
 
-        `is_feature_theme` is passed the theme and nothing else, so a
-        non-feature word living in the BODY is never inspected. On main
-        (colon outside the bold only) this already admits
-        "- **Improvements**: to **CI automation**: ..."; accepting the
-        colon-inside spelling necessarily admits its twin. Anchoring the
-        colon to the FIRST bold is what stops the theme group itself from
-        running past a later bold; main already does that and this change
-        preserves it, so the anchoring is load-bearing but not new here.
-
-        The residual hole is the filter's input, not the pattern, and
-        closing it means inspecting the body too - a behaviour change to
-        what counts as a feature entry, out of scope here.
+        `is_feature_theme` was passed the theme and nothing else, so a
+        non-feature word in a SECOND bold in the body was never inspected:
+        "- **Improvements**: to **CI automation**: ..." carried CI content into
+        the README. A bold in the body is a theme in all but position and is
+        now held to the same rule. Prose is deliberately not: four current
+        NEWS.md entries say "test suite", "type-test patterns", "this release"
+        or "benchmark" in passing and must keep passing; nor is inline code,
+        where two `**kwargs`-style tokens would otherwise pair into a bold.
         """
-        # Preserved by this change, also [] on main: the theme group cannot
-        # end at a LATER bold.
+        # The theme group cannot end at a LATER bold (anchored to the first).
         assert extract_bullets("- **Improvements** to **CI automation**: x.") == []
         assert extract_bullets("* **Improvements** to **CI automation**: x.") == []
-        # Not fixed, and equally true before it: a colon directly after the
-        # first bold makes everything else a body the filter never reads.
-        leaked = extract_bullets("- **Improvements**: to **CI automation**: x.")
-        assert leaked == ["- **Improvements**: to **CI automation**: x."]
+        # The colon-after-first-bold twin, which used to leak.
+        assert extract_bullets("- **Improvements**: to **CI automation**: x.") == []
+        assert extract_bullets("* **Improvements:** to **CI automation**: x.") == []
+        # A feature-named bold in the body is fine.
+        assert extract_bullets("- **Improvements**: to **Web Search** ranking.") == [
+            "- **Improvements**: to **Web Search** ranking."
+        ]
+        # Prose mentions of non-feature words are not themes and stay.
+        prose = (
+            "- **Runtime Call Tracing**: runs your code (typically the test suite) "
+            "and merges the calls, handling type-test patterns; this release "
+            "adds a benchmark harness."
+        )
+        assert extract_bullets(prose) == [prose]
+        code = "- **Python Taint**: follows `**kwargs` through tests and `**args` too."
+        assert extract_bullets(code) == [code]
         assert is_feature_theme("Improvements") is True
         assert is_feature_theme("CI automation") is False
+        assert body_themes_are_features("plain tests and docs in prose") is True
+        assert body_themes_are_features("see **docs** for more") is False
 
     def test_both_extractors_accept_a_missing_space_after_the_colon(self) -> None:
         """The unification issue #1609 asked for, in the permissive direction.

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -118,8 +118,11 @@ def is_feature_theme(theme: str) -> bool:
 
 BODY_THEME = re.compile(r"\*\*(?P<theme>[^*]+?)\*\*")
 # Inline code is not prose: two `**kwargs`-style tokens would otherwise pair
-# up into a pseudo-bold whose "theme" is the text between them.
-CODE_SPAN = re.compile(r"`[^`]*`")
+# up into a pseudo-bold whose "theme" is the text between them. A span opens
+# with a run of backticks and closes with a run of the SAME length, so
+# ``**CI**`` (a double-backtick span) is one span, not two empty ones with a
+# bold left between them (#1748 review).
+CODE_SPAN = re.compile(r"(?P<delimiter>`+).*?(?P=delimiter)")
 
 
 def body_themes_are_features(text: str) -> bool:

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -44,10 +44,10 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 # preserves main's behaviour rather than adding to it: main's `\*\*:` already
 # rejects a later-bold theme, and the alternation keeps that. A looser
 # `:?\*\*:?` would instead let the theme group end at a LATER bold, so
-# "- **Improvements** to **CI automation**: ..." captures theme="Improvements"
-# and leaves "CI automation" in the body, where is_feature_theme never
-# inspects it - a CI entry then reaches Latest News, which is the one thing
-# this module exists to prevent.
+# "- **Improvements** to **CI automation**: ..." would capture
+# theme="Improvements" and leave "CI automation" in the body. The anchoring
+# keeps the theme stable for dedup and normalisation; a bold left in the body
+# is separately rejected by body_themes_are_features (issue #1608).
 # The separator is ` *`, not ` +`, so a bullet with no space after the colon
 # parses here exactly as it does in HIGHLIGHT_BULLET below. The two disagreed
 # until #1609: this pattern rejected it while HIGHLIGHT_BULLET accepted it, so
@@ -116,6 +116,31 @@ def is_feature_theme(theme: str) -> bool:
     return NON_FEATURE_THEME.search(theme) is None
 
 
+BODY_THEME = re.compile(r"\*\*(?P<theme>[^*]+?)\*\*")
+# Inline code is not prose: two `**kwargs`-style tokens would otherwise pair
+# up into a pseudo-bold whose "theme" is the text between them.
+CODE_SPAN = re.compile(r"`[^`]*`")
+
+
+def body_themes_are_features(text: str) -> bool:
+    """True when every bold span in a bullet's BODY passes `is_feature_theme`.
+
+    The filter used to read the theme and nothing else, so a generator that
+    wrote "**Improvements**: to **CI automation**: ..." put its real subject in
+    a second bold the filter never saw, and CI content reached the README
+    (issue #1608). A bold in the body is a theme in all but position, so it is
+    held to the theme's rule. Plain prose is NOT: a feature entry legitimately
+    says "the test suite", "type-test patterns", "this release" or "a benchmark
+    harness" in passing (four current NEWS.md entries do), and rejecting on
+    those words would drop the features this filter exists to keep. Code spans
+    are stripped first, so `**kwargs` in backticks cannot open a bold.
+    """
+    prose = CODE_SPAN.sub("", text)
+    return all(
+        is_feature_theme(match.group("theme")) for match in BODY_THEME.finditer(prose)
+    )
+
+
 def _normalize_dashes(text: str) -> str:
     """Replace em-dashes and en-dashes with a hyphen; house style forbids them.
 
@@ -129,8 +154,9 @@ def _normalize_dashes(text: str) -> str:
 def extract_bullets(fragment: str) -> list[str]:
     """Return the well-formed, feature-themed news bullets in a fragment.
 
-    A bullet must match the NEWS.md entry format AND name a product feature;
-    non-feature themes (CI/devx/release/bug/etc.) are discarded here so neither
+    A bullet must match the NEWS.md entry format AND name a product feature,
+    in its theme and in any bold the body carries (issue #1608); non-feature
+    themes (CI/devx/release/bug/etc.) are discarded here so neither
     the count cap nor the dedup downstream ever considers them. Highlights-style
     `* ` bullets are accepted and normalised to the NEWS.md `- ` marker, as
     is a colon inside the bold theme (`**Theme:**`), which the generator
@@ -142,7 +168,11 @@ def extract_bullets(fragment: str) -> list[str]:
         if stripped.startswith("* "):
             stripped = f"- {stripped[2:]}"
         match = BULLET_PATTERN.match(stripped)
-        if match and is_feature_theme(match.group("theme")):
+        if (
+            match
+            and is_feature_theme(match.group("theme"))
+            and body_themes_are_features(match.group("text"))
+        ):
             theme = match.group("theme").strip()
             bullets.append(f"- **{theme}**: {match.group('text')}")
     return bullets


### PR DESCRIPTION
Closes #1608.

## The leak

`extract_bullets` in `scripts/update_news.py` passed a bullet's THEME to `is_feature_theme` and nothing else. A generator that wrote `- **Improvements**: to **CI automation**: ...` put its real subject in a second bold the filter never saw, and CI content reached the README's Latest News. The colon-anchoring fix in #1606 stops the theme group running past a later bold; it cannot inspect a body it never reads.

## The fix

A bold in the body is a theme in all but position, so `body_themes_are_features` holds every `**...**` span in the body to `is_feature_theme`, and `extract_bullets` requires both checks. Prose is deliberately NOT inspected: four current NEWS.md entries say "test suite", "type-test patterns", "this release" or "benchmark harness" in passing, and the non-feature regex would drop them; every one of the 23 NEWS.md entries and the 6 README entries still passes. Inline code is stripped first, so two `**kwargs`-style tokens in backticks cannot pair into a pseudo-bold (found in local review). The stale pattern comment that described the body as uninspected is rewritten.

## Tests

The test that pinned the old limit is replaced by `test_a_non_feature_bold_in_the_body_is_rejected_like_a_theme`: the two colon spellings of the leak are rejected, a feature-named bold in the body is kept, prose with four non-feature words is kept, the backtick case is kept, and `body_themes_are_features` is exercised directly. Red on `main` for the two leak lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release-note filtering to reject bullets containing non-feature bold headings in their body.
  - Preserved valid bullets with recognized feature themes.
  - Correctly ignores non-feature words in regular prose and inline code.
  - Handles single- and double-backtick code spans without misclassifying their contents.
  - Applies validation consistently across supported bullet styles and colon placements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->