### PR TITLE
refactor: split the C++ field-declarator name reader and the Go selector walk (Sonar S3776)

### DIFF
--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -183,28 +183,27 @@ def _extract_name_from_declaration(func_node: Node) -> str | None:
 
 
 def _extract_name_from_field_declaration(func_node: Node) -> str | None:
-    has_function_declarator = any(
-        child.type == cs.CppNodeType.FUNCTION_DECLARATOR for child in func_node.children
-    )
-    if not has_function_declarator:
-        return None
-
     for child in func_node.children:
-        if child.type == cs.CppNodeType.FUNCTION_DECLARATOR:
-            declarator = child.child_by_field_name(cs.FIELD_DECLARATOR)
-            if (
-                declarator
-                and declarator.type == cs.CppNodeType.FIELD_IDENTIFIER
-                and declarator.text
-            ):
-                return safe_decode_text(declarator)
+        if child.type != cs.CppNodeType.FUNCTION_DECLARATOR:
+            continue
+        if (name := _function_declarator_field_name(child)) is not None:
+            return name
+    return None
 
-            for grandchild in child.children:
-                if (
-                    grandchild.type == cs.CppNodeType.FIELD_IDENTIFIER
-                    and grandchild.text
-                ):
-                    return safe_decode_text(grandchild)
+
+def _function_declarator_field_name(declarator_node: Node) -> str | None:
+    """The field identifier a `function_declarator` names: its `declarator`
+    field when that is one, else the first field-identifier child."""
+    declarator = declarator_node.child_by_field_name(cs.FIELD_DECLARATOR)
+    if (
+        declarator
+        and declarator.type == cs.CppNodeType.FIELD_IDENTIFIER
+        and declarator.text
+    ):
+        return safe_decode_text(declarator)
+    for grandchild in declarator_node.children:
+        if grandchild.type == cs.CppNodeType.FIELD_IDENTIFIER and grandchild.text:
+            return safe_decode_text(grandchild)
     return None
 
 

--- a/codebase_rag/parsers/go/type_inference.py
+++ b/codebase_rag/parsers/go/type_inference.py
@@ -18,6 +18,24 @@ from .utils import type_identifier_text
 GO_EXTERNAL_TARGET: tuple[str, str] = ("", "")
 
 
+def _selector_segments(selector: Node) -> list[str] | None:
+    """`e.trees.get` -> `["e", "trees", "get"]`: the field identifiers of a
+    selector chain, root first, or None when a link is not a plain identifier."""
+    segments: list[str] = []
+    current: Node | None = selector
+    while current is not None and current.type == cs.TS_GO_SELECTOR_EXPRESSION:
+        field = current.child_by_field_name(cs.FIELD_FIELD)
+        if field is None or field.type != cs.TS_GO_FIELD_IDENTIFIER:
+            return None
+        segments.append(safe_decode_text(field) or "")
+        current = current.child_by_field_name(cs.FIELD_OPERAND)
+    if current is None or current.type != cs.TS_IDENTIFIER or not current.text:
+        return None
+    segments.append(safe_decode_text(current) or "")
+    segments.reverse()
+    return segments
+
+
 class GoTypeInferenceEngine:
     # Maps local variable / parameter / receiver names to their bare Go type name
     # within a function or method body, so the resolver can bind a receiver-dispatch
@@ -275,20 +293,8 @@ class GoTypeInferenceEngine:
             return [safe_decode_text(func) or ""] if func.text else None
         if func.type != cs.TS_GO_SELECTOR_EXPRESSION:
             return None
-        segments: list[str] = []
-        current: Node | None = func
-        while current is not None and current.type == cs.TS_GO_SELECTOR_EXPRESSION:
-            field = current.child_by_field_name(cs.FIELD_FIELD)
-            operand = current.child_by_field_name(cs.FIELD_OPERAND)
-            if field is None or field.type != cs.TS_GO_FIELD_IDENTIFIER:
-                return None
-            segments.append(safe_decode_text(field) or "")
-            current = operand
-        if current is None or current.type != cs.TS_IDENTIFIER or not current.text:
-            return None
-        segments.append(safe_decode_text(current) or "")
-        segments.reverse()
-        return segments if all(segments) else None
+        segments = _selector_segments(func)
+        return segments if segments and all(segments) else None
 
     def infer_value_type(self, value: Node) -> str | None:
         if value.type == cs.TS_GO_COMPOSITE_LITERAL:

--- a/codebase_rag/tests/test_cpp_field_declarator_list.py
+++ b/codebase_rag/tests/test_cpp_field_declarator_list.py
@@ -1,0 +1,53 @@
+"""A field declaration listing several declarators names the first function.
+
+`class A { void (*fp)(int), g(); };` declares a function-pointer field and a
+method in one `field_declaration`. The first `function_declarator` (the
+pointer's) yields no field name, so the name reader must move on to the next
+declarator rather than stop at the first one; nothing in the suite pinned that
+order before the reader was split for #1669.
+"""
+
+from __future__ import annotations
+
+import pytest
+from tree_sitter import Node
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.cpp import utils as cpp_utils
+
+
+@pytest.fixture
+def cpp_parser():
+    parsers, _ = load_parsers()
+    if cs.SupportedLanguage.CPP not in parsers:
+        pytest.skip("cpp parser not available")
+    return parsers[cs.SupportedLanguage.CPP]
+
+
+def _field_declarations(node: Node) -> list[Node]:
+    found: list[Node] = []
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if current.type == cs.CppNodeType.FIELD_DECLARATION:
+            found.append(current)
+        stack.extend(current.children)
+    return found
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("class A { void (*fp)(int), g(); };", "g"),
+        ("class A { void (*a)(), (*b)(), k(); };", "k"),
+        ("class A { void g(); };", "g"),
+    ],
+)
+def test_the_first_declarator_with_a_name_wins(
+    cpp_parser, source: str, expected: str
+) -> None:
+    tree = cpp_parser.parse(source.encode())
+    declarations = _field_declarations(tree.root_node)
+    assert len(declarations) == 1, [d.type for d in declarations]
+    assert cpp_utils.extract_function_name(declarations[0]) == expected


### PR DESCRIPTION
Part of #1669: two cognitive-complexity findings (python:S3776), both at 16 against the limit of 15.

In `codebase_rag/parsers/cpp/utils.py`, `_extract_name_from_field_declaration` scanned the children once to see whether any `function_declarator` existed and then scanned them again to read a name. The pre-scan is gone, since the loop answers the same question, and reading one declarator's name (its `declarator` field when that is a field identifier, otherwise the first field-identifier child) is now `_function_declarator_field_name`. The first declarator that yields a name still wins, and a declarator that yields none still lets the loop move to the next.

In `codebase_rag/parsers/go/type_inference.py`, the walk that turns a selector chain such as `e.trees.get` into its identifier segments moves out of `callee_segments` into `_selector_segments`; `callee_segments` keeps the plain-identifier case and the guard that any empty segment makes the callee unresolved.

No behaviour changes. The C++ and Go test files pass: 522 passed, 1 xfailed (the xfail is the same on `main`).

The local review found that no test pinned the declarator-list order the C++ reader preserves, so `test_cpp_field_declarator_list.py` parses `class A { void (*fp)(int), g(); };` and the three-declarator form and asserts the first declarator that carries a name wins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C++ parsing for field declarations with multiple declarators, correctly identifying the first named declarator.
  * Improved Go selector expression handling for more reliable type inference.
* **Tests**
  * Added coverage for C++ field declarations containing multiple declarators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->