### PR TITLE
fix: a module-level class alias is a class receiver, so Alias.Inner() constructs like Outer.Inner()

### DIFF
--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -18,6 +18,13 @@ TS_PY_LIST_COMPREHENSION = "list_comprehension"
 TS_PY_FOR_STATEMENT = "for_statement"
 TS_PY_FOR_IN_CLAUSE = "for_in_clause"
 TS_PY_ASSIGNMENT = "assignment"
+# Unpacking targets: `a, b = ...`, `(a, b) = ...`, `[a, b] = ...`.
+TS_PY_PATTERN_LIST = "pattern_list"
+TS_PY_TUPLE_PATTERN = "tuple_pattern"
+TS_PY_LIST_PATTERN = "list_pattern"
+PY_UNPACKING_TARGET_TYPES = frozenset(
+    {TS_PY_PATTERN_LIST, TS_PY_TUPLE_PATTERN, TS_PY_LIST_PATTERN}
+)
 PY_ASSIGNMENT_QUERY = "(assignment) @assignment"
 PY_RETURN_QUERY = "(return_statement) @return_stmt"
 TS_PY_CLASS_DEFINITION = "class_definition"

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -86,13 +86,26 @@ def _php_fold(name: str) -> str:
 
 
 def _module_level_assignments(root_node: Node) -> Iterator[Node]:
-    """Every `assignment` that is a top-level expression statement of the module."""
+    """Every `assignment` that is a top-level expression statement of the module.
+
+    A chained `Alias = Other = Outer` nests an assignment on the outer
+    right-hand side; each link is yielded, so every direct target is seen
+    (CodeRabbit, #1759).
+    """
     for child in root_node.children:
         if child.type != cs.TS_PY_EXPRESSION_STATEMENT or not child.children:
             continue
-        assignment = child.children[0]
-        if assignment.type == cs.TS_PY_ASSIGNMENT:
+        assignment: Node | None = child.children[0]
+        while assignment is not None and assignment.type == cs.TS_PY_ASSIGNMENT:
             yield assignment
+            assignment = assignment.child_by_field_name(cs.TS_FIELD_RIGHT)
+
+
+def _terminal_value(node: Node | None) -> Node | None:
+    """The value at the end of an assignment chain: `Outer` in `A = B = Outer`."""
+    while node is not None and node.type == cs.TS_PY_ASSIGNMENT:
+        node = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+    return node
 
 
 def _rebound_alias(assignment: Node, name: str, bound: str | None) -> str | None:
@@ -108,7 +121,7 @@ def _rebound_alias(assignment: Node, name: str, bound: str | None) -> str | None
         return None if _binds_identifier(left, name) else bound
     if left.type != cs.TS_PY_IDENTIFIER or safe_decode_text(left) != name:
         return bound
-    right = assignment.child_by_field_name(cs.TS_FIELD_RIGHT)
+    right = _terminal_value(assignment.child_by_field_name(cs.TS_FIELD_RIGHT))
     if right is not None and right.type in (cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE):
         return safe_decode_text(right)
     return None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -85,10 +85,17 @@ def _php_fold(name: str) -> str:
 
 
 def _binds_identifier(target: Node, name: str) -> bool:
-    """Whether an unpacking target names `name` at any depth."""
+    """Whether an unpacking target binds the bare name `name` at any depth.
+
+    Only bare identifiers bind a module-level name: `holder.Alias, x = ...`
+    assigns an attribute and `table[Alias], x = ...` a subscript, so those
+    subtrees are not descended into (#1759 review).
+    """
     stack = [target]
     while stack:
         node = stack.pop()
+        if node.type in (cs.TS_PY_ATTRIBUTE, cs.TS_PY_SUBSCRIPT):
+            continue
         if node.type == cs.TS_PY_IDENTIFIER and safe_decode_text(node) == name:
             return True
         stack.extend(node.named_children)

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict, deque
+from collections.abc import Iterator
 from pathlib import PurePath
 
 from loguru import logger
@@ -82,6 +83,35 @@ _PHP_ASCII_FOLD = str.maketrans(
 def _php_fold(name: str) -> str:
     """ASCII-lowercase `name` for PHP-style case-insensitive comparison."""
     return name.translate(_PHP_ASCII_FOLD)
+
+
+def _module_level_assignments(root_node: Node) -> Iterator[Node]:
+    """Every `assignment` that is a top-level expression statement of the module."""
+    for child in root_node.children:
+        if child.type != cs.TS_PY_EXPRESSION_STATEMENT or not child.children:
+            continue
+        assignment = child.children[0]
+        if assignment.type == cs.TS_PY_ASSIGNMENT:
+            yield assignment
+
+
+def _rebound_alias(assignment: Node, name: str, bound: str | None) -> str | None:
+    """`bound` after `assignment`: the alias it binds `name` to, None when it
+    rebinds `name` to a value, `bound` unchanged when it does not touch `name`."""
+    left = assignment.child_by_field_name(cs.TS_FIELD_LEFT)
+    if left is None:
+        return bound
+    # An unpacking target (`Alias, other = make_pair()`) rebinds the name to
+    # a runtime value just as a plain assignment does, and it is never an
+    # alias (#1759 review).
+    if left.type in cs.PY_UNPACKING_TARGET_TYPES:
+        return None if _binds_identifier(left, name) else bound
+    if left.type != cs.TS_PY_IDENTIFIER or safe_decode_text(left) != name:
+        return bound
+    right = assignment.child_by_field_name(cs.TS_FIELD_RIGHT)
+    if right is not None and right.type in (cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE):
+        return safe_decode_text(right)
+    return None
 
 
 def _binds_identifier(target: Node, name: str) -> bool:
@@ -604,6 +634,15 @@ class CallResolver:
         decides: `Alias = Outer` followed by `Alias = make()` holds a value
         by the time anything runs, so it names nothing (#1672 local review).
         """
+        root_node = self._cached_module_root(module_qn)
+        if root_node is None:
+            return None
+        bound: str | None = None
+        for assignment in _module_level_assignments(root_node):
+            bound = _rebound_alias(assignment, name, bound)
+        return bound
+
+    def _cached_module_root(self, module_qn: str) -> Node | None:
         file_path = self.type_inference.module_qn_to_file_path.get(module_qn)
         if file_path is None:
             return None
@@ -613,35 +652,7 @@ class CallResolver:
         if not isinstance(entry, tuple) or len(entry) != 2:
             return None
         root_node = entry[0]
-        if not isinstance(root_node, Node):
-            return None
-        bound: str | None = None
-        for child in root_node.children:
-            if child.type != cs.TS_PY_EXPRESSION_STATEMENT or not child.children:
-                continue
-            assignment = child.children[0]
-            if assignment.type != cs.TS_PY_ASSIGNMENT:
-                continue
-            left = assignment.child_by_field_name(cs.TS_FIELD_LEFT)
-            if left is None:
-                continue
-            # An unpacking target (`Alias, other = make_pair()`) rebinds the
-            # name to a runtime value just as a plain assignment does, and
-            # it is never an alias (#1759 review).
-            if left.type in cs.PY_UNPACKING_TARGET_TYPES:
-                if _binds_identifier(left, name):
-                    bound = None
-                continue
-            if left.type != cs.TS_PY_IDENTIFIER or safe_decode_text(left) != name:
-                continue
-            right = assignment.child_by_field_name(cs.TS_FIELD_RIGHT)
-            bound = (
-                safe_decode_text(right)
-                if right is not None
-                and right.type in (cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE)
-                else None
-            )
-        return bound
+        return root_node if isinstance(root_node, Node) else None
 
     def _class_is_nested_in(self, class_qn: str, owner_qn: str) -> bool:
         """Whether `class_qn` is declared inside `owner_qn` or one of its bases.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -439,7 +439,35 @@ class CallResolver:
             receiver, module_qn, result[1], class_context, local_var_types
         ):
             return result
+        # The member lookup that produced `result` searches by bare name and
+        # can land on a same-named class nested in ANOTHER type (`Other.Inner`
+        # for `Outer.Inner()`). Rejecting that answer must not lose the
+        # construction the call spells out, so resolve the member under the
+        # receiver class itself, walking its bases (#1759 review).
+        member = call_name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        if redirected := self._nested_class_under_receiver(receiver, module_qn, member):
+            return cs.NodeLabel.CLASS, redirected
         logger.debug(ls.CALL_UNRESOLVED, call_name=call_name)
+        return None
+
+    def _nested_class_under_receiver(
+        self, receiver: str, module_qn: str, member: str
+    ) -> str | None:
+        """`<receiver class>.<member>` when the receiver names a class that
+        declares (or inherits) a nested class called `member`."""
+        head, _, rest = receiver.partition(cs.SEPARATOR_DOT)
+        if not head or not head.isidentifier():
+            return None
+        base = self._receiver_base_qn(head, module_qn)
+        if base is None:
+            return None
+        owner = base if not rest else f"{base}{cs.SEPARATOR_DOT}{rest}"
+        if self.function_registry.get(owner) != cs.NodeLabel.CLASS:
+            return None
+        for ancestor in self._mro(owner):
+            candidate = f"{ancestor}{cs.SEPARATOR_DOT}{member}"
+            if self.function_registry.get(candidate) == cs.NodeLabel.CLASS:
+                return candidate
         return None
 
     def _receiver_names_a_type_or_module(

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -484,6 +484,14 @@ class CallResolver:
         # `from m import instance` and `import m` both land in the map, and only
         # the second is a namespace.
         full = base if not rest else f"{base}{cs.SEPARATOR_DOT}{rest}"
+        # A CLASS receiver constructs only its own nested classes: the member
+        # lookup that produced `resolved_qn` falls back to a search by the
+        # bare member name, which can land on a same-named class nested in
+        # another type, and an alias receiver has no precise member path at
+        # all (CodeRabbit, #1759). A module receiver keeps the namespace
+        # check.
+        if self.function_registry.get(full) == cs.NodeLabel.CLASS:
+            return self._class_is_nested_in(resolved_qn, full)
         return self._import_target_is_a_namespace(full)
 
     def _receiver_owns_nested_class(

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -16,7 +16,7 @@ from .py import resolve_class_name
 from .rs import utils as rs_utils
 from .semantic_call_join import call_site_key, declared_location
 from .type_inference import TypeInferenceEngine
-from .utils import follow_reexports
+from .utils import follow_reexports, safe_decode_text
 
 _SEPARATOR_PATTERN = re.compile(r"[.:]|::")
 _SEARCH_NAME_CACHE: dict[str, str] = {}
@@ -510,7 +510,79 @@ class CallResolver:
         if class_qn and self.function_registry.get(class_qn) == cs.NodeLabel.CLASS:
             return class_qn
         import_map = self.import_processor.import_mapping.get(module_qn) or {}
-        return import_map.get(head)
+        if (imported := import_map.get(head)) is not None:
+            if self.function_registry.get(
+                imported
+            ) == cs.NodeLabel.CLASS or self._import_target_is_a_namespace(imported):
+                return imported
+            # An imported name that is neither a class nor a namespace may be
+            # an alias defined in the module it was imported FROM
+            # (`from mod_b import Alias` where mod_b says `Alias = Outer`);
+            # look it up there (#1672 local review).
+            owner_qn, _, alias_name = imported.rpartition(cs.SEPARATOR_DOT)
+            return self._class_bound_by_module_alias(alias_name, owner_qn)
+        # A module-level `Alias = Outer` names the class it binds: it is an
+        # assignment rather than an import, so it is in neither the class
+        # lookup nor the import map, and `Alias.Inner()` lost the INSTANTIATES
+        # edge `Outer.Inner()` keeps (issue #1672). Only a right-hand side
+        # that itself resolves to a Class counts; `inst = make()` still holds
+        # a value.
+        return self._class_bound_by_module_alias(head, module_qn)
+
+    def _class_bound_by_module_alias(self, name: str, module_qn: str) -> str | None:
+        if not name or not module_qn:
+            return None
+        target = self._module_level_alias_target(name, module_qn)
+        if target is None:
+            return None
+        alias_qn = self._resolve_class_name(target, module_qn)
+        if alias_qn and self.function_registry.get(alias_qn) == cs.NodeLabel.CLASS:
+            return alias_qn
+        return None
+
+    def _module_level_alias_target(self, name: str, module_qn: str) -> str | None:
+        """The name a module-level Python `name = Other` binds, or None.
+
+        Reads the module's cached AST rather than a recorded map: the
+        definition pass records no module-level assignments, and the
+        dotted spelling (`Alias = pkg.Outer`) is kept so the class lookup
+        can follow the import it names. The LAST module-level binding
+        decides: `Alias = Outer` followed by `Alias = make()` holds a value
+        by the time anything runs, so it names nothing (#1672 local review).
+        """
+        file_path = self.type_inference.module_qn_to_file_path.get(module_qn)
+        if file_path is None:
+            return None
+        entry = self.type_inference.ast_cache.load(file_path)
+        # A guard, not a contract: resolver tests drive this with a stub cache
+        # whose `load` answers something that is not a (root, language) pair.
+        if not isinstance(entry, tuple) or len(entry) != 2:
+            return None
+        root_node = entry[0]
+        if not isinstance(root_node, Node):
+            return None
+        bound: str | None = None
+        for child in root_node.children:
+            if child.type != cs.TS_PY_EXPRESSION_STATEMENT or not child.children:
+                continue
+            assignment = child.children[0]
+            if assignment.type != cs.TS_PY_ASSIGNMENT:
+                continue
+            left = assignment.child_by_field_name(cs.TS_FIELD_LEFT)
+            if (
+                left is None
+                or left.type != cs.TS_PY_IDENTIFIER
+                or safe_decode_text(left) != name
+            ):
+                continue
+            right = assignment.child_by_field_name(cs.TS_FIELD_RIGHT)
+            bound = (
+                safe_decode_text(right)
+                if right is not None
+                and right.type in (cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE)
+                else None
+            )
+        return bound
 
     def _class_is_nested_in(self, class_qn: str, owner_qn: str) -> bool:
         """Whether `class_qn` is declared inside `owner_qn` or one of its bases.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -84,6 +84,17 @@ def _php_fold(name: str) -> str:
     return name.translate(_PHP_ASCII_FOLD)
 
 
+def _binds_identifier(target: Node, name: str) -> bool:
+    """Whether an unpacking target names `name` at any depth."""
+    stack = [target]
+    while stack:
+        node = stack.pop()
+        if node.type == cs.TS_PY_IDENTIFIER and safe_decode_text(node) == name:
+            return True
+        stack.extend(node.named_children)
+    return False
+
+
 class CallResolver:
     __slots__ = (
         "_py_rel_to_module",
@@ -569,11 +580,16 @@ class CallResolver:
             if assignment.type != cs.TS_PY_ASSIGNMENT:
                 continue
             left = assignment.child_by_field_name(cs.TS_FIELD_LEFT)
-            if (
-                left is None
-                or left.type != cs.TS_PY_IDENTIFIER
-                or safe_decode_text(left) != name
-            ):
+            if left is None:
+                continue
+            # An unpacking target (`Alias, other = make_pair()`) rebinds the
+            # name to a runtime value just as a plain assignment does, and
+            # it is never an alias (#1759 review).
+            if left.type in cs.PY_UNPACKING_TARGET_TYPES:
+                if _binds_identifier(left, name):
+                    bound = None
+                continue
+            if left.type != cs.TS_PY_IDENTIFIER or safe_decode_text(left) != name:
                 continue
             right = assignment.child_by_field_name(cs.TS_FIELD_RIGHT)
             bound = (

--- a/codebase_rag/tests/test_class_alias_receiver.py
+++ b/codebase_rag/tests/test_class_alias_receiver.py
@@ -181,3 +181,21 @@ def test_an_alias_never_constructs_a_rival_nested_class(tmp_path: Path) -> None:
         # Exactly the receiver's own nested class: not the rival, and not
         # nothing (#1759 review, second round).
         assert by_caller.get(caller) == {"proj.mod_a.Outer.Inner"}, (caller, by_caller)
+
+
+def test_a_chained_assignment_binds_every_alias(tmp_path: Path) -> None:
+    # `Alias = Other = Outer` nests the second assignment on the first one's
+    # right-hand side; both names bind the terminal value (CodeRabbit, #1759).
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod_a.py").write_text(MOD_A, encoding="utf-8")
+    (root / "mod_b.py").write_text(
+        "from mod_a import Outer\n\nAlias = Second = Outer\n\n\n"
+        "def via_alias():\n    return Alias.Inner(3)\n\n\n"
+        "def via_second():\n    return Second.Inner(3)\n",
+        encoding="utf-8",
+    )
+
+    by_caller = _instantiates(root)
+    for caller in ("proj.mod_b.via_alias", "proj.mod_b.via_second"):
+        assert by_caller.get(caller) == {"proj.mod_a.Outer.Inner"}, (caller, by_caller)

--- a/codebase_rag/tests/test_class_alias_receiver.py
+++ b/codebase_rag/tests/test_class_alias_receiver.py
@@ -178,6 +178,6 @@ def test_an_alias_never_constructs_a_rival_nested_class(tmp_path: Path) -> None:
 
     by_caller = _instantiates(root)
     for caller in ("proj.mod_b.via_alias", "proj.mod_b.via_class"):
-        targets = by_caller.get(caller, set())
-        assert "proj.mod_a.Other.Inner" not in targets, (caller, by_caller)
-        assert targets <= {"proj.mod_a.Outer.Inner"}, (caller, by_caller)
+        # Exactly the receiver's own nested class: not the rival, and not
+        # nothing (#1759 review, second round).
+        assert by_caller.get(caller) == {"proj.mod_a.Outer.Inner"}, (caller, by_caller)

--- a/codebase_rag/tests/test_class_alias_receiver.py
+++ b/codebase_rag/tests/test_class_alias_receiver.py
@@ -156,3 +156,28 @@ def test_an_attribute_target_in_an_unpacking_does_not_rebind_the_alias(
     assert by_caller.get("proj.mod_b.via_alias") == {"proj.mod_a.Outer.Inner"}, (
         by_caller
     )
+
+
+def test_an_alias_never_constructs_a_rival_nested_class(tmp_path: Path) -> None:
+    # `Alias.Inner()` resolves its member by bare name, so with a same-named
+    # `Inner` nested in another class the lookup may land on the rival. A
+    # class receiver may only construct a class nested in itself (CodeRabbit,
+    # #1759): the edge, if any, is to `Outer.Inner`, never `Other.Inner`.
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod_a.py").write_text(
+        "class Other:\n    class Inner:\n        pass\n\n\n" + MOD_A,
+        encoding="utf-8",
+    )
+    (root / "mod_b.py").write_text(
+        "from mod_a import Outer\n\nAlias = Outer\n\n\n"
+        "def via_alias():\n    return Alias.Inner(3)\n\n\n"
+        "def via_class():\n    return Outer.Inner(3)\n",
+        encoding="utf-8",
+    )
+
+    by_caller = _instantiates(root)
+    for caller in ("proj.mod_b.via_alias", "proj.mod_b.via_class"):
+        targets = by_caller.get(caller, set())
+        assert "proj.mod_a.Other.Inner" not in targets, (caller, by_caller)
+        assert targets <= {"proj.mod_a.Outer.Inner"}, (caller, by_caller)

--- a/codebase_rag/tests/test_class_alias_receiver.py
+++ b/codebase_rag/tests/test_class_alias_receiver.py
@@ -134,3 +134,25 @@ def test_an_alias_rebound_by_unpacking_no_longer_constructs(tmp_path: Path) -> N
 
     by_caller = _instantiates(root)
     assert "proj.mod_b.via_alias" not in by_caller, by_caller
+
+
+def test_an_attribute_target_in_an_unpacking_does_not_rebind_the_alias(
+    tmp_path: Path,
+) -> None:
+    # `holder.Alias, other = make_pair()` assigns an attribute, not the
+    # module-level name, so the alias keeps constructing (#1759 review).
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod_a.py").write_text(MOD_A, encoding="utf-8")
+    (root / "mod_b.py").write_text(
+        "from mod_a import Outer, make_pair\n\n"
+        "class Holder:\n    pass\n\n\nholder = Holder()\n"
+        "Alias = Outer\nholder.Alias, other = make_pair()\n\n\n"
+        "def via_alias():\n    return Alias.Inner(3)\n",
+        encoding="utf-8",
+    )
+
+    by_caller = _instantiates(root)
+    assert by_caller.get("proj.mod_b.via_alias") == {"proj.mod_a.Outer.Inner"}, (
+        by_caller
+    )

--- a/codebase_rag/tests/test_class_alias_receiver.py
+++ b/codebase_rag/tests/test_class_alias_receiver.py
@@ -1,0 +1,117 @@
+"""A module-level class alias is a class receiver for nested construction.
+
+`Alias = Outer` at module level binds the class, so `Alias.Inner(3)` constructs
+`Outer.Inner` exactly as `Outer.Inner(3)` does. The receiver guard added for
+#1641 asks whether a dotted call's receiver names a type or a module, and an
+alias satisfied none of its branches (not `self`, not a typed local, not in
+the class lookup, not in the import map because the binding is an assignment),
+so the INSTANTIATES edge was dropped (issue #1672). A receiver bound to a
+VALUE (`inst = make()`) is still not a constructor, which is the #1641 rule.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+MOD_A = (
+    "class Outer:\n"
+    "    class Inner:\n"
+    "        def __init__(self, v):\n"
+    "            self.v = v\n\n\n"
+    "def make():\n"
+    "    return Outer()\n"
+)
+MOD_B = (
+    "from mod_a import Outer, make\n\n"
+    "Alias = Outer\n"
+    "inst = make()\n\n\n"
+    "def via_alias():\n"
+    "    return Alias.Inner(3)\n\n\n"
+    "def via_class():\n"
+    "    return Outer.Inner(3)\n\n\n"
+    "def via_value():\n"
+    "    return inst.Inner(3)\n"
+)
+
+
+def _instantiates(root: Path) -> dict[str, set[str]]:
+    parsers, queries = load_parsers()
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    out: dict[str, set[str]] = {}
+    for _sl, src, rel, _tl, dst in store.edges:
+        if rel == cs.RelationshipType.INSTANTIATES.value:
+            out.setdefault(str(src), set()).add(str(dst))
+    return out
+
+
+def test_a_module_level_alias_constructs_the_nested_class_like_the_class_does(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod_a.py").write_text(MOD_A, encoding="utf-8")
+    (root / "mod_b.py").write_text(MOD_B, encoding="utf-8")
+
+    by_caller = _instantiates(root)
+    inner = "proj.mod_a.Outer.Inner"
+    assert by_caller.get("proj.mod_b.via_class") == {inner}, (
+        f"fixture guard: the direct spelling lost its edge: {by_caller}"
+    )
+    assert by_caller.get("proj.mod_b.via_alias") == {inner}, (
+        f"the aliased spelling lost its INSTANTIATES edge: {by_caller}"
+    )
+    # The #1641 rule stands: a receiver bound to a value never constructs.
+    assert "proj.mod_b.via_value" not in by_caller, by_caller
+
+
+def test_an_alias_imported_from_its_defining_module_still_constructs(
+    tmp_path: Path,
+) -> None:
+    # `from mod_b import Alias` lands in the import map, which the guard
+    # consulted before the alias fallback, and `proj.mod_b.Alias` is neither
+    # a class nor a namespace, so the edge was dropped exactly as before the
+    # fix (#1672 local review). The alias is read in the module it came from.
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod_a.py").write_text(MOD_A, encoding="utf-8")
+    (root / "mod_b.py").write_text(
+        "from mod_a import Outer\n\nAlias = Outer\n", encoding="utf-8"
+    )
+    (root / "mod_c.py").write_text(
+        "from mod_b import Alias\n\n\ndef via_alias():\n    return Alias.Inner(3)\n",
+        encoding="utf-8",
+    )
+
+    by_caller = _instantiates(root)
+    assert by_caller.get("proj.mod_c.via_alias") == {"proj.mod_a.Outer.Inner"}, (
+        by_caller
+    )
+
+
+def test_an_alias_rebound_to_a_value_no_longer_constructs(tmp_path: Path) -> None:
+    # The LAST module-level binding decides: after `Alias = make()` the name
+    # holds a value, and a value never constructs (#1641; #1672 local review).
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod_a.py").write_text(MOD_A, encoding="utf-8")
+    (root / "mod_b.py").write_text(
+        "from mod_a import Outer, make\n\nAlias = Outer\nAlias = make()\n\n\n"
+        "def via_alias():\n    return Alias.Inner(3)\n",
+        encoding="utf-8",
+    )
+
+    by_caller = _instantiates(root)
+    assert "proj.mod_b.via_alias" not in by_caller, by_caller

--- a/codebase_rag/tests/test_class_alias_receiver.py
+++ b/codebase_rag/tests/test_class_alias_receiver.py
@@ -24,7 +24,9 @@ MOD_A = (
     "        def __init__(self, v):\n"
     "            self.v = v\n\n\n"
     "def make():\n"
-    "    return Outer()\n"
+    "    return Outer()\n\n\n"
+    "def make_pair():\n"
+    "    return Outer(), 1\n"
 )
 MOD_B = (
     "from mod_a import Outer, make\n\n"
@@ -109,6 +111,23 @@ def test_an_alias_rebound_to_a_value_no_longer_constructs(tmp_path: Path) -> Non
     (root / "mod_a.py").write_text(MOD_A, encoding="utf-8")
     (root / "mod_b.py").write_text(
         "from mod_a import Outer, make\n\nAlias = Outer\nAlias = make()\n\n\n"
+        "def via_alias():\n    return Alias.Inner(3)\n",
+        encoding="utf-8",
+    )
+
+    by_caller = _instantiates(root)
+    assert "proj.mod_b.via_alias" not in by_caller, by_caller
+
+
+def test_an_alias_rebound_by_unpacking_no_longer_constructs(tmp_path: Path) -> None:
+    # `Alias, other = make_pair()` rebinds `Alias` to a runtime value just as
+    # a plain assignment does (#1759 review).
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "mod_a.py").write_text(MOD_A, encoding="utf-8")
+    (root / "mod_b.py").write_text(
+        "from mod_a import Outer, make_pair\n\nAlias = Outer\n"
+        "Alias, other = make_pair()\n\n\n"
         "def via_alias():\n    return Alias.Inner(3)\n",
         encoding="utf-8",
     )


### PR DESCRIPTION
Closes #1672.

The receiver guard added for #1641 asks whether a dotted call's receiver names a type or a module before it lets a Class resolution stand as a construction. A module-level alias (`Alias = Outer`) satisfied none of its branches: it is not `self` or a typed local, the class lookup does not know it, and it is not in the import map because the binding is an assignment rather than an import. So `Alias.Inner(3)` lost the INSTANTIATES edge that `Outer.Inner(3)` keeps, a real if narrow loss against the pre-#1641 behaviour.

`_receiver_base_qn` now falls through to the module's cached AST and reads a module-level Python `name = Other` assignment whose right-hand side is a bare or dotted name; when that name resolves to a registered Class, the alias answers like the class it binds. A right-hand side that is a call (`inst = make()`) still names a value, so the #1641 rule is unchanged. The change is contained to the guard, the narrower of the two directions the issue offered; making `_resolve_class_name` alias-aware for every consumer is a wider change left for its own issue if a case needs it.

The test indexes the issue's two modules and asserts the aliased and the direct spelling both emit the edge to `Outer.Inner`, and that the value receiver emits nothing. It fails on `main` at the alias assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of dotted calls made through class aliases, including aliases imported from other modules.
  * Improved handling of chained assignments so aliases resolve to the final class or value.
  * Prevented incorrect nested-class construction when aliases are reassigned or rebound through tuple, list, or pattern-based unpacking.
  * Improved handling of similarly named classes to ensure nested classes are constructed only from the correct receiver.
  * Class and module references are now more reliably tracked after assignments and alias changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->