### PR TITLE
test: pin that rehydration re-adds a C++ module interface held only by the graph

### DIFF
--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -438,6 +438,70 @@ def test_a_cpp_interface_parsed_this_run_survives_rehydration(
     assert implements, "the interface was dropped before its impl resolved"
 
 
+@pytest.mark.parametrize("reuse_updater", [False, True], ids=["fresh", "reused"])
+def test_rehydration_readds_an_interface_held_only_by_the_graph(
+    temp_repo: Path, reuse_updater: bool
+) -> None:
+    # The positive direction of the rebuild (issue #1736): an interface parsed
+    # in an EARLIER run and untouched now is absent from
+    # cpp_interfaces_parsed_this_run, so only the graph rows can put it back.
+    # resolve_deferred_cpp_module_impls checks membership in
+    # cpp_module_interfaces, so with the re-add gone an implementation unit
+    # edited on its own loses its IMPLEMENTS edge. A sibling's fixture guard
+    # ("the shape did not rehydrate") does catch the missing membership, but
+    # nothing asserted the IMPLEMENTS edge on the incremental run or covered
+    # a reused updater (measured: a resolver reading
+    # cpp_interfaces_parsed_this_run instead of cpp_module_interfaces leaves
+    # every other test in this file green and fails only this one). A fresh
+    # updater has never parsed the interface at all; a reused one parsed it
+    # last run, and the per-run reset of the companion set is what makes the
+    # graph the only source there too.
+    root = temp_repo / "proj"
+    _materialise(
+        root,
+        {
+            "iface.cppm": "export module M;\nexport int f();\n",
+            "impl.cpp": "module M;\nint f() { return 1; }\n",
+        },
+    )
+    store = _StatefulIngestor()
+    first = _updater(store, root, cs.SupportedLanguage.CPP)
+    if cs.SupportedLanguage.CPP not in first.parsers:
+        pytest.skip("cpp parser not available")
+    first.run(force=True)
+    assert [
+        edge for edge in store.edges if edge[2] == cs.RelationshipType.IMPLEMENTS.value
+    ], "fixture guard: the clean index did not resolve impl.cpp against M"
+
+    second = first if reuse_updater else _updater(store, root, cs.SupportedLanguage.CPP)
+    (root / "impl.cpp").write_text(
+        "module M;\nint f() { return 2; }\n", encoding="utf-8"
+    )
+    _bump(root, "impl.cpp")
+    dp = second.factory.definition_processor
+    with patch.object(
+        store, "ensure_relationship_batch", wraps=store.ensure_relationship_batch
+    ) as spy:
+        second.run(force=False)
+
+    assert "proj.M" not in dp.cpp_interfaces_parsed_this_run, (
+        "fixture guard: the interface was re-parsed, so the companion set and "
+        "not the graph rows would have kept it"
+    )
+    assert "proj.M" in dp.cpp_module_interfaces, (
+        "rehydration did not re-add the interface the graph holds: "
+        f"{sorted(dp.cpp_module_interfaces)}"
+    )
+    implements_now = [
+        call
+        for call in spy.call_args_list
+        if str(call.args[1]) == cs.RelationshipType.IMPLEMENTS.value
+    ]
+    assert implements_now, (
+        "the edited implementation unit lost its IMPLEMENTS edge on the incremental run"
+    )
+
+
 def test_a_cpp_interface_the_graph_lost_is_forgotten(temp_repo: Path) -> None:
     # The mirror case: an interface another writer deleted must not linger,
     # or resolve_deferred_cpp_module_impls mints an IMPLEMENTS edge to a

--- a/codebase_rag/tests/test_incremental_deleted_state.py
+++ b/codebase_rag/tests/test_incremental_deleted_state.py
@@ -469,9 +469,18 @@ def test_rehydration_readds_an_interface_held_only_by_the_graph(
     if cs.SupportedLanguage.CPP not in first.parsers:
         pytest.skip("cpp parser not available")
     first.run(force=True)
-    assert [
+    clean_edges = [
         edge for edge in store.edges if edge[2] == cs.RelationshipType.IMPLEMENTS.value
-    ], "fixture guard: the clean index did not resolve impl.cpp against M"
+    ]
+    assert len(clean_edges) == 1, (
+        f"fixture guard: the clean index did not resolve impl.cpp against M: {clean_edges}"
+    )
+    impl_label, impl_qn, _rel, iface_label, iface_qn = clean_edges[0]
+    assert (str(iface_label), str(iface_qn)) == (
+        cs.NodeLabel.MODULE_INTERFACE.value,
+        "proj.M",
+    ), clean_edges
+    assert str(impl_label) == cs.NodeLabel.MODULE_IMPLEMENTATION.value, clean_edges
 
     second = first if reuse_updater else _updater(store, root, cs.SupportedLanguage.CPP)
     (root / "impl.cpp").write_text(
@@ -492,13 +501,24 @@ def test_rehydration_readds_an_interface_held_only_by_the_graph(
         "rehydration did not re-add the interface the graph holds: "
         f"{sorted(dp.cpp_module_interfaces)}"
     )
+    # The same endpoints the clean index produced, not just any IMPLEMENTS
+    # (CodeRabbit, #1754): the implementation unit as source, `proj.M` as the
+    # ModuleInterface target.
     implements_now = [
-        call
+        (
+            str(call.args[0][0]),
+            str(call.args[0][2]),
+            str(call.args[2][0]),
+            str(call.args[2][2]),
+        )
         for call in spy.call_args_list
         if str(call.args[1]) == cs.RelationshipType.IMPLEMENTS.value
     ]
-    assert implements_now, (
-        "the edited implementation unit lost its IMPLEMENTS edge on the incremental run"
+    assert implements_now == [
+        (str(impl_label), str(impl_qn), str(iface_label), str(iface_qn))
+    ], (
+        "the edited implementation unit lost its IMPLEMENTS edge on the "
+        f"incremental run, or emitted it between other endpoints: {implements_now}"
     )
 
 


### PR DESCRIPTION
Closes #1736.

`_rehydrate_registry_from_graph` re-adds every `ModuleInterface` the graph holds to `cpp_module_interfaces`, and that re-add is what lets an implementation unit resolve on an incremental run when its interface was parsed in an earlier run and is not re-parsed now. The positive direction had thin coverage: the one positive test keeps the interface through `cpp_interfaces_parsed_this_run`, the two negative tests assert only that a lost interface is forgotten, and nothing asserted the `IMPLEMENTS` edge on the incremental run or exercised a reused updater. (The issue's premise that deleting the re-add leaves the file green no longer holds: a sibling's fixture guard added on 2026-09-04 fails on the missing membership. What was missing is the edge and the reused path.)

The new test indexes `iface.cppm` and `impl.cpp` together, then edits and re-runs only `impl.cpp`, on a fresh updater and on the reused one. It asserts the interface is absent from the per-run companion set (so the graph rows are the only source), present in `cpp_module_interfaces` after rehydration, and that the incremental run emits the `IMPLEMENTS` edge, observed through a spy on the ingestor because the stateful store still holds the first run's edge. With the re-add replaced by `pass` both parametrisations fail; with the resolver made to read `cpp_interfaces_parsed_this_run` instead of `cpp_module_interfaces`, only this test fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for incremental C++ module-interface rehydration.
  * Verified that previously parsed interfaces are restored during subsequent runs.
  * Confirmed that implementation relationships remain intact for edited implementation units.
  * Covered both fresh and reused updater scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->