### PR TITLE
test: one raising call per pytest.raises block (Sonar S5778)

### DIFF
--- a/codebase_rag/tests/test_decorators.py
+++ b/codebase_rag/tests/test_decorators.py
@@ -140,8 +140,9 @@ class TestAsyncTimingDecorator:
             async def async_failing() -> None:
                 raise ValueError("async error")
 
+            failing = async_failing()
             with pytest.raises(ValueError, match="async error"):
-                asyncio.run(async_failing())
+                asyncio.run(failing)
 
     def test_preserves_function_metadata(self) -> None:
         @async_timing_decorator
@@ -507,21 +508,24 @@ class TestMcpTryExcept:
         async def handler_with_interrupt() -> str:
             raise KeyboardInterrupt()
 
+        handler = handler_with_interrupt()
         with pytest.raises(KeyboardInterrupt):
-            asyncio.run(handler_with_interrupt())
+            asyncio.run(handler)
 
     def test_reraises_system_exit(self) -> None:
         @mcp_try_except(lambda e: f"error: {e}")
         async def handler_with_exit() -> str:
             raise SystemExit(1)
 
+        handler = handler_with_exit()
         with pytest.raises(SystemExit):
-            asyncio.run(handler_with_exit())
+            asyncio.run(handler)
 
     def test_reraises_cancelled_error(self) -> None:
         @mcp_try_except(lambda e: f"error: {e}")
         async def handler_with_cancel() -> str:
             raise asyncio.CancelledError()
 
+        handler = handler_with_cancel()
         with pytest.raises(asyncio.CancelledError):
-            asyncio.run(handler_with_cancel())
+            asyncio.run(handler)

--- a/codebase_rag/tests/test_mcp_server.py
+++ b/codebase_rag/tests/test_mcp_server.py
@@ -195,8 +195,9 @@ class TestServiceLifecycle:
         mock_ingestor = MagicMock()
 
         with patch.object(srv, "close_qdrant_client") as mock_close:
+            lifecycle = srv._service_lifecycle(mock_ingestor)
             with pytest.raises(RuntimeError):
-                with srv._service_lifecycle(mock_ingestor):
+                with lifecycle:
                     raise RuntimeError("boom")
             mock_close.assert_called_once_with()
             mock_ingestor.__exit__.assert_called_once()

--- a/codebase_rag/tests/test_vector_store_batch.py
+++ b/codebase_rag/tests/test_vector_store_batch.py
@@ -58,12 +58,13 @@ class TestUpsertWithRetry:
         mock_client = MagicMock()
         mock_client.upsert.side_effect = ConnectionError("timeout")
 
+        points = [MagicMock()]
         with (
             patch(_PATCH_CLIENT, return_value=mock_client),
             patch(_PATCH_SLEEP),
             pytest.raises(ConnectionError, match="timeout"),
         ):
-            _upsert_with_retry([MagicMock()])
+            _upsert_with_retry(points)
 
     def test_exponential_backoff_delays(self) -> None:
         from codebase_rag.vector_store import _upsert_with_retry


### PR DESCRIPTION
Part of #1669: the exception-test findings (python:S5778), six of the open Sonar issues on `main`.

Each `pytest.raises` block now holds exactly one invocation that can raise. The four async decorator tests build the coroutine outside the block and only `asyncio.run` it inside; the service-lifecycle test creates the context manager outside and enters it inside; the retry test builds its points list outside and calls `_upsert_with_retry` inside. The exception in every case still comes from the call the test is about, and nothing can now raise before the block is entered.

Three test files change, no production code. The three files pass: 65 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved exception-handling test setup for asynchronous operations and service lifecycle failures.
  - Clarified retry-exhaustion test data preparation.
  - Preserved existing exception behavior and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->