### PR TITLE
fix: match the std token when prefixing a system include so stdio.h lands under std. like signal.h

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -4167,9 +4167,15 @@ class ImportProcessor:
                 local_name = header_name
 
             if is_system_include:
+                # The token, not the substring: `startswith("std")` took
+                # `<stdio.h>`, `<stdlib.h>`, `<stdint.h>` and the rest of that
+                # family as already prefixed, so they became ExternalModule
+                # `stdio.h` while `<signal.h>` in the same file became
+                # `std.signal.h` (issue #1744).
                 full_name = (
                     include_path
-                    if include_path.startswith(cs.CPP_STD_PREFIX)
+                    if include_path == cs.CPP_STD_PREFIX
+                    or include_path.startswith(cs.IMPORT_STD_PREFIX)
                     else f"{cs.IMPORT_STD_PREFIX}{include_path}"
                 )
             elif resolved := self._resolve_cpp_include_target(include_path, module_qn):

--- a/codebase_rag/tests/test_c_include_imports.py
+++ b/codebase_rag/tests/test_c_include_imports.py
@@ -106,3 +106,41 @@ def test_a_c_files_system_include_names_the_same_external_module_as_cpps(
         f"a .c system include named {from_c} where the same include from .cpp "
         f"named {from_cpp}"
     )
+
+
+@pytest.mark.parametrize("includer", ["a.c", "a.cpp"])
+def test_every_system_header_lands_under_the_std_prefix(
+    tmp_path: Path, includer: str
+) -> None:
+    # `startswith("std")` was a substring match: `<stdio.h>` and its family
+    # read as already prefixed and named ExternalModule `stdio.h`, while
+    # `<signal.h>` and `<vector>` in the same file named `std.signal.h` and
+    # `std.vector` (issue #1744). Every system header takes the one prefix.
+    parsers, queries = load_parsers()
+    for language in (cs.SupportedLanguage.C, cs.SupportedLanguage.CPP):
+        if language not in parsers:
+            pytest.skip(f"{language} parser not available")
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / includer).write_text(
+        "#include <stdio.h>\n#include <stdlib.h>\n#include <signal.h>\n"
+        "#include <vector>\nint x;\n",
+        encoding="utf-8",
+    )
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    targets = {
+        str(dst)
+        for (_sl, _src, rel, _tl, dst) in store.edges
+        if rel == cs.RelationshipType.IMPORTS.value
+    }
+    assert targets == {"std.stdio.h", "std.stdlib.h", "std.signal.h", "std.vector"}, (
+        targets
+    )


### PR DESCRIPTION
Closes #1744.

`ImportProcessor._parse_cpp_include` decided whether a system include already carried the std prefix with a `startswith("std")` test on the header name, which is a substring match. `<stdio.h>`, `<stdlib.h>`, `<stdint.h>`, `<stdbool.h>`, `<stddef.h>` and `<stdarg.h>` were taken as already prefixed and became ExternalModule `stdio.h` and so on, while `<signal.h>` or `<vector>` in the same file became `std.signal.h` and `std.vector`. Since #1654 the same branch serves C, where that family is the most common set of includes.

The test now matches the token: the path is left alone only when it is exactly `std` or starts with `std.`; everything else takes the `std.` prefix. The regression indexes a file with `<stdio.h>`, `<stdlib.h>`, `<signal.h>` and `<vector>` from a `.c` and a `.cpp` unit and asserts every IMPORTS target is under `std.`; on `main` two of the four land outside it.
