### PR TITLE
fix: reingest prunes the seeded module-qn map, with its own re-parsed paths (#1712)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2324,7 +2324,9 @@ class GraphUpdater:
                 continue
             module_map.setdefault(qn, self.repo_path / path)
 
-    def _prune_stale_seeded_module_qns(self) -> None:
+    def _prune_stale_seeded_module_qns(
+        self, exempt_paths: set[Path] | None = None
+    ) -> None:
         """Drop map entries for modules the graph no longer holds.
 
         `_seed_module_qns_from_graph` only ever adds, so on a reused updater
@@ -2343,11 +2345,17 @@ class GraphUpdater:
         different path sets, the second covering only the gone files, so a
         prune running inside it would delete what the first call seeded.
 
-        `reingest` therefore never prunes, since it does not go through
-        `run()`: a retained updater that indexes once and then only makes
-        scoped re-ingest calls (the MCP server's `_live_updater`) still
-        accumulates. That is the same class of bug in a path this fix does
-        not reach, not something it closes.
+        `reingest` calls this too (issue #1712), passing the paths IT
+        re-parsed as `exempt_paths`. It cannot use the default: the exemption
+        means "parsed by this operation, so the Module node may be
+        unflushed", and `_parsed_files` only carries that meaning on `run()`,
+        which clears it per run. `reingest` never clears it -- deliberately,
+        because `_hydrate_for_reingest` reads it as a LIVENESS PROXY
+        (non-empty means "this updater already has live state, skip the
+        rehydration read"). So on a retained updater the default would exempt
+        every file parsed since the process started, and the map would never
+        shrink -- the accumulation #1712 is about, in a fix that looks
+        correct and does nothing from the second call onwards.
         """
         if not isinstance(self.ingestor, QueryProtocol):
             return
@@ -2373,7 +2381,11 @@ class GraphUpdater:
         if not in_graph:
             logger.warning(ls.SEED_PRUNE_NO_VERDICT)
             return
-        parsed_this_run = {path for path, _lang in self._parsed_files}
+        parsed_this_run = (
+            exempt_paths
+            if exempt_paths is not None
+            else {path for path, _lang in self._parsed_files}
+        )
         for qn in [qn for qn in module_map if qn not in in_graph]:
             # A file this run parsed writes its own entry and its Module node
             # may still be unflushed, so the read above cannot see it.
@@ -4782,6 +4794,14 @@ class GraphUpdater:
         )
         self._reingest_delete(reparse, gone, hashes)
         parsed = self._reingest_reparse(reparse, gone)
+        # After BOTH seed calls and after the re-parse, so a re-parsed file's
+        # own entry is exempt while its Module node is still unflushed
+        # (issue #1712). The exemption is the paths THIS call re-parsed, not
+        # `_parsed_files`: that field accumulates here on purpose, since
+        # `_hydrate_for_reingest` reads it as a liveness proxy, so the default
+        # would exempt everything the process has ever parsed and the map
+        # would never shrink on the retained updater this fix exists for.
+        self._prune_stale_seeded_module_qns(set(reparse.values()))
         self._reingest_resolve(reparse, captured)
         self._reingest_update_hashes(cache_path, hashes, reparse, parsed, gone)
 

--- a/codebase_rag/tests/test_reingest_prunes_seeded_module_qns.py
+++ b/codebase_rag/tests/test_reingest_prunes_seeded_module_qns.py
@@ -1,0 +1,234 @@
+"""`reingest` must prune the seeded module-qn map, like `run()` does (#1712).
+
+`_prune_stale_seeded_module_qns` was reachable only from `run()`. An MCP
+session that indexes once and then only makes scoped re-ingest calls holds a
+retained updater that never re-enters `run()`, so a qn whose Module another
+writer deleted stayed in `module_qn_to_file_path` with a real path -- still
+offered by `known_module_paths()`, and still winning the Rust sub-scope
+ownership arbitration against the file that legitimately owns the scope.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+class BufferingIngestor:
+    """A sink whose reads see only FLUSHED writes, as production does.
+
+    The test needs this rather than the suite's write-through fake. The
+    prune exempts a file this operation re-parsed precisely because its
+    Module node may not be flushed yet, so a sink that makes a just-written
+    node instantly readable means the exemption never has to do anything --
+    the very case it exists for is invisible, and a prune that ignored the
+    exemption entirely would pass.
+    """
+
+    def __init__(self) -> None:
+        self.flushed: dict[str, str] = {}  # qn -> path
+        self.pending: dict[str, str] = {}
+        self.writes: list[tuple[str, dict[str, Any]]] = []
+
+    # -- the QueryProtocol surface the prune uses -------------------------
+    def fetch_all(self, query: str, params: dict | None = None) -> list[dict]:
+        if "MATCH (m:Module)" in query:
+            return [
+                {cs.KEY_QUALIFIED_NAME: qn, cs.KEY_PATH: p}
+                for qn, p in self.flushed.items()
+            ]
+        return []
+
+    def execute_write(self, query: str, params: dict | None = None) -> None:
+        # Declared explicitly, not via __getattr__: `QueryProtocol` is a
+        # runtime-checkable Protocol and `isinstance` inspects the CLASS, so a
+        # method supplied by __getattr__ does not satisfy it. Without this the
+        # prune's `isinstance(self.ingestor, QueryProtocol)` guard returns
+        # early and the whole fix appears not to work.
+        return None
+
+    def ensure_node_batch(self, label: Any, props: dict[str, Any]) -> None:
+        self.writes.append((str(label), props))
+        if str(label).endswith("MODULE") or str(label) == "Module":
+            qn = props.get("qualified_name")
+            if isinstance(qn, str):
+                self.pending[qn] = str(props.get("path", ""))
+
+    def flush_all(self) -> None:
+        self.flushed.update(self.pending)
+        self.pending.clear()
+
+    def __getattr__(self, name: str) -> Any:  # every other sink call is a no-op
+        def _noop(*_a: Any, **_k: Any) -> None:
+            return None
+
+        return _noop
+
+
+def test_the_fake_satisfies_the_protocol_the_prune_gates_on() -> None:
+    """`_prune_stale_seeded_module_qns` returns early unless this holds.
+
+    `QueryProtocol` is runtime-checkable, so `isinstance` inspects the CLASS:
+    a method supplied by `__getattr__` does not satisfy it. A fake missing
+    `execute_write` makes the prune a silent no-op and every assertion below
+    fails for a reason that has nothing to do with the fix -- measured, and
+    it cost a full mutation matrix before it was found.
+    """
+    from codebase_rag.services import QueryProtocol
+
+    assert isinstance(BufferingIngestor(), QueryProtocol), (
+        "the fake does not satisfy QueryProtocol, so the prune's isinstance "
+        "guard returns early and nothing under test ever runs"
+    )
+
+
+def test_the_buffering_fake_actually_buffers() -> None:
+    """Validate the instrument before trusting a result that depends on it.
+
+    If `fetch_all` saw pending writes, this fake would be write-through and
+    every assertion below about the exemption would pass for free.
+    """
+    ing = BufferingIngestor()
+    ing.ensure_node_batch(
+        cs.NodeLabel.MODULE, {"qualified_name": "p.m", "path": "m.py"}
+    )
+    assert ing.fetch_all("MATCH (m:Module) RETURN m.path AS path") == [], (
+        "the fake is write-through: a pending module is visible before flush, "
+        "so the unflushed case this suite tests cannot occur"
+    )
+    ing.flush_all()
+    assert [r[cs.KEY_QUALIFIED_NAME] for r in ing.fetch_all("MATCH (m:Module) x")] == [
+        "p.m"
+    ], "flush_all did not move pending writes into the readable set"
+
+
+def _updater(repo: Path, ingestor: BufferingIngestor) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=ingestor,  # type: ignore[arg-type]
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "a.py").write_text("def a():\n    pass\n", encoding="utf-8")
+    (root / "b.py").write_text("def b():\n    pass\n", encoding="utf-8")
+    return root
+
+
+def test_reingest_drops_a_qn_whose_module_another_writer_deleted(repo: Path) -> None:
+    """The defect: a retained updater never re-enters `run()`, so never prunes.
+
+    A second writer (another updater, a delete_project then re-index, a run in
+    another clone) removes a Module from the graph. The qn stays in this
+    updater's seeded map with a REAL path, so `known_module_paths()` keeps
+    offering it.
+    """
+    ing = BufferingIngestor()
+    updater = _updater(repo, ing)
+    updater.run()
+    ing.flush_all()
+
+    dp = updater.factory.definition_processor
+    victim = next(qn for qn in dp.module_qn_to_file_path if qn.endswith(".b"))
+    assert victim in dp.module_qn_to_file_path, "fixture guard: b must be mapped"
+
+    # Another writer deletes b's Module from the graph. The map still holds it.
+    del ing.flushed[victim]
+
+    updater.reingest(["a.py"])
+
+    assert victim not in dp.module_qn_to_file_path, (
+        "a scoped reingest left a qn in the seeded map whose Module the graph "
+        "no longer holds, so known_module_paths() keeps offering it with a "
+        "real path"
+    )
+
+
+def test_a_file_this_reingest_reparsed_survives_its_own_unflushed_write(
+    repo: Path,
+) -> None:
+    """The exemption, and why the fake must buffer.
+
+    A re-parsed file writes its own map entry, and its Module node may still
+    be unflushed when the prune reads. Dropping it would delete the entry the
+    operation just created. With a write-through sink the module is instantly
+    readable and this case cannot arise -- which is why the fake buffers.
+    """
+    ing = BufferingIngestor()
+    updater = _updater(repo, ing)
+    updater.run()
+    ing.flush_all()
+
+    dp = updater.factory.definition_processor
+    target = next(qn for qn in dp.module_qn_to_file_path if qn.endswith(".a"))
+
+    # a.py's Module is absent from the readable set for the whole reingest:
+    # exactly the unflushed shape, since the re-parse rewrites it as pending.
+    del ing.flushed[target]
+
+    updater.reingest(["a.py"])
+
+    assert target in dp.module_qn_to_file_path, (
+        "the prune dropped the entry for the file this reingest re-parsed, "
+        "whose Module node is still unflushed"
+    )
+
+
+def test_the_prune_keeps_working_across_repeated_reingest_calls(repo: Path) -> None:
+    """The accumulation case, which a single-call test cannot see.
+
+    `_parsed_files` accumulates across reingest calls (deliberately --
+    `_hydrate_for_reingest` reads it as a liveness proxy). So a fix that
+    reused it as the exemption exempts everything the process ever parsed.
+
+    Measured, this does NOT catch anything the first test misses: the naive
+    mutation reddens both, because that test's `run()` parses b.py into
+    `_parsed_files` and the stale exemption covers it there too. Both fail
+    for one reason -- an exemption left by an EARLIER operation -- so this is
+    a second instance of that reason, not an independent axis.
+
+    Kept anyway, for a reason worth stating rather than pretending it
+    discriminates: it pins the multi-call shape the issue is actually about
+    (an MCP `_live_updater` making repeated scoped calls), which the first
+    test reaches only incidentally through `run()`. If the first test were
+    ever rewritten to seed the map without a full run, it would stop covering
+    accumulation and this one would be the only thing left holding it.
+    """
+    ing = BufferingIngestor()
+    updater = _updater(repo, ing)
+    updater.run()
+    ing.flush_all()
+    dp = updater.factory.definition_processor
+
+    # First call: parses a.py, so a.py joins _parsed_files for good.
+    updater.reingest(["a.py"])
+    ing.flush_all()
+
+    victim = next(qn for qn in dp.module_qn_to_file_path if qn.endswith(".a"))
+    assert victim in dp.module_qn_to_file_path, "fixture guard: a must be mapped"
+    assert any(p.name == "a.py" for p, _ in updater._parsed_files), (
+        "fixture guard: a.py must be in the accumulated _parsed_files, or the "
+        "naive exemption would not wrongly protect it and this proves nothing"
+    )
+
+    # Now another writer deletes a's Module, and we reingest a DIFFERENT file.
+    del ing.flushed[victim]
+    updater.reingest(["b.py"])
+
+    assert victim not in dp.module_qn_to_file_path, (
+        "the second reingest did not prune a stale qn, because the exemption "
+        "still covered a file parsed by an EARLIER call: the map never shrinks "
+        "on the retained updater this fix exists for"
+    )


### PR DESCRIPTION
Closes #1712.

## The defect

`_prune_stale_seeded_module_qns` had exactly one call site — inside `run()`. `reingest` does not go through `run()`: it seeds the module-qn map twice and never prunes.

So an MCP session that indexes once and then only makes scoped re-ingest calls holds a retained `_live_updater` that never re-enters `run()`. A qn whose `Module` another writer deleted stays in `module_qn_to_file_path` **with a real path**, so `known_module_paths()` keeps offering it and it wins the Rust sub-scope ownership arbitration against the file that legitimately owns the scope.

## Why the obvious fix is wrong

The helper exempts files "this operation parsed", because a re-parsed file writes its own map entry and its `Module` node may still be unflushed when the prune reads. It takes that set from `self._parsed_files`.

That field means different things on the two paths:

- `run()` **clears** it (line 1544) before pruning → "parsed this run"
- `reingest` **never** clears it → "parsed since the process started"

And `reingest` not clearing it is load-bearing, not an oversight. `_hydrate_for_reingest` reads it as a **liveness proxy**:

```python
if self._reingest_hydrated or self._parsed_files:
    self._reingest_hydrated = True
    return   # "a reused updater already has live state"
```

Clearing it there would force a full rehydration read on every scoped call — the cost that check exists to avoid.

So calling the helper as-is from `reingest` exempts every file the process has ever parsed. The map never shrinks on exactly the retained updater this issue is about: a fix that looks correct, passes a first-call test, and is **inert from the second call onwards**.

## The fix

`_prune_stale_seeded_module_qns(exempt_paths: set[Path] | None = None)`, defaulting to `_parsed_files` so `run()` is untouched. `reingest` passes `set(reparse.values())` — the paths *it* re-parsed — after both seed calls and after the re-parse. Same meaning at both call sites, without disturbing the liveness proxy.

## Verification

The fixture **buffers** node writes until `flush_all`, as production does. A write-through fake makes a just-parsed module instantly readable, so the exemption never has to do anything and the case it exists for is invisible. Two instrument checks guard this:

- `test_the_fake_satisfies_the_protocol_the_prune_gates_on` — `QueryProtocol` is runtime-checkable and needs `fetch_all` **and** `execute_write`; `isinstance` inspects the class, so a method from `__getattr__` does not satisfy it. Without this the prune returns early and every other assertion fails for an unrelated reason (measured — it cost a full mutation matrix before it was found).
- `test_the_buffering_fake_actually_buffers` — a pending module must not be readable before `flush_all`, or the fake is write-through and the exemption assertions pass for free.

Mutation matrix, with the seam each targets:

| mutation | seam | red |
|---|---|---|
| remove the call | reingest never prunes | the two prune tests |
| pass no exemption set (`_parsed_files` default) | stale exemption | the two prune tests |
| pass `set()` | no exemption at all | the unflushed-survival test |

Green: 5 passed. Restored: 5 passed.

One prediction was wrong and the docstring records it: I expected only the repeated-calls test to catch the `_parsed_files` variant. It catches both, because the first test's `run()` parses both fixture files, so the stale exemption covers the victim there too. Both fail for the same reason, so the repeated-calls test is a second instance rather than an independent axis — kept because it pins the multi-call shape the issue is about, which the first test reaches only incidentally.

Regression sweep: 155 passed across reingest, incremental, watch and single-file; 258 passed over a `-k` sweep of everything naming reingest, seed, prune, module_qn or watch. `ty` reports 9 diagnostics here and 9 on clean `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reingestion now removes stale module entries when the corresponding modules are no longer available.
  * Re-parsed files retain their current module entries during reingestion.
  * Repeated reingestion now consistently cleans up outdated module references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->