### PR TITLE
fix: pin UV_PYTHON_INSTALL_DIR so the built image's venv actually runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,15 @@ WORKDIR /app
 # .venv only symlinks to that interpreter, so pin the install dir under /app
 # and copy it into the final stage too, or the venv's python symlink dangles
 # once /root is left behind.
+#
+# uv only populates this directory when it actually downloads a managed
+# interpreter -- if the pinned Python version ever matches this image's
+# system Python, uv uses that instead and never creates the directory,
+# which would make the unconditional COPY below fail the build outright.
+# Pre-create it so COPY always has something to copy, whichever
+# interpreter uv picks.
 ENV UV_PYTHON_INSTALL_DIR=/app/.uv-python
+RUN mkdir -p "$UV_PYTHON_INSTALL_DIR"
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --extra treesitter-full --no-install-project --no-binary-package pymgclient

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,13 @@ WORKDIR /app
 # once /root is left behind.
 #
 # uv only populates this directory when it actually downloads a managed
-# interpreter -- if the pinned Python version ever matches this image's
-# system Python, uv uses that instead and never creates the directory,
-# which would make the unconditional COPY below fail the build outright.
-# Pre-create it so COPY always has something to copy, whichever
-# interpreter uv picks.
+# interpreter -- if the pinned Python version ever matched this image's
+# system Python, uv would use that instead and never create the
+# directory, and the unconditional COPY below would fail the build
+# outright. only-managed rules that out: uv always uses (and downloads
+# if needed) its own interpreter, never the system one.
 ENV UV_PYTHON_INSTALL_DIR=/app/.uv-python
-RUN mkdir -p "$UV_PYTHON_INSTALL_DIR"
+ENV UV_PYTHON_PREFERENCE=only-managed
 
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --extra treesitter-full --no-install-project --no-binary-package pymgclient

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,13 @@ RUN apt-get update && \
 
 WORKDIR /app
 
+# uv installs its managed Python interpreter outside the project directory by
+# default ($HOME/.local/share/uv/python, i.e. /root/.local when run as root).
+# .venv only symlinks to that interpreter, so pin the install dir under /app
+# and copy it into the final stage too, or the venv's python symlink dangles
+# once /root is left behind.
+ENV UV_PYTHON_INSTALL_DIR=/app/.uv-python
+
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --extra treesitter-full --no-install-project --no-binary-package pymgclient
 
@@ -27,6 +34,7 @@ RUN useradd --create-home appuser
 USER appuser
 WORKDIR /app
 
+COPY --from=builder --chown=appuser:appuser /app/.uv-python /app/.uv-python
 COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 COPY --from=builder --chown=appuser:appuser /app/codebase_rag /app/codebase_rag
 COPY --from=builder --chown=appuser:appuser /app/codec /app/codec


### PR DESCRIPTION
## Summary

The builder stage lets `uv sync` install uv's managed Python interpreter to its default location (`$HOME/.local/share/uv/python`, i.e. `/root/.local/...` since the builder stage runs as root). `.venv` only *symlinks* to that interpreter rather than containing it, and the final stage only copies `/app/.venv` out of the builder -- not `/root/.local` -- so the copied venv's `python` symlink dangles and the built image doesn't run at all.

Pinning `UV_PYTHON_INSTALL_DIR` under `/app` before `uv sync` runs, and copying that directory into the final stage alongside `.venv`, fixes it.

## Test plan

- Built the patched Dockerfile locally with both the default BuildKit builder (`docker build`) and the classic non-BuildKit builder (`DOCKER_BUILDKIT=0 docker build`), to also confirm compatibility with ACR Tasks-style remote builds that don't use BuildKit.
- Confirmed `.venv/bin/python` resolves to a real interpreter and runs (`readlink -f /app/.venv/bin/python` -> `/app/.uv-python/cpython-3.12.13-linux-*/bin/python3.12`; `python --version` succeeds).
- Confirmed `code-graph-rag --help` works through the real entrypoint (`/entrypoint.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container builds now consistently use the managed Python interpreter.
  * Improved reliability when running the application under the non-root user.
  * Ensured the required Python environment remains available after the container switches users.
  * Preserved access to the pinned Python installation in the final container image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->