### PR TITLE
fix: name a Lua function built into a table constructor by its field key under its table

### DIFF
--- a/codebase_rag/constants/ast_lua.py
+++ b/codebase_rag/constants/ast_lua.py
@@ -28,6 +28,13 @@ LUA_METHOD_SEPARATOR = ":"
 TS_LUA_CHUNK = "chunk"
 TS_LUA_FUNCTION_DECLARATION = "function_declaration"
 TS_LUA_FUNCTION_DEFINITION = "function_definition"
+# A `key = value` entry of a table constructor (`{ f = function() end }`): the
+# key is the `name` field (an identifier, or a string for `["key"] =`), the
+# value the `value` field.
+TS_LUA_FIELD = "field"
+# The token that opens a computed or string key: `["k"] = v`, `[k] = v`.
+LUA_OPEN_BRACKET = "["
+TS_LUA_TABLE_CONSTRUCTOR = "table_constructor"
 
 # Import processor function names
 IMPORT_REQUIRE = "require"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1893,17 +1893,22 @@ class CallProcessor:
                 # all, and without this the body's calls were dropped or
                 # credited to the enclosing function (#1631 review).
                 field = lua_utils.field_function_path(func_node)
-                func_name = (
-                    field[0]
-                    if field is not None
-                    else lua_utils.extract_assigned_name(
+                if field is not None:
+                    func_name = field[0]
+                elif lua_utils.is_field_value(func_node):
+                    # A field with no name is anonymous in the definition
+                    # pass too; naming it after the assignment here would
+                    # credit its calls to a node that does not exist
+                    # (#1750 review).
+                    func_name = None
+                else:
+                    func_name = lua_utils.extract_assigned_name(
                         func_node,
                         accepted_var_types=(
                             cs.TS_DOT_INDEX_EXPRESSION,
                             cs.TS_IDENTIFIER,
                         ),
                     )
-                )
             if not func_name:
                 # A nameless JS/TS function expression that a NAMED pass
                 # registered (`exports.f = function`, `x: function`) has a

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1886,10 +1886,23 @@ class CallProcessor:
                 # A function expression bound to a variable or table field
                 # (`local f = function()`, `M.f = function()`) has no name field;
                 # the definition pass names it after its assignment target, so
-                # recover the same name here or the whole body is skipped.
-                func_name = lua_utils.extract_assigned_name(
-                    func_node,
-                    accepted_var_types=(cs.TS_DOT_INDEX_EXPRESSION, cs.TS_IDENTIFIER),
+                # recover the same name here or the whole body is skipped. A
+                # table-constructor field value is named by its key path first
+                # (issue #1631), through the SAME helper the definition pass
+                # uses: a returned or passed table has no assignment target at
+                # all, and without this the body's calls were dropped or
+                # credited to the enclosing function (#1631 review).
+                field = lua_utils.field_function_path(func_node)
+                func_name = (
+                    field[0]
+                    if field is not None
+                    else lua_utils.extract_assigned_name(
+                        func_node,
+                        accepted_var_types=(
+                            cs.TS_DOT_INDEX_EXPRESSION,
+                            cs.TS_IDENTIFIER,
+                        ),
+                    )
                 )
             if not func_name:
                 # A nameless JS/TS function expression that a NAMED pass

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1238,13 +1238,21 @@ class FunctionIngestMixin:
         lang_config: LanguageSpec,
     ) -> FunctionResolution:
         func_name = self._extract_function_name(func_node)
+        # A function expression that is the VALUE of a table-constructor field
+        # (`s = { set = function() end }`) is named by its key, under the table
+        # it is built into: qn `s.set`, name `set`. Before, the enclosing
+        # assignment's left side named it, so every function in the table was
+        # `s` and only an `@line` suffix told them apart (issue #1631).
+        display_name: str | None = None
 
         if (
             not func_name
             and language == cs.SupportedLanguage.LUA
             and func_node.type == cs.TS_LUA_FUNCTION_DEFINITION
         ):
-            func_name = self._extract_lua_assignment_function_name(func_node)
+            func_name, display_name = self._extract_lua_field_function_name(func_node)
+            if not func_name:
+                func_name = self._extract_lua_assignment_function_name(func_node)
 
         is_anonymous = not func_name
         if not func_name:
@@ -1254,7 +1262,9 @@ class FunctionIngestMixin:
             func_node, module_qn, func_name, language, lang_config
         )
         is_exported = export_detection.is_exported(func_node, func_name, language)
-        return FunctionResolution(func_qn, func_name, is_exported, is_anonymous)
+        return FunctionResolution(
+            func_qn, display_name or func_name, is_exported, is_anonymous
+        )
 
     def _build_function_qn(
         self,
@@ -1566,6 +1576,17 @@ class FunctionIngestMixin:
             func_node,
             accepted_var_types=(cs.TS_DOT_INDEX_EXPRESSION, cs.TS_IDENTIFIER),
         )
+
+    def _extract_lua_field_function_name(
+        self, func_node: Node
+    ) -> tuple[str | None, str | None]:
+        """(`table.key` path, `key`) for a table field's function value, else Nones.
+
+        The walk lives in `lua_utils.field_function_path`, shared with the
+        call pass so both name the node identically (#1631 review).
+        """
+        found = lua_utils.field_function_path(func_node)
+        return found if found is not None else (None, None)
 
     def _build_nested_qualified_name(
         self,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1251,7 +1251,10 @@ class FunctionIngestMixin:
             and func_node.type == cs.TS_LUA_FUNCTION_DEFINITION
         ):
             func_name, display_name = self._extract_lua_field_function_name(func_node)
-            if not func_name:
+            # A field value whose field has no name is anonymous; only a
+            # function that is NOT a field value may take the assignment's
+            # name (#1750 review).
+            if not func_name and not lua_utils.is_field_value(func_node):
                 func_name = self._extract_lua_assignment_function_name(func_node)
 
         is_anonymous = not func_name

--- a/codebase_rag/parsers/lua/utils.py
+++ b/codebase_rag/parsers/lua/utils.py
@@ -94,3 +94,73 @@ def extract_pcall_second_identifier(call_node: Node) -> str | None:
                     names.append(decoded)
 
     return names[1] if len(names) >= 2 else None
+
+
+def field_key_name(field: Node) -> str | None:
+    """The key a table-constructor `field` binds: `f` in `f = ...`, `set` in
+    `["set"] = ...`. None for a positional entry or a computed key.
+
+    tree-sitter-lua exposes `k = v` and `[k] = v` alike as `name: identifier`;
+    the opening bracket is what tells a computed key from a literal one
+    (#1631 review), so a bracketed identifier is computed and names nothing.
+    """
+    key = field.child_by_field_name(cs.FIELD_NAME)
+    if key is None:
+        return None
+    bracketed = bool(field.children) and field.children[0].type == cs.LUA_OPEN_BRACKET
+    if key.type == cs.TS_LUA_IDENTIFIER:
+        return None if bracketed else safe_decode_text(key)
+    if key.type in cs.LUA_STRING_TYPES:
+        content = next(
+            (c for c in key.named_children if c.type == cs.TS_LUA_STRING_CONTENT),
+            None,
+        )
+        return safe_decode_text(content) if content is not None else None
+    return None
+
+
+def field_function_path(func_node: Node) -> tuple[str, str] | None:
+    """(`table.key` path, `key`) for a function that is a table field's value.
+
+    Shared by the definition pass, which registers the node under the path,
+    and the call pass, which must recover the same name or the body's calls
+    are skipped or credited to the enclosing function (#1631 review). Nested
+    constructors chain their keys (`M = { sub = { f = ... } }` gives
+    `M.sub.f`); the outermost table takes the name its statement assigns it,
+    through `extract_assigned_name`. A constructor with no assignment (a
+    returned or passed table) names the function by its keys alone.
+
+    None when the function is not a field value, when its key is positional
+    or computed, or when any enclosing constructor sits in a positional or
+    computed field: `{ { run = function() end } }` has no field `run` on the
+    outer list, and inventing `list.run` brings back the `@line` collisions
+    this exists to remove. The caller then falls back to the assignment form.
+    """
+    field = func_node.parent
+    if (
+        field is None
+        or field.type != cs.TS_LUA_FIELD
+        or field.child_by_field_name(cs.FIELD_VALUE) != func_node
+    ):
+        return None
+    key = field_key_name(field)
+    if not key:
+        return None
+    parts = [key]
+    table = field.parent
+    while table is not None and table.type == cs.TS_LUA_TABLE_CONSTRUCTOR:
+        enclosing = table.parent
+        if enclosing is None or enclosing.type != cs.TS_LUA_FIELD:
+            break
+        outer_key = field_key_name(enclosing)
+        if not outer_key:
+            return None
+        parts.insert(0, outer_key)
+        table = enclosing.parent
+    if table is not None:
+        owner = extract_assigned_name(
+            table, accepted_var_types=(cs.TS_DOT_INDEX_EXPRESSION, cs.TS_IDENTIFIER)
+        )
+        if owner:
+            parts.insert(0, owner)
+    return cs.SEPARATOR_DOT.join(parts), key

--- a/codebase_rag/parsers/lua/utils.py
+++ b/codebase_rag/parsers/lua/utils.py
@@ -157,10 +157,44 @@ def field_function_path(func_node: Node) -> tuple[str, str] | None:
             return None
         parts.insert(0, outer_key)
         table = enclosing.parent
-    if table is not None:
+    # The outermost constructor takes an owner only when it IS the value the
+    # statement assigns: a direct child of the assignment's expression list.
+    # `extract_assigned_name` accepts any descendant of a value, so a table
+    # passed as an ARGUMENT (`local r = register({ f = ... })`) would take
+    # `r`, which receives `register`'s return value and not the table, and
+    # the function would carry a false identity `r.f` (#1750 review).
+    if table is not None and _is_assigned_value(table):
         owner = extract_assigned_name(
             table, accepted_var_types=(cs.TS_DOT_INDEX_EXPRESSION, cs.TS_IDENTIFIER)
         )
         if owner:
             parts.insert(0, owner)
     return cs.SEPARATOR_DOT.join(parts), key
+
+
+def _is_assigned_value(node: Node) -> bool:
+    values = node.parent
+    return (
+        values is not None
+        and values.type == cs.TS_LUA_EXPRESSION_LIST
+        and values.parent is not None
+        and values.parent.type == cs.TS_LUA_ASSIGNMENT_STATEMENT
+    )
+
+
+def is_field_value(func_node: Node) -> bool:
+    """True when `func_node` is the value of a table-constructor field.
+
+    The tri-state the callers need: `field_function_path` says None both for
+    a function that is not a field value and for one whose field has no name
+    (a computed `[k]` key, a positional entry, a nesting under either). Only
+    the first may fall back to the enclosing assignment's name; the second
+    is anonymous, and falling back named `{ [k] = function() end }` after the
+    table it sits in (#1750 review).
+    """
+    field = func_node.parent
+    return (
+        field is not None
+        and field.type == cs.TS_LUA_FIELD
+        and field.child_by_field_name(cs.FIELD_VALUE) == func_node
+    )

--- a/codebase_rag/parsers/lua/utils.py
+++ b/codebase_rag/parsers/lua/utils.py
@@ -136,12 +136,8 @@ def field_function_path(func_node: Node) -> tuple[str, str] | None:
     outer list, and inventing `list.run` brings back the `@line` collisions
     this exists to remove. The caller then falls back to the assignment form.
     """
-    field = func_node.parent
-    if (
-        field is None
-        or field.type != cs.TS_LUA_FIELD
-        or field.child_by_field_name(cs.FIELD_VALUE) != func_node
-    ):
+    field = _field_valued_by(func_node)
+    if field is None:
         return None
     key = field_key_name(field)
     if not key:
@@ -192,9 +188,25 @@ def is_field_value(func_node: Node) -> bool:
     is anonymous, and falling back named `{ [k] = function() end }` after the
     table it sits in (#1750 review).
     """
-    field = func_node.parent
-    return (
-        field is not None
-        and field.type == cs.TS_LUA_FIELD
-        and field.child_by_field_name(cs.FIELD_VALUE) == func_node
-    )
+    return _field_valued_by(func_node) is not None
+
+
+def _field_valued_by(func_node: Node) -> Node | None:
+    """The table field whose value is `func_node`, seen through parentheses.
+
+    `f = (function() end)` parses as field > parenthesized_expression >
+    function_definition, so the field's value is the parentheses and not
+    the function; without unwrapping, the function was not a field value
+    and fell back to the assignment's name (CodeRabbit, #1750).
+    """
+    value: Node = func_node
+    parent = value.parent
+    while parent is not None and parent.type == cs.TS_PARENTHESIZED_EXPRESSION:
+        value, parent = parent, parent.parent
+    if (
+        parent is None
+        or parent.type != cs.TS_LUA_FIELD
+        or parent.child_by_field_name(cs.FIELD_VALUE) != value
+    ):
+        return None
+    return parent

--- a/codebase_rag/tests/test_lua_table_constructor_functions.py
+++ b/codebase_rag/tests/test_lua_table_constructor_functions.py
@@ -1,0 +1,141 @@
+"""A Lua function built into a table constructor is named by its field key.
+
+`local s = { set_namespace = function(self, ns) ... end, set = function ... }`
+declares two functions. They were both named `s`, after the enclosing
+assignment's left side, and told apart only by an `@line` suffix: the field
+key never reached the graph, so on plenary.nvim zero functions were named
+`set_namespace`, `set_fallback`, `__index` or `__call` although the source
+defines dozens that way (issue #1631). The declaration form
+(`function Job.chain()`) was already right and is the control here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+SAY_LUA = (
+    "local s = {\n"
+    "  set_namespace = function(self, ns) return ns end,\n"
+    '  ["set"] = function(self, k) return k end,\n'
+    "  sub = { f = function() return 1 end },\n"
+    "}\n"
+    "local Job = {}\n"
+    "function Job.chain(a) return a end\n"
+    "local t = {}\n"
+    "t.__index = function() end\n"
+    "M.__meta = { __call = function() end }\n"
+    "return s\n"
+)
+
+
+def _functions(root: Path) -> dict[str, str]:
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.LUA not in parsers:
+        pytest.skip("lua parser not available")
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    return {
+        str(uid): str(props.get(cs.KEY_NAME))
+        for (label, uid), props in store.nodes.items()
+        if label == cs.NodeLabel.FUNCTION.value
+    }
+
+
+def test_table_constructor_functions_take_their_field_key(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "say.lua").write_text(SAY_LUA, encoding="utf-8")
+
+    functions = _functions(root)
+
+    # Identifier key, bracketed string key, nested constructor, and a
+    # constructor assigned to a dotted target: each function sits under the
+    # table it is built into and carries its own key as its name.
+    assert functions.get("proj.say.s.set_namespace") == "set_namespace", functions
+    assert functions.get("proj.say.s.set") == "set", functions
+    assert functions.get("proj.say.s.sub.f") == "f", functions
+    assert functions.get("proj.say.M.__meta.__call") == "__call", functions
+    # Nothing is named after the table any more, and nothing needs a
+    # duplicate-name suffix to stay distinct.
+    assert "proj.say.s" not in functions, functions
+    assert not any("@" in qn for qn in functions), functions
+    # The controls: the declaration and plain-assignment forms are unchanged.
+    assert functions.get("proj.say.Job.chain") == "chain", functions
+    assert functions.get("proj.say.t.__index") == "t.__index", functions
+
+
+REVIEW_LUA = (
+    "local function helper() end\n"
+    "local function helper2() end\n"
+    "local s = { [k] = function() end, { run = function() end } }\n"
+    "local handlers = { { run = function() helper() end }, { run = function() end } }\n"
+    "register({ on_event = function() helper2() end })\n"
+    "local function outer() return { f = function() helper() end } end\n"
+    "return { setup = function() helper() end }\n"
+)
+
+
+def _calls(root: Path) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    return {
+        (str(src), str(dst))
+        for (_sl, src, rel, _tl, dst) in store.edges
+        if rel == cs.RelationshipType.CALLS.value
+    }
+
+
+def test_keys_that_name_nothing_fall_back_and_named_fields_keep_their_calls(
+    tmp_path: Path,
+) -> None:
+    """The three shapes the local review found (#1631 review).
+
+    A computed `[k]` key and a positional entry are not fields with a name, so
+    they fall back to the assignment form rather than being misnamed; a table
+    nested in a POSITIONAL entry has no field on the outer list either, so
+    `handlers.run` must not be invented. And a field function with no
+    enclosing assignment at all (a returned table, a table passed as an
+    argument, a table returned from a function) is named by its keys and
+    keeps the CALLS edges of its body, because the call pass names callers
+    through the same helper the definition pass does.
+    """
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod.lua").write_text(REVIEW_LUA, encoding="utf-8")
+
+    functions = _functions(root)
+    assert "proj.mod.s.k" not in functions, functions
+    assert not any(qn.startswith("proj.mod.handlers.") for qn in functions), functions
+    for qn, name in (
+        ("proj.mod.setup", "setup"),
+        ("proj.mod.on_event", "on_event"),
+        ("proj.mod.outer.f", "f"),
+    ):
+        assert functions.get(qn) == name, (qn, functions)
+
+    calls = _calls(root)
+    for caller in ("proj.mod.setup", "proj.mod.outer.f"):
+        assert (caller, "proj.mod.helper") in calls, (caller, sorted(calls))
+    assert ("proj.mod.on_event", "proj.mod.helper2") in calls, sorted(calls)

--- a/codebase_rag/tests/test_lua_table_constructor_functions.py
+++ b/codebase_rag/tests/test_lua_table_constructor_functions.py
@@ -85,6 +85,7 @@ REVIEW_LUA = (
     "local handlers = { { run = function() helper() end }, { run = function() end } }\n"
     "local result = register({ on_event = function() helper2() end })\n"
     "local function outer() return { f = function() helper() end } end\n"
+    "local p = { f = (function() helper() end) }\n"
     "return { setup = function() helper() end }\n"
 )
 
@@ -147,10 +148,13 @@ def test_keys_that_name_nothing_fall_back_and_named_fields_keep_their_calls(
         ("proj.mod.setup", "setup"),
         ("proj.mod.on_event", "on_event"),
         ("proj.mod.outer.f", "f"),
+        # A parenthesised function value is still the field's value
+        # (CodeRabbit, #1750).
+        ("proj.mod.p.f", "f"),
     ):
         assert functions.get(qn) == name, (qn, functions)
 
     calls = _calls(root)
-    for caller in ("proj.mod.setup", "proj.mod.outer.f"):
+    for caller in ("proj.mod.setup", "proj.mod.outer.f", "proj.mod.p.f"):
         assert (caller, "proj.mod.helper") in calls, (caller, sorted(calls))
     assert ("proj.mod.on_event", "proj.mod.helper2") in calls, sorted(calls)

--- a/codebase_rag/tests/test_lua_table_constructor_functions.py
+++ b/codebase_rag/tests/test_lua_table_constructor_functions.py
@@ -83,7 +83,7 @@ REVIEW_LUA = (
     "local function helper2() end\n"
     "local s = { [k] = function() end, { run = function() end } }\n"
     "local handlers = { { run = function() helper() end }, { run = function() end } }\n"
-    "register({ on_event = function() helper2() end })\n"
+    "local result = register({ on_event = function() helper2() end })\n"
     "local function outer() return { f = function() helper() end } end\n"
     "return { setup = function() helper() end }\n"
 )
@@ -113,13 +113,17 @@ def test_keys_that_name_nothing_fall_back_and_named_fields_keep_their_calls(
     """The three shapes the local review found (#1631 review).
 
     A computed `[k]` key and a positional entry are not fields with a name, so
-    they fall back to the assignment form rather than being misnamed; a table
-    nested in a POSITIONAL entry has no field on the outer list either, so
-    `handlers.run` must not be invented. And a field function with no
-    enclosing assignment at all (a returned table, a table passed as an
-    argument, a table returned from a function) is named by its keys and
-    keeps the CALLS edges of its body, because the call pass names callers
-    through the same helper the definition pass does.
+    their functions are ANONYMOUS: falling back to the assignment form named
+    both after the table (`s`, `s@1`) and conflated unrelated callbacks under
+    one identity (#1750 review). A table nested in a POSITIONAL entry has no
+    field on the outer list either, so `handlers.run` must not be invented.
+    A field function whose table is not itself assigned (a returned table, a
+    table passed as an ARGUMENT, a table returned from a function) is named
+    by its keys alone and keeps the CALLS edges of its body, because the call
+    pass names callers through the same helper the definition pass does. The
+    argument case is pinned with an assignment around it: `result` receives
+    `register`'s return value, not the table, so `result.on_event` would be a
+    false identity (#1750 review).
     """
     root = tmp_path / "proj"
     root.mkdir()
@@ -127,7 +131,18 @@ def test_keys_that_name_nothing_fall_back_and_named_fields_keep_their_calls(
 
     functions = _functions(root)
     assert "proj.mod.s.k" not in functions, functions
-    assert not any(qn.startswith("proj.mod.handlers.") for qn in functions), functions
+    for owner in ("proj.mod.s", "proj.mod.handlers", "proj.mod.result"):
+        assert owner not in functions, (owner, functions)
+        assert not any(
+            qn.startswith((f"{owner}.", f"{owner}{cs.DUP_QN_MARKER}"))
+            for qn in functions
+        ), (owner, functions)
+    anonymous = [
+        qn for qn, name in functions.items() if name.startswith(cs.PREFIX_ANONYMOUS)
+    ]
+    assert len(anonymous) == 4, (
+        f"the two nameless `s` entries and both `handlers` entries are anonymous: {functions}"
+    )
     for qn, name in (
         ("proj.mod.setup", "setup"),
         ("proj.mod.on_event", "on_event"),


### PR DESCRIPTION
Closes #1631.

## The defect

A Lua function expression that is the value of a table-constructor field was named after the enclosing assignment's left side. `local s = { set_namespace = function(...) end, set = function(...) end }` produced two functions both named `s`, told apart only by an `@line` suffix, and the field keys never reached the graph: on plenary.nvim zero functions were named `set_namespace`, `set_fallback`, `__index` or `__call` although the source defines dozens that way (146 field functions, 154 `@line` suffixes). The declaration form `function Job.chain()` was already right, which is what made this a bug rather than a Lua limitation.

## The fix

`_extract_lua_field_function_name` recognises a `function_definition` that is a `field`'s value, takes the field key (an identifier, or the content of a `["string"]` key), chains the keys of nested constructors (`M = { sub = { f = ... } }` gives `M.sub.f`), and names the outermost table through the same helper the `t.f = function` form already uses. The Function node's qn is `module.table.key` and its `name` is the key, matching the declaration form (`...Job.chain`, name `chain`). Positional entries and computed keys stay anonymous rather than misnamed.

## Tests

`test_lua_table_constructor_functions.py` pins the identifier key, the bracketed string key, the nested constructor and a constructor assigned to a dotted target, asserts nothing is named after the table or needs an `@` suffix, and keeps the declaration and plain-assignment forms as controls. Red on `main`, green with the fix alongside every Lua suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Lua analysis so functions defined within table constructors receive accurate names based on their field keys.
  - Preserved anonymous naming for computed keys, positional entries, and other cases where a reliable name cannot be determined.
  - Improved call-graph relationships for functions stored in returned, passed, or nested tables.
  - Prevented incorrect assignment-based names and duplicate name suffixes in Lua function results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->