### PR TITLE
fix: prune the two class-keyed maps when a file leaves the state (#1772)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3133,6 +3133,11 @@ class GraphUpdater:
             module_qn_prefixes=module_qn_prefixes,
         )
 
+        # The two cross-language class-keyed maps, same defect for two more
+        # (issue #1772). Separate from the C# sweep above because every
+        # language's class ingest writes these.
+        self._prune_class_keyed_maps(module_qn_prefixes, file_path)
+
         for simple_name, qn_set in self.simple_name_lookup.items():
             original_count = len(qn_set)
             new_qn_set = qn_set - qns_to_remove
@@ -3238,6 +3243,70 @@ class GraphUpdater:
         }
         if function_qns or class_qns:
             type_inference.drop_csharp_side_tables(function_qns, class_qns)
+
+    def _prune_class_keyed_maps(
+        self, module_qn_prefixes: set[str], file_path: Path
+    ) -> None:
+        """Drop a removed file's entries from `class_inheritance` and
+        `class_field_types`.
+
+        Both are keyed by a CLASS qn and neither was ever mentioned in
+        `remove_file_from_state`, so a deleted file's rows outlived it on a
+        reused updater (issue #1772). That is a wrong answer rather than a
+        missing one: `class_field_types` types a receiver reached through a
+        field, and `class_inheritance` is walked to reach base-class members
+        and drives the OVERRIDES arbitration -- both at a class that is gone.
+        Same defect class as #1668, #1738, #1753 and #1769.
+
+        Unlike #1769's four maps these are written by EVERY language, so the
+        owner index consulted here is the cross-language `class_owner_module`
+        rather than the C#-only one. Ownership is read from that record and
+        never inferred from the qn, for the reason #1769's review established:
+        a C# class qn embeds its namespace, so `proj/Core.cs` declaring
+        `namespace Util` yields `proj.Core.Util.Helper`, which sits under the
+        SIBLING module `proj.Core.Util`; a prefix rule errs in both directions
+        there.
+
+        Ownership comes from two records, because two different paths write
+        `class_inheritance`. Classes this updater PARSED are keyed in
+        `class_owner_module` at ingest. Classes it only REHYDRATED from the
+        graph never reach that ingest, so an incremental run -- where most
+        classes are rehydrated rather than re-parsed -- would otherwise leave
+        every one of their entries behind, which is the very defect this
+        closes. Their declaring file is already known: the rehydrate records
+        `rehydrated_definition_paths[qn] = path`, the same map
+        `remove_file_from_state` sweeps further down. That path is relative
+        and posix-formed, so it is compared as such.
+        """
+        processor = self.factory.definition_processor
+        owner_module = processor.class_owner_module
+        stale = {
+            qn
+            for qn, module_qn in owner_module.items()
+            if module_qn in module_qn_prefixes
+        }
+        # The rehydrated half. This runs BEFORE the caller's own
+        # `rehydrated_definition_paths` sweep further down, so those rows are
+        # still present to read; moving this call after that sweep would
+        # silently stop pruning rehydrated classes.
+        relative_posix = cached_relative_path(file_path, self.repo_path).as_posix()
+        stale |= {
+            qn
+            for qn, path in processor.rehydrated_definition_paths.items()
+            if path == relative_posix
+        }
+        if not stale:
+            return
+        # Mutated in place: TypeInference and the lazily built per-language
+        # engines share these same dict objects by reference, so rebinding
+        # any of them would leave those readers on the pre-prune state.
+        for qn in stale:
+            processor.class_inheritance.pop(qn, None)
+            processor.class_field_types.pop(qn, None)
+            # The owner record goes with them: it names a file this updater
+            # no longer has, and keeping it would re-sweep the same qn on the
+            # next deletion of a file that happens to reuse the module qn.
+            owner_module.pop(qn, None)
 
     @staticmethod
     def _under(qn: str, module_qn_prefixes: Collection[str]) -> bool:

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -161,6 +161,7 @@ class ClassIngestMixin:
     flow_capture_enabled: bool
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
+    class_owner_module: dict[str, str]
     dart_annotated_overrides: dict[str, list[tuple[str, str]]]
     dart_extends_type_args: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
@@ -1103,6 +1104,13 @@ class ClassIngestMixin:
             if cs.SEPARATOR_DOUBLE_COLON in class_name:
                 leaf = class_name.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1]
                 self.simple_name_lookup[leaf].add(class_qn)
+
+        # The declaring module, for the class-keyed maps' prune (#1772).
+        # Recorded here rather than in the per-language field-type branches
+        # below, because `class_inheritance` is written for EVERY language
+        # while those branches cover only five, and a class carries no span
+        # record for the sweep to attribute it by.
+        self.class_owner_module[class_qn] = module_qn
 
         parent_label, parent_qn, parent_span = self._determine_function_parent(
             class_node, class_qn, module_qn, lang_config, language

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -91,6 +91,18 @@ class DefinitionProcessor(
         # (directory, clause), so receiver binding needs both.
         self.go_package_names: dict[str, str] = {}
         self.class_inheritance: dict[str, list[str]] = {}
+        # {class qn: module qn of the file that DECLARED it}, written for
+        # EVERY language at class ingest. `class_inheritance` and
+        # `class_field_types` are keyed by a class qn, and a class records
+        # no function span, so the span-based ownership the registry sweep
+        # uses cannot attribute one. Nor can a prefix rule: a C# class qn
+        # embeds its namespace, so `proj/Core.cs` with `namespace Util`
+        # yields `proj.Core.Util.Helper`, sitting under the SIBLING module
+        # `proj.Core.Util` (#1769 review). This is the C#-only
+        # `csharp_class_owner_module`'s cross-language counterpart, needed
+        # because both maps above are written by every language's ingest
+        # (#1772).
+        self.class_owner_module: dict[str, str] = {}
         # {class_qn: [(method_qn, method_name)]} for Dart @override methods;
         # whether they override an EXTERNAL base is only decidable once every
         # class is registered, so resolve_deferred_inherits consumes this.

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -44,6 +44,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
     module_qn_to_file_path: dict[str, Path]
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
+    class_owner_module: dict[str, str]
     _handler: LanguageHandler
 
     @abstractmethod
@@ -142,6 +143,12 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
 
                 if child_qn not in self.class_inheritance:
                     self.class_inheritance[child_qn] = []
+                # JS prototype inheritance writes class_inheritance WITHOUT
+                # going through class ingest, so the owner has to be recorded
+                # here too or the entry survives its file's deletion (#1772).
+                # `child_qn` is built from `module_qn` directly above, so the
+                # declaring module is exact rather than inferred.
+                self.class_owner_module[child_qn] = module_qn
                 if parent_qn not in self.class_inheritance[child_qn]:
                     self.class_inheritance[child_qn].append(parent_qn)
 

--- a/codebase_rag/tests/test_class_keyed_maps_forget_deleted_file.py
+++ b/codebase_rag/tests/test_class_keyed_maps_forget_deleted_file.py
@@ -1,0 +1,329 @@
+"""A deleted file's class-keyed maps must leave with it, in every language.
+
+`remove_file_from_state` prunes the registry, the return-type maps and the
+C# side tables, but never mentioned `class_field_types` or
+`class_inheritance`: after `run()`, deleting a file and removing its state
+left both holding the deleted file's entries on a reused updater (issue
+#1772). Same defect class as #1668, #1738, #1753 and #1769, for two more
+maps -- and unlike #1769's four, these two are written by every language's
+class ingest, so the prune and these fixtures are language-agnostic.
+
+A stale entry here is a wrong answer rather than a missing one:
+`class_field_types` types a receiver reached through a field, and
+`class_inheritance` is walked to reach base-class members and drives the
+OVERRIDES arbitration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import _MockIngestor
+
+# Declared by `proj/Core.cs`. A C# class qn embeds the namespace, so
+# `namespace Util` puts these classes at `proj.Core.Util.*` -- under the
+# module qn of the SIBLING file below, not under this file's own `proj.Core`
+# alone. Ownership must therefore come from the recorded declaring module;
+# a prefix rule on the qn confuses the two files in both directions.
+A_CS = """namespace Util
+{
+    public class Base
+    {
+        public int Shared;
+    }
+    public class K : Base
+    {
+        public string Field;
+    }
+}
+"""
+
+# Declared by `proj/Core/Util.cs`, whose MODULE qn is `proj.Core.Util` --
+# the very prefix A_CS's class qns sit under. A prefix rule on the qn
+# therefore attributes A_CS's classes to this file and vice versa, which is
+# what makes the recorded owner load-bearing rather than decorative (#1769
+# review).
+B_CS = """namespace Deep
+{
+    public class SibBase
+    {
+        public int Held;
+    }
+    public class L : SibBase
+    {
+        public string Kept;
+    }
+}
+"""
+
+A_GO = """package main
+
+type ABase struct {
+\tShared int
+}
+
+type AThing struct {
+\tField ABase
+}
+"""
+
+B_GO = """package main
+
+type BBase struct {
+\tHeld int
+}
+
+type BThing struct {
+\tKept BBase
+}
+"""
+
+# JS prototype inheritance (`Child.prototype = Object.create(...)`) writes
+# `class_inheritance` from js_ts/ingest.py directly, WITHOUT passing through
+# class ingest -- so it needs its own owner record or the entry outlives the
+# file. Measured: before that record existed, deleting a.js left
+# `proj.a.AChild` in the map.
+A_JS = """function AParent() {}
+function AChild() {}
+AChild.prototype = Object.create(AParent.prototype);
+"""
+
+B_JS = """function BParent() {}
+function BChild() {}
+BChild.prototype = Object.create(BParent.prototype);
+"""
+
+A_PY = """class ABase:
+    pass
+
+
+class AThing(ABase):
+    pass
+"""
+
+B_PY = """class BBase:
+    pass
+
+
+class BThing(BBase):
+    pass
+"""
+
+
+def _create_graph_updater(root: Path, language: str) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    if language not in parsers:
+        pytest.skip(f"{language} parser not available")
+    return GraphUpdater(
+        ingestor=_MockIngestor(),
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+
+
+def _only_qn(store: dict[str, object], needle: str) -> str | None:
+    return next((qn for qn in store if needle in qn), None)
+
+
+@pytest.mark.parametrize(
+    ("language", "gone_name", "kept_name", "files", "checks_bases", "checks_fields"),
+    [
+        pytest.param(
+            cs.SupportedLanguage.CSHARP,
+            ".K",
+            ".L",
+            {"Core.cs": A_CS, "Core/Util.cs": B_CS},
+            True,
+            True,
+            id="csharp",
+        ),
+        pytest.param(
+            cs.SupportedLanguage.GO,
+            ".AThing",
+            ".BThing",
+            {"a.go": A_GO, "b.go": B_GO},
+            # Go records a class_inheritance key with an EMPTY base list:
+            # struct embedding is not extracted into that map. Only the
+            # field-type half carries a real value here.
+            False,
+            True,
+            id="go",
+        ),
+        pytest.param(
+            cs.SupportedLanguage.JS,
+            ".AChild",
+            ".BChild",
+            {"a.js": A_JS, "b.js": B_JS},
+            True,
+            # JS records no class_field_types here; the prototype chain is
+            # the inheritance half.
+            False,
+            id="javascript-prototype",
+        ),
+        pytest.param(
+            cs.SupportedLanguage.PYTHON,
+            ".AThing",
+            ".BThing",
+            {"a.py": A_PY, "b.py": B_PY},
+            True,
+            # Python records no field types; the inheritance half is the
+            # one that carries a value.
+            False,
+            id="python",
+        ),
+    ],
+)
+def test_a_deleted_files_class_keyed_maps_are_forgotten(
+    temp_repo: Path,
+    language: str,
+    gone_name: str,
+    kept_name: str,
+    files: dict[str, str],
+    checks_bases: bool,
+    checks_fields: bool,
+) -> None:
+    root = temp_repo / "proj"
+    root.mkdir()
+    for name, body in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    updater = _create_graph_updater(root, language)
+    updater.run()
+    processor = updater.factory.definition_processor
+
+    inheritance = processor.class_inheritance
+    field_types = processor.class_field_types
+
+    gone_inherit = kept_inherit = None
+    if checks_bases:
+        gone_inherit = _only_qn(inheritance, gone_name)
+        kept_inherit = _only_qn(inheritance, kept_name)
+        assert gone_inherit, (
+            f"fixture guard: deleted file recorded no bases: {inheritance}"
+        )
+        assert kept_inherit, f"fixture guard: sibling recorded no bases: {inheritance}"
+        # A recorded key with an EMPTY base list would satisfy the presence
+        # check above while proving nothing about the map that steers
+        # resolution.
+        assert inheritance[gone_inherit], (
+            f"fixture guard: deleted file's class has no bases: {inheritance}"
+        )
+
+    gone_fields = kept_fields = None
+    if checks_fields:
+        gone_fields = _only_qn(field_types, gone_name)
+        kept_fields = _only_qn(field_types, kept_name)
+        assert gone_fields, (
+            f"fixture guard: deleted file recorded no field types: {field_types}"
+        )
+        assert kept_fields, (
+            f"fixture guard: sibling recorded no field types: {field_types}"
+        )
+        assert field_types[gone_fields], (
+            f"fixture guard: deleted file's class has no field types: {field_types}"
+        )
+
+    deleted = next(iter(files))
+    (root / deleted).unlink()
+    updater.remove_file_from_state(root / deleted)
+
+    if checks_bases:
+        assert gone_inherit not in inheritance, (
+            f"the deleted file's class_inheritance entry survived: {inheritance}"
+        )
+        assert kept_inherit in inheritance, (
+            f"a sibling's class_inheritance entry was swept along: {inheritance}"
+        )
+    if checks_fields:
+        assert gone_fields not in field_types, (
+            f"the deleted file's class_field_types entry survived: {field_types}"
+        )
+        assert kept_fields in field_types, (
+            f"a sibling's class_field_types entry was swept along: {field_types}"
+        )
+
+
+def test_a_rehydrated_class_is_pruned_with_its_file(temp_repo: Path) -> None:
+    """A class read back from the graph leaves with its file too.
+
+    An incremental run re-parses only the changed files and REHYDRATES the
+    rest from the graph, so on such a run most classes never pass through
+    class ingest and get no `class_owner_module` row. Attributing only the
+    parsed ones would leave every rehydrated class's bases behind -- the same
+    defect #1772 closes, on the majority of an incremental run's map. The
+    declaring file is known regardless: the rehydrate records it in
+    `rehydrated_definition_paths`.
+    """
+    root = temp_repo / "proj"
+    root.mkdir()
+    (root / "a.py").write_text("class ABase:\n    pass\n", encoding="utf-8")
+    (root / "b.py").write_text("class BBase:\n    pass\n", encoding="utf-8")
+
+    parsers, queries = load_parsers()
+    if cs.SupportedLanguage.PYTHON not in parsers:
+        pytest.skip("python parser not available")
+
+    ingestor = _MockIngestor()
+
+    def rows(query: str, params: object = None) -> list[dict[str, object]]:
+        if "INHERITS" in query:
+            return [
+                {
+                    "child_qn": "proj.a.AThing",
+                    "base_qn": "proj.a.ABase",
+                    "base_index": 0,
+                },
+                {
+                    "child_qn": "proj.b.BThing",
+                    "base_qn": "proj.b.BBase",
+                    "base_index": 0,
+                },
+            ]
+        return [
+            {"qualified_name": "proj.a.AThing", "label": "Class", "path": "a.py"},
+            {"qualified_name": "proj.b.BThing", "label": "Class", "path": "b.py"},
+        ]
+
+    ingestor.fetch_all.side_effect = rows
+    updater = GraphUpdater(
+        ingestor=ingestor,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater._rehydrate_registry_from_graph()
+    updater._rehydrate_class_inheritance_from_graph()
+
+    processor = updater.factory.definition_processor
+    inheritance = processor.class_inheritance
+    # These classes came from the graph, not from a parse, so they carry no
+    # ingest-time owner row -- which is exactly the condition under test.
+    assert "proj.a.AThing" in inheritance, (
+        f"fixture guard: not rehydrated: {inheritance}"
+    )
+    assert "proj.b.BThing" in inheritance, (
+        f"fixture guard: not rehydrated: {inheritance}"
+    )
+    assert "proj.a.AThing" not in processor.class_owner_module, (
+        "fixture guard: a rehydrated class must have no ingest owner row, "
+        "or this test would pass through the parsed-class path instead"
+    )
+
+    (root / "a.py").unlink()
+    updater.remove_file_from_state(root / "a.py")
+
+    assert "proj.a.AThing" not in inheritance, (
+        f"the deleted file's rehydrated class survived: {inheritance}"
+    )
+    assert "proj.b.BThing" in inheritance, (
+        f"a sibling's rehydrated class was swept along: {inheritance}"
+    )


### PR DESCRIPTION
`remove_file_from_state` never mentioned `class_field_types` or
`class_inheritance`, so a deleted file's entries survived on a reused updater
and went on steering resolution at a class that no longer exists — a wrong
answer rather than a missing one. `class_field_types` types a receiver reached
through a field; `class_inheritance` is walked to reach base-class members and
drives the OVERRIDES arbitration.

Fixes #1772. Same defect class as #1668, #1738, #1753 and #1769, for two more
maps. Unlike #1769's four, these are written by every language, so the prune is
language-agnostic.

## Ownership is recorded, not inferred

The issue suggested attributing a class by its module-qn prefix. That is wrong,
for the reason #1769's review established: a C# class qn embeds its namespace,
so `proj/Core.cs` declaring `namespace Util` yields `proj.Core.Util.Helper`,
which sits under the **sibling** module `proj.Core.Util` (the qn of
`proj/Core/Util.cs`). A prefix rule errs in both directions — deleting the
sibling drops a live class, deleting the real declarer keeps a dead one.

So this adds a cross-language `class_owner_module`, the counterpart to the
C#-only `csharp_class_owner_module`, and reads ownership from it.

## Three writers, three ownership paths

Both maps are written from more places than the issue lists, and two of them
bypass class ingest entirely:

| Writer | Owner source |
|---|---|
| Class ingest (every language) | `class_owner_module`, recorded at ingest |
| JS prototype inheritance (`js_ts/ingest.py`) | same map, recorded at that write site |
| Rehydration from the graph | `rehydrated_definition_paths` |

The rehydrated case is the one that matters most in practice: an incremental
run re-parses only the changed files and rehydrates the rest, so on such a run
most classes never pass through ingest. Attributing only the parsed ones would
have left the majority of the map unpruned — the very defect this closes.

## Validation

* 5 new tests, parametrized over C#, Go, Python and JS plus a rehydration case.
  All fail on `main` and pass here.
* The C# fixture is `proj/Core.cs` (`namespace Util`) beside `proj/Core/Util.cs`,
  so the namespace/sibling-module collision is exercised rather than described.
* Five mutations, each reddening exactly the predicted cases and nothing else:
  prefix rule instead of the owner record → C#; removing each map's `pop`
  independently → C#+Python and C#+Go respectively; removing the JS owner
  record → the JS case only; removing the rehydrated half → the rehydration
  case only.
* 694 passed, 5 skipped, 0 failed across the inheritance, incremental,
  deleted-file, side-table and js_ts modules, on a settled tree under the host
  suite lock. No full suite run locally; CI covers that.
* `ruff check` and `ruff format` clean.

Purely additive: 425 insertions, no deletions, no existing signature changed.

## Note for review

`csharp_class_owner_module` is now a strict subset of the new
`class_owner_module` — same key, same value, written only for generic C#
classes. Harmless duplication left alone deliberately, since consolidating it
would touch #1769's prune; it belongs in its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed files are now fully cleared from class inheritance and field-type information.
  - Prevents outdated class relationships and type details from appearing after source files are deleted.
  - Cleanup works consistently across C#, Go, JavaScript, and Python, including data restored from the graph.
  - Unrelated files and their class information remain unchanged.

- **Tests**
  - Added regression coverage for deleted-file cleanup across supported languages and restored graph data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->