### PR TITLE
refactor: split the pubspec line scanner and the C# base-name reader (Sonar S3776)

### DIFF
--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -37,22 +37,34 @@ def _csharp_base_written_name(node: Node) -> str | None:
     # qualified_name (`System.Exception`), or a record positional base
     # unwrapped to its type. predefined_type (an enum's underlying type) and
     # punctuation (`:`, `,`) yield None so they are dropped.
-    if node.type == cs.TS_CSHARP_IDENTIFIER and node.text:
-        return safe_decode_text(node)
-    if node.type == cs.TS_CSHARP_GENERIC_NAME:
-        ident = find_child_by_type(node, cs.TS_CSHARP_IDENTIFIER)
-        return safe_decode_text(ident) if ident and ident.text else None
-    if node.type == cs.TS_CSHARP_QUALIFIED_NAME and node.text:
-        # A qualified generic base (`System.Collections.Generic.List<int>`)
-        # is one qualified_name whose text carries the type arguments; strip
-        # them so the written name matches the registered, generic-free qn.
-        text = safe_decode_text(node)
-        return text.split(cs.CHAR_ANGLE_OPEN, 1)[0] if text else None
-    if node.type == cs.TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE:
-        for child in node.children:
-            if name := _csharp_base_written_name(child):
-                return name
+    match node.type:
+        case cs.TS_CSHARP_IDENTIFIER:
+            return safe_decode_text(node) if node.text else None
+        case cs.TS_CSHARP_GENERIC_NAME:
+            ident = find_child_by_type(node, cs.TS_CSHARP_IDENTIFIER)
+            return safe_decode_text(ident) if ident and ident.text else None
+        case cs.TS_CSHARP_QUALIFIED_NAME:
+            return _csharp_qualified_base_name(node)
+        case cs.TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE:
+            return next(
+                (
+                    name
+                    for child in node.children
+                    if (name := _csharp_base_written_name(child))
+                ),
+                None,
+            )
     return None
+
+
+def _csharp_qualified_base_name(node: Node) -> str | None:
+    # A qualified generic base (`System.Collections.Generic.List<int>`)
+    # is one qualified_name whose text carries the type arguments; strip
+    # them so the written name matches the registered, generic-free qn.
+    if not node.text:
+        return None
+    text = safe_decode_text(node)
+    return text.split(cs.CHAR_ANGLE_OPEN, 1)[0] if text else None
 
 
 def _csharp_looks_like_interface(simple_name: str) -> bool:

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -61,10 +61,28 @@ def _csharp_qualified_base_name(node: Node) -> str | None:
     # A qualified generic base (`System.Collections.Generic.List<int>`)
     # is one qualified_name whose text carries the type arguments; strip
     # them so the written name matches the registered, generic-free qn.
+    # Every argument span goes, not the tail from the first `<`: a nested
+    # type of a generic outer (`Outer<int>.Inner`) keeps its `.Inner`
+    # (CodeRabbit, #1770).
     if not node.text:
         return None
     text = safe_decode_text(node)
-    return text.split(cs.CHAR_ANGLE_OPEN, 1)[0] if text else None
+    return _strip_type_arguments(text) if text else None
+
+
+def _strip_type_arguments(text: str) -> str:
+    """`Outer<int>.Inner<Map<K, V>>` -> `Outer.Inner`: drop every balanced
+    angle-bracket span, however deep."""
+    kept: list[str] = []
+    depth = 0
+    for char in text:
+        if char == cs.CHAR_ANGLE_OPEN:
+            depth += 1
+        elif char == cs.CHAR_ANGLE_CLOSE:
+            depth = max(depth - 1, 0)
+        elif depth == 0:
+            kept.append(char)
+    return "".join(kept)
 
 
 def _csharp_looks_like_interface(simple_name: str) -> bool:

--- a/codebase_rag/parsers/dependency_parser.py
+++ b/codebase_rag/parsers/dependency_parser.py
@@ -278,33 +278,45 @@ class PubspecYamlParser(DependencyParser):
         # (spec = "").
         dependencies: list[Dependency] = []
         try:
-            in_deps = False
-            entry_indent: int | None = None
+            scanner = _PubspecScanner()
             with open(file_path, encoding=cs.ENCODING_UTF8) as f:
                 for raw in f:
-                    line = raw.rstrip()
-                    if not line or line.lstrip().startswith(cs.PUBSPEC_COMMENT_PREFIX):
-                        continue
-                    indent = len(line) - len(line.lstrip())
-                    stripped = line.strip()
-                    if indent == 0:
-                        key = stripped.split(cs.PUBSPEC_KEY_SEP, 1)[0]
-                        in_deps = key in cs.PUBSPEC_DEP_KEYS
-                        entry_indent = None
-                        continue
-                    if not in_deps or cs.PUBSPEC_KEY_SEP not in stripped:
-                        continue
-                    if entry_indent is None:
-                        entry_indent = indent
-                    if indent != entry_indent:
-                        continue
-                    name, _, spec = stripped.partition(cs.PUBSPEC_KEY_SEP)
-                    name = name.strip()
-                    if name:
-                        dependencies.append(Dependency(name, spec.strip()))
+                    if (dependency := scanner.feed(raw.rstrip())) is not None:
+                        dependencies.append(dependency)
         except Exception as e:
             logger.error(ls.DEP_PARSE_ERROR_PUBSPEC.format(path=file_path, error=e))
         return dependencies
+
+
+class _PubspecScanner:
+    """The line-by-line state of `PubspecYamlParser.parse`: which top-level
+    block the scan is in, and the indent its entries use."""
+
+    __slots__ = ("entry_indent", "in_deps")
+
+    def __init__(self) -> None:
+        self.in_deps = False
+        self.entry_indent: int | None = None
+
+    def feed(self, line: str) -> Dependency | None:
+        if not line or line.lstrip().startswith(cs.PUBSPEC_COMMENT_PREFIX):
+            return None
+        indent = len(line) - len(line.lstrip())
+        stripped = line.strip()
+        if indent == 0:
+            key = stripped.split(cs.PUBSPEC_KEY_SEP, 1)[0]
+            self.in_deps = key in cs.PUBSPEC_DEP_KEYS
+            self.entry_indent = None
+            return None
+        if not self.in_deps or cs.PUBSPEC_KEY_SEP not in stripped:
+            return None
+        if self.entry_indent is None:
+            self.entry_indent = indent
+        if indent != self.entry_indent:
+            return None
+        name, _, spec = stripped.partition(cs.PUBSPEC_KEY_SEP)
+        name = name.strip()
+        return Dependency(name, spec.strip()) if name else None
 
 
 def parse_dependencies(file_path: Path) -> list[Dependency]:

--- a/codebase_rag/parsers/py/utils.py
+++ b/codebase_rag/parsers/py/utils.py
@@ -76,19 +76,30 @@ def _class_by_simple_name(
     # `Adapter`), prefer one nested in the CURRENT module: a sibling/enclosing
     # nested class shadows a same-named class elsewhere, so `class Sub extends
     # Adapter` binds to its own file's Adapter, not another file's that merely
-    # sorts first. Fall back to the first full-segment match otherwise.
+    # sorts first. Fall back to the first full-segment match otherwise. A
+    # dotted name (`Outer.Inner`, a nested type through its outer) matches on
+    # its whole segment sequence; `class_name in parts` could never match it
+    # and left every such base unresolved (CodeRabbit, #1770).
+    wanted = class_name.split(SEPARATOR_DOT)
     module_prefix = f"{module_qn}{SEPARATOR_DOT}"
     same_module = [
         match
         for match in matches
-        if match.startswith(module_prefix) and class_name in match.split(SEPARATOR_DOT)
+        if match.startswith(module_prefix) and _ends_with_segments(match, wanted)
     ]
     if same_module:
         return str(min(same_module, key=len))
     for match in matches:
-        if class_name in match.split(SEPARATOR_DOT):
+        if _ends_with_segments(match, wanted):
             return str(match)
     return None
+
+
+def _ends_with_segments(qualified_name: str, wanted: list[str]) -> bool:
+    """Whether the last `len(wanted)` dotted segments of `qualified_name` are
+    exactly `wanted`: a full-segment match, one segment or several."""
+    parts = qualified_name.split(SEPARATOR_DOT)
+    return len(parts) >= len(wanted) and parts[-len(wanted) :] == wanted
 
 
 def external_stdlib_base_method_names(parent_qns: list[str]) -> frozenset[str]:

--- a/codebase_rag/tests/test_csharp_inheritance.py
+++ b/codebase_rag/tests/test_csharp_inheritance.py
@@ -311,3 +311,26 @@ def test_enum_underlying_type_is_not_inheritance(
     # `enum Color : byte` names an underlying integral type, not a base.
     assert not any(ch.endswith("N.Color") for ch, _ in inherits), inherits
     assert not any(ch.endswith("N.Color") for ch, _ in implements), implements
+
+
+def test_record_positional_base_emits_inherits(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # A record's base is a `primary_constructor_base_type` wrapping the type
+    # and the arguments; the written name is the type's, generic arguments
+    # stripped (#1669 review: nothing exercised that branch before).
+    (csharp_project / "Rec.cs").write_text(
+        """
+namespace N;
+public record Base(int x);
+public record Gen<T>(T x);
+public record R(int x) : Base(x);
+public record R2(int x) : Gen<int>(x);
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert _has(inherits, "N.R", "N.Base"), inherits
+    assert _has(inherits, "N.R2", "N.Gen"), inherits

--- a/codebase_rag/tests/test_csharp_inheritance.py
+++ b/codebase_rag/tests/test_csharp_inheritance.py
@@ -334,3 +334,27 @@ public record R2(int x) : Gen<int>(x);
     inherits = _pairs(mock_ingestor, "INHERITS")
     assert _has(inherits, "N.R", "N.Base"), inherits
     assert _has(inherits, "N.R2", "N.Gen"), inherits
+
+
+def test_nested_type_of_a_generic_outer_keeps_its_qualified_base(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # `Outer<int>.Inner` is one qualified_name whose text carries the outer
+    # type's arguments; stripping from the first `<` dropped `.Inner` and
+    # bound the base to `Outer` (CodeRabbit, #1770).
+    (csharp_project / "Nested.cs").write_text(
+        """
+namespace N;
+public class Outer<T>
+{
+    public class Inner { }
+}
+public class D : Outer<int>.Inner { }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert _has(inherits, "N.D", "N.Outer.Inner"), inherits
+    assert not _has(inherits, "N.D", "N.Outer"), inherits

--- a/codebase_rag/tests/test_dependency_parser.py
+++ b/codebase_rag/tests/test_dependency_parser.py
@@ -11,6 +11,7 @@ from codebase_rag.parsers.dependency_parser import (
     GemfileParser,
     GoModParser,
     PackageJsonParser,
+    PubspecYamlParser,
     PyProjectTomlParser,
     RequirementsTxtParser,
     _extract_pep508_package_name,
@@ -866,3 +867,34 @@ class TestParseDependencies:
         deps = parse_dependencies(csproj)
 
         assert len(deps) == 1
+
+
+class TestPubspecYamlParser:
+    def test_exact_entries_under_dependency_blocks(self, tmp_path: Path) -> None:
+        # One line per rule the scanner applies: a comment, a nested `sdk:`
+        # key under a name-only parent (`flutter:`), a shallower late entry
+        # that is not at the block's entry indent, a nameless line, a block
+        # that is not a dependencies block, and a dev block (#1669 review:
+        # the previous tests asserted membership only, so the deeper-key
+        # skip and the empty-name drop could not go red).
+        pubspec = tmp_path / "pubspec.yaml"
+        pubspec.write_text(
+            "name: demo\n"
+            "dependencies:\n"
+            "  # a comment\n"
+            "  flutter:\n"
+            "    sdk: flutter\n"
+            "  http: ^1.0.0\n"
+            " shallow: 1\n"
+            "  : nameless\n"
+            "environment:\n"
+            "  sdk: '>=3.0.0'\n"
+            "dev_dependencies:\n"
+            "  test: ^1.24.0\n",
+            encoding="utf-8",
+        )
+        assert PubspecYamlParser().parse(pubspec) == [
+            Dependency("flutter", ""),
+            Dependency("http", "^1.0.0"),
+            Dependency("test", "^1.24.0"),
+        ]


### PR DESCRIPTION
Part of #1669: two cognitive-complexity findings (python:S3776), both at 16 against the limit of 15.

In `codebase_rag/parsers/dependency_parser.py`, `PubspecYamlParser.parse` keeps the file loop and the error handling, and the per-line state it carried (which top-level block the scan is in, and the indent the block's entries use) lives in a small `_PubspecScanner` whose `feed` classifies one line and returns a dependency or nothing. Every rule is unchanged: blank and comment lines are skipped, a zero-indent key enters or leaves a dependencies block and resets the entry indent, the first entry fixes the indent, deeper lines are a nested block's keys, and a parent key with no inline scalar is recorded name-only.

In `codebase_rag/parsers/class_ingest/parent_extraction.py`, `_csharp_base_written_name` is a `match` on the node type; the qualified-name case (strip the type arguments) is `_csharp_qualified_base_name`, and the record positional base is the first child that yields a name. An identifier or qualified name with empty text still yields nothing.

No behaviour changes. The dependency-parser and C# test files pass: 325 passed.

The local review found that the moved branches had no discriminating test, so `test_dependency_parser.py` gains an exact-list pubspec case (comment, nested key under a name-only parent, shallower late entry, nameless line, non-dependency block, dev block) and `test_csharp_inheritance.py` gains a record with a positional base, plain and generic.

Review also surfaced a pre-existing gap the refactor made visible: a nested type of a generic outer (`class D : Outer<int>.Inner`) lost its `.Inner` when the type arguments were stripped from the first `<`, and a dotted base name could never match the resolver's full-segment check. Both are fixed here: every balanced angle-bracket span is dropped, and `resolve_class_name` matches a dotted name on its whole segment sequence. `test_nested_type_of_a_generic_outer_keeps_its_qualified_base` pins the INHERITS edge to `N.Outer.Inner` and fails on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved C# inheritance resolution for qualified and nested generic base types, including primary-constructor bases.
  - Improved Python nested-type resolution for references such as `Outer.Inner`.
  - Preserved Dart dependency parsing behavior while maintaining correct handling of indentation, comments, nested keys, and unrelated sections.

- **Tests**
  - Added coverage for nested generic C# inheritance.
  - Added validation for `pubspec.yaml` dependencies and development dependencies, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->