### PR TITLE
refactor: accumulate one sampled speedscope stack in its own helper (Sonar S3776)

### DIFF
--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -82,17 +82,30 @@ def _accumulate_sampled(
         if not isinstance(stack, list):
             return False
         weight = _sample_weight(cast("list[object]", weights), position)
-        ancestor: str | None = None
-        for frame_index in stack:
-            if not _valid_index(frame_index, len(names)):
-                return False
-            current = names[frame_index]
-            if current is None:
-                continue
-            if ancestor is not None:
-                key = (ancestor, current)
-                edges[key] = edges.get(key, 0) + weight
-            ancestor = current
+        if not _accumulate_stack(cast("list[object]", stack), names, weight, edges):
+            return False
+    return True
+
+
+def _accumulate_stack(
+    stack: list[object],
+    names: list[str | None],
+    weight: float,
+    edges: dict[tuple[str, str], float],
+) -> bool:
+    """One sampled stack, root first: each in-scope frame under the nearest
+    in-scope ancestor adds `weight` to that edge. False on a bad frame index."""
+    ancestor: str | None = None
+    for frame_index in stack:
+        if not _valid_index(frame_index, len(names)):
+            return False
+        current = names[frame_index]
+        if current is None:
+            continue
+        if ancestor is not None:
+            key = (ancestor, current)
+            edges[key] = edges.get(key, 0) + weight
+        ancestor = current
     return True
 
 

--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -82,13 +82,13 @@ def _accumulate_sampled(
         if not isinstance(stack, list):
             return False
         weight = _sample_weight(cast("list[object]", weights), position)
-        if not _accumulate_stack(cast("list[object]", stack), names, weight, edges):
+        if not _accumulate_stack(stack, names, weight, edges):
             return False
     return True
 
 
 def _accumulate_stack(
-    stack: list[object],
+    stack: Sequence[object],
     names: list[str | None],
     weight: float,
     edges: dict[tuple[str, str], float],


### PR DESCRIPTION
Part of #1669: one cognitive-complexity finding (python:S3776), `_accumulate_sampled` in `codebase_rag/trace/speedscope.py`, at 16 against the limit of 15.

The per-stack inner loop, which walks one sampled stack root first and adds the sample's weight to the edge between each in-scope frame and its nearest in-scope ancestor, is now its own helper, `_accumulate_stack`. The outer loop keeps its shape: a non-list sample or a bad frame index anywhere still aborts the whole accumulation with False, leaving what was already accumulated, and the ancestor still resets for every stack.

No behaviour changes. The full unit suite was run against the change: 10711 passed, 40 skipped, 1 xfailed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined sampled-profile stack processing while preserving existing behavior and output accuracy.
  * Maintained correct handling of weighted relationships in sampled profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->