### PR TITLE
fix: a single-file target deleted after construction is removed from state and cache rather than skipped as unreadable

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3257,6 +3257,24 @@ class GraphUpdater:
         # costs a redundant rehash; erring late loses an edit.
         self._pending_cache_observed_at = time.time()
 
+        # A single-file target that existed at construction and is gone by
+        # now is a DELETION, not an unreadable file (issue #1737). Left on the
+        # unreadable path the run logged "Skipped 1 unreadable files",
+        # returned normally and republished a cache still naming the file,
+        # with the file's definitions still in the registry: a caller of the
+        # file-target constructor got a success signal for a file that was
+        # not indexed (the orphan prune had already removed its graph nodes).
+        # Its state, nodes and cache entry go the way `deleted_keys` takes
+        # them below.
+        single_gone_key: str | None = None
+        if (
+            self._single_file is not None
+            and eligible_files
+            and not self._single_file.exists()
+        ):
+            single_gone_key = eligible_files[0][1]
+            eligible_files = []
+
         changed_entries: list[tuple[Path, str, bool, bytes]] = []
         for filepath, file_key in eligible_files:
             if not force and file_key in old_hashes:
@@ -3524,11 +3542,18 @@ class GraphUpdater:
         # names only that file and every sibling looks deleted. It cannot
         # speak for the project's file set, for the same reason `run` guards
         # the exclusion stamp with `self._single_file is None` (#1619).
-        deleted_keys = (
-            (set(old_hashes.keys()) | graph_paths) - current_file_keys - unreadable_keys
-            if self._single_file is None
-            else set()
-        )
+        if self._single_file is None:
+            deleted_keys = (
+                (set(old_hashes.keys()) | graph_paths)
+                - current_file_keys
+                - unreadable_keys
+            )
+        elif single_gone_key is not None:
+            # The one file this run was asked about is gone: exactly that key,
+            # never the siblings the project-wide terms would name (#1737).
+            deleted_keys = {single_gone_key}
+        else:
+            deleted_keys = set()
         if deleted_keys:
             logger.info(ls.INCREMENTAL_DELETED, count=len(deleted_keys))
             for deleted_key in deleted_keys:
@@ -3589,10 +3614,14 @@ class GraphUpdater:
             # reconciles properly (#1619 review, round 5). Measured: with the
             # cache removed, a single-file run then a project run left
             # `module_b.py` undeleted after an edit.
+            merged_hashes = {**pristine_hashes, **new_hashes}
+            if single_gone_key is not None:
+                # The deleted target must leave the cache too, or the next
+                # project run reads it as indexed and never reconciles the
+                # graph (#1737).
+                merged_hashes.pop(single_gone_key, None)
             self._pending_hash_cache = (
-                (cache_path, {**pristine_hashes, **new_hashes})
-                if pristine_hashes
-                else None
+                (cache_path, merged_hashes) if pristine_hashes else None
             )
             # And it must carry the PREVIOUS cache's mtime forward rather
             # than stamping this run's instant. The merged entries are mostly

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3078,12 +3078,24 @@ class GraphUpdater:
         self._delombok_state_candidate = current
 
     def _single_target_vanished(self, filepath: Path) -> bool:
-        """Whether `filepath` is this run's single target and is now gone."""
-        return (
-            self._single_file is not None
-            and filepath == self._single_file
-            and not filepath.exists()
-        )
+        """Whether `filepath` is this run's single target and its entry is gone.
+
+        Judged by the MISSING-PATH error from `lstat`, not by `Path.exists()`:
+        `exists()` answers False to any metadata failure, so a target that is
+        merely unreadable would have been classified as deleted and lose its
+        state and cache entry (#1755 review). `lstat` needs only search
+        permission on the directory, and `FileNotFoundError` from it means the
+        directory entry itself is gone.
+        """
+        if self._single_file is None or filepath != self._single_file:
+            return False
+        try:
+            os.lstat(filepath)
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        return False
 
     def _collect_eligible_files(self) -> list[tuple[Path, str]]:
         if self._single_file is not None:
@@ -3288,8 +3300,12 @@ class GraphUpdater:
             if not force and file_key in old_hashes:
                 try:
                     file_mtime = filepath.stat().st_mtime
-                except OSError:
-                    if self._single_target_vanished(filepath):
+                except OSError as stat_error:
+                    # The stat's own error decides: a missing path is a
+                    # deletion, any other failure an unreadable file.
+                    if isinstance(
+                        stat_error, FileNotFoundError
+                    ) and self._single_target_vanished(filepath):
                         single_gone_key = file_key
                         continue
                     unreadable_count += 1

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3077,6 +3077,14 @@ class GraphUpdater:
         # already reprocessed. Single-file runs never commit it either.
         self._delombok_state_candidate = current
 
+    def _single_target_vanished(self, filepath: Path) -> bool:
+        """Whether `filepath` is this run's single target and is now gone."""
+        return (
+            self._single_file is not None
+            and filepath == self._single_file
+            and not filepath.exists()
+        )
+
     def _collect_eligible_files(self) -> list[tuple[Path, str]]:
         if self._single_file is not None:
             if not should_skip_path(
@@ -3281,6 +3289,9 @@ class GraphUpdater:
                 try:
                     file_mtime = filepath.stat().st_mtime
                 except OSError:
+                    if self._single_target_vanished(filepath):
+                        single_gone_key = file_key
+                        continue
                     unreadable_count += 1
                     unreadable_keys.add(file_key)
                     continue
@@ -3292,6 +3303,13 @@ class GraphUpdater:
 
             hashed = _hash_file_with_bytes(filepath)
             if hashed is None:
+                # The same deletion, one step later: a target that passed the
+                # existence check and was removed before its stat or read is
+                # gone all the same, and the unreadable path would keep its
+                # state and cache entry (#1755 review).
+                if self._single_target_vanished(filepath):
+                    single_gone_key = file_key
+                    continue
                 unreadable_count += 1
                 unreadable_keys.add(file_key)
                 continue

--- a/codebase_rag/tests/test_single_file_target_gone.py
+++ b/codebase_rag/tests/test_single_file_target_gone.py
@@ -1,0 +1,118 @@
+"""A single-file target deleted after construction is a deletion, not a no-op.
+
+`GraphUpdater(repo_path=<existing file>)` records the file as its single
+target. If the file is deleted between construction and `run()`, the run used
+to take the unreadable path: it logged "Skipped 1 unreadable files", returned
+normally and republished a hash cache that still carried the file, with the
+file's definitions still in the registry, so the caller got a success signal
+for a file that was not indexed (issue #1737; the orphan prune had already
+removed its graph nodes). The run now removes the file's state, its Module
+subtree and File node, and its cache entry, the way a project run treats a
+deleted file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+
+def _create_graph_updater(target: Path, store: _StatefulIngestor) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=store,
+        repo_path=target,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+def _writes(spy: MagicMock) -> list[tuple[str, dict[str, object]]]:
+    # The updater may reach the store through a forwarding wrapper that passes
+    # the query and params by keyword, so read both spellings.
+    out: list[tuple[str, dict[str, object]]] = []
+    for call in spy.call_args_list:
+        query = call.args[0] if call.args else call.kwargs["query"]
+        params = call.args[1] if len(call.args) > 1 else call.kwargs.get("params")
+        out.append((str(query), dict(params or {})))
+    return out
+
+
+def _cache(root: Path) -> dict[str, str]:
+    return json.loads((root / cs.HASH_CACHE_FILENAME).read_text(encoding="utf-8"))
+
+
+def test_a_single_file_target_gone_before_run_is_deleted_not_skipped(
+    temp_repo: Path,
+) -> None:
+    (temp_repo / "module_a.py").write_text("def func_a():\n    pass\n")
+    (temp_repo / "module_b.py").write_text("def func_b():\n    pass\n")
+    store = _StatefulIngestor()
+    _create_graph_updater(temp_repo, store).run()
+    store.flush_all()
+    before = _cache(temp_repo)
+    assert "module_a.py" in before, f"fixture guard: {before}"
+
+    target = temp_repo / "module_a.py"
+    updater = _create_graph_updater(target, store)
+    target.unlink()
+    with patch.object(store, "execute_write", wraps=store.execute_write) as spy:
+        updater.run()
+    store.flush_all()
+
+    deletes = [
+        (query, params.get(cs.KEY_PATH))
+        for query, params in _writes(spy)
+        if query in (cs.CYPHER_DELETE_MODULE, cs.CYPHER_DELETE_FILE)
+    ]
+    assert (cs.CYPHER_DELETE_MODULE, "module_a.py") in deletes, (
+        f"the deleted target's Module subtree was not removed: {deletes}"
+    )
+    assert (cs.CYPHER_DELETE_FILE, target.resolve().as_posix()) in deletes, (
+        f"the deleted target's File node was not removed: {deletes}"
+    )
+    # Exactly the target: a single-file run must not sweep its siblings.
+    assert all(
+        path in ("module_a.py", target.resolve().as_posix()) for _, path in deletes
+    ), deletes
+    assert not any(
+        qn.startswith("proj.module_a") for qn in updater.function_registry.keys()
+    ), "the deleted target's definitions are still registered"
+
+    after = _cache(temp_repo)
+    assert "module_a.py" not in after, (
+        f"the cache still lists the deleted target: {after}"
+    )
+    assert after.get("module_b.py") == before["module_b.py"], (
+        "the sibling's cache entry did not survive the single-file run"
+    )
+
+
+def test_a_single_file_target_that_still_exists_is_indexed_as_before(
+    temp_repo: Path,
+) -> None:
+    # The control: the deletion branch must not fire for a present target.
+    (temp_repo / "module_a.py").write_text("def func_a():\n    pass\n")
+    store = _StatefulIngestor()
+    _create_graph_updater(temp_repo, store).run()
+    store.flush_all()
+
+    target = temp_repo / "module_a.py"
+    target.write_text("def func_a():\n    return 1\n")
+    updater = _create_graph_updater(target, store)
+    with patch.object(store, "execute_write", wraps=store.execute_write) as spy:
+        updater.run()
+    store.flush_all()
+
+    assert not [
+        query for query, _params in _writes(spy) if query == cs.CYPHER_DELETE_FILE
+    ], "a present single-file target was treated as deleted"
+    assert "module_a.py" in _cache(temp_repo)
+    assert "proj.module_a.func_a" in updater.function_registry

--- a/codebase_rag/tests/test_single_file_target_gone.py
+++ b/codebase_rag/tests/test_single_file_target_gone.py
@@ -167,3 +167,39 @@ def test_a_target_deleted_during_hashing_is_a_deletion_too(temp_repo: Path) -> N
     after = _cache(temp_repo)
     assert "module_a.py" not in after, f"the cache still lists the target: {after}"
     assert after.get("module_b.py") == before["module_b.py"]
+
+
+def test_an_unreadable_but_present_target_is_not_treated_as_deleted(
+    temp_repo: Path,
+) -> None:
+    # The other side of the race rule (#1755 review): a read that fails for a
+    # reason other than a missing path (here the hash helper returns nothing
+    # while the file is still there) must stay on the unreadable path and
+    # keep the target's state and cache entry.
+    (temp_repo / "module_a.py").write_text("def func_a():\n    pass\n")
+    (temp_repo / "module_b.py").write_text("def func_b():\n    pass\n")
+    store = _StatefulIngestor()
+    _create_graph_updater(temp_repo, store).run()
+    store.flush_all()
+    before = _cache(temp_repo)
+
+    target = temp_repo / "module_a.py"
+    cache_mtime = (temp_repo / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    os.utime(target, (cache_mtime + 2, cache_mtime + 2))
+    updater = _create_graph_updater(target, store)
+
+    with (
+        patch.object(graph_updater_module, "_hash_file_with_bytes", lambda _p: None),
+        patch.object(store, "execute_write", wraps=store.execute_write) as spy,
+    ):
+        updater.run()
+    store.flush_all()
+
+    assert target.exists()
+    assert not [
+        query for query, _params in _writes(spy) if query == cs.CYPHER_DELETE_FILE
+    ], "an unreadable target that still exists was treated as deleted"
+    assert any(
+        qn.startswith("proj.module_a") for qn in updater.function_registry.keys()
+    ), "the unreadable target lost its definitions"
+    assert _cache(temp_repo).get("module_a.py") == before["module_a.py"]

--- a/codebase_rag/tests/test_single_file_target_gone.py
+++ b/codebase_rag/tests/test_single_file_target_gone.py
@@ -14,10 +14,12 @@ deleted file.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from codebase_rag import constants as cs
+from codebase_rag import graph_updater as graph_updater_module
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from evals.cgr_graph import _StatefulIngestor
@@ -116,3 +118,52 @@ def test_a_single_file_target_that_still_exists_is_indexed_as_before(
     ], "a present single-file target was treated as deleted"
     assert "module_a.py" in _cache(temp_repo)
     assert "proj.module_a.func_a" in updater.function_registry
+
+
+def test_a_target_deleted_during_hashing_is_a_deletion_too(temp_repo: Path) -> None:
+    # The race the first fix left open (#1755 review): the target passes the
+    # existence check and is removed before its bytes are read. That read
+    # returning nothing used to count as an unreadable file, which kept the
+    # registry entry and republished the cache with the target in it.
+    (temp_repo / "module_a.py").write_text("def func_a():\n    pass\n")
+    (temp_repo / "module_b.py").write_text("def func_b():\n    pass\n")
+    store = _StatefulIngestor()
+    _create_graph_updater(temp_repo, store).run()
+    store.flush_all()
+    before = _cache(temp_repo)
+
+    target = temp_repo / "module_a.py"
+    # Later than the cache, so the run reaches the read rather than the
+    # in-sync skip.
+    cache_mtime = (temp_repo / cs.HASH_CACHE_FILENAME).stat().st_mtime
+    os.utime(target, (cache_mtime + 2, cache_mtime + 2))
+    updater = _create_graph_updater(target, store)
+    real_hash = graph_updater_module._hash_file_with_bytes
+
+    def _vanish_then_hash(path: Path):
+        # The updater hashes its RESOLVED target (`/private/var/...` for a
+        # `/var/...` temp dir on macOS), so compare resolved paths.
+        if path.resolve() == target.resolve() and target.exists():
+            target.unlink()
+        return real_hash(path)
+
+    with (
+        patch.object(graph_updater_module, "_hash_file_with_bytes", _vanish_then_hash),
+        patch.object(store, "execute_write", wraps=store.execute_write) as spy,
+    ):
+        updater.run()
+    store.flush_all()
+
+    assert not target.exists(), "fixture guard: the hash hook did not remove the target"
+    deletes = {
+        (query, params.get(cs.KEY_PATH))
+        for query, params in _writes(spy)
+        if query in (cs.CYPHER_DELETE_MODULE, cs.CYPHER_DELETE_FILE)
+    }
+    assert (cs.CYPHER_DELETE_MODULE, "module_a.py") in deletes, deletes
+    assert not any(
+        qn.startswith("proj.module_a") for qn in updater.function_registry.keys()
+    ), "the target deleted during hashing kept its definitions"
+    after = _cache(temp_repo)
+    assert "module_a.py" not in after, f"the cache still lists the target: {after}"
+    assert after.get("module_b.py") == before["module_b.py"]


### PR DESCRIPTION
Closes #1737.

A `GraphUpdater` constructed on an existing file records it as its single target. When that file is deleted between construction and `run()`, the run took the unreadable path: it logged "Skipped 1 unreadable files", returned normally, left the file's definitions in the registry and republished a hash cache still carrying the file, so the caller got a success signal for a file that was not indexed. (The orphan prune had already removed the file's graph nodes; what survived was the in-memory state and the cache entry.)

The run now treats a vanished single-file target as a deletion of exactly that key. It is taken out of the eligible set before hashing, put through the same `deleted_keys` path a project run uses for a deleted file (state removal, Module subtree and File node deletes), and dropped from the merged single-file cache before it is published. Siblings are untouched: the project-wide terms that would sweep them stay disabled on a single-file run.

`test_single_file_target_gone.py` indexes two modules, constructs on one, deletes it and runs. It asserts the delete queries name only that file, its definitions are gone from the registry, its cache entry is gone and the sibling's entry is unchanged; a control asserts a present target is indexed as before. The test fails on `main` at the registry assertion, and each of the two fix lines was checked to be load-bearing by mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling for single-file targets deleted before or during processing.
  - Removed deleted targets from indexed content, cached data, and related metadata.
  - Preserved existing behavior for readable files and files that remain present but cannot be read.
- **Tests**
  - Added coverage for deleted, available, and unreadable single-file targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->