### PR TITLE
fix: a single-file run must not prune Modules it never walked (#1756)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -4734,6 +4734,15 @@ class GraphUpdater:
             # the containment gate that spares out-of-repo File and Folder
             # rows never runs for them.
             logger.info(ls.PRUNE_SKIPPED_SINGLE_FILE)
+            # The two sweeps below still run. Unlike the path-keyed loop they
+            # take no path and no project: each deletes only nodes with zero
+            # inbound edges, so a partial walk cannot make them over-delete.
+            # And a single-file run DOES orphan them -- it deletes and
+            # re-ingests its target's entities, which is exactly what strands
+            # an ExternalModule whose import was removed or a Resource whose
+            # endpoint was (#1756 review).
+            self.ingestor.execute_write(cs.CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES)
+            prune_unanchored_resources(self.ingestor)
             return
 
         logger.info(ls.PRUNE_START)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -4716,6 +4716,25 @@ class GraphUpdater:
         """Remove graph nodes whose files/folders no longer exist on disk."""
         if not isinstance(self.ingestor, QueryProtocol):
             return
+        if self._single_file is not None:
+            # A single-file run walked one file and cannot say what the
+            # project still holds, exactly as it cannot speak for the
+            # project's file set (`deleted_keys`) or its exclusion set (the
+            # stamp in `run`). The prune is a whole-project claim: it deletes
+            # every node whose path is absent from disk, on the premise that
+            # a full walk established which paths those are.
+            #
+            # Left unguarded it did not merely over-reach, it emptied the
+            # graph (issue #1756). `repo_path` is the TARGET'S PARENT here,
+            # so `pkg/module_a.py` makes it `pkg/` and every module's
+            # relative path is resolved against the wrong root:
+            # `root_module.py` is tested as `pkg/root_module.py`, is absent,
+            # and is deleted. Modules are the worst case because
+            # CYPHER_ALL_MODULE_PATHS_INTERNAL returns no `absolute_path`, so
+            # the containment gate that spares out-of-repo File and Folder
+            # rows never runs for them.
+            logger.info(ls.PRUNE_SKIPPED_SINGLE_FILE)
+            return
 
         logger.info(ls.PRUNE_START)
         total_pruned = 0

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -987,6 +987,12 @@ PRUNE_DELETING = "Pruning orphan {label}: {path}"
 PRUNE_LEGACY_IDENTITIES = "Swept {count} legacy target-resolved File record(s)"
 PRUNE_COMPLETE = "Pruning complete. Removed {count} orphan nodes."
 PRUNE_SKIP = "No orphan nodes found. Graph is clean."
+# Distinct from PRUNE_SKIP: the prune did not run, which is not the
+# same claim as running and finding nothing (issue #1756).
+PRUNE_SKIPPED_SINGLE_FILE = (
+    "Single-file run: skipping the orphan prune, which can only speak "
+    "for a full project walk."
+)
 FILE_HASH_UNCHANGED = "File unchanged (hash match): {path}"
 FILE_HASH_CHANGED = "File changed (hash mismatch): {path}"
 FILE_HASH_NEW = "New file detected: {path}"

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -670,3 +670,59 @@ class TestSingleFileRunScope:
             "a single-file run on a file in a subdirectory pruned modules it "
             f"was never asked about: {sorted(swept)}"
         )
+
+    def test_a_single_file_run_still_sweeps_the_edgeless_orphans(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """Skipping the path-keyed prune must not skip these two (#1756).
+
+        `CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES` and
+        `prune_unanchored_resources` take no path and no project: each deletes
+        only nodes with zero inbound edges, so a partial walk cannot make them
+        over-delete, and the "cannot speak for the project" reasoning that
+        justifies the guard does not reach them.
+
+        They are also exactly what a single-file run orphans. It deletes and
+        re-ingests its target's entities, so an import or an endpoint removed
+        from that one file strands an ExternalModule or a Resource that
+        nothing else will ever collect -- `deleted_keys` is guarded off for
+        these runs too.
+
+        Asserts the queries are ISSUED rather than their effect, because the
+        fake store holds no edges to make a node orphaned in the first place.
+        """
+        repo = self._nested_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        second = _MockIngestor()
+        GraphUpdater(
+            ingestor=second,
+            repo_path=repo / "pkg" / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+            project_name="nested",
+        ).run()
+
+        issued = {
+            call.args[0] for call in second.execute_write.call_args_list if call.args
+        }
+        assert cs.CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES in issued, (
+            "the single-file guard skipped the external-module sweep, so an "
+            "import removed from the target's own file strands its "
+            "ExternalModule with nothing left to collect it"
+        )
+        from codebase_rag.services.resource_cleanup import (
+            CYPHER_DELETE_UNANCHORED_RESOURCES,
+        )
+
+        assert CYPHER_DELETE_UNANCHORED_RESOURCES in issued, (
+            "the single-file guard skipped the unanchored-resource sweep, so "
+            "an endpoint removed from the target's own file strands its "
+            "Resource node"
+        )

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -581,3 +581,92 @@ class TestSingleFileRunScope:
             "first, so the old parse's nodes and edges survive alongside the "
             "new ones"
         )
+
+    @staticmethod
+    def _nested_project(tmp_path: Path) -> Path:
+        """A project whose modules live in a SUBDIRECTORY and at the root.
+
+        The existing fixture puts every module at the repo root, so
+        `repo_path` derived from the target's parent IS the project root and
+        the defect cannot fire. Only a target inside a subdirectory separates
+        the two.
+        """
+        repo = tmp_path / "nested"
+        pkg = repo / "pkg"
+        pkg.mkdir(parents=True)
+        (repo / "__init__.py").touch()
+        (repo / "root_module.py").write_text(
+            "def at_the_root():\n    pass\n", encoding="utf-8"
+        )
+        (pkg / "__init__.py").touch()
+        (pkg / "module_a.py").write_text(
+            "class Alpha:\n    def greet(self):\n        return 1\n", encoding="utf-8"
+        )
+        (pkg / "module_b.py").write_text("def func_b():\n    pass\n", encoding="utf-8")
+        return repo
+
+    def test_a_target_in_a_subdirectory_prunes_no_module_outside_it(
+        self, tmp_path: Path, mock_ingestor: MagicMock
+    ) -> None:
+        """The orphan prune must not act on a run that walked one file (#1756).
+
+        `GraphUpdater(repo_path=<file>)` sets `repo_path` to the file's
+        PARENT, so for `pkg/module_a.py` that is `pkg/`. `_prune_orphan_nodes`
+        then resolves every Module's relative path against `pkg/` and deletes
+        the ones that do not exist there -- which is every module outside
+        `pkg/`, and, because Module rows carry no `absolute_path`, the
+        containment gate that protects File and Folder rows never runs for
+        them. The measured result was a graph holding no Modules at all.
+
+        This is the same claim the run already refuses to make elsewhere: a
+        single-file run cannot speak for the project's file set, which is why
+        `deleted_keys` and the exclusion stamp are both guarded on
+        `self._single_file is None`. The prune is guarded for that reason too.
+
+        The target is deliberately NOT at the repo root: with a root-level
+        target the derived `repo_path` equals the project root and the whole
+        defect is invisible, which is why every test above passes on the
+        broken code.
+        """
+        repo = self._nested_project(tmp_path)
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        ).run()
+
+        # The graph the second run sees: the modules the project run wrote,
+        # keyed relative to the PROJECT root. A plain MagicMock would make
+        # the prune skip entirely (it is gated on QueryProtocol), so the
+        # defect would be invisible rather than absent.
+        second = _MockIngestor()
+        second.fetch_all.return_value = [
+            {cs.KEY_PATH: "root_module.py", "qualified_name": "nested.root_module"},
+            {cs.KEY_PATH: "pkg/module_a.py", "qualified_name": "nested.pkg.module_a"},
+            {cs.KEY_PATH: "pkg/module_b.py", "qualified_name": "nested.pkg.module_b"},
+        ]
+        # The SAME project name as the project run, which is what the issue
+        # measured. Without it the derived name is `pkg`, every row fails the
+        # `qn.startswith(project_prefix)` gate before the path test is
+        # reached, and the prune skips them for an unrelated reason -- so the
+        # test would pass on the broken code.
+        single = GraphUpdater(
+            ingestor=second,
+            repo_path=repo / "pkg" / "module_a.py",
+            parsers=parsers,
+            queries=queries,
+            project_name="nested",
+        )
+        assert single.repo_path == repo / "pkg", (
+            "fixture guard: the constructor must derive the TARGET'S PARENT "
+            f"as repo_path, or the defect cannot fire: {single.repo_path}"
+        )
+        single.run()
+
+        swept = self._swept_module_keys(second)
+        assert swept == set(), (
+            "a single-file run on a file in a subdirectory pruned modules it "
+            f"was never asked about: {sorted(swept)}"
+        )


### PR DESCRIPTION
Closes #1756.

## The defect

`GraphUpdater(repo_path=<a file>)` sets `repo_path` to the file's **parent**. For a target in a subdirectory (`pkg/module_a.py`) that parent is `pkg/`, and `_prune_orphan_nodes` then resolves every Module's relative path against `pkg/`. A module recorded as `root_module.py` is tested as `pkg/root_module.py`, does not exist, and is deleted.

Every Module outside the target's own directory goes. The measured result in the issue was a graph holding **no Modules at all**.

Two things combine to make it total rather than partial:

- `CYPHER_ALL_MODULE_PATHS_INTERNAL` returns `path` and `qualified_name` but **no `absolute_path`**, so the component-aware containment gate that protects File, Folder and Package rows never runs for Modules.
- The remaining test is `(self.repo_path / path).exists()`, which is exactly the one that misreads the root.

## The fix

The prune is a whole-project claim, and a single-file run has not walked the project. That principle is already settled in this file — `deleted_keys` and the exclusion stamp are both guarded on `self._single_file is None`, with the comment "a single-file run walks one file and cannot speak for the project's exclusion set". The prune is the same claim, so it takes the same guard.

Chosen over the issue's other option (locating the project root and re-keying the target) because that changes what `repo_path`, `project_name` and the hash-cache location mean for every single-file caller, to fix a pass that this kind of run should not be making in the first place.

## Verification

- The new test builds a project with modules both at the root and in `pkg/`, runs a full build, then a single-file run on `pkg/module_a.py`, and asserts no module is swept.
- The target is deliberately **not** at the repo root. Every existing test in `TestSingleFileRunScope` uses a root-level target, where the derived `repo_path` equals the project root and the defect cannot fire — which is why they all pass on the broken code.
- The second ingestor is a `_MockIngestor`, not a plain `MagicMock`: the prune is gated on `isinstance(self.ingestor, QueryProtocol)`, so a plain mock makes the defect invisible rather than absent.
- `_swept_module_keys` counts deletes **not followed by a re-add**, because `CYPHER_DELETE_MODULE` also serves delete-before-reingest on a file that still exists.

## Measured

With a matching project name, the unguarded single-file run on `pkg/module_a.py` issues:

```
DELETE_MODULE: ['root_module.py', 'pkg/module_a.py', 'pkg/module_b.py']
```

All three, including the file it was asked to index. With the guard: none. That is the issue's `modules=[]` exactly.

The test's fixture passes `project_name="nested"` explicitly, and asserts `repo_path == repo/"pkg"` as a guard. Without the explicit name the derived one is `pkg`, every row fails the `qn.startswith(project_prefix)` gate before the path test runs, and the prune skips them for an unrelated reason — the first version of this test passed on the broken code for exactly that reason.

## What the guard still does

The early return sits **below** the two path-independent sweeps, which continue to run:

```python
logger.info(ls.PRUNE_SKIPPED_SINGLE_FILE)
self.ingestor.execute_write(cs.CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES)
prune_unanchored_resources(self.ingestor)
return
```

Both take no path and no project, and delete only nodes with zero inbound edges, so a partial walk cannot make them over-delete. They are also precisely what a single-file run orphans: it deletes and re-ingests its target's entities, so an import or endpoint removed from that one file strands an ExternalModule or Resource that nothing else collects — `deleted_keys` is guarded off for these runs too. Skipping them was a P1 in review.

## Known limits (not addressed here)

- A subdirectory single-file run also **misroots what it writes**: modules and classes are keyed `nested.module_a` rather than `nested.pkg.module_a`. It issues no deletes, so the correct nodes survive and a duplicate wrong-key set is added. This PR stops the deletion half of #1756; the duplication half is live and needs the root-locating remedy.
- The same run overwrites `Project.root_path` with the subdirectory.
- A single-file run whose target **is** at the repo root has a correct `repo_path`, so its prune was safe; the guard skips it anyway. Conservative, and recoverable later with a `repo_path == <project root>` condition.

Each is pre-existing and worth its own issue rather than widening this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed single-file processing so modules outside the target file’s directory are no longer incorrectly removed.
  - Preserved cleanup of genuinely orphaned external modules and unanchored resources during single-file runs.
  - Improved project-aware synchronization across repeated runs.
  - Added clearer logging when path-based orphan cleanup is skipped for single-file processing.
  - Added clearer reporting for structural failures during re-ingestion.

- **Tests**
  - Added regression coverage for nested project paths and orphan cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->