### PR TITLE
fix: reap the integration suite's orphaned Memgraph containers at session start by label

### DIFF
--- a/codebase_rag/tests/container_reaper.py
+++ b/codebase_rag/tests/container_reaper.py
@@ -7,22 +7,38 @@ containers were found running on one box, one per killed run, the oldest three
 weeks old and each a permanent charge against the memory the next run needs.
 
 The remedy that survives the process dying is external to it: label our
-containers with a marker of our own, and at the START of a session remove
-every container carrying it. The suite runs one container per session and the
-host runs one suite at a time, so a labelled container that already exists
-when a session starts is a previous run's corpse.
+containers with a marker of our own AND the session that owns them (host and
+pid), and at the START of a session remove every labelled container whose
+owner is gone. Ownership is what makes this safe when two sessions share one
+Docker daemon: a container whose owning pid is still alive on this host is a
+running suite's database, not a corpse, and one owned by another host cannot
+be judged from here at all, so both are left alone (#1751 review).
 """
 
 from __future__ import annotations
 
+import os
+import socket
+from collections.abc import Callable
 from typing import Protocol
+
+from loguru import logger
 
 CGR_CONTAINER_LABEL = "cgr.integration"
 CGR_CONTAINER_LABEL_VALUE = "memgraph"
+CGR_OWNER_HOST_LABEL = "cgr.integration.host"
+CGR_OWNER_PID_LABEL = "cgr.integration.pid"
+
+REAPER_REMOVED = "Removed orphaned integration container(s): {names}"
+REAPER_REMOVE_FAILED = "Could not remove orphaned integration container {name}: {error}"
+REAPER_KEPT_LIVE = (
+    "Integration container {name} belongs to live pid {pid} on this host; kept"
+)
 
 
 class _Removable(Protocol):
     name: str
+    labels: dict[str, str]
 
     def remove(self, force: bool = ...) -> None: ...
 
@@ -35,23 +51,75 @@ class ContainerClient(Protocol):
     containers: _Containers
 
 
-def cgr_container_labels() -> dict[str, str]:
-    return {CGR_CONTAINER_LABEL: CGR_CONTAINER_LABEL_VALUE}
+def cgr_container_labels(
+    *, host: str | None = None, pid: int | None = None
+) -> dict[str, str]:
+    """The labels a session puts on its own container: marker plus owner."""
+    return {
+        CGR_CONTAINER_LABEL: CGR_CONTAINER_LABEL_VALUE,
+        CGR_OWNER_HOST_LABEL: host if host is not None else socket.gethostname(),
+        CGR_OWNER_PID_LABEL: str(pid if pid is not None else os.getpid()),
+    }
 
 
-def reap_orphaned_containers(client: ContainerClient) -> list[str]:
-    """Remove every container carrying our label; return the names removed.
+def pid_is_alive(pid: int) -> bool:
+    """Whether `pid` is a running process on THIS host.
 
-    `all=True` so a stopped-but-not-removed corpse goes too. A container that
-    refuses to go (already gone, or an engine error) is skipped rather than
-    failing the session: the reaper is housekeeping, not a precondition.
+    Signal 0 probes without delivering anything; a pid we may not signal is
+    still alive. On Windows `os.kill` cannot probe (any signal other than the
+    two console events terminates the target), so a pid there is reported
+    alive and its container is never reaped: leaving a corpse is the cheap
+    error, killing a live suite's database the expensive one.
     """
+    if os.name == "nt":
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def reap_orphaned_containers(
+    client: ContainerClient,
+    *,
+    host: str | None = None,
+    pid_alive: Callable[[int], bool] = pid_is_alive,
+) -> list[str]:
+    """Remove every labelled container whose owning session is gone.
+
+    `all=True` so a stopped-but-not-removed corpse goes too. A container is
+    removed only when its owner labels name THIS host and a pid that is no
+    longer running here. Another host's container, one without owner labels,
+    or one whose owner is alive is kept: the first two cannot be judged from
+    here, and the third is a running suite (#1751 review). A container that
+    refuses to go (already gone, or an engine error) is logged and skipped
+    rather than failing the session: the reaper is housekeeping, not a
+    precondition.
+    """
+    this_host = host if host is not None else socket.gethostname()
     removed: list[str] = []
     label = f"{CGR_CONTAINER_LABEL}={CGR_CONTAINER_LABEL_VALUE}"
     for container in client.containers.list(all=True, filters={"label": label}):
+        name = str(getattr(container, "name", ""))
+        labels = getattr(container, "labels", None) or {}
+        if labels.get(CGR_OWNER_HOST_LABEL) != this_host:
+            continue
+        try:
+            owner_pid = int(labels.get(CGR_OWNER_PID_LABEL, ""))
+        except ValueError:
+            continue
+        if pid_alive(owner_pid):
+            logger.info(REAPER_KEPT_LIVE.format(name=name, pid=owner_pid))
+            continue
         try:
             container.remove(force=True)
-        except Exception:  # noqa: BLE001 -- housekeeping must not fail the run
+        except Exception as e:  # noqa: BLE001 -- housekeeping must not fail the run
+            logger.warning(REAPER_REMOVE_FAILED.format(name=name, error=e))
             continue
-        removed.append(str(getattr(container, "name", "")))
+        removed.append(name)
+    if removed:
+        logger.info(REAPER_REMOVED.format(names=", ".join(removed)))
     return removed

--- a/codebase_rag/tests/container_reaper.py
+++ b/codebase_rag/tests/container_reaper.py
@@ -25,6 +25,8 @@ from typing import Protocol
 
 from loguru import logger
 
+from codebase_rag import constants as cs
+
 CGR_CONTAINER_LABEL = "cgr.integration"
 CGR_CONTAINER_LABEL_VALUE = "memgraph"
 CGR_OWNER_HOST_LABEL = "cgr.integration.host"
@@ -91,6 +93,7 @@ def process_start_time(pid: int) -> str | None:
             ["ps", "-o", "lstart=", "-p", str(pid)],
             capture_output=True,
             text=True,
+            encoding=cs.ENCODING_UTF8,
             timeout=5,
             check=False,
         )

--- a/codebase_rag/tests/container_reaper.py
+++ b/codebase_rag/tests/container_reaper.py
@@ -1,0 +1,57 @@
+"""Reap integration-suite Memgraph containers a killed run left behind (#1628).
+
+`memgraph_container` stops its container after `yield`, which is correct for
+every run that ends normally. A run killed by an OOM kill, a CI timeout or a
+`kill -9` never reaches that line, and nothing in-process can: eight such
+containers were found running on one box, one per killed run, the oldest three
+weeks old and each a permanent charge against the memory the next run needs.
+
+The remedy that survives the process dying is external to it: label our
+containers with a marker of our own, and at the START of a session remove
+every container carrying it. The suite runs one container per session and the
+host runs one suite at a time, so a labelled container that already exists
+when a session starts is a previous run's corpse.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+CGR_CONTAINER_LABEL = "cgr.integration"
+CGR_CONTAINER_LABEL_VALUE = "memgraph"
+
+
+class _Removable(Protocol):
+    name: str
+
+    def remove(self, force: bool = ...) -> None: ...
+
+
+class _Containers(Protocol):
+    def list(self, all: bool = ..., filters: dict[str, str] | None = ...) -> list: ...
+
+
+class ContainerClient(Protocol):
+    containers: _Containers
+
+
+def cgr_container_labels() -> dict[str, str]:
+    return {CGR_CONTAINER_LABEL: CGR_CONTAINER_LABEL_VALUE}
+
+
+def reap_orphaned_containers(client: ContainerClient) -> list[str]:
+    """Remove every container carrying our label; return the names removed.
+
+    `all=True` so a stopped-but-not-removed corpse goes too. A container that
+    refuses to go (already gone, or an engine error) is skipped rather than
+    failing the session: the reaper is housekeeping, not a precondition.
+    """
+    removed: list[str] = []
+    label = f"{CGR_CONTAINER_LABEL}={CGR_CONTAINER_LABEL_VALUE}"
+    for container in client.containers.list(all=True, filters={"label": label}):
+        try:
+            container.remove(force=True)
+        except Exception:  # noqa: BLE001 -- housekeeping must not fail the run
+            continue
+        removed.append(str(getattr(container, "name", "")))
+    return removed

--- a/codebase_rag/tests/container_reaper.py
+++ b/codebase_rag/tests/container_reaper.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 import socket
+import subprocess
 from collections.abc import Callable
 from typing import Protocol
 
@@ -28,6 +29,7 @@ CGR_CONTAINER_LABEL = "cgr.integration"
 CGR_CONTAINER_LABEL_VALUE = "memgraph"
 CGR_OWNER_HOST_LABEL = "cgr.integration.host"
 CGR_OWNER_PID_LABEL = "cgr.integration.pid"
+CGR_OWNER_STARTED_LABEL = "cgr.integration.started"
 
 REAPER_REMOVED = "Removed orphaned integration container(s): {names}"
 REAPER_REMOVE_FAILED = "Could not remove orphaned integration container {name}: {error}"
@@ -52,24 +54,64 @@ class ContainerClient(Protocol):
 
 
 def cgr_container_labels(
-    *, host: str | None = None, pid: int | None = None
+    *,
+    host: str | None = None,
+    pid: int | None = None,
+    started: str | None = None,
 ) -> dict[str, str]:
-    """The labels a session puts on its own container: marker plus owner."""
+    """The labels a session puts on its own container: marker plus owner.
+
+    The owner is host, pid AND the process start time: a killed suite's pid
+    can be handed to an unrelated process later, and a pid alone would then
+    read the corpse as owned by a live session forever (#1751 review).
+    """
+    owner_pid = pid if pid is not None else os.getpid()
     return {
         CGR_CONTAINER_LABEL: CGR_CONTAINER_LABEL_VALUE,
         CGR_OWNER_HOST_LABEL: host if host is not None else socket.gethostname(),
-        CGR_OWNER_PID_LABEL: str(pid if pid is not None else os.getpid()),
+        CGR_OWNER_PID_LABEL: str(owner_pid),
+        CGR_OWNER_STARTED_LABEL: (
+            started if started is not None else process_start_time(owner_pid) or ""
+        ),
     }
+
+
+def process_start_time(pid: int) -> str | None:
+    """`ps`'s start time for `pid`, or None where it cannot be read.
+
+    `lstart` is the full timestamp on both BSD and GNU ps, so it changes
+    when a pid is reused. Windows has no `ps`; None there, and the reaper
+    then has nothing to compare, which is the same conservative answer as
+    an unprobeable pid.
+    """
+    if os.name == "nt":
+        return None
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    started = completed.stdout.strip()
+    return started or None
 
 
 def pid_is_alive(pid: int) -> bool:
     """Whether `pid` is a running process on THIS host.
 
     Signal 0 probes without delivering anything; a pid we may not signal is
-    still alive. On Windows `os.kill` cannot probe (any signal other than the
-    two console events terminates the target), so a pid there is reported
-    alive and its container is never reaped: leaving a corpse is the cheap
-    error, killing a live suite's database the expensive one.
+    still alive. A pid the probe cannot even express (an `OverflowError` on
+    a value past the platform's pid range, or any other `OSError`) is
+    reported alive too, so a garbled label keeps its container rather than
+    aborting the fixture before `start()` (CodeRabbit, #1751). On Windows
+    `os.kill` cannot probe (any signal other than the two console events
+    terminates the target), so a pid there is reported alive and its
+    container is never reaped: leaving a corpse is the cheap error, killing
+    a live suite's database the expensive one.
     """
     if os.name == "nt":
         return True
@@ -77,7 +119,7 @@ def pid_is_alive(pid: int) -> bool:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    except PermissionError:
+    except (OSError, OverflowError, ValueError):
         return True
     return True
 
@@ -87,17 +129,21 @@ def reap_orphaned_containers(
     *,
     host: str | None = None,
     pid_alive: Callable[[int], bool] = pid_is_alive,
+    start_time: Callable[[int], str | None] = process_start_time,
 ) -> list[str]:
     """Remove every labelled container whose owning session is gone.
 
     `all=True` so a stopped-but-not-removed corpse goes too. A container is
-    removed only when its owner labels name THIS host and a pid that is no
-    longer running here. Another host's container, one without owner labels,
-    or one whose owner is alive is kept: the first two cannot be judged from
-    here, and the third is a running suite (#1751 review). A container that
-    refuses to go (already gone, or an engine error) is logged and skipped
-    rather than failing the session: the reaper is housekeeping, not a
-    precondition.
+    removed only when its owner labels name THIS host and a process that is
+    no longer running here: the pid is gone, or the pid is held by a process
+    whose start time differs from the one recorded at labelling, which is a
+    reused pid and not the owner (#1751 review). Another host's container,
+    one without owner labels, or one whose owner is alive is kept: the first
+    two cannot be judged from here, and the third is a running suite. Where
+    a start time cannot be read on either side the pid check alone decides,
+    in the keeping direction. A container that refuses to go (already gone,
+    or an engine error) is logged and skipped rather than failing the
+    session: the reaper is housekeeping, not a precondition.
     """
     this_host = host if host is not None else socket.gethostname()
     removed: list[str] = []
@@ -111,7 +157,9 @@ def reap_orphaned_containers(
             owner_pid = int(labels.get(CGR_OWNER_PID_LABEL, ""))
         except ValueError:
             continue
-        if pid_alive(owner_pid):
+        if pid_alive(owner_pid) and not _pid_was_reused(
+            owner_pid, labels.get(CGR_OWNER_STARTED_LABEL), start_time
+        ):
             logger.info(REAPER_KEPT_LIVE.format(name=name, pid=owner_pid))
             continue
         try:
@@ -123,3 +171,12 @@ def reap_orphaned_containers(
     if removed:
         logger.info(REAPER_REMOVED.format(names=", ".join(removed)))
     return removed
+
+
+def _pid_was_reused(
+    pid: int, recorded_start: str | None, start_time: Callable[[int], str | None]
+) -> bool:
+    if not recorded_start:
+        return False
+    current = start_time(pid)
+    return current is not None and current != recorded_start

--- a/codebase_rag/tests/integration/conftest.py
+++ b/codebase_rag/tests/integration/conftest.py
@@ -45,8 +45,9 @@ def memgraph_container() -> Generator[dict[str, str | int], None, None]:
     # the `container.stop()` below and left its container running; each one
     # is a permanent charge against the memory the next run needs (issue
     # #1628). Nothing in-process survives being killed, so the next session
-    # cleans up for the last one, by the label this fixture puts on its own
-    # container.
+    # cleans up for the last one, by the labels this fixture puts on its own
+    # container: the marker, and the host and pid that own it, so a session
+    # sharing the daemon with a LIVE suite leaves that suite's database alone.
     reap_orphaned_containers(DockerClient().client)
 
     # Same engine line the packaged stack pins (issue #1257): integration

--- a/codebase_rag/tests/integration/conftest.py
+++ b/codebase_rag/tests/integration/conftest.py
@@ -9,6 +9,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.tests.container_reaper import (
+    cgr_container_labels,
+    reap_orphaned_containers,
+)
 
 if TYPE_CHECKING:
     import mgclient
@@ -34,12 +38,22 @@ def memgraph_container() -> Generator[dict[str, str | int], None, None]:
     import time
 
     from testcontainers.core.container import DockerContainer
+    from testcontainers.core.docker_client import DockerClient
     from testcontainers.core.wait_strategies import LogMessageWaitStrategy
+
+    # A previous run that was killed (OOM, CI timeout, kill -9) never reached
+    # the `container.stop()` below and left its container running; each one
+    # is a permanent charge against the memory the next run needs (issue
+    # #1628). Nothing in-process survives being killed, so the next session
+    # cleans up for the last one, by the label this fixture puts on its own
+    # container.
+    reap_orphaned_containers(DockerClient().client)
 
     # Same engine line the packaged stack pins (issue #1257): integration
     # tests must exercise the syntax the shipped Memgraph actually accepts.
     container = DockerContainer("memgraph/memgraph:3.3.0")
     container.with_exposed_ports(7687)
+    container.with_kwargs(labels=cgr_container_labels())
     container.waiting_for(LogMessageWaitStrategy("You are running Memgraph"))
 
     container.start()

--- a/codebase_rag/tests/test_container_reaper.py
+++ b/codebase_rag/tests/test_container_reaper.py
@@ -14,8 +14,10 @@ from codebase_rag.tests.container_reaper import (
     CGR_CONTAINER_LABEL_VALUE,
     CGR_OWNER_HOST_LABEL,
     CGR_OWNER_PID_LABEL,
+    CGR_OWNER_STARTED_LABEL,
     cgr_container_labels,
     pid_is_alive,
+    process_start_time,
     reap_orphaned_containers,
 )
 
@@ -27,13 +29,22 @@ def _dead(pid: int) -> bool:
     return pid not in DEAD
 
 
-def _container(name: str, *, host: str = HOST, pid: int | str = 4242) -> MagicMock:
+STARTED = "Sat Sep  5 22:00:00 2026"
+
+
+def _container(
+    name: str, *, host: str = HOST, pid: int | str = 4242, started: str = STARTED
+) -> MagicMock:
     container = MagicMock(name=name)
     container.name = name
-    container.labels = cgr_container_labels(host=host, pid=pid)  # type: ignore[arg-type]
-    if not isinstance(pid, int):
-        container.labels[CGR_OWNER_PID_LABEL] = str(pid)
+    owner_pid = pid if isinstance(pid, int) else 0
+    container.labels = cgr_container_labels(host=host, pid=owner_pid, started=started)
+    container.labels[CGR_OWNER_PID_LABEL] = str(pid)
     return container
+
+
+def _started(pid: int) -> str | None:
+    return STARTED
 
 
 def _client(*containers: MagicMock) -> MagicMock:
@@ -42,8 +53,10 @@ def _client(*containers: MagicMock) -> MagicMock:
     return client
 
 
-def _reap(client: MagicMock) -> list[str]:
-    return reap_orphaned_containers(client, host=HOST, pid_alive=_dead)
+def _reap(client: MagicMock, start_time=_started) -> list[str]:
+    return reap_orphaned_containers(
+        client, host=HOST, pid_alive=_dead, start_time=start_time
+    )
 
 
 def test_every_orphaned_container_is_force_removed() -> None:
@@ -72,6 +85,38 @@ def test_a_live_sessions_container_is_kept() -> None:
     live.remove.assert_not_called()
     dead.remove.assert_called_once_with(force=True)
     assert removed == ["dead"]
+
+
+def test_a_reused_pid_does_not_pass_for_the_owner() -> None:
+    # The owner's pid is alive again, but held by a process started later:
+    # that is a corpse whose pid was handed out again, not a live suite
+    # (#1751 review). With no recorded start time, or none readable now,
+    # the pid check alone decides, in the keeping direction.
+    reused = _container("reused", pid=os.getpid())
+    unknown_then = _container("unknown-then", pid=os.getpid(), started="")
+    client = _client(reused, unknown_then)
+
+    removed = reap_orphaned_containers(
+        client,
+        host=HOST,
+        pid_alive=_dead,
+        start_time=lambda _pid: "Sun Sep  6 04:00:00 2026",
+    )
+
+    assert removed == ["reused"], removed
+    unknown_then.remove.assert_not_called()
+
+    unreadable = _container("unreadable", pid=os.getpid())
+    assert (
+        reap_orphaned_containers(
+            _client(unreadable),
+            host=HOST,
+            pid_alive=_dead,
+            start_time=lambda _pid: None,
+        )
+        == []
+    )
+    unreadable.remove.assert_not_called()
 
 
 def test_containers_this_host_cannot_judge_are_kept() -> None:
@@ -119,6 +164,18 @@ def test_pid_probe_tells_this_process_from_a_dead_one() -> None:
         # A pid no process holds; the largest allowed value is never in use
         # on a box that is not at its process limit.
         assert not pid_is_alive(2**22 - 1)
+    # A value the probe cannot even express must read as alive, not raise
+    # and abort the fixture before start() (CodeRabbit, #1751).
+    assert pid_is_alive(2**62)
+
+
+def test_a_start_time_is_read_for_this_process() -> None:
+    started = process_start_time(os.getpid())
+    if os.name == "nt":
+        assert started is None
+    else:
+        assert started, "ps -o lstart= gave nothing for a live pid"
+        assert cgr_container_labels()[CGR_OWNER_STARTED_LABEL] == started
 
 
 def test_own_labels_name_this_session() -> None:
@@ -126,6 +183,7 @@ def test_own_labels_name_this_session() -> None:
     assert labels[CGR_CONTAINER_LABEL] == CGR_CONTAINER_LABEL_VALUE
     assert labels[CGR_OWNER_HOST_LABEL]
     assert labels[CGR_OWNER_PID_LABEL] == str(os.getpid())
+    assert CGR_OWNER_STARTED_LABEL in labels
 
 
 def test_the_fixture_labels_its_container_and_reaps_before_starting() -> None:

--- a/codebase_rag/tests/test_container_reaper.py
+++ b/codebase_rag/tests/test_container_reaper.py
@@ -1,17 +1,39 @@
-"""The integration container reaper removes exactly our labelled corpses (#1628)."""
+"""The integration container reaper removes exactly our orphaned corpses (#1628)."""
 
 from __future__ import annotations
 
 import ast
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
+
+from loguru import logger
 
 from codebase_rag.tests.container_reaper import (
     CGR_CONTAINER_LABEL,
     CGR_CONTAINER_LABEL_VALUE,
+    CGR_OWNER_HOST_LABEL,
+    CGR_OWNER_PID_LABEL,
     cgr_container_labels,
+    pid_is_alive,
     reap_orphaned_containers,
 )
+
+HOST = "this-box"
+DEAD = {4242}
+
+
+def _dead(pid: int) -> bool:
+    return pid not in DEAD
+
+
+def _container(name: str, *, host: str = HOST, pid: int | str = 4242) -> MagicMock:
+    container = MagicMock(name=name)
+    container.name = name
+    container.labels = cgr_container_labels(host=host, pid=pid)  # type: ignore[arg-type]
+    if not isinstance(pid, int):
+        container.labels[CGR_OWNER_PID_LABEL] = str(pid)
+    return container
 
 
 def _client(*containers: MagicMock) -> MagicMock:
@@ -20,12 +42,15 @@ def _client(*containers: MagicMock) -> MagicMock:
     return client
 
 
-def test_every_labelled_container_is_force_removed() -> None:
-    first, second = MagicMock(name="c1"), MagicMock(name="c2")
-    first.name, second.name = "magical_archimedes", "adoring_edison"
+def _reap(client: MagicMock) -> list[str]:
+    return reap_orphaned_containers(client, host=HOST, pid_alive=_dead)
+
+
+def test_every_orphaned_container_is_force_removed() -> None:
+    first, second = _container("magical_archimedes"), _container("adoring_edison")
     client = _client(first, second)
 
-    removed = reap_orphaned_containers(client)
+    removed = _reap(client)
 
     client.containers.list.assert_called_once_with(
         all=True,
@@ -36,20 +61,71 @@ def test_every_labelled_container_is_force_removed() -> None:
     assert removed == ["magical_archimedes", "adoring_edison"]
 
 
-def test_a_container_that_refuses_to_go_does_not_stop_the_others() -> None:
-    stuck, fine = MagicMock(), MagicMock()
-    stuck.name, fine.name = "stuck", "fine"
+def test_a_live_sessions_container_is_kept() -> None:
+    # Two sessions on one daemon: the later one must not remove the earlier
+    # one's running database (#1751 review). The live pid is the discriminator.
+    live, dead = _container("live", pid=os.getpid()), _container("dead")
+    client = _client(live, dead)
+
+    removed = _reap(client)
+
+    live.remove.assert_not_called()
+    dead.remove.assert_called_once_with(force=True)
+    assert removed == ["dead"]
+
+
+def test_containers_this_host_cannot_judge_are_kept() -> None:
+    # Another host's pid space is not ours to probe; a container with no
+    # owner labels, or an unparseable pid, is not provably a corpse either.
+    elsewhere = _container("elsewhere", host="other-box")
+    unowned = MagicMock()
+    unowned.name, unowned.labels = (
+        "unowned",
+        {CGR_CONTAINER_LABEL: CGR_CONTAINER_LABEL_VALUE},
+    )
+    garbled = _container("garbled", pid="not-a-pid")
+    client = _client(elsewhere, unowned, garbled)
+
+    assert _reap(client) == []
+    for container in (elsewhere, unowned, garbled):
+        container.remove.assert_not_called()
+
+
+def test_a_container_that_refuses_to_go_is_logged_and_does_not_stop_the_others() -> (
+    None
+):
+    stuck, fine = _container("stuck"), _container("fine")
     stuck.remove.side_effect = RuntimeError("engine error")
     client = _client(stuck, fine)
-
-    removed = reap_orphaned_containers(client)
+    records: list[str] = []
+    sink = logger.add(lambda m: records.append(str(m)), level="WARNING")
+    try:
+        removed = _reap(client)
+    finally:
+        logger.remove(sink)
 
     fine.remove.assert_called_once_with(force=True)
     assert removed == ["fine"], "the failure must be skipped, not raised or counted"
+    assert any("stuck" in r and "engine error" in r for r in records), records
 
 
 def test_nothing_to_reap_is_a_no_op() -> None:
-    assert reap_orphaned_containers(_client()) == []
+    assert _reap(_client()) == []
+
+
+def test_pid_probe_tells_this_process_from_a_dead_one() -> None:
+    assert pid_is_alive(os.getpid())
+    if os.name != "nt":
+        # A pid no process holds; the largest allowed value is never in use
+        # on a box that is not at its process limit.
+        assert not pid_is_alive(2**22 - 1)
+
+
+def test_own_labels_name_this_session() -> None:
+    labels = cgr_container_labels()
+    assert labels[CGR_CONTAINER_LABEL] == CGR_CONTAINER_LABEL_VALUE
+    assert labels[CGR_OWNER_HOST_LABEL]
+    assert labels[CGR_OWNER_PID_LABEL] == str(os.getpid())
 
 
 def test_the_fixture_labels_its_container_and_reaps_before_starting() -> None:
@@ -64,8 +140,20 @@ def test_the_fixture_labels_its_container_and_reaps_before_starting() -> None:
         encoding="utf-8"
     )
     tree = ast.parse(source)
+    fixture = next(
+        (
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == "memgraph_container"
+        ),
+        None,
+    )
+    assert fixture is not None, "the memgraph_container fixture is gone"
+    # Walk the FIXTURE only: a same-named call elsewhere in the module must
+    # not satisfy this sequence while the fixture itself is miswired (#1751
+    # review).
     calls: list[str] = []
-    for node in ast.walk(tree):
+    for node in ast.walk(fixture):
         if isinstance(node, ast.Call):
             func = node.func
             name = (
@@ -79,10 +167,10 @@ def test_the_fixture_labels_its_container_and_reaps_before_starting() -> None:
                     labels = {kw.arg: kw.value for kw in node.keywords}
                     assert "labels" in labels, "with_kwargs must pass labels="
                     value = labels["labels"]
-                    assert (
-                        isinstance(value, ast.Call)
-                        and getattr(value.func, "id", "") == "cgr_container_labels"
-                    ), (
+                    assert isinstance(value, ast.Call), (
+                        "labels= must be a call, or the reaper matches nothing"
+                    )
+                    assert getattr(value.func, "id", "") == "cgr_container_labels", (
                         "labels= must be cgr_container_labels(), or the reaper matches nothing"
                     )
     assert "reap_orphaned_containers" in calls, "the fixture never reaps"
@@ -96,4 +184,3 @@ def test_the_fixture_labels_its_container_and_reaps_before_starting() -> None:
         f"the label must be set before start(): {calls}"
     )
     assert calls.count("with_kwargs") == 1, calls
-    assert cgr_container_labels() == {CGR_CONTAINER_LABEL: CGR_CONTAINER_LABEL_VALUE}

--- a/codebase_rag/tests/test_container_reaper.py
+++ b/codebase_rag/tests/test_container_reaper.py
@@ -1,0 +1,99 @@
+"""The integration container reaper removes exactly our labelled corpses (#1628)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.container_reaper import (
+    CGR_CONTAINER_LABEL,
+    CGR_CONTAINER_LABEL_VALUE,
+    cgr_container_labels,
+    reap_orphaned_containers,
+)
+
+
+def _client(*containers: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.containers.list.return_value = list(containers)
+    return client
+
+
+def test_every_labelled_container_is_force_removed() -> None:
+    first, second = MagicMock(name="c1"), MagicMock(name="c2")
+    first.name, second.name = "magical_archimedes", "adoring_edison"
+    client = _client(first, second)
+
+    removed = reap_orphaned_containers(client)
+
+    client.containers.list.assert_called_once_with(
+        all=True,
+        filters={"label": f"{CGR_CONTAINER_LABEL}={CGR_CONTAINER_LABEL_VALUE}"},
+    )
+    first.remove.assert_called_once_with(force=True)
+    second.remove.assert_called_once_with(force=True)
+    assert removed == ["magical_archimedes", "adoring_edison"]
+
+
+def test_a_container_that_refuses_to_go_does_not_stop_the_others() -> None:
+    stuck, fine = MagicMock(), MagicMock()
+    stuck.name, fine.name = "stuck", "fine"
+    stuck.remove.side_effect = RuntimeError("engine error")
+    client = _client(stuck, fine)
+
+    removed = reap_orphaned_containers(client)
+
+    fine.remove.assert_called_once_with(force=True)
+    assert removed == ["fine"], "the failure must be skipped, not raised or counted"
+
+
+def test_nothing_to_reap_is_a_no_op() -> None:
+    assert reap_orphaned_containers(_client()) == []
+
+
+def test_the_fixture_labels_its_container_and_reaps_before_starting() -> None:
+    """The fixture needs Docker, so its wiring is pinned at the source level.
+
+    Both halves are load-bearing and neither implies the other: without the
+    label the reaper matches nothing, and without the reaper call the label
+    is decoration. The reaper must also run BEFORE `start()`, or a session
+    would remove the container it just created.
+    """
+    source = (Path(__file__).parent / "integration" / "conftest.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+    calls: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else getattr(func, "id", "")
+            )
+            if name in {"reap_orphaned_containers", "with_kwargs", "start"}:
+                calls.append(name)
+                if name == "with_kwargs":
+                    labels = {kw.arg: kw.value for kw in node.keywords}
+                    assert "labels" in labels, "with_kwargs must pass labels="
+                    value = labels["labels"]
+                    assert (
+                        isinstance(value, ast.Call)
+                        and getattr(value.func, "id", "") == "cgr_container_labels"
+                    ), (
+                        "labels= must be cgr_container_labels(), or the reaper matches nothing"
+                    )
+    assert "reap_orphaned_containers" in calls, "the fixture never reaps"
+    assert "with_kwargs" in calls, "the fixture never labels its container"
+    assert calls.index("reap_orphaned_containers") < calls.index("start"), (
+        f"the reaper must run before start(): {calls}"
+    )
+    # `with_kwargs` REPLACES the container's kwargs, so it must precede
+    # start() and be the last such call, or the label is silently dropped.
+    assert calls.index("with_kwargs") < calls.index("start"), (
+        f"the label must be set before start(): {calls}"
+    )
+    assert calls.count("with_kwargs") == 1, calls
+    assert cgr_container_labels() == {CGR_CONTAINER_LABEL: CGR_CONTAINER_LABEL_VALUE}


### PR DESCRIPTION
Closes #1628.

## The leak

`memgraph_container` in `codebase_rag/tests/integration/conftest.py` stops its container after `yield`, which is right for every run that ends normally. A run killed by an OOM kill, a CI timeout or a `kill -9` never reaches that line, and nothing in-process can: eight Memgraph containers were found running on one box, one per killed run, the oldest three weeks old, each a permanent charge against the memory the next run needs, which makes the next kill likelier.

## The fix

The remedy that survives the process dying is external to it. The fixture labels its container `cgr.integration=memgraph` through `DockerContainer.with_kwargs(labels=...)`, and before starting a new one calls `reap_orphaned_containers`, which lists every container (running or stopped) carrying that label and force-removes it, skipping any that refuse to go. The suite runs one container per session and the host runs one suite at a time, so a labelled container that already exists when a session starts is a previous run's corpse. Verified in review against a live engine: the label reaches the engine merged with testcontainers' own labels, and the filter matches exactly that container. Ryuk is enabled by default in testcontainers 4.14 and should reap these after a socket drop, which the eight orphans show did not happen on that box; the reaper is additive and runs before Ryuk is instantiated.

## Tests

`test_container_reaper.py` drives the reaper with fake clients (every labelled container force-removed, a refusing one skipped without stopping the rest, an empty list a no-op) and pins the fixture's wiring at the source level, since Docker is not available on this host: the reaper runs before `start()`, the label is set before `start()` exactly once with `cgr_container_labels()`, so neither half can be silently dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Integration test runs now automatically clean up leftover Memgraph containers from interrupted previous runs.
  - Cleanup targets only containers owned by the current host and an inactive test session, avoiding interference with active or unrelated runs.
  - Cleanup continues even if an individual container cannot be removed, improving test-run reliability.

- **Tests**
  - Added coverage for container cleanup, ownership checks, failure handling, no-op scenarios, process detection, labeling, and cleanup ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->