### PR TITLE
fix: prune a deleted file's C# method return types with the same ownership filter as the other return-type maps

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2983,7 +2983,14 @@ class GraphUpdater:
         # writes `...A.Clone`, its span record says `...A.Clone@3`), and a
         # few writers (deferred Rust functions, duplicate C++ out-of-class
         # methods) key the map by the `@line` name itself (#1752 review).
-        method_return_types = self.factory.type_inference.method_return_types
+        # The C# map (`csharp_method_return_types`, keyed the same way with a
+        # (type, arity) value) is the same defect for a third map (issue
+        # #1753), so both are swept by one filter.
+        type_inference = self.factory.type_inference
+        method_return_types = (
+            type_inference.method_return_types.keys()
+            | type_inference.csharp_method_return_types.keys()
+        )
         owned_natural = {_natural_qn(qn) for qn in owned_qns}
         stale_method_qns = [
             qn

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -618,14 +618,16 @@ class TypeInferenceEngine:
         self._go_free_fn_index_size = -1
 
     def drop_method_return_types(self, qns: Collection[str]) -> None:
-        """Forget the return types recorded under `qns` (issue #1738).
+        """Forget the return types recorded under `qns` (issues #1738, #1753).
 
         `GraphUpdater.remove_file_from_state` calls this for a deleted or
-        re-parsed file's definitions, beside `drop_go_return_types`. The map
-        is read directly, with no derived index to invalidate.
+        re-parsed file's definitions, beside `drop_go_return_types`. Both
+        maps, the general one and the C# `(type, arity)` one, are read
+        directly, with no derived index to invalidate.
         """
         for qn in qns:
             self.method_return_types.pop(qn, None)
+            self.csharp_method_return_types.pop(qn, None)
 
     def _go_free_fn_return_type(self, name: str, module_qn: str) -> str | None:
         # Same module (file) first; then the enclosing package's sibling files

--- a/codebase_rag/tests/test_csharp_return_types_forget_deleted_file.py
+++ b/codebase_rag/tests/test_csharp_return_types_forget_deleted_file.py
@@ -1,0 +1,60 @@
+"""A deleted C# file's method return types must leave with its registry rows.
+
+`TypeInferenceEngine.csharp_method_return_types` records `(type, arity)` per
+C# method qualified name. `remove_file_from_state` pruned the registry and,
+since #1752, the general return-type map, but never this one: after
+`run()`, deleting `A.cs` and removing its state, the registry row for
+`proj.A.N.K.Self` was gone while the map still held `('K', 0)` (issue #1753).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import _MockIngestor
+
+A_CS = "namespace N\n{\n    public class K\n    {\n        public K Self() { return this; }\n    }\n}\n"
+B_CS = "namespace N\n{\n    public class L\n    {\n        public L Twin() { return this; }\n    }\n}\n"
+
+
+def _create_graph_updater(root: Path) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.CSHARP not in parsers:
+        pytest.skip("csharp parser not available")
+    return GraphUpdater(
+        ingestor=_MockIngestor(),
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+def test_a_deleted_csharp_files_return_types_are_forgotten(temp_repo: Path) -> None:
+    root = temp_repo / "proj"
+    root.mkdir()
+    (root / "A.cs").write_text(A_CS, encoding="utf-8")
+    (root / "B.cs").write_text(B_CS, encoding="utf-8")
+    updater = _create_graph_updater(root)
+    updater.run()
+    recorded = updater.factory.type_inference.csharp_method_return_types
+    self_qn = next((qn for qn in recorded if qn.endswith("K.Self")), None)
+    twin_qn = next((qn for qn in recorded if qn.endswith("L.Twin")), None)
+    assert self_qn and twin_qn, (
+        f"fixture guard: the first run recorded nothing: {recorded}"
+    )
+
+    (root / "A.cs").unlink()
+    updater.remove_file_from_state(root / "A.cs")
+
+    assert self_qn not in recorded, (
+        f"the deleted file's return-type entry survived remove_file_from_state: {recorded}"
+    )
+    assert twin_qn in recorded, (
+        "a sibling's entry was swept along with the deleted file's"
+    )

--- a/codebase_rag/tests/test_csharp_return_types_forget_deleted_file.py
+++ b/codebase_rag/tests/test_csharp_return_types_forget_deleted_file.py
@@ -45,9 +45,8 @@ def test_a_deleted_csharp_files_return_types_are_forgotten(temp_repo: Path) -> N
     recorded = updater.factory.type_inference.csharp_method_return_types
     self_qn = next((qn for qn in recorded if qn.endswith("K.Self")), None)
     twin_qn = next((qn for qn in recorded if qn.endswith("L.Twin")), None)
-    assert self_qn and twin_qn, (
-        f"fixture guard: the first run recorded nothing: {recorded}"
-    )
+    assert self_qn, f"fixture guard: A.cs recorded nothing: {recorded}"
+    assert twin_qn, f"fixture guard: B.cs recorded nothing: {recorded}"
 
     (root / "A.cs").unlink()
     updater.remove_file_from_state(root / "A.cs")


### PR DESCRIPTION
Closes #1753.

`TypeInferenceEngine.csharp_method_return_types` records a `(type, arity)` pair per C# method qualified name and is read by the C# type-inference engine through the same dict. `remove_file_from_state` prunes the function registry, the Go free-function return-type map (#1668) and the general method return-type map (#1738), but never this one, so on a reused updater a deleted C# file's entries persisted: after indexing, deleting `A.cs` and removing its state, the registry row for `proj.A.N.K.Self` was gone while the map still held `('K', 0)`.

The sweep now runs the ownership filter from #1752 over the union of both maps' keys, and `drop_method_return_types` pops the stale names from both. Neither map has a derived index, so nothing else needs invalidating, and the union cannot change which general-map entries go because the filter is applied per key.

The new test indexes two C# files, deletes one, removes its state and asserts its method's entry is gone while the sibling's stays. It fails on `main` with the entry still present, exactly as the issue describes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale C# method return-type information remaining after a file is deleted or reprocessed.
  - Preserved return-type information for files that remain in the project.

- **Tests**
  - Added regression coverage verifying that deleted C# files are removed from return-type tracking without affecting sibling files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->