### PR TITLE
refactor: split resolve_class_name into its three lookup steps (Sonar S3776)

### DIFF
--- a/codebase_rag/parsers/py/utils.py
+++ b/codebase_rag/parsers/py/utils.py
@@ -16,30 +16,61 @@ def resolve_class_name(
     function_registry: FunctionRegistryTrieProtocol,
     require_registered: bool = False,
 ) -> str | None:
-    if module_qn in import_processor.import_mapping:
-        import_map = import_processor.import_mapping[module_qn]
-        if class_name in import_map:
-            mapped = import_map[class_name]
-            # C++ include entries map header STEMS to MODULE qns; when the
-            # stem coincides with a class name (Directive.h defining class
-            # Directive, the dominant C++ layout) the map answer is a module,
-            # not a class. Callers that need a real registered node (call
-            # attribution in Pass 3) must fall through to the registry-backed
-            # steps below (issue #652: 11k phantom callers on souffle).
-            if not require_registered or function_registry.get(mapped) is not None:
-                return mapped
+    """The class qn `class_name` names from `module_qn`: import map first, then
+    the module and its enclosing packages, then the registry's name search."""
+    # `is not None`, not truthiness: an import-map entry can be the empty
+    # string (a relative JS specifier that climbs to the root), and the
+    # original returned it as the answer rather than falling through.
+    mapped = _import_mapped_class(
+        class_name, module_qn, import_processor, function_registry, require_registered
+    )
+    if mapped is not None:
+        return mapped
+    return _class_in_module_or_enclosing_package(
+        class_name, module_qn, function_registry
+    ) or _class_by_simple_name(class_name, module_qn, function_registry)
 
+
+def _import_mapped_class(
+    class_name: str,
+    module_qn: str,
+    import_processor: ImportProcessor,
+    function_registry: FunctionRegistryTrieProtocol,
+    require_registered: bool,
+) -> str | None:
+    import_map = import_processor.import_mapping.get(module_qn)
+    if not import_map or class_name not in import_map:
+        return None
+    mapped = import_map[class_name]
+    # C++ include entries map header STEMS to MODULE qns; when the
+    # stem coincides with a class name (Directive.h defining class
+    # Directive, the dominant C++ layout) the map answer is a module,
+    # not a class. Callers that need a real registered node (call
+    # attribution in Pass 3) must fall through to the registry-backed
+    # steps below (issue #652: 11k phantom callers on souffle).
+    if require_registered and function_registry.get(mapped) is None:
+        return None
+    return mapped
+
+
+def _class_in_module_or_enclosing_package(
+    class_name: str, module_qn: str, function_registry: FunctionRegistryTrieProtocol
+) -> str | None:
     same_module_qn = f"{module_qn}.{class_name}"
     if same_module_qn in function_registry:
         return same_module_qn
-
     module_parts = module_qn.split(SEPARATOR_DOT)
     for i in range(len(module_parts) - 1, 0, -1):
         parent_module = SEPARATOR_DOT.join(module_parts[:i])
         potential_qn = f"{parent_module}.{class_name}"
         if potential_qn in function_registry:
             return potential_qn
+    return None
 
+
+def _class_by_simple_name(
+    class_name: str, module_qn: str, function_registry: FunctionRegistryTrieProtocol
+) -> str | None:
     matches = function_registry.find_ending_with(class_name)
     # Among same-named candidates in different files (gson's per-factory nested
     # `Adapter`), prefer one nested in the CURRENT module: a sibling/enclosing
@@ -54,12 +85,9 @@ def resolve_class_name(
     ]
     if same_module:
         return str(min(same_module, key=len))
-
     for match in matches:
-        match_parts = match.split(SEPARATOR_DOT)
-        if class_name in match_parts:
+        if class_name in match.split(SEPARATOR_DOT):
             return str(match)
-
     return None
 
 


### PR DESCRIPTION
Part of #1669: the first of the cognitive-complexity findings (python:S3776), `resolve_class_name` in `codebase_rag/parsers/py/utils.py`, which sat at 16 against the limit of 15.

The lookup has three steps that were interleaved in one function: the import map (with the fall-through for a mapped name that is not a registered node, the #652 phantom-caller guard), the module itself and each enclosing package, and finally the registry's search by simple name with its preference for a candidate nested in the current module. Each step is now its own helper and `resolve_class_name` is the `or` chain of the three in the original order. Conditions, return values and the comments that explain the two non-obvious steps are unchanged; the only structural difference is that the import-map step returns None to fall through instead of continuing inline.

No behaviour changes. The resolver, receiver, nested-class, Python, C++ and Java inheritance test files pass: 695 passed, 1 skipped, 1 xfailed (the skip and xfail are the same on `main`).
