### PR TITLE
test: split every composite assertion into one assertion per operand (Sonar S9073)

### DIFF
--- a/codebase_rag/tests/test_ast_grep_service.py
+++ b/codebase_rag/tests/test_ast_grep_service.py
@@ -47,7 +47,8 @@ def test_replace_dry_run_produces_diff_without_writing(tmp_path: Path) -> None:
     target.write_text("print(x)\n")
     svc = AstGrepService(str(tmp_path))
     changes = svc.replace("print($A)", "log($A)", dry_run=True)
-    assert changes and changes[0]["applied"] is False
+    assert changes
+    assert changes[0]["applied"] is False
     assert "log(x)" in changes[0]["diff"]
     # file left untouched in dry-run.
     assert target.read_text() == "print(x)\n"
@@ -60,7 +61,8 @@ def test_replace_applies_and_interpolates_single_metavar(tmp_path: Path) -> None
     changes = svc.replace("print($A)", "log($A)", dry_run=False)
     assert changes[0]["applied"] is True
     txt = target.read_text()
-    assert "log(x)" in txt and "log(y)" in txt
+    assert "log(x)" in txt
+    assert "log(y)" in txt
     assert "print(" not in txt
 
 

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -329,7 +329,8 @@ class TestProjectIsolation:
             for query, params in ingestor.writes_with_params
             if "repo_prefix" in (params or {})
         ]
-        assert prefixes and all(p.endswith("/") for p in prefixes), prefixes
+        assert prefixes, prefixes
+        assert all(p.endswith("/") for p in prefixes), prefixes
 
 
 class TestCaptureGate:

--- a/codebase_rag/tests/test_cpp_basic_syntax.py
+++ b/codebase_rag/tests/test_cpp_basic_syntax.py
@@ -845,8 +845,9 @@ void globalUtility() {
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"

--- a/codebase_rag/tests/test_cpp_classes_inheritance.py
+++ b/codebase_rag/tests/test_cpp_classes_inheritance.py
@@ -1375,9 +1375,10 @@ void testTemplateInheritance() {
             f"Source class should contain test file name: {source_class}"
         )
 
-        assert isinstance(target_class, str) and target_class, (
+        assert isinstance(target_class, str), (
             f"Target should be non-empty string: {target_class}"
         )
+        assert target_class, f"Target should be non-empty string: {target_class}"
 
     assert defines_relationships, "Should still have DEFINES relationships"
 

--- a/codebase_rag/tests/test_cpp_includes.py
+++ b/codebase_rag/tests/test_cpp_includes.py
@@ -858,7 +858,10 @@ void demonstrateAllIncludes() {
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
+            f"Target module should be non-empty string: {target_module}"
+        )
+        assert target_module, (
             f"Target module should be non-empty string: {target_module}"
         )
 

--- a/codebase_rag/tests/test_cpp_member_field_receiver.py
+++ b/codebase_rag/tests/test_cpp_member_field_receiver.py
@@ -58,7 +58,8 @@ class DBImpl {
         "buffer_": "string",
         "ptr_": "Foo",
     }, fields
-    assert "Lock" not in fields and "Count" not in fields
+    assert "Lock" not in fields
+    assert "Count" not in fields
 
 
 # A first-party member field receiver: `mutex_.Lock()` must resolve to the field's

--- a/codebase_rag/tests/test_cpp_oracle.py
+++ b/codebase_rag/tests/test_cpp_oracle.py
@@ -122,16 +122,14 @@ def test_cgr_matches_libclang_oracle_on_cpp_structure(
     ):
         aggregate = _aggregate(result.rows)
         assert aggregate is not None, (label, result.rows, result.diff)
-        assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-            label,
-            aggregate,
-            result.diff,
-        )
+        assert aggregate["precision"] == 1.0, (label, aggregate, result.diff)
+        assert aggregate["recall"] == 1.0, (label, aggregate, result.diff)
     # Guard the sample is non-trivial (class + struct + 4 methods + function).
     node_aggregate = _aggregate(
         score_node_kinds(cgr, oracle, ec.CPP_SCORED_NODE_KINDS).rows
     )
-    assert node_aggregate is not None and node_aggregate["tp"] >= 7, node_aggregate
+    assert node_aggregate is not None, node_aggregate
+    assert node_aggregate["tp"] >= 7, node_aggregate
 
 
 INHERIT_H = """\
@@ -180,10 +178,8 @@ def test_libclang_oracle_emits_inherits_edges(tmp_path: Path) -> None:
     aggregate = _aggregate(result.rows)
     assert aggregate is not None, (result.rows, result.diff)
     assert aggregate["tp"] >= 1, (aggregate, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
 
 
 def test_restrict_to_files_scopes_graph_to_universe() -> None:

--- a/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
+++ b/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
@@ -167,10 +167,16 @@ def test_cpp_non_conflicting_inner_block_local_is_recorded() -> None:
 def test_cpp_multi_declarator_declaration_maps_all_names() -> None:
     node = _first_function_node("void f() { Zeta a, b; Foo* p, q; }")
     var_types = CppTypeInferenceEngine().build_local_variable_type_map(node, "m")
-    assert var_types.get("a") == "Zeta" and var_types.get("b") == "Zeta", (
+    assert var_types.get("a") == "Zeta", (
         f"both a and b should map to Zeta, got {var_types}"
     )
-    assert var_types.get("p") == "Foo" and var_types.get("q") == "Foo", (
+    assert var_types.get("b") == "Zeta", (
+        f"both a and b should map to Zeta, got {var_types}"
+    )
+    assert var_types.get("p") == "Foo", (
+        f"both p and q should map to Foo, got {var_types}"
+    )
+    assert var_types.get("q") == "Foo", (
         f"both p and q should map to Foo, got {var_types}"
     )
 

--- a/codebase_rag/tests/test_cpp_typedef_alias_receiver.py
+++ b/codebase_rag/tests/test_cpp_typedef_alias_receiver.py
@@ -111,4 +111,5 @@ void f() {
     # function-local `L`/`Inner` are never collected.
     assert aliases == {"Lock": "Mutex", "AliasT": "Lock"}, aliases
     assert "Handle" in conflicts
-    assert "L" not in aliases and "Inner" not in aliases
+    assert "L" not in aliases
+    assert "Inner" not in aliases

--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -91,7 +91,8 @@ def test_cgr_matches_roslyn_oracle_on_nodes(
     for label in ("Class", "Interface", "Enum", "Method", "Function"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)
 
 
 def test_oracle_agrees_with_cgr_nodes_exactly(
@@ -124,7 +125,8 @@ def test_cgr_matches_roslyn_oracle_on_containment(
     for label in ("DEFINES", "DEFINES_METHOD"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)
 
 
 def test_cgr_matches_roslyn_oracle_on_inheritance(
@@ -138,7 +140,8 @@ def test_cgr_matches_roslyn_oracle_on_inheritance(
     for label in ("INHERITS", "IMPLEMENTS"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)
 
 
 def test_oracle_ignores_cgr_ignored_dirs_for_classification(
@@ -209,7 +212,8 @@ def test_same_scope_arity_pair_inherits_grades_clean(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     row = by_label.get("INHERITS")
     assert row is not None, by_label
-    assert row["precision"] == 1.0 and row["recall"] == 1.0, row
+    assert row["precision"] == 1.0, row
+    assert row["recall"] == 1.0, row
 
 
 def test_oracle_suppresses_preprocessor_split_phantom_members(
@@ -342,4 +346,5 @@ def test_cgr_matches_roslyn_oracle_on_spans(
     result = score_span(cgr, oracle, ec.CSHARP_SCORED_NODE_KINDS)
     assert result.rows, "no span rows produced"
     for row in result.rows:
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, row
+        assert row["precision"] == 1.0, row
+        assert row["recall"] == 1.0, row

--- a/codebase_rag/tests/test_eval_score_span.py
+++ b/codebase_rag/tests/test_eval_score_span.py
@@ -28,8 +28,11 @@ def test_span_exact_match_scores_perfect() -> None:
     oracle = _graph(("a.rs", 1, 5), ("a.rs", 10, 20))
     by_label = {row["label"]: row for row in score_span(cgr, oracle, _KINDS).rows}
     row = by_label[_FUNC]
-    assert row["precision"] == 1.0 and row["recall"] == 1.0
-    assert row["tp"] == 2 and row["fp"] == 0 and row["fn"] == 0
+    assert row["precision"] == 1.0
+    assert row["recall"] == 1.0
+    assert row["tp"] == 2
+    assert row["fp"] == 0
+    assert row["fn"] == 0
 
 
 def test_span_end_line_mismatch_is_penalized_and_surfaced() -> None:
@@ -38,8 +41,11 @@ def test_span_end_line_mismatch_is_penalized_and_surfaced() -> None:
     result = score_span(cgr, oracle, _KINDS)
     by_label = {row["label"]: row for row in result.rows}
     row = by_label[_FUNC]
-    assert row["tp"] == 1 and row["fp"] == 1 and row["fn"] == 1
-    assert row["precision"] == 0.5 and row["recall"] == 0.5
+    assert row["tp"] == 1
+    assert row["fp"] == 1
+    assert row["fn"] == 1
+    assert row["precision"] == 0.5
+    assert row["recall"] == 0.5
     bucket = result.diff[ec.DIFF_SPAN_PREFIX + _FUNC]
     assert any("10-20" in line for line in bucket["missing"]), bucket
     assert any("10-99" in line for line in bucket["extra"]), bucket
@@ -51,4 +57,6 @@ def test_span_only_grades_co_identified_nodes() -> None:
     oracle = _graph(("a.rs", 1, 5))
     by_label = {row["label"]: row for row in score_span(cgr, oracle, _KINDS).rows}
     row = by_label[_FUNC]
-    assert row["tp"] == 1 and row["fp"] == 0 and row["fn"] == 0
+    assert row["tp"] == 1
+    assert row["fp"] == 0
+    assert row["fn"] == 0

--- a/codebase_rag/tests/test_flow_verdict.py
+++ b/codebase_rag/tests/test_flow_verdict.py
@@ -180,7 +180,8 @@ def test_protobuf_export_preserves_flow_coverage(tmp_path: Path) -> None:
     raw = (tmp_path / cs.PROTOBUF_INDEX_FILE).read_bytes()
     index = pb.GraphCodeIndex.FromString(raw)
     modules = [n.module for n in index.nodes if n.WhichOneof("payload") == "module"]
-    assert modules and modules[0].flow_covered is True
+    assert modules
+    assert modules[0].flow_covered is True
 
 
 def test_inline_modules_are_never_spurious_coverage_gaps(

--- a/codebase_rag/tests/test_frontends_registry.py
+++ b/codebase_rag/tests/test_frontends_registry.py
@@ -26,7 +26,8 @@ def test_csharp_frontend_is_registered() -> None:
 def test_empty_facts_are_fresh_and_empty() -> None:
     a = empty_facts()
     b = empty_facts()
-    assert a.is_empty() and b.is_empty()
+    assert a.is_empty()
+    assert b.is_empty()
     # Never a shared constant: mutating one must not affect a later fresh bundle.
     a.resolved_call_sites[("f.cs", 1, 2, "M")] = ResolvedCallSite("M", "g.cs", 3, 4)
     a.external_sites.add(("f.cs", 5, 6, "N"))

--- a/codebase_rag/tests/test_go_containment_oracle.py
+++ b/codebase_rag/tests/test_go_containment_oracle.py
@@ -60,8 +60,5 @@ def test_cgr_matches_go_oracle_on_containment_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_go_frontend.py
+++ b/codebase_rag/tests/test_go_frontend.py
@@ -130,7 +130,8 @@ def test_find_go_module_discovers_gomod(tmp_path: Path) -> None:
     assert find_go_module(tmp_path) is None
     (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.23\n")
     found = find_go_module(tmp_path)
-    assert found is not None and found.name == "go.mod"
+    assert found is not None
+    assert found.name == "go.mod"
 
 
 def test_applies_requires_a_go_module(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_go_span_oracle.py
+++ b/codebase_rag/tests/test_go_span_oracle.py
@@ -65,8 +65,6 @@ def test_cgr_matches_go_oracle_on_node_spans(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     aggregate = by_label.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, (by_label, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     assert aggregate["tp"] >= 5, aggregate

--- a/codebase_rag/tests/test_health_checker.py
+++ b/codebase_rag/tests/test_health_checker.py
@@ -100,4 +100,5 @@ def test_check_graph_integrity_reports_orphans(
 
     assert len(results) == 1
     assert results[0].passed is False
-    assert results[0].error is not None and "427" in results[0].error
+    assert results[0].error is not None
+    assert "427" in results[0].error

--- a/codebase_rag/tests/test_indexing_bench.py
+++ b/codebase_rag/tests/test_indexing_bench.py
@@ -61,7 +61,8 @@ def test_markdown_row_pins_corpus_commit_and_scale(tmp_path: Path) -> None:
     assert "63 s wall" in row
     assert "1.5 GiB peak RSS" in row
     assert "50000 nodes / 120000 edges" in row
-    assert row.startswith("|") and row.endswith("| — |")
+    assert row.startswith("|")
+    assert row.endswith("| — |")
 
 
 def test_markdown_row_without_rss_or_commit() -> None:

--- a/codebase_rag/tests/test_java_containment_oracle.py
+++ b/codebase_rag/tests/test_java_containment_oracle.py
@@ -63,8 +63,5 @@ def test_cgr_matches_jdk_oracle_on_containment_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_java_inheritance_oracle.py
+++ b/codebase_rag/tests/test_java_inheritance_oracle.py
@@ -52,8 +52,5 @@ def test_cgr_matches_jdk_oracle_on_inheritance_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_java_span_oracle.py
+++ b/codebase_rag/tests/test_java_span_oracle.py
@@ -66,8 +66,6 @@ def test_cgr_matches_jdk_oracle_on_node_spans(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     aggregate = by_label.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, (by_label, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     assert aggregate["tp"] >= 5, aggregate

--- a/codebase_rag/tests/test_java_structure_oracle.py
+++ b/codebase_rag/tests/test_java_structure_oracle.py
@@ -68,4 +68,5 @@ def test_cgr_matches_jdk_oracle_on_java_structure(tmp_path: Path) -> None:
     for label in ("Class", "Interface", "Enum", "Method", "Function"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)

--- a/codebase_rag/tests/test_javascript_async_patterns.py
+++ b/codebase_rag/tests/test_javascript_async_patterns.py
@@ -1544,8 +1544,9 @@ function delay(ms) {
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"

--- a/codebase_rag/tests/test_javascript_classes.py
+++ b/codebase_rag/tests/test_javascript_classes.py
@@ -1098,8 +1098,9 @@ const testResult = testClasses();
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"

--- a/codebase_rag/tests/test_javascript_closures_scoping.py
+++ b/codebase_rag/tests/test_javascript_closures_scoping.py
@@ -1359,8 +1359,9 @@ const scopeResult = accessScopes();
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"

--- a/codebase_rag/tests/test_javascript_containment_oracle.py
+++ b/codebase_rag/tests/test_javascript_containment_oracle.py
@@ -102,11 +102,8 @@ def test_cgr_matches_tsc_oracle_on_js_containment_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)
 
 
 def test_cgr_matches_tsc_oracle_on_prototype_method_containment(
@@ -124,4 +121,5 @@ def test_cgr_matches_tsc_oracle_on_prototype_method_containment(
     by_label = {row["label"]: row for row in result.rows}
     row = by_label.get(cs.RelationshipType.DEFINES.value)
     assert row is not None, (by_label, result.diff)
-    assert row["precision"] == 1.0 and row["recall"] == 1.0, (row, result.diff)
+    assert row["precision"] == 1.0, (row, result.diff)
+    assert row["recall"] == 1.0, (row, result.diff)

--- a/codebase_rag/tests/test_javascript_destructuring.py
+++ b/codebase_rag/tests/test_javascript_destructuring.py
@@ -789,8 +789,9 @@ const formatted = formatData({
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"

--- a/codebase_rag/tests/test_javascript_functions.py
+++ b/codebase_rag/tests/test_javascript_functions.py
@@ -950,8 +950,9 @@ const orchestrated = orchestrator();
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"

--- a/codebase_rag/tests/test_javascript_imports.py
+++ b/codebase_rag/tests/test_javascript_imports.py
@@ -827,7 +827,10 @@ const url = API_URL;
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
+            f"Target module should be non-empty string: {target_module}"
+        )
+        assert target_module, (
             f"Target module should be non-empty string: {target_module}"
         )
 

--- a/codebase_rag/tests/test_javascript_span_oracle.py
+++ b/codebase_rag/tests/test_javascript_span_oracle.py
@@ -61,8 +61,6 @@ def test_cgr_matches_tsc_oracle_on_javascript_node_spans(tmp_path: Path) -> None
     by_label = {row["label"]: row for row in result.rows}
     aggregate = by_label.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, (by_label, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     assert aggregate["tp"] >= 4, aggregate

--- a/codebase_rag/tests/test_javascript_structure_oracle.py
+++ b/codebase_rag/tests/test_javascript_structure_oracle.py
@@ -58,4 +58,5 @@ def test_cgr_matches_tsc_oracle_on_javascript_structure(tmp_path: Path) -> None:
     for label in ("Class", "Function", "Method"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)

--- a/codebase_rag/tests/test_l3_decorator_normalization.py
+++ b/codebase_rag/tests/test_l3_decorator_normalization.py
@@ -40,7 +40,8 @@ MOD_SRC = textwrap.dedent(
 
 def _load_module(mod_path: Path):
     spec = importlib.util.spec_from_file_location("evaltest_decorator_mod", mod_path)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/codebase_rag/tests/test_lua_containment_oracle.py
+++ b/codebase_rag/tests/test_lua_containment_oracle.py
@@ -53,5 +53,6 @@ def test_cgr_matches_luaparse_oracle_on_containment_edges(tmp_path: Path) -> Non
     # Lua only has DEFINES (no methods, so no DEFINES_METHOD row at all).
     row = by_label.get(cs.RelationshipType.DEFINES.value)
     assert row is not None, (by_label, result.diff)
-    assert row["precision"] == 1.0 and row["recall"] == 1.0, (row, result.diff)
+    assert row["precision"] == 1.0, (row, result.diff)
+    assert row["recall"] == 1.0, (row, result.diff)
     assert cs.RelationshipType.DEFINES_METHOD.value not in by_label, by_label

--- a/codebase_rag/tests/test_lua_span_oracle.py
+++ b/codebase_rag/tests/test_lua_span_oracle.py
@@ -52,8 +52,6 @@ def test_cgr_matches_luaparse_oracle_on_node_spans(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     aggregate = by_label.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, (by_label, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     assert aggregate["tp"] >= 3, aggregate

--- a/codebase_rag/tests/test_lua_structure_oracle.py
+++ b/codebase_rag/tests/test_lua_structure_oracle.py
@@ -52,4 +52,5 @@ def test_cgr_matches_luaparse_oracle_on_lua_structure(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     row = by_label.get(cs.NodeLabel.FUNCTION.value)
     assert row is not None, by_label
-    assert row["precision"] == 1.0 and row["recall"] == 1.0, row
+    assert row["precision"] == 1.0, row
+    assert row["recall"] == 1.0, row

--- a/codebase_rag/tests/test_module_qn_language_collision.py
+++ b/codebase_rag/tests/test_module_qn_language_collision.py
@@ -50,7 +50,8 @@ def test_same_stem_files_get_distinct_module_qns(
     }
     py_mod = modules.get("pkg/shape.py")
     cpp_mod = modules.get("pkg/shape.cpp")
-    assert py_mod and cpp_mod, f"both module nodes expected: {modules}"
+    assert py_mod, f"both module nodes expected: {modules}"
+    assert cpp_mod, f"both module nodes expected: {modules}"
     assert py_mod != cpp_mod, f"module qn collision: {py_mod}"
 
 
@@ -63,7 +64,8 @@ def test_same_stem_methods_do_not_collide(
     area = _qns_by_path(mock_ingestor, NodeLabel.METHOD, "area")
     py_area = area.get("pkg/shape.py")
     cpp_area = area.get("pkg/shape.cpp")
-    assert py_area and cpp_area, f"both area methods expected: {area}"
+    assert py_area, f"both area methods expected: {area}"
+    assert cpp_area, f"both area methods expected: {area}"
     assert py_area != cpp_area, f"method qn collision across languages: {area}"
 
     # The method qn must derive from its own (disambiguated) module qn, not a

--- a/codebase_rag/tests/test_php_containment_oracle.py
+++ b/codebase_rag/tests/test_php_containment_oracle.py
@@ -59,8 +59,5 @@ def test_cgr_matches_php_parser_oracle_on_containment_edges(tmp_path: Path) -> N
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_php_inheritance_oracle.py
+++ b/codebase_rag/tests/test_php_inheritance_oracle.py
@@ -52,8 +52,5 @@ def test_cgr_matches_php_parser_oracle_on_inheritance_edges(tmp_path: Path) -> N
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_php_span_oracle.py
+++ b/codebase_rag/tests/test_php_span_oracle.py
@@ -68,8 +68,6 @@ def test_cgr_matches_php_parser_oracle_on_node_spans(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     aggregate = by_label.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, (by_label, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     assert aggregate["tp"] >= 4, aggregate

--- a/codebase_rag/tests/test_php_structure_oracle.py
+++ b/codebase_rag/tests/test_php_structure_oracle.py
@@ -69,4 +69,5 @@ def test_cgr_matches_php_parser_oracle_on_php_structure(tmp_path: Path) -> None:
     for label in ("Class", "Interface", "Enum", "Method", "Function"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)

--- a/codebase_rag/tests/test_python_imports.py
+++ b/codebase_rag/tests/test_python_imports.py
@@ -557,7 +557,10 @@ if True:
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
+            f"Target module should be non-empty string: {target_module}"
+        )
+        assert target_module, (
             f"Target module should be non-empty string: {target_module}"
         )
 

--- a/codebase_rag/tests/test_python_span_oracle.py
+++ b/codebase_rag/tests/test_python_span_oracle.py
@@ -63,8 +63,6 @@ def test_cgr_matches_ast_oracle_on_python_node_spans(tmp_path: Path) -> None:
     assert span_rows, [r["category"] for r in result.rows]
     aggregate = span_rows.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, span_rows
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     assert aggregate["tp"] >= 5, aggregate

--- a/codebase_rag/tests/test_rust.py
+++ b/codebase_rag/tests/test_rust.py
@@ -2433,9 +2433,10 @@ fn demonstrate_comprehensive_rust() {
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"
 

--- a/codebase_rag/tests/test_rust_auto_discovery_optout.py
+++ b/codebase_rag/tests/test_rust_auto_discovery_optout.py
@@ -310,7 +310,8 @@ def test_manifest_refresh_evicts_newly_disabled_entry_stems(tmp_path: Path) -> N
     (tmp_path / "src" / "main.rs").write_text("fn main() {}\n")
     processor = _processor(tmp_path)
     warmed = processor._rust_entry_decls(["src"])
-    assert "lib" in warmed and "main" in warmed
+    assert "lib" in warmed
+    assert "main" in warmed
 
     (tmp_path / "Cargo.toml").write_text(
         '[package]\nname = "fixture"\nversion = "0.1.0"\n'
@@ -318,6 +319,7 @@ def test_manifest_refresh_evicts_newly_disabled_entry_stems(tmp_path: Path) -> N
     )
     processor.refresh_rust_path_caches_for(tmp_path / "Cargo.toml", created=False)
     refreshed = processor._rust_entry_decls(["src"])
-    assert "lib" not in refreshed and "main" not in refreshed
+    assert "lib" not in refreshed
+    assert "main" not in refreshed
     fresh = _processor(tmp_path)._rust_entry_decls(["src"])
     assert set(refreshed) == set(fresh)

--- a/codebase_rag/tests/test_rust_closure_containment_oracle.py
+++ b/codebase_rag/tests/test_rust_closure_containment_oracle.py
@@ -67,7 +67,8 @@ def test_cgr_matches_syn_oracle_on_closure_containment(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     row = by_label.get(cs.RelationshipType.DEFINES.value)
     assert row is not None, (by_label, result.diff)
-    assert row["precision"] == 1.0 and row["recall"] == 1.0, (row, result.diff)
+    assert row["precision"] == 1.0, (row, result.diff)
+    assert row["recall"] == 1.0, (row, result.diff)
     # The method-nested closures must contribute resolvable DEFINES edges,
     # not just the free-function one (the gap this fix closes).
     assert row["tp"] >= 5, (row, result.diff)

--- a/codebase_rag/tests/test_rust_containment_oracle.py
+++ b/codebase_rag/tests/test_rust_containment_oracle.py
@@ -82,8 +82,5 @@ def test_cgr_matches_syn_oracle_on_containment_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -3775,7 +3775,8 @@ def test_enum_discriminant_block_use_binds_the_blocks_own_call(
     assert (f"{base}.a.f", f"{base}.beta.helper") in calls, calls
     assert (f"{base}.a.f", f"{base}.gamma.helper") not in calls, calls
     mapping = updater.factory.import_processor.import_mapping.get(f"{base}.a")
-    assert mapping and mapping.get("helper") == f"{base}.beta.helper", mapping
+    assert mapping, mapping
+    assert mapping.get("helper") == f"{base}.beta.helper", mapping
 
 
 def test_initializer_block_use_binds_the_blocks_own_call_in_a_fn(

--- a/codebase_rag/tests/test_rust_inheritance_oracle.py
+++ b/codebase_rag/tests/test_rust_inheritance_oracle.py
@@ -52,8 +52,5 @@ def test_cgr_matches_syn_oracle_on_inheritance_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_rust_span_oracle.py
+++ b/codebase_rag/tests/test_rust_span_oracle.py
@@ -74,9 +74,7 @@ def test_cgr_matches_syn_oracle_on_node_spans(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     aggregate = by_label.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, (by_label, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     # Guard the sample actually exercises multi-line spans (else it is vacuous).
     assert aggregate["tp"] >= 5, aggregate

--- a/codebase_rag/tests/test_rust_structure_oracle.py
+++ b/codebase_rag/tests/test_rust_structure_oracle.py
@@ -65,4 +65,5 @@ def test_cgr_matches_syn_oracle_on_rust_structure(tmp_path: Path) -> None:
     for label in ("Class", "Interface", "Enum", "Type", "Function", "Method"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)

--- a/codebase_rag/tests/test_stack_manager.py
+++ b/codebase_rag/tests/test_stack_manager.py
@@ -145,7 +145,8 @@ def test_compose_cmd_uses_project_and_file(stack_home: Path, tmp_path: Path) -> 
     cmd = mgr._compose_cmd("up", "-d")
     assert cmd[0] == "docker"
     assert cmd[1] == "compose"
-    assert "-p" in cmd and "cgr-test" in cmd
+    assert "-p" in cmd
+    assert "cgr-test" in cmd
     assert "-f" in cmd
     assert str(mgr.compose_file) in cmd
     assert cmd[-2:] == ["up", "-d"]

--- a/codebase_rag/tests/test_typescript_containment_oracle.py
+++ b/codebase_rag/tests/test_typescript_containment_oracle.py
@@ -62,8 +62,5 @@ def test_cgr_matches_tsc_oracle_on_containment_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_typescript_inheritance_oracle.py
+++ b/codebase_rag/tests/test_typescript_inheritance_oracle.py
@@ -51,8 +51,5 @@ def test_cgr_matches_tsc_oracle_on_inheritance_edges(tmp_path: Path) -> None:
     ):
         row = by_label.get(label)
         assert row is not None, (label, by_label, result.diff)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (
-            label,
-            row,
-            result.diff,
-        )
+        assert row["precision"] == 1.0, (label, row, result.diff)
+        assert row["recall"] == 1.0, (label, row, result.diff)

--- a/codebase_rag/tests/test_typescript_span_oracle.py
+++ b/codebase_rag/tests/test_typescript_span_oracle.py
@@ -78,8 +78,6 @@ def test_cgr_matches_tsc_oracle_on_node_spans(tmp_path: Path) -> None:
     by_label = {row["label"]: row for row in result.rows}
     aggregate = by_label.get(ec.AGGREGATE_LABEL)
     assert aggregate is not None, (by_label, result.diff)
-    assert aggregate["precision"] == 1.0 and aggregate["recall"] == 1.0, (
-        aggregate,
-        result.diff,
-    )
+    assert aggregate["precision"] == 1.0, (aggregate, result.diff)
+    assert aggregate["recall"] == 1.0, (aggregate, result.diff)
     assert aggregate["tp"] >= 5, aggregate

--- a/codebase_rag/tests/test_typescript_structure_oracle.py
+++ b/codebase_rag/tests/test_typescript_structure_oracle.py
@@ -62,4 +62,5 @@ def test_cgr_matches_tsc_oracle_on_typescript_structure(tmp_path: Path) -> None:
     for label in ("Class", "Interface", "Enum", "Type", "Function", "Method"):
         row = by_label.get(label)
         assert row is not None, (label, by_label)
-        assert row["precision"] == 1.0 and row["recall"] == 1.0, (label, row)
+        assert row["precision"] == 1.0, (label, row)
+        assert row["recall"] == 1.0, (label, row)

--- a/codebase_rag/tests/test_typescript_types.py
+++ b/codebase_rag/tests/test_typescript_types.py
@@ -1015,8 +1015,9 @@ addEventListener('click', (event) => {
             f"Source module should contain test file name: {source_module}"
         )
 
-        assert isinstance(target_module, str) and target_module, (
+        assert isinstance(target_module, str), (
             f"Target should be non-empty string: {target_module}"
         )
+        assert target_module, f"Target should be non-empty string: {target_module}"
 
     assert defines_relationships, "Should still have DEFINES relationships"

--- a/codebase_rag/tests/test_wheel_smoke_job.py
+++ b/codebase_rag/tests/test_wheel_smoke_job.py
@@ -35,7 +35,8 @@ def _job_run_script(job: dict) -> str:
 @pytest.fixture(scope="module")
 def smoke_module() -> ModuleType:
     spec = importlib.util.spec_from_file_location("smoke_wheel", SMOKE_SCRIPT)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules["smoke_wheel"] = module
     spec.loader.exec_module(module)


### PR DESCRIPTION
Part of #1669: the composite-assertion findings (python:S9073), which are 72 of the 411 open Sonar issues on `main`.

Every `assert a and b` SonarCloud reported was split into one assertion per operand, keeping the original message on each, so a failure names the operand that failed instead of the whole conjunction. The rewrite was done from the AST at the reported positions and then formatted, so only the reported assertions changed and no `and` inside a nested expression was touched. Short-circuit order is preserved: where a later operand relied on an earlier one being true, the earlier assertion now fails first.

57 test files under `codebase_rag/tests/` change; no production code does. Every touched file was run: 431 passed, 4 skipped (grammar-dependent skips that skip on `main` too).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test diagnostics by splitting combined assertions into independent checks.
  - Precision, recall, type, presence, and value validations now report failures more specifically.
  - Test coverage and expected behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->