### PR TITLE
refactor: merge the three remaining pairs of identical branches (Sonar S1871)

### DIFF
--- a/codebase_rag/parsers/handlers/js_ts.py
+++ b/codebase_rag/parsers/handlers/js_ts.py
@@ -99,9 +99,10 @@ class JsTsHandler(BaseLanguageHandler):
 
         while current and current.type not in lang_config.module_node_types:
             if current.type in lang_config.function_node_types:
-                if name := self._extract_node_name(current):
-                    path_parts.append(name)
-                elif name := self.extract_function_name(current):
+                # The declared name first, then the assignment-derived one.
+                if (name := self._extract_node_name(current)) or (
+                    name := self.extract_function_name(current)
+                ):
                     path_parts.append(name)
             elif current.type in lang_config.class_node_types:
                 if not self.is_inside_method_with_object_literals(func_node):

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -606,11 +606,8 @@ def _python_collect_bound_targets(node: Node, out: set[str]) -> None:
                 if name_node is not None and (name := safe_decode_text(name_node)):
                     out.add(name)
                 continue
-            if child_type == cs.TS_PY_ASSIGNMENT:
-                left = child.child_by_field_name(cs.TS_FIELD_LEFT)
-                if left is not None:
-                    _python_collect_target_identifiers(left, out)
-            elif child_type == cs.TS_PY_FOR_STATEMENT:
+            if child_type in (cs.TS_PY_ASSIGNMENT, cs.TS_PY_FOR_STATEMENT):
+                # Both bind whatever their `left` names.
                 left = child.child_by_field_name(cs.TS_FIELD_LEFT)
                 if left is not None:
                     _python_collect_target_identifiers(left, out)

--- a/codebase_rag/tools/shell_command.py
+++ b/codebase_rag/tools/shell_command.py
@@ -982,12 +982,9 @@ def _sed_exec_construct(cmd_parts: list[str]) -> str | None:
 
         if "=" in arg:
             scripts.append(arg.split("=", 1)[1])
-        elif arg in ("-e", "--expression"):
-            add(index + 1)
-            index += 1
-        elif _sed_cluster_tail(arg) == "-e":
-            # A bundled cluster ending in a bare `-e` (`-ne`, `-nEe`): the
-            # script is the NEXT token, exactly as for a standalone `-e`.
+        elif arg in ("-e", "--expression") or _sed_cluster_tail(arg) == "-e":
+            # A standalone `-e`, or a bundled cluster ending in a bare `-e`
+            # (`-ne`, `-nEe`): the script is the NEXT token in both cases.
             # Reading the cluster's own tail letter as the script -- `arg[2:]`
             # of `-ne` is `e` -- left the following `-e 'w FILE'` uncollected.
             add(index + 1)


### PR DESCRIPTION
Part of #1669: the last three identical-branch findings (python:S1871) outside `dead_code.py`, which PR #1762 handles.

Each pair of branches did the same thing under two conditions and is now one branch. In the JS/TS handler the declared name and the assignment-derived name are tried in the same order through one `or` of walrus assignments, so the second lookup still runs only when the first yields nothing. In the Python binding collector, assignment and for-statement nodes share the branch that collects their `left` targets. In the sed validator, a standalone `-e` or `--expression` and a bundled cluster ending in a bare `-e` share the branch that consumes the next token; the comment explaining the cluster case is kept with it, and the later `-eSCRIPT` branch is reached for the same inputs as before.

No behaviour changes. The shell-command, JavaScript and TypeScript test files pass: 1404 passed, 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal name-resolution and target-binding logic without changing behavior.
  * Consolidated equivalent shell expression handling paths while preserving existing command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->