### PR TITLE
fix: name header ExternalModules by the header, and keep every include's edge (#1758)

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -481,6 +481,37 @@ def _cpp_include_spec(include_node: Node) -> tuple[str, bool] | None:
     return spec if spec is not None and spec[0] else None
 
 
+def _dotted_include_path(include_path: str) -> str:
+    """An include path as dotted module segments: `sys/types.h` -> `sys.types.h`.
+
+    The qualified name is a dotted path everywhere else in the graph, so a
+    slash left in it (`std.sys/types.h`) is not addressable by any dotted
+    lookup and does not segment (issue #1758).
+    """
+    return include_path.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
+
+
+def _external_module_name(module_path: str) -> str:
+    """The display name for an ExternalModule qn.
+
+    The last DOTTED segment names a package path (`std.fmt` -> `fmt`), but a
+    C/C++ header carries its extension in that position, so every `.h` include
+    was named `h`: `std.stdio.h`, `std.signal.h` and `std.sys.types.h` all
+    minted an ExternalModule called `h` (issue #1758). A header is named by
+    its own stem instead, the same name `_cpp_include_local_name` binds it
+    under, so the node and the local name agree.
+    """
+    segments = module_path.split(cs.SEPARATOR_DOT)
+    # `stdio.h` occupies the last TWO dotted segments, the stem and the
+    # extension; anything else is named by its last segment as before.
+    if len(segments) >= 2 and f"{cs.SEPARATOR_DOT}{segments[-1]}" in (
+        cs.EXT_H,
+        cs.EXT_HPP,
+    ):
+        return segments[-2]
+    return segments[-1]
+
+
 def _cpp_include_local_name(include_path: str) -> str:
     """The name the include binds locally: the header's stem for `.h`/`.hpp`,
     the bare last path segment otherwise (`<vector>`)."""
@@ -2915,7 +2946,7 @@ class ImportProcessor:
         if cs.SEPARATOR_DOUBLE_COLON in module_path:
             name = module_path.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1]
         else:
-            name = module_path.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+            name = _external_module_name(module_path)
         self.ingestor.ensure_node_batch(
             cs.NodeLabel.EXTERNAL_MODULE,
             {
@@ -4204,7 +4235,11 @@ class ImportProcessor:
                 cs.IMPORT_STD_PREFIX
             ):
                 return include_path
-            return f"{cs.IMPORT_STD_PREFIX}{include_path}"
+            # A slashed include path is segmented like any other module path:
+            # `<sys/types.h>` is the module `types.h` under `sys`, and leaving
+            # the slash in produced the qn `std.sys/types.h`, which no dotted
+            # lookup can address (issue #1758).
+            return f"{cs.IMPORT_STD_PREFIX}{_dotted_include_path(include_path)}"
         if resolved := self._resolve_cpp_include_target(include_path, module_qn):
             # The include resolves to a real repo file; use that file's
             # actual (collision-disambiguated) module qn. The old
@@ -4215,8 +4250,9 @@ class ImportProcessor:
             # (issue #652).
             return resolved
         # A quoted include matching no repo file is a third-party header; a
-        # project-rooted qn would be a phantom.
-        return f"{cs.IMPORT_STD_PREFIX}{include_path}"
+        # project-rooted qn would be a phantom. Segmented like the system
+        # branch above, for the same reason (issue #1758).
+        return f"{cs.IMPORT_STD_PREFIX}{_dotted_include_path(include_path)}"
 
     def _parse_cpp_module_import(self, import_node: Node, module_qn: str) -> None:
         identifier_child = None

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -494,19 +494,34 @@ def _dotted_include_path(include_path: str) -> str:
 def _external_module_name(module_path: str) -> str:
     """The display name for an ExternalModule qn.
 
-    The last DOTTED segment names a package path (`std.fmt` -> `fmt`), but a
-    C/C++ header carries its extension in that position, so every `.h` include
-    was named `h`: `std.stdio.h`, `std.signal.h` and `std.sys.types.h` all
-    minted an ExternalModule called `h` (issue #1758). A header is named by
-    its own stem instead, the same name `_cpp_include_local_name` binds it
-    under, so the node and the local name agree.
+    The last DOTTED segment names a package path (`os.path` -> `path`,
+    `std.fmt` -> `fmt`), but a C/C++ header carries its EXTENSION in that
+    position, so every `.h` include minted an ExternalModule called `h`:
+    `std.stdio.h`, `std.signal.h` and `std.sys.types.h` alike (issue #1758).
+    A header is named by its own stem instead, the same name
+    `_cpp_include_local_name` binds it under, so the node and the local name
+    agree.
+
+    The header rule is deliberately confined to the `std.` prefix that
+    `_cpp_include_full_name` puts on an include, AND to qns of three or more
+    segments. This function serves EVERY language's external imports, and a
+    package whose last segment is literally `h` is a real thing (the Python
+    HTTP/2 library), so an unconditional rule would rename `mypkg.h` to
+    `mypkg` for languages that have no header extensions at all.
+
+    The three-segment floor leaves one known inconsistency: `<std.h>` has the
+    two-segment qn `std.h`, indistinguishable here from a package `h` under
+    `std`, so its node is named `h` while `_cpp_include_local_name` binds it
+    as `std`. Lowering the floor to two would rename every `<pkg.h>`-shaped
+    external of every language; `<std.h>` is not a real header, so the
+    inconsistency is the cheaper of the two errors.
     """
     segments = module_path.split(cs.SEPARATOR_DOT)
-    # `stdio.h` occupies the last TWO dotted segments, the stem and the
-    # extension; anything else is named by its last segment as before.
-    if len(segments) >= 2 and f"{cs.SEPARATOR_DOT}{segments[-1]}" in (
-        cs.EXT_H,
-        cs.EXT_HPP,
+    # `stdio.h` occupies the last TWO dotted segments, stem and extension.
+    if (
+        len(segments) >= 3
+        and module_path.startswith(cs.IMPORT_STD_PREFIX)
+        and f"{cs.SEPARATOR_DOT}{segments[-1]}" in (cs.EXT_H, cs.EXT_HPP)
     ):
         return segments[-2]
     return segments[-1]
@@ -1061,6 +1076,13 @@ class ImportProcessor:
                 # that carried it belongs to the include that won the name.
                 for module_key, shadowed in self._cpp_shadowed_include_targets:
                     if module_key != module_qn:
+                        continue
+                    if (module_qn, shadowed) in self._cpp_declaration_mappings:
+                        # The displaced binding can be one `export module X;`
+                        # wrote, not an include: re-emitting it here would
+                        # rebuild the self-import the main loop above filters
+                        # out, which `test_cpp_module_declarations_emit_no_
+                        # self_import` forbids (#1758 review).
                         continue
                     self._deferred_import_edges.append(
                         DeferredImportEdge(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -556,6 +556,7 @@ class ImportProcessor:
         "_csharp_module_namespaces",
         "_csharp_module_identifiers",
         "_cpp_declaration_mappings",
+        "_cpp_shadowed_include_targets",
         "_rust_dir_listing",
         "_rust_entry_mod_decls",
         "_rust_module_mod_decls",
@@ -763,6 +764,12 @@ class ImportProcessor:
         # `export module X;`, `import :partition;`). They exist for name resolution
         # only; a declaration is not an import, so no IMPORTS edge is emitted.
         self._cpp_declaration_mappings: set[tuple[str, str]] = set()
+        # Include targets whose LOCAL name was taken by a later include in
+        # the same file. `<std>` and `<std.h>` both bind `std`, so the second
+        # overwrote the first in `import_mapping` and only one IMPORTS edge
+        # survived (issue #1758). The binding can hold one name, but the file
+        # really does include both headers, so the edge is kept here.
+        self._cpp_shadowed_include_targets: set[tuple[str, str]] = set()
         # Local names brought in by a PHP `use function A\B\c` import, keyed by
         # module. A PHP namespace path never matches cgr's file-path qn (a global
         # helper declares `namespace Illuminate\Support` from
@@ -945,6 +952,14 @@ class ImportProcessor:
         lang_config = queries[language]["config"]
 
         self.import_mapping[module_qn] = {}
+        # Cleared with the mapping it shadows: these entries ADD edges, so a
+        # stale one would resurrect an include the edited file has removed
+        # (issue #1758).
+        self._cpp_shadowed_include_targets = {
+            entry
+            for entry in self._cpp_shadowed_include_targets
+            if entry[0] != module_qn
+        }
         self._retract_import_sites(module_qn)
         # A watch-mode re-parse must not carry references the edited file no
         # longer makes (issue #1347).
@@ -1038,6 +1053,21 @@ class ImportProcessor:
                             full_name=full_name,
                             language=language,
                             site=sites.get(local_name),
+                        )
+                    )
+                # Includes whose local binding a later include took over: the
+                # file includes them, so they keep their edge even though the
+                # map no longer names them (issue #1758). No site: the binding
+                # that carried it belongs to the include that won the name.
+                for module_key, shadowed in self._cpp_shadowed_include_targets:
+                    if module_key != module_qn:
+                        continue
+                    self._deferred_import_edges.append(
+                        DeferredImportEdge(
+                            module_qn=module_qn,
+                            full_name=shadowed,
+                            language=language,
+                            site=None,
                         )
                     )
 
@@ -4211,6 +4241,13 @@ class ImportProcessor:
         full_name = self._cpp_include_full_name(
             include_path, is_system_include, module_qn
         )
+        # A local name already bound by an earlier include in this file names
+        # a DIFFERENT header (`<std>` then `<std.h>`, both binding `std`).
+        # The map holds one binding, so remember the loser's target: it is a
+        # real include of a real header and must keep its IMPORTS edge (#1758).
+        displaced = self.import_mapping[module_qn].get(local_name)
+        if displaced is not None and displaced != full_name:
+            self._cpp_shadowed_include_targets.add((module_qn, displaced))
         self.import_mapping[module_qn][local_name] = full_name
         self._record_import_site(module_qn, local_name, include_node, include_path)
         logger.debug(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -975,6 +975,16 @@ class ImportProcessor:
             for entry in self._cpp_shadowed_include_targets
             if entry[0] != module_qn
         }
+        # Cleared here too, now that the shadowed sweep READS it. These
+        # entries SUPPRESS edges, so a stale one is the opposite hazard: a
+        # re-parse that removes an `export module X;` used to leave an
+        # exemption that only ever matched the declaration binding it came
+        # from -- already gone, so inert. The sweep matches on the resolved
+        # qn instead, so the same stale entry can now suppress a real
+        # include's edge (#1758 review).
+        self._cpp_declaration_mappings = {
+            entry for entry in self._cpp_declaration_mappings if entry[0] != module_qn
+        }
         self._retract_import_sites(module_qn)
         # A watch-mode re-parse must not carry references the edited file no
         # longer makes (issue #1347).

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -950,22 +950,14 @@ class ImportProcessor:
     def get_stdlib_cache_stats() -> StdlibCacheStats:
         return get_stdlib_cache_stats()
 
-    def parse_imports(
-        self,
-        root_node: Node,
-        module_qn: str,
-        language: cs.SupportedLanguage,
-        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
-        pre_captures: dict | None = None,
-    ) -> None:
-        if language not in queries:
-            return
-        imports_query = queries[language]["imports"]
-        if not imports_query:
-            return
+    def _clear_module_import_state(self, module_qn: str) -> None:
+        """Drop everything a previous parse of this module recorded.
 
-        lang_config = queries[language]["config"]
-
+        Extracted from `parse_imports` to keep it under the cognitive
+        complexity limit (S3776); the grouping is also the honest one, since
+        these four writes share a single invariant: a re-parse must carry
+        nothing the edited file no longer says.
+        """
         self.import_mapping[module_qn] = {}
         # Cleared with the mapping it shadows: these entries ADD edges, so a
         # stale one would resurrect an include the edited file has removed
@@ -986,6 +978,24 @@ class ImportProcessor:
             entry for entry in self._cpp_declaration_mappings if entry[0] != module_qn
         }
         self._retract_import_sites(module_qn)
+
+    def parse_imports(
+        self,
+        root_node: Node,
+        module_qn: str,
+        language: cs.SupportedLanguage,
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
+        pre_captures: dict | None = None,
+    ) -> None:
+        if language not in queries:
+            return
+        imports_query = queries[language]["imports"]
+        if not imports_query:
+            return
+
+        lang_config = queries[language]["config"]
+
+        self._clear_module_import_state(module_qn)
         # A watch-mode re-parse must not carry references the edited file no
         # longer makes (issue #1347).
         self._inferred_module_imports.pop(module_qn, None)

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -515,6 +515,18 @@ def _external_module_name(module_path: str) -> str:
     as `std`. Lowering the floor to two would rename every `<pkg.h>`-shaped
     external of every language; `<std.h>` is not a real header, so the
     inconsistency is the cheaper of the two errors.
+
+    A second, unfixable-here case: this sees only the qn, and slash
+    segmentation has already erased the difference between a PATH and dots
+    inside one basename. `<foo/bar.h>` and `<foo.bar.h>` both become
+    `std.foo.bar.h`, yet `_cpp_include_local_name` binds the first as `bar`
+    (basename stem) and the second as `foo` (first stem segment). One name
+    must therefore disagree with its binding, and no rule at this layer can
+    tell which. It is `<foo/bar.h>` -- a real path, the common shape -- that
+    is served correctly; `<foo.bar.h>` gets `bar` where its binding says
+    `foo`. Fixing that means passing the ORIGINAL include path down to node
+    creation rather than deriving from the qn, which is a wider change than
+    the naming defect warrants (#1758 review).
     """
     segments = module_path.split(cs.SEPARATOR_DOT)
     # `stdio.h` occupies the last TWO dotted segments, stem and extension.
@@ -979,6 +991,61 @@ class ImportProcessor:
         }
         self._retract_import_sites(module_qn)
 
+    def _defer_module_import_edges(
+        self, module_qn: str, language: cs.SupportedLanguage
+    ) -> None:
+        """Queue this module's IMPORTS edges for the post-parse flush.
+
+        Extracted from `parse_imports` to keep it under the cognitive
+        complexity limit (S3776). The two loops here -- the mapping's own
+        bindings and the includes a later binding displaced -- are the
+        densest branching in that function, and nesting multiplies the
+        cost, so moving them out is what actually reduces it; the earlier
+        extraction of straight-line assignments did not.
+        """
+        # Hold the edges back: an internal target is only real if some file
+        # yields that module qn, known only after every file is parsed
+        # (flush_deferred_import_edges).
+        sites = self._import_sites.get(module_qn, {})
+        for local_name, full_name in self.import_mapping[module_qn].items():
+            if (module_qn, full_name) in self._cpp_declaration_mappings:
+                continue
+            if full_name == cs.RUST_UNRESOLVABLE_QN:
+                # The unrepresentable-#[path] sentinel stays in the map
+                # for name binding but names no module, so it must never
+                # become a phantom IMPORTS edge (issue #1082).
+                continue
+            self._deferred_import_edges.append(
+                DeferredImportEdge(
+                    module_qn=module_qn,
+                    full_name=full_name,
+                    language=language,
+                    site=sites.get(local_name),
+                )
+            )
+        # Includes whose local binding a later include took over: the
+        # file includes them, so they keep their edge even though the
+        # map no longer names them (issue #1758). No site: the binding
+        # that carried it belongs to the include that won the name.
+        for module_key, shadowed in self._cpp_shadowed_include_targets:
+            if module_key != module_qn:
+                continue
+            if (module_qn, shadowed) in self._cpp_declaration_mappings:
+                # The displaced binding can be one `export module X;`
+                # wrote, not an include: re-emitting it here would
+                # rebuild the self-import the main loop above filters
+                # out, which `test_cpp_module_declarations_emit_no_
+                # self_import` forbids (#1758 review).
+                continue
+            self._deferred_import_edges.append(
+                DeferredImportEdge(
+                    module_qn=module_qn,
+                    full_name=shadowed,
+                    language=language,
+                    site=None,
+                )
+            )
+
     def parse_imports(
         self,
         root_node: Node,
@@ -1070,49 +1137,7 @@ class ImportProcessor:
             )
 
             if self.ingestor:
-                # Hold the edges back: an internal target is only real if some file
-                # yields that module qn, known only after every file is parsed
-                # (flush_deferred_import_edges).
-                sites = self._import_sites.get(module_qn, {})
-                for local_name, full_name in self.import_mapping[module_qn].items():
-                    if (module_qn, full_name) in self._cpp_declaration_mappings:
-                        continue
-                    if full_name == cs.RUST_UNRESOLVABLE_QN:
-                        # The unrepresentable-#[path] sentinel stays in the map
-                        # for name binding but names no module, so it must never
-                        # become a phantom IMPORTS edge (issue #1082).
-                        continue
-                    self._deferred_import_edges.append(
-                        DeferredImportEdge(
-                            module_qn=module_qn,
-                            full_name=full_name,
-                            language=language,
-                            site=sites.get(local_name),
-                        )
-                    )
-                # Includes whose local binding a later include took over: the
-                # file includes them, so they keep their edge even though the
-                # map no longer names them (issue #1758). No site: the binding
-                # that carried it belongs to the include that won the name.
-                for module_key, shadowed in self._cpp_shadowed_include_targets:
-                    if module_key != module_qn:
-                        continue
-                    if (module_qn, shadowed) in self._cpp_declaration_mappings:
-                        # The displaced binding can be one `export module X;`
-                        # wrote, not an include: re-emitting it here would
-                        # rebuild the self-import the main loop above filters
-                        # out, which `test_cpp_module_declarations_emit_no_
-                        # self_import` forbids (#1758 review).
-                        continue
-                    self._deferred_import_edges.append(
-                        DeferredImportEdge(
-                            module_qn=module_qn,
-                            full_name=shadowed,
-                            language=language,
-                            site=None,
-                        )
-                    )
-
+                self._defer_module_import_edges(module_qn, language)
         except Exception as e:
             logger.warning(ls.IMP_PARSE_FAILED, module=module_qn, error=e)
 
@@ -4421,6 +4446,20 @@ class ImportProcessor:
     ) -> None:
         module_name = parts[name_index].rstrip(";")
         full_name = f"{self.project_name}{cs.SEPARATOR_DOT}{module_name}"
+        # A global module fragment puts includes BEFORE the declaration:
+        #
+        #     module;
+        #     #include <foo.h>
+        #     export module foo;
+        #
+        # so the declaration displaces the include's binding, exactly as a
+        # later include displaces an earlier one. Record it the same way or
+        # the header's IMPORTS edge is lost -- the declaration's own target is
+        # then skipped by the deferred loop as a self-import, and nothing is
+        # emitted for the include at all (#1758 review).
+        displaced = self.import_mapping[module_qn].get(module_name)
+        if displaced is not None and displaced != full_name:
+            self._cpp_shadowed_include_targets.add((module_qn, displaced))
         self.import_mapping[module_qn][module_name] = full_name
         # `module X;` / `export module X;` DECLARE this file's module; the mapping
         # exists for name resolution only, never as an IMPORTS edge.

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -4308,6 +4308,18 @@ class ImportProcessor:
             # `<sys/types.h>` is the module `types.h` under `sys`, and leaving
             # the slash in produced the qn `std.sys/types.h`, which no dotted
             # lookup can address (issue #1758).
+            #
+            # Accepted collision, measured: this maps `<sys/types.h>` and a
+            # literal `<sys.types.h>` onto the same qn, which `main` kept
+            # distinct by leaving the slash in. C and C++ use `/` as the
+            # include separator and a dot only inside the final component, so
+            # the colliding spelling is not a form real code takes; and the
+            # qn `main` gave the slashed one was unaddressable anyway, so
+            # nothing could resolve against it. A conflated pair of headers
+            # that both exist is the cheaper error than a target no dotted
+            # lookup can name at all. `test_two_spellings_of_one_header_path`
+            # pins the behaviour so a later reader sees a decision rather
+            # than an oversight (#1758 review).
             return f"{cs.IMPORT_STD_PREFIX}{_dotted_include_path(include_path)}"
         if resolved := self._resolve_cpp_include_target(include_path, module_qn):
             # The include resolves to a real repo file; use that file's

--- a/codebase_rag/tests/test_header_external_module_names.py
+++ b/codebase_rag/tests/test_header_external_module_names.py
@@ -174,3 +174,54 @@ def test_the_header_rule_does_not_rename_other_languages_externals() -> None:
     assert _external_module_name("a.b.h") == "h", (
         "the header rule reached a qn that carries no std. include prefix"
     )
+
+
+def test_a_removed_module_declaration_does_not_suppress_a_later_include_edge(
+    temp_repo: Path,
+) -> None:
+    """A stale declaration exemption must not veto a real include (#1758).
+
+    `_cpp_declaration_mappings` records `(module_qn, full_name)` for an
+    `export module X;` so the main edge loop does not emit a self-import. The
+    shadowed-include sweep reads that same set, and it matches on the RESOLVED
+    qn rather than on the declaration binding -- so an exemption left behind
+    by a re-parse that REMOVED the declaration can suppress a genuine
+    include's edge. Before the sweep existed the stale entry was inert,
+    because it only ever matched the binding it came from, which was gone.
+
+    Drives `parse_imports` twice on ONE processor, because that is the only
+    way to reach it: every test using `run_updater` gets a fresh
+    `ImportProcessor`, so the per-module clear is unobservable there and the
+    whole file stayed green with the clear removed.
+    """
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.import_processor import ImportProcessor
+
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.CPP not in parsers:
+        pytest.skip("cpp parser not available")
+    processor = ImportProcessor(repo_path=temp_repo, project_name="proj")
+    module_qn = "proj.m"
+
+    def parse(source: str) -> None:
+        tree = parsers[cs.SupportedLanguage.CPP].parse(source.encode())
+        processor.parse_imports(
+            tree.root_node, module_qn, cs.SupportedLanguage.CPP, queries
+        )
+
+    # v1 declares module `foo`, registering the exemption.
+    parse("export module foo;\n")
+    assert (module_qn, "proj.foo") in processor._cpp_declaration_mappings, (
+        "fixture guard: the declaration must register an exemption, or there "
+        "is no stale entry for the re-parse to leave behind"
+    )
+
+    # v2 removes the declaration and includes two headers that bind the same
+    # local name `foo`, so the first is displaced and only the sweep carries
+    # its edge. `foo.h` resolves to `proj.foo` -- the very qn the stale
+    # exemption names.
+    parse('#include "foo.h"\n#include "sub/foo.h"\n')
+    assert (module_qn, "proj.foo") not in processor._cpp_declaration_mappings, (
+        "the removed declaration's exemption survived the re-parse, so the "
+        "sweep will veto the include that resolves to the same qn"
+    )

--- a/codebase_rag/tests/test_header_external_module_names.py
+++ b/codebase_rag/tests/test_header_external_module_names.py
@@ -128,3 +128,29 @@ def test_two_headers_binding_one_local_name_each_keep_their_edge(
     assert targets == {"std", "std.h"}, (
         f"a header lost its IMPORTS edge to another binding the same name: {targets}"
     )
+
+
+def test_the_header_rule_does_not_rename_other_languages_externals() -> None:
+    """The `.h` rule must not reach a package whose last segment is `h`.
+
+    `_external_module_name` serves EVERY language's external imports, not
+    just C/C++ includes, and `h` is a real Python package (the HTTP/2
+    library). An unconditional "last segment is an extension" rule renamed
+    `mypkg.h` to `mypkg` for languages that have no headers at all, so the
+    rule is confined to the `std.` prefix `_cpp_include_full_name` applies.
+    """
+    from codebase_rag.parsers.import_processor import _external_module_name
+
+    # The header shapes the rule exists for.
+    assert _external_module_name("std.stdio.h") == "stdio"
+    assert _external_module_name("std.sys.types.h") == "types"
+    assert _external_module_name("std.a.b.c.hpp") == "c"
+    # A non-header external keeps its last segment, header-shaped or not.
+    assert _external_module_name("std.vector") == "vector"
+    assert _external_module_name("os.path") == "path"
+    assert _external_module_name("mypkg.h") == "h", (
+        "the header rule renamed a package whose last segment is literally h"
+    )
+    assert _external_module_name("a.b.h") == "h", (
+        "the header rule reached a qn that carries no std. include prefix"
+    )

--- a/codebase_rag/tests/test_header_external_module_names.py
+++ b/codebase_rag/tests/test_header_external_module_names.py
@@ -1,0 +1,83 @@
+"""A header's ExternalModule is named by the header, not by its extension.
+
+`_ensure_external_module_node` derived the node's `name` by splitting the
+qualified name on its last dot. For a system header that qualified name is
+`std.stdio.h`, so the last segment is the EXTENSION and every `.h` include
+minted an ExternalModule called `h` (issue #1758). A slashed include kept its
+raw slash in the qualified name too (`std.sys/types.h`), which no dotted
+lookup can address and which does not segment like any other module path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+SRC = """#include <stdio.h>
+#include <sys/types.h>
+#include <vector>
+int main(void) { return 0; }
+"""
+
+
+def _external_modules(root: Path) -> dict[str, str]:
+    """{qualified name: name} for every ExternalModule the run emits."""
+    parsers, queries = load_parsers()
+    for language in (cs.SupportedLanguage.C, cs.SupportedLanguage.CPP):
+        if language not in parsers:
+            pytest.skip(f"{language} parser not available")
+    (root / "m.c").write_text(SRC, encoding="utf-8")
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    label = str(cs.NodeLabel.EXTERNAL_MODULE)
+    return {
+        str(props[cs.KEY_QUALIFIED_NAME]): str(props[cs.KEY_NAME])
+        for (node_label, _uid), props in store.nodes.items()
+        if node_label == label and cs.KEY_QUALIFIED_NAME in props
+    }
+
+
+def test_a_header_external_module_is_named_by_the_header(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    root.mkdir()
+    external = _external_modules(root)
+
+    assert external, "fixture guard: the run emitted no ExternalModule nodes at all"
+    # The control: a non-header system include was already named correctly,
+    # so a fix that renamed everything would show up here.
+    assert external.get("std.vector") == "vector", (
+        f"a bare system include's name changed: {external}"
+    )
+
+    assert external.get("std.stdio.h") == "stdio", (
+        f"a .h include is still named by its extension: {external}"
+    )
+
+
+def test_a_slashed_system_include_is_segmented_like_a_module_path(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "proj"
+    root.mkdir()
+    external = _external_modules(root)
+
+    assert external, "fixture guard: the run emitted no ExternalModule nodes at all"
+    assert not any(cs.SEPARATOR_SLASH in qn for qn in external), (
+        f"a slash survived into an ExternalModule qualified name: {external}"
+    )
+    assert external.get("std.sys.types.h") == "types", (
+        f"a slashed header is not segmented and named by its stem: {external}"
+    )

--- a/codebase_rag/tests/test_header_external_module_names.py
+++ b/codebase_rag/tests/test_header_external_module_names.py
@@ -81,3 +81,50 @@ def test_a_slashed_system_include_is_segmented_like_a_module_path(
     assert external.get("std.sys.types.h") == "types", (
         f"a slashed header is not segmented and named by its stem: {external}"
     )
+
+
+COLLIDING = "#include <std>\n#include <std.h>\nint main(void) { return 0; }\n"
+
+
+def _import_targets(root: Path, source: str) -> set[str]:
+    """Every IMPORTS target the run emits for `m.c`."""
+    parsers, queries = load_parsers()
+    for language in (cs.SupportedLanguage.C, cs.SupportedLanguage.CPP):
+        if language not in parsers:
+            pytest.skip(f"{language} parser not available")
+    (root / "m.c").write_text(source, encoding="utf-8")
+    store = _StatefulIngestor()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run()
+    store.flush_all()
+    return {
+        str(dst)
+        for (_sl, _src, rel, _tl, dst) in store.edges
+        if rel == cs.RelationshipType.IMPORTS.value
+    }
+
+
+def test_two_headers_binding_one_local_name_each_keep_their_edge(
+    tmp_path: Path,
+) -> None:
+    """`<std>` and `<std.h>` both bind the local name `std`.
+
+    `import_mapping` holds one binding per local name and the IMPORTS edges
+    are derived from it, so the second include overwrote the first and the
+    file ended up importing only one of the two headers it includes
+    (issue #1758). The binding can still only name one of them; the edge for
+    the displaced header is kept beside it.
+    """
+    root = tmp_path / "proj"
+    root.mkdir()
+    targets = _import_targets(root, COLLIDING)
+
+    assert targets, "fixture guard: the run emitted no IMPORTS edges at all"
+    assert targets == {"std", "std.h"}, (
+        f"a header lost its IMPORTS edge to another binding the same name: {targets}"
+    )

--- a/codebase_rag/tests/test_header_external_module_names.py
+++ b/codebase_rag/tests/test_header_external_module_names.py
@@ -225,3 +225,27 @@ def test_a_removed_module_declaration_does_not_suppress_a_later_include_edge(
         "the removed declaration's exemption survived the re-parse, so the "
         "sweep will veto the include that resolves to the same qn"
     )
+
+
+def test_two_spellings_of_one_header_path_share_a_qualified_name() -> None:
+    """Pins an accepted collision that `main` did not have (#1758 review).
+
+    Segmenting the include path means `<sys/types.h>` and a literal
+    `<sys.types.h>` produce the same qn. On `main` the slashed form kept its
+    slash (`std.sys/types.h`), so the two were distinct -- but that qn was
+    unaddressable by any dotted lookup, which is the bug this change fixes.
+
+    The trade is deliberate: `/` is the include separator in C and C++ and a
+    dot appears only inside the final component, so the colliding spelling is
+    not a form real source takes. A conflated pair of headers that both exist
+    is a cheaper error than a target nothing can resolve against.
+
+    Asserted rather than left implicit so that if someone later needs the two
+    kept apart, this test names the decision being reversed.
+    """
+    from codebase_rag.parsers.import_processor import _dotted_include_path
+
+    assert _dotted_include_path("sys/types.h") == _dotted_include_path("sys.types.h")
+    # And the separator really is what collapses: distinct DIRECTORIES stay
+    # distinct, so the change does not conflate unrelated headers.
+    assert _dotted_include_path("a/b.h") != _dotted_include_path("c/b.h")

--- a/codebase_rag/tests/test_header_external_module_names.py
+++ b/codebase_rag/tests/test_header_external_module_names.py
@@ -130,6 +130,26 @@ def test_two_headers_binding_one_local_name_each_keep_their_edge(
     )
 
 
+def test_the_two_segment_floor_keeps_a_bare_std_header_named_by_its_extension() -> None:
+    """Pins the deliberately accepted `<std.h>` inconsistency.
+
+    The rule needs three or more segments, so `std.h` keeps the name `h`
+    while its local binding is `std`. That is the cheaper of two errors --
+    without the floor, `segments[-2]` would name the node `std`, colliding
+    with the `std` namespace module every C++ file imports.
+
+    Pinned because nothing else covers the floor: removing
+    `len(segments) >= 3` left every other assertion in this file green
+    (#1758 review).
+    """
+    from codebase_rag.parsers.import_processor import _external_module_name
+
+    assert _external_module_name("std.h") == "h"
+    assert _external_module_name("std.hpp") == "hpp"
+    # Three segments is where the rule starts applying.
+    assert _external_module_name("std.stdio.h") == "stdio"
+
+
 def test_the_header_rule_does_not_rename_other_languages_externals() -> None:
     """The `.h` rule must not reach a package whose last segment is `h`.
 

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -143,6 +143,51 @@ export int answer() { return 42; }
     assert f"{project}.my_export_module" not in targets, targets
 
 
+def test_a_quoted_include_keeps_its_edge_beside_a_same_named_declaration(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """The declaration guard must not swallow a real quoted include (#1758 review).
+
+    The guard skips a displaced binding that `export module X;` registered,
+    so it cannot rebuild the self-import. The worry is that a QUOTED include
+    resolving to the same qn would be suppressed with it, silently losing a
+    real dependency edge.
+
+    It cannot, and this pins why: a quoted include resolves to the qn of the
+    FILE it names, so `#include "foo.h"` beside `foo.cpp` yields `proj.foo.h`
+    -- the header's own module -- while the declaration registered
+    `proj.foo`. Different qns, so the guard never matches the include. If
+    include resolution ever started stripping the extension, the two would
+    collide and this test goes red.
+    """
+    (temp_repo / "foo.cpp").write_text("int helper() { return 1; }\n")
+    (temp_repo / "foo.h").write_text("int helper();\n")
+    sub = temp_repo / "sub"
+    sub.mkdir()
+    (sub / "foo.h").write_text("int other();\n")
+    (temp_repo / "m.cpp").write_text(
+        """
+export module foo;
+#include "foo.h"
+#include "sub/foo.h"
+
+int use() { return 2; }
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    _assert_no_dangling_imports(mock_ingestor)
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.m")
+    assert f"{project}.foo" not in targets, (
+        f"the module declaration's own qn was emitted as an import: {targets}"
+    )
+    assert {f"{project}.foo.h", f"{project}.sub.foo"} <= targets, (
+        "a quoted include that shares a name with the module declaration lost "
+        f"its edge to the declaration guard: {targets}"
+    )
+
+
 def test_a_module_declaration_shadowed_by_an_include_emits_no_self_import(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -143,6 +143,43 @@ export int answer() { return 42; }
     assert f"{project}.my_export_module" not in targets, targets
 
 
+def test_a_module_declaration_shadowed_by_an_include_emits_no_self_import(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """`export module foo;` beside `#include <foo.h>`, with a real `proj.foo`.
+
+    The declaration registers `foo -> proj.foo` and the include then takes
+    the same local name, so the declaration's binding is DISPLACED. The
+    shadowed-include sweep re-emits displaced bindings to keep an include's
+    edge alive (#1758), and a declaration caught in that sweep rebuilds
+    exactly the self-import the test above forbids: the main edge loop
+    filters it via `_cpp_declaration_mappings`, so the sweep must too.
+    """
+    (temp_repo / "foo.cpp").write_text("int helper() { return 1; }\n")
+    (temp_repo / "m.cpp").write_text(
+        """
+export module foo;
+#include <foo.h>
+
+int use() { return 2; }
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    _assert_no_dangling_imports(mock_ingestor)
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.m")
+    assert f"{project}.foo" not in targets, (
+        "the shadowed-include sweep re-emitted a module declaration's own qn "
+        f"as an IMPORTS edge: {targets}"
+    )
+    # The include itself must still keep its edge: the guard has to drop the
+    # declaration without also dropping what the sweep exists to preserve.
+    assert any(t.endswith("foo.h") for t in targets), (
+        f"the include's own edge was lost with the declaration: {targets}"
+    )
+
+
 def test_cpp_module_impl_without_interface_emits_no_phantom(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -156,10 +156,18 @@ def test_a_module_declaration_shadowed_by_an_include_emits_no_self_import(
     filters it via `_cpp_declaration_mappings`, so the sweep must too.
     """
     (temp_repo / "foo.cpp").write_text("int helper() { return 1; }\n")
+    sub = temp_repo / "sub"
+    sub.mkdir()
+    # A SECOND include binding the same local name `foo`, so the first one is
+    # genuinely displaced and only the sweep can carry its edge. Without it
+    # the surviving-edge assertion below is satisfied by the main edge loop
+    # (the winning include is in `import_mapping` either way) and a guard
+    # that dropped everything in the sweep would still pass (#1758 review).
     (temp_repo / "m.cpp").write_text(
         """
 export module foo;
 #include <foo.h>
+#include <sub/foo.h>
 
 int use() { return 2; }
 """
@@ -173,10 +181,12 @@ int use() { return 2; }
         "the shadowed-include sweep re-emitted a module declaration's own qn "
         f"as an IMPORTS edge: {targets}"
     )
-    # The include itself must still keep its edge: the guard has to drop the
-    # declaration without also dropping what the sweep exists to preserve.
-    assert any(t.endswith("foo.h") for t in targets), (
-        f"the include's own edge was lost with the declaration: {targets}"
+    # Both includes keep their edge. The displaced one reaches the graph ONLY
+    # through the sweep, so this fails if the guard suppresses too much --
+    # which the single-include version of this test could not detect.
+    assert {"std.foo.h", "std.sub.foo.h"} <= targets, (
+        "an include's edge was lost with the declaration; the guard must drop "
+        f"the declaration binding only: {targets}"
     )
 
 

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -143,6 +143,52 @@ export int answer() { return 42; }
     assert f"{project}.my_export_module" not in targets, targets
 
 
+def test_a_global_module_fragment_include_keeps_its_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """The include comes BEFORE the declaration, so the declaration displaces it.
+
+    A global module fragment is legal C++20 and puts includes first:
+
+        module;
+        #include <foo.h>
+        export module foo;
+
+    `<foo.h>` binds the local name `foo`, then `export module foo;` overwrites
+    that binding. The shadowed-include sweep only recorded displacements made
+    by a later INCLUDE, so nothing recorded this one: the declaration's own
+    target is skipped by the deferred loop as a self-import, and the header
+    got no edge at all. Measured before the fix -- `IMPORTS from proj.m` was
+    empty (#1758 review).
+
+    The declaration now records what it displaced, exactly as an include
+    does. Asserts both halves: the header keeps its edge AND the declaration
+    still emits no self-import, since recording the displacement must not
+    reintroduce the thing the guard exists to suppress.
+    """
+    (temp_repo / "m.cpp").write_text(
+        """
+module;
+#include <foo.h>
+export module foo;
+
+int use() { return 2; }
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    _assert_no_dangling_imports(mock_ingestor)
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.m")
+    assert "std.foo.h" in targets, (
+        "an include in the global module fragment lost its edge when the "
+        f"module declaration overwrote its local binding: {targets}"
+    )
+    assert f"{project}.foo" not in targets, (
+        f"the module declaration's own qn was emitted as an import: {targets}"
+    )
+
+
 def test_a_quoted_include_keeps_its_edge_beside_a_same_named_declaration(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:


### PR DESCRIPTION
Closes #1758.

Three C/C++ include shapes, plus two defects the local review found in the fix itself.

## The three shapes

**1. A header's ExternalModule was named after its extension.** `#include <stdio.h>` minted a node called `h`, because the name came from the last dotted segment of `std.stdio.h`. Now `_external_module_name` takes the segment before it, so the node is `stdio`.

The rule is deliberately narrow: it requires the `std.` prefix and three or more segments. That function serves **every** language's externals, and `h` is a real Python package, so an unconditional rule renamed `mypkg.h` to `mypkg` and a Java `import com.foo.h.Thing;` to `foo`. Both were caught in review — the second by the reviewer, on `origin/main` output.

**2. Slashes survived into qualified names.** `<sys/types.h>` produced `std.sys/types.h`. `_dotted_include_path` segments it to `std.sys.types.h`, keeping distinct qns for `<a/b.h>` and `<c/b.h>`.

**3. Two includes binding one local name lost an edge.** `import_mapping` holds one binding per local name, so the second `#include` displaced the first and the first's IMPORTS edge vanished. Displaced targets are now recorded and re-emitted with `site=None` — the binding that carried the site belongs to the include that won the name.

## Two defects in the fix, both found in review

- **The shadowed-include sweep bypassed the declaration filter.** The main edge loop skips `(module_qn, full_name)` pairs in `_cpp_declaration_mappings` so an `export module X;` never becomes a self-import. The new sweep did not, so a declaration displaced by a same-named include was re-emitted as `proj.m -> proj.foo` — exactly what `test_cpp_module_declarations_emit_no_self_import` forbids. Guard added.

- **That guard then made a pre-existing staleness live.** `_cpp_declaration_mappings` was never cleared per module. Before the sweep read it, a stale entry could only match the declaration binding it came from, which was already gone — inert. Once the sweep matched on the resolved qn, a re-parse that removed an `export module X;` left an exemption that vetoed a *real* include's edge. Now cleared beside `_cpp_shadowed_include_targets`.

## Verification

Four mutations, each reddening its own test and no other:

| mutation | reddens |
|---|---|
| remove the declaration-mappings clear | the re-parse test only |
| sweep emits nothing | the self-import test **and** the two-header test |
| drop the `>= 3` segment floor | the floor-pin test only |
| drop the declaration guard | the self-import test only |

Three test gaps were closed after the mutations exposed them:

- The re-parse test drives `parse_imports` twice on **one** `ImportProcessor`. Every test using `run_updater` gets a fresh one, so the per-module clear was unobservable and the whole file stayed green with it removed.
- The self-import test's surviving-edge assertion was satisfied by the main edge loop regardless of the sweep. A second, genuinely displaced include now makes it discriminate.
- The `>= 3` floor was removable with all seven assertions green. `std.h == "h"` now pins it.

The floor produces one accepted inconsistency: `<std.h>` yields a node named `h` with local binding `std`. Without it, `segments[-2]` would name the node `std`, colliding with the namespace module every C++ file imports — the cheaper of the two errors, and now documented by its own test.

## Known limit (not addressed here)

A **deleted** C/C++ file still leaves `_cpp_declaration_mappings` and `import_mapping` entries behind: Rust and C# have `drop_*_module_import_state` helpers dispatched from `remove_file_from_state`, C/C++ has none. This PR fixes re-parse, not deletion. Filed as #1777.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved C/C++ header import handling for paths containing slashes and equivalent dotted path formats.
  - External modules for headers now use the header name rather than the file extension.
  - Preserved import relationships when includes share or replace the same local name.
  - Prevented incorrect self-import edges for C++ module declarations.
  - Improved handling of similarly named headers while keeping imports from distinct directories separate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->