### PR TITLE
fix: prune a deleted file's method return types with the same ownership filter as its registry rows

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2713,20 +2713,25 @@ class GraphUpdater:
         # and Go receiver methods record their return type under the
         # definition's qn, and this sweep never reached it. A Go method is
         # keyed by its RECEIVER's module, so its qn can sit under a prefix this
-        # file does not own; `qns_to_remove` already carries the span-record
-        # ownership that catches it, and the prefix filter covers an entry
-        # whose registry row is already gone.
+        # file does not own. Ownership therefore comes from the SPAN records
+        # (`owned_qns`), not from the registry sweep alone: a receiver method
+        # whose registry row is already gone never enters `qns_to_remove`,
+        # and no prefix of the declaring file matches it, so its return type
+        # outlived both (#1752 review). The prefix arm covers an entry filed
+        # under this file's own module; `foreign_qns` protects a qn another
+        # file still owns, exactly as it does for the registry.
         method_return_types = self.factory.type_inference.method_return_types
         stale_method_qns = [
             qn
             for qn in method_return_types
-            if qn in qns_to_remove
-            or (
-                any(
+            if qn not in foreign_qns
+            and (
+                qn in qns_to_remove
+                or qn in owned_qns
+                or any(
                     qn.startswith(f"{prefix}.") or qn == prefix
                     for prefix in module_qn_prefixes
                 )
-                and qn not in foreign_qns
             )
         ]
         if stale_method_qns:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2731,17 +2731,19 @@ class GraphUpdater:
         # re-parsed by this event, so the entry goes and the next parse of
         # the survivor re-records it. A missing type is a degraded answer; a
         # stale one is a wrong answer (#1752 review).
-        # The map is keyed by the NATURAL qn even when the registry filed the
-        # definition as a `@line` duplicate (the second declaration of one
-        # receiver method writes `...A.Clone`, its span record says
-        # `...A.Clone@3`), so ownership is compared on the natural form.
+        # Ownership is compared on the NATURAL qn on both sides: the map is
+        # usually keyed by it even when the registry filed the definition as
+        # a `@line` duplicate (the second declaration of one receiver method
+        # writes `...A.Clone`, its span record says `...A.Clone@3`), and a
+        # few writers (deferred Rust functions, duplicate C++ out-of-class
+        # methods) key the map by the `@line` name itself (#1752 review).
         method_return_types = self.factory.type_inference.method_return_types
         owned_natural = {_natural_qn(qn) for qn in owned_qns}
         stale_method_qns = [
             qn
             for qn in method_return_types
             if qn in qns_to_remove
-            or qn in owned_natural
+            or _natural_qn(qn) in owned_natural
             or (
                 qn not in foreign_qns
                 and any(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -477,6 +477,12 @@ def _touch_empty_json(cache_path: Path) -> None:
         pass
 
 
+def _natural_qn(qualified_name: str) -> str:
+    """`pkg.T.M@3` -> `pkg.T.M`: the duplicate marker lives in the last segment."""
+    head, sep, last = qualified_name.rpartition(cs.SEPARATOR_DOT)
+    return f"{head}{sep}{last.split(cs.DUP_QN_MARKER, 1)[0]}"
+
+
 class GraphUpdater:
     """Drive a full or incremental ingest of a repository into the graph.
 
@@ -2719,16 +2725,26 @@ class GraphUpdater:
         # and no prefix of the declaring file matches it, so its return type
         # outlived both (#1752 review). The prefix arm covers an entry filed
         # under this file's own module; `foreign_qns` protects a qn another
-        # file still owns, exactly as it does for the registry.
+        # file still owns, as it does for the registry, EXCEPT where this
+        # file owns the qn too: the map holds one value per qn, the deleted
+        # definition may be the one that wrote it, and the survivor is not
+        # re-parsed by this event, so the entry goes and the next parse of
+        # the survivor re-records it. A missing type is a degraded answer; a
+        # stale one is a wrong answer (#1752 review).
+        # The map is keyed by the NATURAL qn even when the registry filed the
+        # definition as a `@line` duplicate (the second declaration of one
+        # receiver method writes `...A.Clone`, its span record says
+        # `...A.Clone@3`), so ownership is compared on the natural form.
         method_return_types = self.factory.type_inference.method_return_types
+        owned_natural = {_natural_qn(qn) for qn in owned_qns}
         stale_method_qns = [
             qn
             for qn in method_return_types
-            if qn not in foreign_qns
-            and (
-                qn in qns_to_remove
-                or qn in owned_qns
-                or any(
+            if qn in qns_to_remove
+            or qn in owned_natural
+            or (
+                qn not in foreign_qns
+                and any(
                     qn.startswith(f"{prefix}.") or qn == prefix
                     for prefix in module_qn_prefixes
                 )

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2708,6 +2708,29 @@ class GraphUpdater:
         ]
         if stale_go_qns:
             self.factory.type_inference.drop_go_return_types(stale_go_qns)
+        # `method_return_types` is the same defect for a different map (issue
+        # #1738): C++, Rust and Dart free functions, every language's methods
+        # and Go receiver methods record their return type under the
+        # definition's qn, and this sweep never reached it. A Go method is
+        # keyed by its RECEIVER's module, so its qn can sit under a prefix this
+        # file does not own; `qns_to_remove` already carries the span-record
+        # ownership that catches it, and the prefix filter covers an entry
+        # whose registry row is already gone.
+        method_return_types = self.factory.type_inference.method_return_types
+        stale_method_qns = [
+            qn
+            for qn in method_return_types
+            if qn in qns_to_remove
+            or (
+                any(
+                    qn.startswith(f"{prefix}.") or qn == prefix
+                    for prefix in module_qn_prefixes
+                )
+                and qn not in foreign_qns
+            )
+        ]
+        if stale_method_qns:
+            self.factory.type_inference.drop_method_return_types(stale_method_qns)
 
         for simple_name, qn_set in self.simple_name_lookup.items():
             original_count = len(qn_set)

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -617,6 +617,16 @@ class TypeInferenceEngine:
         self._go_free_fn_index = {}
         self._go_free_fn_index_size = -1
 
+    def drop_method_return_types(self, qns: Collection[str]) -> None:
+        """Forget the return types recorded under `qns` (issue #1738).
+
+        `GraphUpdater.remove_file_from_state` calls this for a deleted or
+        re-parsed file's definitions, beside `drop_go_return_types`. The map
+        is read directly, with no derived index to invalidate.
+        """
+        for qn in qns:
+            self.method_return_types.pop(qn, None)
+
     def _go_free_fn_return_type(self, name: str, module_qn: str) -> str | None:
         # Same module (file) first; then the enclosing package's sibling files
         # (same parent dir), since Go free functions are package-scoped, not

--- a/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
+++ b/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
@@ -147,3 +147,37 @@ def test_an_entry_whose_registry_row_is_already_gone_is_still_forgotten(
         f"the orphaned entry outlived its registry row and its file: {recorded}"
     )
     assert recorded.get("proj.pkg.types.B.Twin") == "B", recorded
+
+
+def test_a_qn_shared_with_a_survivor_is_forgotten_rather_than_left_stale(
+    temp_repo: Path,
+) -> None:
+    """Two files declaring the same receiver method share one map slot.
+
+    The map holds one value per qn, and the later-parsed file wrote it. When
+    that file is deleted the survivor is not re-parsed, so keeping the entry
+    keeps the DELETED definition's return type under the survivor's name;
+    forgetting it costs a lookup until the survivor's next parse (#1752
+    review).
+    """
+    root = temp_repo / "proj"
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "types.go").write_text(TYPES_GO, encoding="utf-8")
+    (root / "pkg" / "methods.go").write_text(METHODS_GO, encoding="utf-8")
+    # Parsed after methods.go, so its return type is the one recorded.
+    (root / "pkg" / "other.go").write_text(
+        "package pkg\n\nfunc (a A) Clone() B { return B{} }\n", encoding="utf-8"
+    )
+    updater = _updater(root)
+    updater.run()
+    recorded = updater.factory.type_inference.method_return_types
+    assert recorded.get("proj.pkg.types.A.Clone") == "B", (
+        f"fixture guard: the later file did not write the shared slot: {recorded}"
+    )
+
+    (root / "pkg" / "other.go").unlink()
+    updater.remove_file_from_state(root / "pkg" / "other.go")
+
+    assert "proj.pkg.types.A.Clone" not in recorded, (
+        f"the deleted definition's return type survives under the survivor: {recorded}"
+    )

--- a/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
+++ b/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from codebase_rag import constants as cs
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.tests.conftest import _MockIngestor
@@ -181,3 +182,26 @@ def test_a_qn_shared_with_a_survivor_is_forgotten_rather_than_left_stale(
     assert "proj.pkg.types.A.Clone" not in recorded, (
         f"the deleted definition's return type survives under the survivor: {recorded}"
     )
+
+
+def test_an_entry_keyed_by_its_duplicate_name_is_forgotten_too(temp_repo: Path) -> None:
+    """Some writers key the map by the registry's `@line` name itself.
+
+    Deferred Rust functions and duplicate C++ out-of-class methods record
+    their return type under the `@line` name, so the ownership comparison
+    normalises the map key as well as the span record (#1752 review). The
+    Go fixture plants such a key for the deleted file's method.
+    """
+    root = temp_repo / "proj"
+    updater = _project(root)
+    recorded = updater.factory.type_inference.method_return_types
+    planted = f"proj.pkg.types.A.Clone{cs.DUP_QN_MARKER}3"
+    recorded[planted] = "A"
+
+    (root / "pkg" / "methods.go").unlink()
+    updater.remove_file_from_state(root / "pkg" / "methods.go")
+
+    assert planted not in recorded, (
+        f"an entry keyed by the deleted method's duplicate name survived: {recorded}"
+    )
+    assert recorded.get("proj.pkg.types.B.Twin") == "B", recorded

--- a/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
+++ b/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
@@ -1,0 +1,124 @@
+"""A deleted file's method return types must leave with its registry rows.
+
+`TypeInferenceEngine.method_return_types` records the return type of C++,
+Rust and Dart free functions, of every language's methods, and of Go receiver
+methods, under the definition's qualified name. `remove_file_from_state`
+pruned the registry and, since #1668, the Go free-function map for a deleted
+file, but never this one: on a reused updater a deleted file's entries
+persisted, and a Go method keyed by its receiver's module could not even be
+reached by a prefix sweep (issue #1738).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import _MockIngestor
+
+TYPES_GO = "package pkg\n\ntype A struct{}\n\ntype B struct{}\n"
+# `Clone` is keyed by A's module (`proj.pkg.types.A.Clone`): no prefix of
+# methods.go matches it, so only span-record ownership can find it.
+METHODS_GO = "package pkg\n\nfunc (a A) Clone() A { return a }\n"
+OTHER_GO = "package pkg\n\nfunc (b B) Twin() B { return b }\n"
+
+
+def _updater(root: Path) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    if "go" not in {str(k) for k in parsers}:
+        pytest.skip("go parser not available")
+    return GraphUpdater(
+        ingestor=_MockIngestor(),
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+def _project(root: Path) -> GraphUpdater:
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "types.go").write_text(TYPES_GO, encoding="utf-8")
+    (root / "pkg" / "methods.go").write_text(METHODS_GO, encoding="utf-8")
+    (root / "pkg" / "other.go").write_text(OTHER_GO, encoding="utf-8")
+    updater = _updater(root)
+    updater.run()
+    recorded = updater.factory.type_inference.method_return_types
+    assert recorded.get("proj.pkg.types.A.Clone") == "A", (
+        f"fixture guard: the first run did not record Clone's return type: {recorded}"
+    )
+    assert recorded.get("proj.pkg.types.B.Twin") == "B", recorded
+    return updater
+
+
+def test_a_deleted_go_files_method_return_types_are_forgotten(
+    temp_repo: Path,
+) -> None:
+    """Delete `methods.go` on a reused updater: `Clone`'s entry must go.
+
+    The entry sits under `types.go`'s prefix, which this event does not
+    touch, so this is exactly the qn a prefix sweep cannot reach; the span
+    records name `methods.go` as the registering module.
+    """
+    root = temp_repo / "proj"
+    updater = _project(root)
+    recorded = updater.factory.type_inference.method_return_types
+
+    (root / "pkg" / "methods.go").unlink()
+    updater.remove_file_from_state(root / "pkg" / "methods.go")
+
+    assert "proj.pkg.types.A.Clone" not in recorded, (
+        "the deleted file's return-type entry survived remove_file_from_state"
+    )
+    # The control: another file's method under the SAME receiver module
+    # stays; only the deleted file's rows go.
+    assert recorded.get("proj.pkg.types.B.Twin") == "B", (
+        "a sibling's entry was swept along with the deleted file's"
+    )
+
+
+def test_a_method_another_file_owns_survives_its_receiver_modules_delete(
+    temp_repo: Path,
+) -> None:
+    """Delete `types.go`: the methods keyed under it stay, as their rows do.
+
+    Both methods sit under `proj.pkg.types` although `methods.go` and
+    `other.go` declare them, and neither of those files is re-parsed by
+    this event. The registry keeps their rows for exactly that reason (the
+    span records name the declaring file, so they are foreign to this
+    delete), and the return-type map must agree with the registry rather
+    than sweep by prefix alone.
+    """
+    root = temp_repo / "proj"
+    updater = _project(root)
+    recorded = updater.factory.type_inference.method_return_types
+
+    (root / "pkg" / "types.go").unlink()
+    updater.remove_file_from_state(root / "pkg" / "types.go")
+
+    assert "proj.pkg.types.A.Clone" in updater.function_registry, (
+        "fixture guard: the registry swept a row another file owns"
+    )
+    assert recorded.get("proj.pkg.types.A.Clone") == "A", (
+        f"the map swept by prefix what the registry kept by ownership: {recorded}"
+    )
+    assert recorded.get("proj.pkg.types.B.Twin") == "B", recorded
+
+
+def test_a_reparse_records_the_new_return_type(temp_repo: Path) -> None:
+    """The point of forgetting: a re-parse must not be shadowed by the old."""
+    root = temp_repo / "proj"
+    updater = _project(root)
+    recorded = updater.factory.type_inference.method_return_types
+
+    (root / "pkg" / "methods.go").write_text(
+        "package pkg\n\nfunc (a A) Clone() B { return B{} }\n", encoding="utf-8"
+    )
+    updater.remove_file_from_state(root / "pkg" / "methods.go")
+    assert "proj.pkg.types.A.Clone" not in recorded
+    updater.run()
+
+    assert recorded.get("proj.pkg.types.A.Clone") == "B", recorded

--- a/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
+++ b/codebase_rag/tests/test_method_return_types_forget_deleted_file.py
@@ -122,3 +122,28 @@ def test_a_reparse_records_the_new_return_type(temp_repo: Path) -> None:
     updater.run()
 
     assert recorded.get("proj.pkg.types.A.Clone") == "B", recorded
+
+
+def test_an_entry_whose_registry_row_is_already_gone_is_still_forgotten(
+    temp_repo: Path,
+) -> None:
+    """Ownership comes from the span records, not the registry sweep.
+
+    A receiver method is keyed under `types.go`, so no prefix of
+    `methods.go` matches it, and with its registry row already removed it
+    never enters the sweep's removal set either. Only the span record that
+    names `methods.go` as the registering module can still find it (#1752
+    review).
+    """
+    root = temp_repo / "proj"
+    updater = _project(root)
+    recorded = updater.factory.type_inference.method_return_types
+    del updater.function_registry["proj.pkg.types.A.Clone"]
+
+    (root / "pkg" / "methods.go").unlink()
+    updater.remove_file_from_state(root / "pkg" / "methods.go")
+
+    assert "proj.pkg.types.A.Clone" not in recorded, (
+        f"the orphaned entry outlived its registry row and its file: {recorded}"
+    )
+    assert recorded.get("proj.pkg.types.B.Twin") == "B", recorded


### PR DESCRIPTION
Closes #1738.

`TypeInferenceEngine.method_return_types` records the return type of C++, Rust and Dart free functions, of every language's methods and of Go receiver methods under the definition's qualified name. `remove_file_from_state` prunes the function registry and, since #1668, the Go free-function return-type map for a deleted or re-parsed file, but it never touched this map, so on a reused updater a deleted file's entries persisted. A Go method is keyed by its receiver type's module, so its entry sits under a prefix the deleting event does not own and no prefix sweep could reach it either.

The sweep now applies the same ownership filter it applies to the registry: an entry is dropped when its qualified name is one the registry sweep removed (which carries the span-record ownership that finds a Go method registered from another file), or when it sits under one of the deleted file's module prefixes and is not owned by another file. `drop_method_return_types` on the engine does the removal; the map has no derived index, so there is nothing to invalidate.

Tests in `test_method_return_types_forget_deleted_file.py` delete the file that declares a Go method whose entry lives under the receiver's module and assert the entry goes while a sibling's entry under the same receiver module stays; delete the receiver module itself and assert every entry under its prefix goes; and re-parse a method with a changed return type and assert the new type is recorded. All three fail on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale method and function return-type information is now cleared when files are removed.
  * Return types from unaffected files and namespaces are preserved.
  * Duplicate method entries are also cleaned up when their source file is removed.
  * Re-parsing a previously removed file now records updated return types without interference from outdated data.

* **Tests**
  * Added coverage for file deletion, shared receiver modules, duplicate entries, and re-parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->