### PR TITLE
chore: pytest.fail over assert False, returning fixtures without teardown, no empty match arms (Sonar S9077, S9100, S108)

### DIFF
--- a/codebase_rag/parsers/go/type_inference.py
+++ b/codebase_rag/parsers/go/type_inference.py
@@ -189,8 +189,6 @@ class GoTypeInferenceEngine:
                 self._collect_var_declaration(node, var_types)
             case cs.TS_GO_SHORT_VAR_DECLARATION:
                 self._collect_short_var_declaration(node, var_types)
-            case _:
-                pass
         for child in node.children:
             self._collect_body_declarations(child, var_types)
 

--- a/codebase_rag/parsers/java/type_inference.py
+++ b/codebase_rag/parsers/java/type_inference.py
@@ -201,7 +201,5 @@ class JavaTypeInferenceEngine(
                     | cs.TS_RECORD_DECLARATION
                 ):
                     return current
-                case _:
-                    pass
             current = current.parent
         return None

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -297,8 +297,6 @@ class JavaTypeResolverMixin:
                     class_name := safe_decode_text(name_node)
                 ):
                     class_names.append(class_name)
-            case _:
-                pass
 
         for child in node.children:
             self._traverse_for_class_declarations(child, class_names)

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -90,8 +90,6 @@ def extract_import_path(import_node: ASTNode) -> dict[str, str]:
 
     for child in import_node.children:
         match child.type:
-            case cs.TS_STATIC:
-                pass
             case cs.TS_SCOPED_IDENTIFIER | cs.TS_IDENTIFIER:
                 imported_path = safe_decode_text(child)
             case cs.TS_ASTERISK:

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -292,8 +292,6 @@ class JavaVariableAnalyzerMixin:
 
                     if object_name and field_name:
                         return f"{object_name}{cs.SEPARATOR_DOT}{field_name}"
-            case _:
-                pass
 
         return None
 
@@ -406,9 +404,6 @@ class JavaVariableAnalyzerMixin:
                 if type_node := expr_node.child_by_field_name(cs.FIELD_TYPE):
                     if base_type := safe_decode_text(type_node):
                         return f"{base_type}{cs.JAVA_ARRAY_SUFFIX}"
-
-            case _:
-                pass
 
         return None
 

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -285,12 +285,12 @@ def _isolate_vector_store(
 @pytest.fixture(autouse=True)
 def _isolate_cgr_home(
     tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
-) -> Generator[Path, None, None]:
+) -> Path:
     from codebase_rag.config import settings
 
     home = tmp_path_factory.mktemp("cgr-home-iso")
     monkeypatch.setattr(settings, "CGR_HOME", home)
-    yield home
+    return home
 
 
 # What `shutil.rmtree` passes to `onexc` besides the removals. None of these

--- a/codebase_rag/tests/test_cgr_state_and_status.py
+++ b/codebase_rag/tests/test_cgr_state_and_status.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -14,14 +13,12 @@ runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
-def _temp_home(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Generator[Path, None, None]:
+def _temp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     from codebase_rag.config import settings
 
     home = tmp_path / "cgr-home"
     monkeypatch.setattr(settings, "CGR_HOME", home)
-    yield home
+    return home
 
 
 class TestRecordSync:

--- a/codebase_rag/tests/test_nested_function_qualified_names.py
+++ b/codebase_rag/tests/test_nested_function_qualified_names.py
@@ -232,13 +232,13 @@ function DatabaseService(connectionString) {
     if missing_functions:
         print(f"❌ Missing correctly nested arrow functions: {missing_functions}")
         print(f"✅ Actually created functions: {sorted(created_functions)}")
-        assert False, (
+        pytest.fail(
             f"Missing nested arrow functions with correct qualified names: {missing_functions}"
         )
 
     if incorrectly_created:
         print(f"❌ Incorrectly created module-level functions: {incorrectly_created}")
-        assert False, (
+        pytest.fail(
             f"Arrow functions incorrectly created at module level: {incorrectly_created}"
         )
 
@@ -317,7 +317,7 @@ class ServiceFactory {
             f"❌ Incorrectly created module-level export functions (should be nested): {incorrectly_created}"
         )
         print(f"✅ Actually created functions: {sorted(created_functions)}")
-        assert False, (
+        pytest.fail(
             f"Export functions should be nested, not at module level: {incorrectly_created}"
         )
 
@@ -427,7 +427,7 @@ class ModuleFactory {
             f"❌ Missing correctly nested CommonJS export functions: {missing_functions}"
         )
         print(f"✅ Actually created functions: {sorted(created_functions)}")
-        assert False, (
+        pytest.fail(
             f"Missing nested CommonJS export functions with correct qualified names: {missing_functions}"
         )
 
@@ -435,6 +435,6 @@ class ModuleFactory {
         print(
             f"❌ Incorrectly created module-level CommonJS exports: {incorrectly_created}"
         )
-        assert False, (
+        pytest.fail(
             f"CommonJS exports should be nested, not at module level: {incorrectly_created}"
         )

--- a/codebase_rag/tests/test_status_bar_config.py
+++ b/codebase_rag/tests/test_status_bar_config.py
@@ -10,11 +10,10 @@ from codebase_rag import main as main_mod
 
 
 @pytest.fixture(autouse=True)
-def reset_session(monkeypatch: pytest.MonkeyPatch):
+def reset_session(monkeypatch: pytest.MonkeyPatch) -> None:
     main_mod.app_context.session.confirm_edits = True
     main_mod.app_context.session.load_cgr_instructions = True
     main_mod.app_context.session.target_repo = None
-    yield
 
 
 @patch("codebase_rag.main.settings")

--- a/codebase_rag/tests/test_workspaces.py
+++ b/codebase_rag/tests/test_workspaces.py
@@ -23,13 +23,11 @@ runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
-def _temp_home(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Generator[Path, None, None]:
+def _temp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     from codebase_rag.config import settings
 
     monkeypatch.setattr(settings, "CGR_HOME", tmp_path / "cgr-home")
-    yield tmp_path / "cgr-home"
+    return tmp_path / "cgr-home"
 
 
 class TestStorage:


### PR DESCRIPTION
Part of #1669: three small rules, fifteen of the open Sonar issues on `main`.

`python:S9077`: the five `assert False, message` sites in `test_nested_function_qualified_names.py` become `pytest.fail(message)`, which is what they meant.

`python:S9100`: three fixtures that had no teardown (`isolated_cgr_home` in `conftest.py` and the `_temp_home` fixtures in `test_cgr_state_and_status.py` and `test_workspaces.py`) return their path instead of yielding it, and the autouse `reset_session` fixture in `test_status_bar_config.py` drops a bare `yield` that had nothing after it. A returning fixture still runs for every test that requests it, and the monkeypatch teardown is pytest's own, not the fixture's.

`python:S108`: five `case _: pass` arms are removed from the Go and Java type-inference and variable-analysis matchers, and the do-nothing `case cs.TS_STATIC: pass` arm from the Java import parser. A `match` without a wildcard falls through on an unmatched value, and the `static` keyword matches none of the remaining arms, so no branch changes.

The nested-function, state, status-bar, workspace, Java and Go test files pass: 573 passed, 15 skipped (grammar-dependent skips that skip on `main` too).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal parsing and type-analysis control flow without changing behavior.
  * Streamlined test fixture setup and return handling.

* **Tests**
  * Improved failure reporting in nested function and export tests.
  * Removed unused test imports and clarified fixture type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->