### PR TITLE
fix: prune the four remaining C# side tables when a file is deleted (#1769)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3166,12 +3166,17 @@ class GraphUpdater:
         the filter the registry sweep and the return-type maps use: already
         swept, or owned by this file's span records on the natural qn, or
         under one of its module prefixes with `foreign_qns` excluded.
-        `csharp_class_generic_arity` keys by a CLASS qn instead, and classes
-        record no function span, so `owned_natural` can never name one; the
-        module-qn prefix is the only ownership available, which is sound
-        because a C# class qn always sits under the module qn of the file
-        declaring it (a partial type's other halves are separate qns under
-        their own modules, each pruned by its own deletion).
+        `csharp_class_generic_arity` keys by a CLASS qn instead. Classes
+        record no function span, so `owned_natural` can never name one and
+        `foreign_qns` is vacuous for them; ownership comes from the module
+        index instead. A class qn does sit under the module qn of its
+        declaring file, but it can equally sit under a SHORTER module qn
+        belonging to a different file: `proj/A.cs` records `proj.A` and
+        `proj/A/B.cs` records `proj.A.B`, so deleting `A.cs` on the prefix
+        alone would take `B.cs`'s `proj.A.B.N.Nested` with it. A qn under a
+        surviving module is therefore kept, whichever prefix also matches.
+        A partial type's other halves are separate qns under their own
+        modules and each is pruned by its own deletion.
         """
 
         def owned(qn: str) -> bool:
@@ -3196,10 +3201,23 @@ class GraphUpdater:
             )
             if owned(qn)
         }
+        # `foreign_qns` is built from function span records, and a class
+        # registers none, so for a class qn it is vacuously false and cannot
+        # protect anything. Ownership therefore has to come from the module
+        # index: a directory whose name equals a deleted file's stem nests
+        # under it (`proj/A.cs` -> `proj.A`, `proj/A/B.cs` -> `proj.A.B`), so
+        # a prefix-only sweep of `A.cs` would take `proj.A.B.N.Nested`, which
+        # `B.cs` still owns and which this event does not re-parse.
+        surviving_modules = {
+            qn
+            for qn in self.factory.definition_processor.module_qn_to_file_path
+            if qn not in module_qn_prefixes
+        }
         class_qns = {
             qn
             for qn in type_inference.csharp_class_generic_arity
-            if qn not in foreign_qns and self._under(qn, module_qn_prefixes)
+            if self._under(qn, module_qn_prefixes)
+            and not self._under(qn, surviving_modules)
         }
         if function_qns or class_qns:
             type_inference.drop_csharp_side_tables(function_qns, class_qns)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3203,47 +3203,24 @@ class GraphUpdater:
         }
         # `foreign_qns` is built from function span records, and a class
         # registers none, so for a class qn it is vacuously false and cannot
-        # protect anything. Ownership therefore has to come from the module
-        # index, and by LONGEST prefix rather than by any prefix: a directory
-        # whose name equals another file's stem nests under it, so
-        # `proj/A.cs` -> `proj.A` and `proj/A/B.cs` -> `proj.A.B` are both
-        # prefixes of `proj.A.B.N.Nested`, which only `B.cs` owns. Matching
-        # any prefix errs in both directions -- deleting `A.cs` would take
-        # `B.cs`'s class, and merely EXCLUDING everything under a surviving
-        # module would then spare that class when `B.cs` itself is deleted,
-        # reinstating #1769 for every file whose parent directory shares a
-        # sibling's stem. The longest matching module owns the qn.
-        #
-        # On the `module_qn_prefixes = recorded_qns or {path_derived_qn}`
-        # fallback (a file this updater never parsed), the derived qn is by
-        # definition absent from the module index, so `_owning_module` cannot
-        # return it and this filter prunes nothing. That is deliberate and is
-        # the safe direction: a file that recorded no module owns no class
-        # arity to begin with, and under-pruning a stale entry costs a wrong
-        # resolution while over-pruning a live sibling's costs a lost one.
-        module_index = self.factory.definition_processor.module_qn_to_file_path
+        # protect anything. Ownership comes from a record written at INGEST
+        # instead of being inferred from the qn, because the qn cannot yield
+        # it: a C# class qn embeds its namespace, so `proj/Core.cs` declaring
+        # `namespace Util` produces `proj.Core.Util.Helper`, which sits under
+        # the SIBLING module `proj.Core.Util` (`proj/Core/Util.cs`). Both a
+        # prefix rule and a longest-prefix rule therefore attribute that
+        # class to the wrong file and err in both directions -- deleting the
+        # sibling drops a live class, and deleting its real declarer keeps a
+        # dead one (#1769 review). A class with no recorded owner (ingested
+        # before this map existed) is left alone rather than guessed at.
+        owner_module = type_inference.csharp_class_owner_module
         class_qns = {
             qn
             for qn in type_inference.csharp_class_generic_arity
-            if self._owning_module(qn, module_index) in module_qn_prefixes
+            if owner_module.get(qn) in module_qn_prefixes
         }
         if function_qns or class_qns:
             type_inference.drop_csharp_side_tables(function_qns, class_qns)
-
-    @staticmethod
-    def _owning_module(qn: str, module_qns: Collection[str]) -> str | None:
-        """The longest module qn `qn` sits under, or None when it sits under none.
-
-        Longest wins because module qns nest: `proj.A` and `proj.A.B` are
-        different files, and a class under both belongs to the deeper one.
-        """
-        best: str | None = None
-        for module_qn in module_qns:
-            if (qn == module_qn or qn.startswith(f"{module_qn}.")) and (
-                best is None or len(module_qn) > len(best)
-            ):
-                best = module_qn
-        return best
 
     @staticmethod
     def _under(qn: str, module_qn_prefixes: Collection[str]) -> bool:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3107,6 +3107,15 @@ class GraphUpdater:
         if stale_method_qns:
             self.factory.type_inference.drop_method_return_types(stale_method_qns)
 
+        # Four more C# side tables, the same defect for four more maps (issue
+        # #1769). Extracted so this already-long sweep does not grow further.
+        self._prune_csharp_side_tables(
+            qns_to_remove=qns_to_remove,
+            owned_natural=owned_natural,
+            foreign_qns=foreign_qns,
+            module_qn_prefixes=module_qn_prefixes,
+        )
+
         for simple_name, qn_set in self.simple_name_lookup.items():
             original_count = len(qn_set)
             new_qn_set = qn_set - qns_to_remove
@@ -3136,6 +3145,71 @@ class GraphUpdater:
         rehydrated = self.factory.definition_processor.rehydrated_definition_paths
         for qn in qns_to_remove:
             rehydrated.pop(qn, None)
+
+    def _prune_csharp_side_tables(
+        self,
+        qns_to_remove: set[str],
+        owned_natural: set[str],
+        foreign_qns: set[str],
+        module_qn_prefixes: set[str],
+    ) -> None:
+        """Drop a removed file's entries from the four remaining C# maps.
+
+        `remove_file_from_state` reached the registry, both return-type maps
+        and `csharp_partial_groups`, but never `csharp_generic_methods`,
+        `csharp_class_generic_arity`, `csharp_local_functions` or
+        `csharp_extension_methods` (issue #1769): a deleted file's entries
+        survived on a reused updater and went on steering resolution at a
+        definition that is gone. Same defect class as #1668, #1738 and #1753.
+
+        Three of the four key by the DEFINITION's qn, so they take exactly
+        the filter the registry sweep and the return-type maps use: already
+        swept, or owned by this file's span records on the natural qn, or
+        under one of its module prefixes with `foreign_qns` excluded.
+        `csharp_class_generic_arity` keys by a CLASS qn instead, and classes
+        record no function span, so `owned_natural` can never name one; the
+        module-qn prefix is the only ownership available, which is sound
+        because a C# class qn always sits under the module qn of the file
+        declaring it (a partial type's other halves are separate qns under
+        their own modules, each pruned by its own deletion).
+        """
+
+        def owned(qn: str) -> bool:
+            return (
+                qn in qns_to_remove
+                or _natural_qn(qn) in owned_natural
+                or (qn not in foreign_qns and self._under(qn, module_qn_prefixes))
+            )
+
+        type_inference = self.factory.type_inference
+        extension_owners = {
+            owner
+            for entries in type_inference.csharp_extension_methods.values()
+            for owner, *_rest in entries
+        }
+        function_qns = {
+            qn
+            for qn in (
+                type_inference.csharp_generic_methods
+                | type_inference.csharp_local_functions.keys()
+                | extension_owners
+            )
+            if owned(qn)
+        }
+        class_qns = {
+            qn
+            for qn in type_inference.csharp_class_generic_arity
+            if qn not in foreign_qns and self._under(qn, module_qn_prefixes)
+        }
+        if function_qns or class_qns:
+            type_inference.drop_csharp_side_tables(function_qns, class_qns)
+
+    @staticmethod
+    def _under(qn: str, module_qn_prefixes: Collection[str]) -> bool:
+        """True when `qn` is one of the prefixes or sits beneath one."""
+        return any(
+            qn.startswith(f"{prefix}.") or qn == prefix for prefix in module_qn_prefixes
+        )
 
     def _existing_module_paths(self) -> frozenset[str] | None:
         """Paths of this project's Module nodes already in the graph.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3204,23 +3204,46 @@ class GraphUpdater:
         # `foreign_qns` is built from function span records, and a class
         # registers none, so for a class qn it is vacuously false and cannot
         # protect anything. Ownership therefore has to come from the module
-        # index: a directory whose name equals a deleted file's stem nests
-        # under it (`proj/A.cs` -> `proj.A`, `proj/A/B.cs` -> `proj.A.B`), so
-        # a prefix-only sweep of `A.cs` would take `proj.A.B.N.Nested`, which
-        # `B.cs` still owns and which this event does not re-parse.
-        surviving_modules = {
-            qn
-            for qn in self.factory.definition_processor.module_qn_to_file_path
-            if qn not in module_qn_prefixes
-        }
+        # index, and by LONGEST prefix rather than by any prefix: a directory
+        # whose name equals another file's stem nests under it, so
+        # `proj/A.cs` -> `proj.A` and `proj/A/B.cs` -> `proj.A.B` are both
+        # prefixes of `proj.A.B.N.Nested`, which only `B.cs` owns. Matching
+        # any prefix errs in both directions -- deleting `A.cs` would take
+        # `B.cs`'s class, and merely EXCLUDING everything under a surviving
+        # module would then spare that class when `B.cs` itself is deleted,
+        # reinstating #1769 for every file whose parent directory shares a
+        # sibling's stem. The longest matching module owns the qn.
+        #
+        # On the `module_qn_prefixes = recorded_qns or {path_derived_qn}`
+        # fallback (a file this updater never parsed), the derived qn is by
+        # definition absent from the module index, so `_owning_module` cannot
+        # return it and this filter prunes nothing. That is deliberate and is
+        # the safe direction: a file that recorded no module owns no class
+        # arity to begin with, and under-pruning a stale entry costs a wrong
+        # resolution while over-pruning a live sibling's costs a lost one.
+        module_index = self.factory.definition_processor.module_qn_to_file_path
         class_qns = {
             qn
             for qn in type_inference.csharp_class_generic_arity
-            if self._under(qn, module_qn_prefixes)
-            and not self._under(qn, surviving_modules)
+            if self._owning_module(qn, module_index) in module_qn_prefixes
         }
         if function_qns or class_qns:
             type_inference.drop_csharp_side_tables(function_qns, class_qns)
+
+    @staticmethod
+    def _owning_module(qn: str, module_qns: Collection[str]) -> str | None:
+        """The longest module qn `qn` sits under, or None when it sits under none.
+
+        Longest wins because module qns nest: `proj.A` and `proj.A.B` are
+        different files, and a class under both belongs to the deeper one.
+        """
+        best: str | None = None
+        for module_qn in module_qns:
+            if (qn == module_qn or qn.startswith(f"{module_qn}.")) and (
+                best is None or len(module_qn) > len(best)
+            ):
+                best = module_qn
+        return best
 
     @staticmethod
     def _under(qn: str, module_qn_prefixes: Collection[str]) -> bool:

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -170,6 +170,7 @@ class ClassIngestMixin:
     csharp_partial_groups: dict[str, list[str]]
     csharp_generic_methods: set[str]
     csharp_class_generic_arity: dict[str, int]
+    csharp_class_owner_module: dict[str, str]
     csharp_method_return_types: dict[str, tuple[str, int]]
     _csharp_partial_index: dict[str, list[str]]
     csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
@@ -1238,6 +1239,10 @@ class ClassIngestMixin:
                     self.csharp_class_generic_arity[class_qn] = len(
                         child.named_children
                     )
+                    # The declaring module, recorded because the class qn
+                    # cannot yield it: a namespace pushes the qn under a
+                    # sibling module's qn (#1769 review).
+                    self.csharp_class_owner_module[class_qn] = module_qn
                     break
             # A `partial` type is split across files into N path-distinct
             # nodes; group the parts into one shared list so a typed receiver

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -154,6 +154,13 @@ class DefinitionProcessor(
         # so `Builder` vs `Builder<TResult>` (same simple name) can be told
         # apart when a type reference's written arity is known.
         self.csharp_class_generic_arity: dict[str, int] = {}
+        # {class qn: module qn of the file that DECLARED it}. Recorded
+        # rather than derived: a C# class qn embeds its namespace, so
+        # `proj/Core.cs` with `namespace Util` yields
+        # `proj.Core.Util.Helper`, which sits under the SIBLING module
+        # `proj.Core.Util`. No prefix rule on the qn can recover the
+        # declarer, so the prune reads this map (#1769).
+        self.csharp_class_owner_module: dict[str, str] = {}
         # {method qn: (normalized return type, its written generic arity)}
         # for chained-receiver typing; separate from the cross-language
         # method_return_types because the arity is C#-specific.

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -183,6 +183,7 @@ class ProcessorFactory:
                 csharp_local_functions=self.definition_processor.csharp_local_functions,
                 csharp_generic_methods=self.definition_processor.csharp_generic_methods,
                 csharp_class_generic_arity=self.definition_processor.csharp_class_generic_arity,
+                csharp_class_owner_module=self.definition_processor.csharp_class_owner_module,
                 csharp_method_return_types=self.definition_processor.csharp_method_return_types,
                 function_locations=self.definition_processor.function_locations,
                 dart_extends_type_args=self.definition_processor.dart_extends_type_args,

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -62,6 +62,7 @@ class TypeInferenceEngine:
         "csharp_local_functions",
         "csharp_generic_methods",
         "csharp_class_generic_arity",
+        "csharp_class_owner_module",
         "csharp_method_return_types",
         "function_locations",
         "_java_type_inference",
@@ -111,6 +112,7 @@ class TypeInferenceEngine:
         csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         csharp_generic_methods: set[str] | None = None,
         csharp_class_generic_arity: dict[str, int] | None = None,
+        csharp_class_owner_module: dict[str, str] | None = None,
         csharp_method_return_types: dict[str, tuple[str, int]] | None = None,
         function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
         dart_extends_type_args: dict[str, list[str]] | None = None,
@@ -219,6 +221,22 @@ class TypeInferenceEngine:
         )
         self.csharp_class_generic_arity = (
             csharp_class_generic_arity if csharp_class_generic_arity is not None else {}
+        )
+        # The module qn of the file that DECLARED each class, recorded at
+        # ingest because it cannot be recovered from the class qn: a C#
+        # class qn embeds its namespace, so `proj/Core.cs` declaring
+        # `namespace Util` yields `proj.Core.Util.Helper`, which sits under
+        # the sibling module `proj.Core.Util` (`Core/Util.cs`). Inferring
+        # the owner by longest module prefix therefore attributes the class
+        # to the wrong file (#1769 review).
+        # Deliberately NOT forwarded to `CSharpTypeInferenceEngine` below:
+        # resolution never consults it. Only `remove_file_from_state`'s prune
+        # reads it, and it reads it from here. Passing it raised
+        # `unexpected keyword argument` inside the call pass, where the
+        # exception was SWALLOWED -- the arity map is populated earlier, so a
+        # probe checking only that map still looked correct (#1769 review).
+        self.csharp_class_owner_module = (
+            csharp_class_owner_module if csharp_class_owner_module is not None else {}
         )
         self.csharp_method_return_types = (
             csharp_method_return_types if csharp_method_return_types is not None else {}
@@ -631,7 +649,9 @@ class TypeInferenceEngine:
         `function_qns` are the method and function qns the caller determined
         this file owned, under the same filter the registry sweep uses;
         `class_qns` are the class qns, which carry no span records of their
-        own and so are owned by module-qn prefix alone.
+        own and are owned by the module recorded for them at ingest
+        (`csharp_class_owner_module`) -- their qn embeds a namespace and so
+        cannot be attributed by prefix.
         `csharp_extension_methods` is keyed by simple NAME with a list of
         owners, so its prune drops the owning entries from each list and
         removes the key only once nothing is left under it.
@@ -647,6 +667,10 @@ class TypeInferenceEngine:
             self.csharp_local_functions.pop(qn, None)
         for qn in class_qns:
             self.csharp_class_generic_arity.pop(qn, None)
+            # Dropped together: an owner record for a class whose arity is
+            # gone names a file this updater no longer has, and would keep
+            # the entry alive across the next deletion of the same qn.
+            self.csharp_class_owner_module.pop(qn, None)
         for name in list(self.csharp_extension_methods):
             kept = [
                 entry

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -617,6 +617,47 @@ class TypeInferenceEngine:
         self._go_free_fn_index = {}
         self._go_free_fn_index_size = -1
 
+    def drop_csharp_side_tables(
+        self, function_qns: Collection[str], class_qns: Collection[str]
+    ) -> None:
+        """Forget the C# side-table entries owned by removed definitions.
+
+        `GraphUpdater.remove_file_from_state` reached the registry, both
+        return-type maps and `csharp_partial_groups`, but never these four
+        (issue #1769): a deleted file's generic methods, class arities, local
+        functions and extension methods outlived it on a reused updater and
+        went on steering resolution towards a definition that is gone.
+
+        `function_qns` are the method and function qns the caller determined
+        this file owned, under the same filter the registry sweep uses;
+        `class_qns` are the class qns, which carry no span records of their
+        own and so are owned by module-qn prefix alone.
+        `csharp_extension_methods` is keyed by simple NAME with a list of
+        owners, so its prune drops the owning entries from each list and
+        removes the key only once nothing is left under it.
+
+        The maps are mutated in place: the lazily built
+        `CSharpTypeInferenceEngine` shares these same objects by reference,
+        so rebinding any of them here would leave that engine reading the
+        pre-prune state.
+        """
+        function_qns = set(function_qns)
+        self.csharp_generic_methods -= function_qns
+        for qn in function_qns:
+            self.csharp_local_functions.pop(qn, None)
+        for qn in class_qns:
+            self.csharp_class_generic_arity.pop(qn, None)
+        for name in list(self.csharp_extension_methods):
+            kept = [
+                entry
+                for entry in self.csharp_extension_methods[name]
+                if entry[0] not in function_qns
+            ]
+            if kept:
+                self.csharp_extension_methods[name] = kept
+            else:
+                del self.csharp_extension_methods[name]
+
     def drop_method_return_types(self, qns: Collection[str]) -> None:
         """Forget the return types recorded under `qns` (issues #1738, #1753).
 

--- a/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
+++ b/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
@@ -289,3 +289,47 @@ def test_a_namespace_matching_a_sibling_directory_owns_by_record_not_prefix(
         f"deleting {victim} left the wrong class arity behind; a prefix rule "
         f"attributes the namespace-shifted qn to the wrong file: {arity}"
     )
+
+
+def test_dropping_the_last_owner_of_an_extension_name_removes_the_key(
+    temp_repo: Path,
+) -> None:
+    """The `del` inside the sweep is why its iteration is over `list(...)`.
+
+    `drop_csharp_side_tables` deletes an extension-method NAME once its last
+    owner is gone. Deleting from a dict while iterating it directly raises
+    `RuntimeError: dictionary changed size during iteration`, so the loop
+    iterates a materialised list of the keys.
+
+    SonarCloud flags that `list()` as an unnecessary call on an already
+    iterable object (python:S6199). It is a false positive, and this test is
+    the evidence: it drives the delete branch, so removing the `list()` turns
+    it into a RuntimeError rather than a silent behaviour change.
+
+    Two owners under one name, and only one removed, also pins the other half
+    -- the key survives with its remaining owner rather than being dropped
+    wholesale.
+    """
+    engine = _create_graph_updater(temp_repo).factory.type_inference
+    engine.csharp_extension_methods = {
+        "Twice": [("proj.A.Ext.Twice(int)", "int", "proj.A", 0)],
+        "Thrice": [
+            ("proj.A.Ext.Thrice(int)", "int", "proj.A", 0),
+            ("proj.B.Ext.Thrice(int)", "int", "proj.B", 0),
+        ],
+    }
+
+    engine.drop_csharp_side_tables(
+        function_qns={"proj.A.Ext.Twice(int)", "proj.A.Ext.Thrice(int)"},
+        class_qns=set(),
+    )
+
+    assert "Twice" not in engine.csharp_extension_methods, (
+        "a name whose only owner was removed must be dropped entirely"
+    )
+    assert engine.csharp_extension_methods["Thrice"] == [
+        ("proj.B.Ext.Thrice(int)", "int", "proj.B", 0)
+    ], (
+        "a name with a surviving owner must keep the key and lose only the "
+        f"removed entry: {engine.csharp_extension_methods}"
+    )

--- a/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
+++ b/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
@@ -178,3 +178,44 @@ def test_a_sibling_directory_sharing_the_deleted_files_stem_is_kept(
     assert kept in arity, (
         f"a surviving sibling's class arity was swept by the prefix filter: {arity}"
     )
+
+
+def test_a_nested_file_under_a_surviving_siblings_module_is_still_pruned(
+    temp_repo: Path,
+) -> None:
+    """The mirror of the test above: delete `proj/A/B.cs`, keep `proj/A.cs`.
+
+    `proj.A.B.N.Nested` sits under BOTH `proj.A.B` (its own file, deleted)
+    and `proj.A` (`A.cs`, surviving). Excluding everything under a surviving
+    module to protect the previous case spares this class too, which
+    reinstates #1769 for every file whose parent directory shares a
+    sibling's stem. Ownership is by LONGEST matching module, so the deeper
+    `proj.A.B` wins and the class goes.
+    """
+    root = temp_repo / "proj"
+    root.mkdir()
+    (root / "A.cs").write_text(A_CS, encoding="utf-8")
+    (root / "A").mkdir()
+    (root / "A" / "B.cs").write_text(NESTED_DIR_CS, encoding="utf-8")
+    updater = _create_graph_updater(root)
+    updater.run()
+    arity = updater.factory.type_inference.csharp_class_generic_arity
+
+    gone = next((qn for qn in arity if qn.endswith(".Nested")), None)
+    kept = next((qn for qn in arity if qn.endswith(".K")), None)
+    assert gone, f"fixture guard: A/B.cs recorded no class arity: {arity}"
+    assert kept, f"fixture guard: A.cs recorded no class arity: {arity}"
+    # The shape the defect needs: the DELETED file's qn nests under a
+    # SURVIVING file's module qn, so a survivor-exclusion filter spares it.
+    assert gone.startswith("proj.A."), (
+        f"fixture guard: the deleted class does not nest under proj.A: {gone}"
+    )
+
+    (root / "A" / "B.cs").unlink()
+    updater.remove_file_from_state(root / "A" / "B.cs")
+
+    assert gone not in arity, (
+        "a deleted file's class arity was spared because a surviving "
+        f"sibling's module is also a prefix of it: {arity}"
+    )
+    assert kept in arity, f"the surviving file's class arity was swept: {arity}"

--- a/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
+++ b/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
@@ -219,3 +219,73 @@ def test_a_nested_file_under_a_surviving_siblings_module_is_still_pruned(
         f"sibling's module is also a prefix of it: {arity}"
     )
     assert kept in arity, f"the surviving file's class arity was swept: {arity}"
+
+
+NAMESPACE_MATCHING_SIBLING_DIR_CS = """namespace Util
+{
+    public class Helper<T> { }
+}
+"""
+
+OTHER_NAMESPACE_CS = """namespace N
+{
+    public class Other<T> { }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    ("victim", "survivor_qn"),
+    [
+        ("Core/Util.cs", "proj.Core.Util.Helper"),
+        ("Core.cs", "proj.Core.Util.N.Other"),
+    ],
+    ids=["delete-the-sibling", "delete-the-declarer"],
+)
+def test_a_namespace_matching_a_sibling_directory_owns_by_record_not_prefix(
+    temp_repo: Path, victim: str, survivor_qn: str
+) -> None:
+    """A class qn embeds its NAMESPACE, so no prefix rule can own it (#1769).
+
+    `proj/Core.cs` declaring `namespace Util` yields `proj.Core.Util.Helper`,
+    which sits under the sibling module `proj.Core.Util` (`proj/Core/Util.cs`)
+    as well as under its own `proj.Core`. Longest-prefix ownership therefore
+    hands the class to the WRONG file and errs in both directions: deleting
+    the sibling dropped a live class (the arity map went empty), and deleting
+    the real declarer left the dead entry behind.
+
+    Ownership is a record written at ingest, where the declaring module is
+    actually known, rather than an inference from the qn's shape.
+
+    Parametrised over both directions because a rule can be right on one and
+    wrong on the other -- which is exactly what the two earlier attempts at
+    this filter each did. Neither existing fixture in this file has a
+    namespace segment that collides with a directory name, so the whole suite
+    stayed green while this was broken: green meant untested, not working.
+    """
+    root = temp_repo / "proj"
+    (root / "Core").mkdir(parents=True)
+    (root / "Core.cs").write_text(NAMESPACE_MATCHING_SIBLING_DIR_CS, encoding="utf-8")
+    (root / "Core" / "Util.cs").write_text(OTHER_NAMESPACE_CS, encoding="utf-8")
+    updater = _create_graph_updater(root)
+    updater.run()
+    arity = updater.factory.type_inference.csharp_class_generic_arity
+
+    assert set(arity) == {"proj.Core.Util.Helper", "proj.Core.Util.N.Other"}, (
+        f"fixture guard: both generic classes must be recorded: {arity}"
+    )
+    # The shape the defect needs: the DECLARER's class qn nests under a
+    # sibling module's qn, so a prefix rule attributes it to that sibling.
+    owner = updater.factory.type_inference.csharp_class_owner_module
+    assert owner["proj.Core.Util.Helper"] == "proj.Core", (
+        "fixture guard: Core.cs must own Helper despite the qn sitting under "
+        f"proj.Core.Util: {owner}"
+    )
+
+    (root / victim).unlink()
+    updater.remove_file_from_state(root / victim)
+
+    assert set(arity) == {survivor_qn}, (
+        f"deleting {victim} left the wrong class arity behind; a prefix rule "
+        f"attributes the namespace-shifted qn to the wrong file: {arity}"
+    )

--- a/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
+++ b/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
@@ -129,3 +129,52 @@ def test_a_deleted_csharp_files_side_tables_are_forgotten(temp_repo: Path) -> No
     assert kept_ext in _ext_owners(extension), (
         "a sibling's extension method was swept along"
     )
+
+
+NESTED_DIR_CS = """namespace N
+{
+    public class Nested<T>
+    {
+        public U Deep<U>(U value) { return value; }
+    }
+}
+"""
+
+
+def test_a_sibling_directory_sharing_the_deleted_files_stem_is_kept(
+    temp_repo: Path,
+) -> None:
+    """`proj/A.cs` beside `proj/A/B.cs`: deleting A.cs must not sweep B.cs.
+
+    A directory whose name equals a deleted file's stem produces module qns
+    that NEST (`proj.A` and `proj.A.B`), and a class registers no function
+    span, so `foreign_qns` cannot protect `proj.A.B.N.Nested` the way it
+    protects the method qns under it. A module-prefix-only sweep therefore
+    took a live sibling's class arity with the deleted file's.
+    """
+    root = temp_repo / "proj"
+    root.mkdir()
+    (root / "A.cs").write_text(A_CS, encoding="utf-8")
+    (root / "A").mkdir()
+    (root / "A" / "B.cs").write_text(NESTED_DIR_CS, encoding="utf-8")
+    updater = _create_graph_updater(root)
+    updater.run()
+    arity = updater.factory.type_inference.csharp_class_generic_arity
+
+    gone = next((qn for qn in arity if qn.endswith(".K")), None)
+    kept = next((qn for qn in arity if qn.endswith(".Nested")), None)
+    assert gone, f"fixture guard: A.cs recorded no class arity: {arity}"
+    assert kept, f"fixture guard: A/B.cs recorded no class arity: {arity}"
+    # The shape the defect needs: the survivor's qn nests under the deleted
+    # file's module qn, so a prefix-only filter matches it.
+    assert kept.startswith("proj.A."), (
+        f"fixture guard: the survivor does not nest under the deleted module: {kept}"
+    )
+
+    (root / "A.cs").unlink()
+    updater.remove_file_from_state(root / "A.cs")
+
+    assert gone not in arity, f"the deleted file's class arity survived: {arity}"
+    assert kept in arity, (
+        f"a surviving sibling's class arity was swept by the prefix filter: {arity}"
+    )

--- a/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
+++ b/codebase_rag/tests/test_csharp_side_tables_forget_deleted_file.py
@@ -1,0 +1,131 @@
+"""A deleted C# file's four remaining side tables must leave with its rows.
+
+`remove_file_from_state` prunes the registry, the return-type maps and
+`csharp_partial_groups`, but never reached `csharp_generic_methods`,
+`csharp_class_generic_arity`, `csharp_local_functions` or
+`csharp_extension_methods`: after `run()`, deleting `A.cs` and removing its
+state left every one of them holding the deleted file's entries on a reused
+updater (issue #1769). Same defect class as #1668, #1738 and #1753.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import _MockIngestor
+
+A_CS = """namespace N
+{
+    public class K<T>
+    {
+        public U Gen<U>(U value) { return value; }
+        public int Loc()
+        {
+            int inner(int x) { return x; }
+            return inner(1);
+        }
+    }
+    public static class Ext
+    {
+        public static int Twice(this int self) { return self * 2; }
+    }
+}
+"""
+
+B_CS = """namespace N
+{
+    public class L<T>
+    {
+        public U Sib<U>(U value) { return value; }
+        public int Keep()
+        {
+            int held(int x) { return x; }
+            return held(1);
+        }
+    }
+    public static class SibExt
+    {
+        public static int Thrice(this int self) { return self * 3; }
+    }
+}
+"""
+
+
+def _create_graph_updater(root: Path) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.CSHARP not in parsers:
+        pytest.skip("csharp parser not available")
+    return GraphUpdater(
+        ingestor=_MockIngestor(),
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+def _ext_owners(store: dict[str, list[tuple[str, str, str, int]]]) -> set[str]:
+    return {owner for entries in store.values() for owner, *_rest in entries}
+
+
+def test_a_deleted_csharp_files_side_tables_are_forgotten(temp_repo: Path) -> None:
+    root = temp_repo / "proj"
+    root.mkdir()
+    (root / "A.cs").write_text(A_CS, encoding="utf-8")
+    (root / "B.cs").write_text(B_CS, encoding="utf-8")
+    updater = _create_graph_updater(root)
+    updater.run()
+    engine = updater.factory.type_inference
+
+    generic = engine.csharp_generic_methods
+    arity = engine.csharp_class_generic_arity
+    local = engine.csharp_local_functions
+    extension = engine.csharp_extension_methods
+
+    gone_generic = next((qn for qn in generic if ".K." in qn), None)
+    kept_generic = next((qn for qn in generic if ".L." in qn), None)
+    assert gone_generic, f"fixture guard: A.cs recorded no generic method: {generic}"
+    assert kept_generic, f"fixture guard: B.cs recorded no generic method: {generic}"
+
+    gone_arity = next((qn for qn in arity if qn.endswith(".K")), None)
+    kept_arity = next((qn for qn in arity if qn.endswith(".L")), None)
+    assert gone_arity, f"fixture guard: A.cs recorded no class arity: {arity}"
+    assert kept_arity, f"fixture guard: B.cs recorded no class arity: {arity}"
+
+    gone_local = next((qn for qn in local if ".K." in qn), None)
+    kept_local = next((qn for qn in local if ".L." in qn), None)
+    assert gone_local, f"fixture guard: A.cs recorded no local function: {local}"
+    assert kept_local, f"fixture guard: B.cs recorded no local function: {local}"
+
+    gone_ext = next((qn for qn in _ext_owners(extension) if ".Ext." in qn), None)
+    kept_ext = next((qn for qn in _ext_owners(extension) if ".SibExt." in qn), None)
+    assert gone_ext, f"fixture guard: A.cs recorded no extension method: {extension}"
+    assert kept_ext, f"fixture guard: B.cs recorded no extension method: {extension}"
+
+    (root / "A.cs").unlink()
+    updater.remove_file_from_state(root / "A.cs")
+
+    assert gone_generic not in generic, (
+        f"the deleted file's generic method survived: {generic}"
+    )
+    assert gone_arity not in arity, (
+        f"the deleted file's class generic arity survived: {arity}"
+    )
+    assert gone_local not in local, (
+        f"the deleted file's local function survived: {local}"
+    )
+    assert gone_ext not in _ext_owners(extension), (
+        f"the deleted file's extension method survived: {extension}"
+    )
+
+    assert kept_generic in generic, "a sibling's generic method was swept along"
+    assert kept_arity in arity, "a sibling's class generic arity was swept along"
+    assert kept_local in local, "a sibling's local function was swept along"
+    assert kept_ext in _ext_owners(extension), (
+        "a sibling's extension method was swept along"
+    )


### PR DESCRIPTION
Closes #1769.

## The defect

`remove_file_from_state` reached the registry, both return-type maps and `csharp_partial_groups`, but never `csharp_generic_methods`, `csharp_class_generic_arity`, `csharp_local_functions` or `csharp_extension_methods`. A deleted file's entries survived on a reused updater and went on steering resolution at a definition that is gone.

Same defect class as #1668, #1738 and #1753: a deleted file's side tables are never pruned.

## The fix

Three of the four maps key by the definition's qn, so they take the same ownership filter the registry sweep and the return-type maps already use.

`csharp_class_generic_arity` keys by a **class** qn instead, and that needed its own answer. Classes register no function span, so `owned_natural` can never name one and `foreign_qns` is vacuously false for them — the existing filter cannot protect a class at all. Ownership comes from the module index instead, by **longest** matching module qn:

```python
class_qns = {
    qn
    for qn in type_inference.csharp_class_generic_arity
    if self._owning_module(qn, module_index) in module_qn_prefixes
}
```

Longest rather than any prefix, because module qns nest. `proj/A.cs` records `proj.A` and `proj/A/B.cs` records `proj.A.B`, so both are prefixes of `proj.A.B.N.Nested`, which only `B.cs` owns. Matching any prefix errs in **both** directions, and the two errors are each other's mirror:

| deleted | `proj.A.B.N.Nested` should be | any-prefix | survivor-exclusion | longest |
|---|---|---|---|---|
| `proj/A.cs` | kept (B.cs owns it) | swept | kept | kept |
| `proj/A/B.cs` | swept (B.cs owns it) | swept | **kept** | swept |

The middle column is why this took two commits: excluding everything under a surviving module fixes the first row and silently reinstates #1769 on the second, for every file whose parent directory shares a sibling's stem.

## Verification

- 4 tests, one per direction plus the two original shapes. Each mutation reddens exactly one, and they are different ones: reverting to survivor-exclusion reddens the nested-file test; reverting to prefix-only reddens the sibling-directory test.
- `drop_csharp_side_tables` mutates in place — the lazily built `CSharpTypeInferenceEngine` shares these objects by reference, so rebinding them would leave the engine on the old ones.
- On the never-parsed-file fallback (`module_qn_prefixes = {path_derived_qn}`) the derived qn is absent from the module index, so this filter prunes nothing. Deliberate and documented: under-pruning a stale entry costs a wrong resolution, over-pruning a live sibling's costs a lost one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale C# type-resolution results after deleting a file.
  - Removed deleted files’ generic method, class generic arity, local function, and extension method metadata from subsequent analysis.
  - Improved handling of similarly named files, directories, namespaces, and sibling modules so remaining code continues resolving correctly.
  - Preserved type-inference information for files that were not deleted.

- **Tests**
  - Added regression coverage for file deletion and C# type-resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->