### PR TITLE
refactor: split the C++ include parser and the macro body scan (Sonar S3776)

### DIFF
--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -19,7 +19,7 @@ from . import constants as fc
 from .qn import CppQnResolver
 
 if TYPE_CHECKING:
-    from clang.cindex import Cursor
+    from clang.cindex import Cursor, Token
 
 _NodeKey = tuple[str, str]
 _EdgeKey = tuple[str, str, str, str, str]
@@ -98,6 +98,47 @@ def _classify(cursor: Cursor) -> str | None:
             return fc.LABEL_METHOD
         return fc.LABEL_FUNCTION
     return None
+
+
+def _macro_body_identifiers(cursor: Cursor) -> set[str]:
+    """Identifiers a macro's body references, excluding its own name and its
+    parameters.
+
+    Body tokens are those after the macro's own name. A function-like macro
+    ('(' abutting the name, the standard's distinction from an object-like
+    body that starts with a parenthesis) has its parameter list skipped and
+    those names excluded from the body: a parameter is substituted by the
+    caller's argument, so one named like a real macro is not a reference to
+    it.
+    """
+    tokens = list(cursor.get_tokens())
+    body_start, params = _macro_parameter_list(tokens)
+    return {
+        t.spelling
+        for t in tokens[body_start:]
+        if t.spelling.isidentifier()
+        and t.spelling != cursor.spelling
+        and t.spelling not in params
+    }
+
+
+def _macro_parameter_list(tokens: list[Token]) -> tuple[int, set[str]]:
+    """(index of the first body token, parameter names) for a macro's tokens."""
+    name_end = tokens[0].extent.end
+    if not (
+        len(tokens) > 1
+        and tokens[1].spelling == fc.TOKEN_LPAREN
+        and tokens[1].extent.start.line == name_end.line
+        and tokens[1].extent.start.column == name_end.column
+    ):
+        return 1, set()
+    params: set[str] = set()
+    for i, tok in enumerate(tokens[2:], start=2):
+        if tok.spelling == fc.TOKEN_RPAREN:
+            return i + 1, params
+        if tok.spelling.isidentifier():
+            params.add(tok.spelling)
+    return len(tokens), params
 
 
 class _Collector:
@@ -407,36 +448,7 @@ class _Collector:
             fc.LABEL_FUNCTION,
             qn,
         )
-        # Body tokens after the macro's own name. A function-like macro ('('
-        # abutting the name, the standard's distinction from an object-like
-        # body that starts with a parenthesis) has its parameter list skipped
-        # and those names excluded from the body: a parameter is substituted by
-        # the caller's argument, so one named like a real macro is not a
-        # reference to it.
-        tokens = list(cursor.get_tokens())
-        body_start = 1
-        params: set[str] = set()
-        name_end = tokens[0].extent.end
-        if (
-            len(tokens) > 1
-            and tokens[1].spelling == fc.TOKEN_LPAREN
-            and tokens[1].extent.start.line == name_end.line
-            and tokens[1].extent.start.column == name_end.column
-        ):
-            body_start = len(tokens)
-            for i, tok in enumerate(tokens[2:], start=2):
-                if tok.spelling == fc.TOKEN_RPAREN:
-                    body_start = i + 1
-                    break
-                if tok.spelling.isidentifier():
-                    params.add(tok.spelling)
-        refs = {
-            t.spelling
-            for t in tokens[body_start:]
-            if t.spelling.isidentifier()
-            and t.spelling != cursor.spelling
-            and t.spelling not in params
-        }
+        refs = _macro_body_identifiers(cursor)
         if refs:
             self._macro_body_refs.setdefault(qn, set()).update(refs)
 

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -466,6 +466,30 @@ def _rust_norm_manifest_path(path: str) -> str:
     return posixpath.normpath(path.replace("\\", cs.SEPARATOR_SLASH))
 
 
+def _cpp_include_spec(include_node: Node) -> tuple[str, bool] | None:
+    """(include path, is a system include) from a `preproc_include`, or None.
+
+    The LAST string child wins, as it always did; a quoted path is stripped
+    of its quotes and an angle-bracket path of its brackets.
+    """
+    spec: tuple[str, bool] | None = None
+    for child in include_node.children:
+        if child.type == cs.TS_STRING_LITERAL:
+            spec = (safe_decode_with_fallback(child).strip('"'), False)
+        elif child.type == cs.TS_SYSTEM_LIB_STRING:
+            spec = (safe_decode_with_fallback(child).strip("<>"), True)
+    return spec if spec is not None and spec[0] else None
+
+
+def _cpp_include_local_name(include_path: str) -> str:
+    """The name the include binds locally: the header's stem for `.h`/`.hpp`,
+    the bare last path segment otherwise (`<vector>`)."""
+    header_name = include_path.rsplit(cs.SEPARATOR_SLASH, maxsplit=1)[-1]
+    if header_name.endswith(cs.EXT_H) or header_name.endswith(cs.EXT_HPP):
+        return header_name.split(cs.SEPARATOR_DOT)[0]
+    return header_name
+
+
 class ImportProcessor:
     __slots__ = (
         "repo_path",
@@ -4148,58 +4172,51 @@ class ImportProcessor:
         return self._cpp_module_qn_map[matches[0]]
 
     def _parse_cpp_include(self, include_node: Node, module_qn: str) -> None:
-        include_path = None
-        is_system_include = False
+        spec = _cpp_include_spec(include_node)
+        if spec is None:
+            return
+        include_path, is_system_include = spec
+        local_name = _cpp_include_local_name(include_path)
+        full_name = self._cpp_include_full_name(
+            include_path, is_system_include, module_qn
+        )
+        self.import_mapping[module_qn][local_name] = full_name
+        self._record_import_site(module_qn, local_name, include_node, include_path)
+        logger.debug(
+            ls.IMP_CPP_INCLUDE,
+            local=local_name,
+            full=full_name,
+            system=is_system_include,
+        )
 
-        for child in include_node.children:
-            if child.type == cs.TS_STRING_LITERAL:
-                include_path = safe_decode_with_fallback(child).strip('"')
-                is_system_include = False
-            elif child.type == cs.TS_SYSTEM_LIB_STRING:
-                include_path = safe_decode_with_fallback(child).strip("<>")
-                is_system_include = True
-
-        if include_path:
-            header_name = include_path.split(cs.SEPARATOR_SLASH)[-1]
-            if header_name.endswith(cs.EXT_H) or header_name.endswith(cs.EXT_HPP):
-                local_name = header_name.split(cs.SEPARATOR_DOT)[0]
-            else:
-                local_name = header_name
-
-            if is_system_include:
-                # The token, not the substring: `startswith("std")` took
-                # `<stdio.h>`, `<stdlib.h>`, `<stdint.h>` and the rest of that
-                # family as already prefixed, so they became ExternalModule
-                # `stdio.h` while `<signal.h>` in the same file became
-                # `std.signal.h` (issue #1744).
-                full_name = (
-                    include_path
-                    if include_path == cs.CPP_STD_PREFIX
-                    or include_path.startswith(cs.IMPORT_STD_PREFIX)
-                    else f"{cs.IMPORT_STD_PREFIX}{include_path}"
-                )
-            elif resolved := self._resolve_cpp_include_target(include_path, module_qn):
-                # The include resolves to a real repo file; use that file's
-                # actual (collision-disambiguated) module qn. The old
-                # project-rooted, extension-stripped guess produced phantom
-                # module qns (self-imports for same-stem header/source pairs,
-                # wrong roots for -I style includes), which poisoned both the
-                # IMPORTS edges and class resolution via the import map
-                # (issue #652).
-                full_name = resolved
-            else:
-                # A quoted include matching no repo file is a third-party header; a
-                # project-rooted qn would be a phantom.
-                full_name = f"{cs.IMPORT_STD_PREFIX}{include_path}"
-
-            self.import_mapping[module_qn][local_name] = full_name
-            self._record_import_site(module_qn, local_name, include_node, include_path)
-            logger.debug(
-                ls.IMP_CPP_INCLUDE,
-                local=local_name,
-                full=full_name,
-                system=is_system_include,
-            )
+    def _cpp_include_full_name(
+        self, include_path: str, is_system_include: bool, module_qn: str
+    ) -> str:
+        """The module qn an include names: `std.<path>` for a system header or
+        an unresolved quoted one, else the repo file the include resolves to."""
+        if is_system_include:
+            # The token, not the substring: `startswith("std")` took
+            # `<stdio.h>`, `<stdlib.h>`, `<stdint.h>` and the rest of that
+            # family as already prefixed, so they became ExternalModule
+            # `stdio.h` while `<signal.h>` in the same file became
+            # `std.signal.h` (issue #1744).
+            if include_path == cs.CPP_STD_PREFIX or include_path.startswith(
+                cs.IMPORT_STD_PREFIX
+            ):
+                return include_path
+            return f"{cs.IMPORT_STD_PREFIX}{include_path}"
+        if resolved := self._resolve_cpp_include_target(include_path, module_qn):
+            # The include resolves to a real repo file; use that file's
+            # actual (collision-disambiguated) module qn. The old
+            # project-rooted, extension-stripped guess produced phantom
+            # module qns (self-imports for same-stem header/source pairs,
+            # wrong roots for -I style includes), which poisoned both the
+            # IMPORTS edges and class resolution via the import map
+            # (issue #652).
+            return resolved
+        # A quoted include matching no repo file is a third-party header; a
+        # project-rooted qn would be a phantom.
+        return f"{cs.IMPORT_STD_PREFIX}{include_path}"
 
     def _parse_cpp_module_import(self, import_node: Node, module_qn: str) -> None:
         identifier_child = None


### PR DESCRIPTION
Part of #1669: two cognitive-complexity findings (python:S3776), both at 16 against the limit of 15.

In `codebase_rag/parsers/import_processor.py`, `_parse_cpp_include` did three things in one body: read the include's path and kind from the node, derive the local name, and decide the module qn. Those are now `_cpp_include_spec` (the last string or system-lib child wins, an empty path records nothing), `_cpp_include_local_name` (the stem for `.h`/`.hpp`, the bare segment for `<vector>`) and `_cpp_include_full_name` (the `std.` token rule from #1744 for a system header, the resolved repo file for a quoted include that matches one, the `std.` prefix for a third-party header). The recording and the debug line are unchanged.

In `codebase_rag/parsers/cpp_frontend/frontend.py`, the token scan that finds the identifiers a macro body references moves out of `_process_macro_definition` into `_macro_body_identifiers`, with `_macro_parameter_list` deciding whether the macro is function-like (the `(` must abut the name) and which names are its parameters; the fallback when no closing parenthesis is found is kept.

No behaviour changes. The include and C++ frontend test files pass with libclang present: 55 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal processing of C++ macros and include directives while preserving existing behavior.
  - Maintained handling for quoted, system, and header-file includes, including name resolution and collision disambiguation.
  - C++ include statements without a usable path are handled more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->