### PR TITLE
test: fail the peak-memory invariance only on a drift a leak could cause

### DIFF
--- a/codebase_rag/tests/test_indexing_benchmark.py
+++ b/codebase_rag/tests/test_indexing_benchmark.py
@@ -157,8 +157,9 @@ def test_peak_memory_is_local_to_the_run_not_the_process(tmp_path: Path) -> None
 
     Allocating and releasing the buffer BETWEEN the two measurements is what
     gives the test its teeth: in-process `ru_maxrss` would raise the second
-    reading to at least the ballast, while a subprocess measurement is
-    unmoved.
+    reading to at least the ballast, while a subprocess measurement is not
+    raised by it (it still drifts either way with host load; the assertion
+    below is one-sided for that reason).
     """
     corpus = _write_corpus(tmp_path / "repo", files=1)
 
@@ -177,11 +178,18 @@ def test_peak_memory_is_local_to_the_run_not_the_process(tmp_path: Path) -> None
     after = measure_indexing(corpus, project_name="bench_fixture")
 
     # Same corpus, same work: the ballast must not show up in the second
-    # reading. Allow generous jitter for allocator noise between two real
-    # indexing runs, but far less than the ballast a leak would contribute.
-    drift = abs(after.peak_rss_bytes - before.peak_rss_bytes)
+    # reading. DIRECTIONAL, not absolute: a leak of the parent's history can
+    # only RAISE the second reading (the ballast was allocated between the
+    # two), while the noise between two real subprocess runs on a loaded host
+    # -- allocator behaviour, page-cache pressure, scheduling -- moves it
+    # either way. `abs()` made a second run that happened to peak LOWER fail
+    # for a reason that is not the defect this test exists to catch, and it
+    # did, on the same commit minutes apart under a load average above 30
+    # (issue #1643). Generous jitter is still allowed upward, but far less
+    # than the ballast a leak would contribute.
+    drift = after.peak_rss_bytes - before.peak_rss_bytes
     assert drift < ballast_size // 2, (
-        f"peak moved by {drift} bytes across a released {ballast_size}-byte "
+        f"peak rose by {drift} bytes across a released {ballast_size}-byte "
         "parent allocation; the reported peak is tracking the parent process "
         "rather than the indexing run"
     )


### PR DESCRIPTION
Closes #1643.

## The flake

`test_peak_memory_is_local_to_the_run_not_the_process` took two peak-RSS readings from separate subprocess indexing runs and asserted `abs(after - before) < ballast_size // 2`. Under a load average above 30 the two runs did not see comparable conditions and the drift exceeded 96 MiB; the test failed and then passed on the same commit minutes apart, which reads as a regression to whoever meets it.

## The change

The assertion is directional: `after - before < ballast_size // 2`. A leak of the parent's history can only RAISE the second reading (the 192 MiB ballast is allocated between the two), while allocator, page-cache and scheduling noise between two real subprocess runs moves it either way. Verified against the original in-process implementation (`3debd5c8`, a monotonic `ru_maxrss` high-water mark): the ballast raised it by 201 MB here, above the 100 MiB threshold, so the defect the test exists for is still caught, and a high-water mark can never produce a negative drift, so nothing is lost by ignoring the downward side. The docstring's "a subprocess measurement is unmoved" is corrected to what the fix rests on: it is not raised by the ballast, though it drifts with load.

The change strictly weakens the assertion, so every run that passed before passes now; the failing set shrinks to upward drifts only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated peak-memory isolation checks to account for memory variation in either direction.
  * Improved failure diagnostics by reporting the direction of unexpected memory drift.
  * Tests now focus on detecting upward memory growth consistent with allocation leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->