### PR TITLE
fix: memoise C# chained-call resolution so fluent chains are linear (#1800)

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -412,6 +412,13 @@ class CallResolver:
         # old path and never learn the new one, and every JEDI fact
         # targeting the renamed file would miss its declared location.
         self._py_rel_to_module.clear()
+        # The C# chained-receiver memo (issue #1800) is a resolution cache
+        # like the rest and expires with them: it is keyed by byte span, and a
+        # re-parsed file's spans name different code. Reached through the
+        # PRIVATE attribute so a project with no C# does not build an engine
+        # just to clear an empty dict.
+        if (csharp := self.type_inference._csharp_type_inference) is not None:
+            csharp._call_memo.clear()
 
     def resolve_function_call(
         self,

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -379,20 +379,7 @@ class CSharpTypeInferenceEngine:
         # Polly's hide-object-members regions) and the call must emit nothing;
         # the trie fallback was self-looping it onto the caller's own override.
         if receiver.type == cs.TS_CSHARP_BASE_EXPRESSION:
-            if class_qn := self._containing_class_qn(caller_qn):
-                seen: set[str] = set()
-                for root in self._partial_roots(class_qn):
-                    for base_qn in self.class_inheritance.get(root, []):
-                        if hit := self._find_method_by_arity(
-                            base_qn, method_name, arg_count, seen
-                        ):
-                            return cs.NodeLabel.METHOD.value, hit
-                seen = set()
-                for root in self._partial_roots(class_qn):
-                    for base_qn in self.class_inheritance.get(root, []):
-                        if hit := self._find_method_by_name(base_qn, method_name, seen):
-                            return cs.NodeLabel.METHOD.value, hit
-            return CSHARP_EXTERNAL_TARGET
+            return self._resolve_base_call(method_name, arg_count, caller_qn)
 
         receiver_class_qn = self._resolve_receiver_class_qn(
             receiver, local_var_types or {}, module_qn, caller_qn
@@ -445,6 +432,39 @@ class CSharpTypeInferenceEngine:
         ):
             return CSHARP_EXTERNAL_TARGET
         return None
+
+    def _resolve_base_call(
+        self, method_name: str, arg_count: int, caller_qn: str | None
+    ) -> tuple[str, str] | None:
+        """Resolve `base.X()` against the BASE chain only.
+
+        Split out of `_resolve_csharp_method_call` to keep that function under
+        the cognitive-complexity limit; the two nested walks below are its
+        densest part and are self-contained.
+
+        A first-party base's member wins when one exists; otherwise the base is
+        external (`object.Equals` in Polly's hide-object-members regions) and
+        the call must emit nothing, because the trie fallback was self-looping
+        it onto the caller's own override. Arity-exact matches are tried across
+        every partial part first, then name-only, mirroring the order the
+        instance path uses.
+        """
+        class_qn = self._containing_class_qn(caller_qn)
+        if class_qn is None:
+            return CSHARP_EXTERNAL_TARGET
+        seen: set[str] = set()
+        for root in self._partial_roots(class_qn):
+            for base_qn in self.class_inheritance.get(root, []):
+                if hit := self._find_method_by_arity(
+                    base_qn, method_name, arg_count, seen
+                ):
+                    return cs.NodeLabel.METHOD.value, hit
+        seen = set()
+        for root in self._partial_roots(class_qn):
+            for base_qn in self.class_inheritance.get(root, []):
+                if hit := self._find_method_by_name(base_qn, method_name, seen):
+                    return cs.NodeLabel.METHOD.value, hit
+        return CSHARP_EXTERNAL_TARGET
 
     def _externally_targeted(
         self,

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -357,13 +357,7 @@ class CSharpTypeInferenceEngine:
         if func is None:
             return None
         if func.type != cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
-            # A bare `Foo(...)`/`Foo<T>(...)` follows C# simple-name lookup:
-            # an in-scope local function first (it shadows same-name method
-            # overloads), then an arity-matched member of the enclosing
-            # type. A miss falls to the generic simple-name path.
-            if func.type in (cs.TS_CSHARP_IDENTIFIER, cs.TS_CSHARP_GENERIC_NAME):
-                return self._resolve_bare_call(func, call_node, module_qn, caller_qn)
-            return None
+            return self._resolve_non_member_call(func, call_node, module_qn, caller_qn)
         method_name = safe_decode_text(func.child_by_field_name(cs.FIELD_NAME))
         receiver = func.child_by_field_name(cs.TS_CSHARP_FIELD_EXPRESSION)
         if not method_name or receiver is None:
@@ -389,17 +383,15 @@ class CSharpTypeInferenceEngine:
         # name-only fallback. Trying the name-only fallback before extensions
         # would bind `c.Foo(1)` to a lone `C.Foo()` and never reach the
         # arity-correct `static Foo(this C, int)` extension.
-        if receiver_class_qn is not None:
-            if arity_hit := self._find_arity_across_parts(
+        if receiver_class_qn is not None and (
+            arity_hit := self._find_arity_across_parts(
                 receiver_class_qn, method_name, arg_count
-            ):
-                # A delegate-typed PROPERTY registers as a METHOD node with
-                # a bare (arity-0) qn, so a 0-arg invoke slips through the
-                # ARITY path too: `entry.Callback()` is Delegate.Invoke,
-                # not a call to the property node.
-                if self.function_registry.is_property(arity_hit):
-                    return CSHARP_EXTERNAL_TARGET
-                return cs.NodeLabel.METHOD.value, arity_hit
+            )
+        ):
+            # A delegate-typed PROPERTY registers as a METHOD node with a bare
+            # (arity-0) qn, so a 0-arg invoke slips through the ARITY path too:
+            # `entry.Callback()` is Delegate.Invoke, not a call to the property.
+            return self._method_or_property_target(arity_hit)
         # An extension method (`static M(this T x, ...)` on an unrelated static
         # class) whose `this` receiver type matches the call's receiver; the
         # only path that binds `x.M()` to a method not in x's hierarchy.
@@ -412,26 +404,75 @@ class CSharpTypeInferenceEngine:
             arg_count,
         ):
             return cs.NodeLabel.METHOD.value, ext
-        if receiver_class_qn is not None:
-            if name_hit := self._find_name_across_parts(receiver_class_qn, method_name):
-                # A delegate-typed PROPERTY invoked with call syntax
-                # (`options.ShouldHandle(args)`) is Delegate.Invoke, not a
-                # method call; binding the property as a METHOD fabricates
-                # an edge. Its reachability comes from the read pass.
-                if self.function_registry.is_property(name_hit):
-                    return CSHARP_EXTERNAL_TARGET
-                return cs.NodeLabel.METHOD.value, name_hit
-        # An object-virtual miss on a TYPED receiver (`severity.ToString()`
-        # on an enum, `options.GetType()`) resolves to System.Object/Enum;
-        # falling to the trie lands on whatever unrelated
-        # hide-object-members override exists (Polly's PolicyBuilder).
+        if receiver_class_qn is not None and (
+            name_hit := self._find_name_across_parts(receiver_class_qn, method_name)
+        ):
+            # A delegate-typed PROPERTY invoked with call syntax
+            # (`options.ShouldHandle(args)`) is Delegate.Invoke, not a method
+            # call; binding the property as a METHOD fabricates an edge. Its
+            # reachability comes from the read pass.
+            return self._method_or_property_target(name_hit)
+        return self._external_or_unresolved(
+            receiver,
+            method_name,
+            receiver_class_qn,
+            local_var_types or {},
+            caller_qn,
+        )
+
+    def _external_or_unresolved(
+        self,
+        receiver: Node,
+        method_name: str,
+        receiver_class_qn: str | None,
+        local_var_types: dict[str, str],
+        caller_qn: str | None,
+    ) -> tuple[str, str] | None:
+        """The last word: an external target, or nothing.
+
+        An object-virtual miss on a TYPED receiver (`severity.ToString()` on an
+        enum, `options.GetType()`) resolves to System.Object/Enum; falling to
+        the trie instead lands on whatever unrelated hide-object-members
+        override exists (Polly's PolicyBuilder). An UNTYPED receiver is
+        external when `_externally_targeted` says so; otherwise the call is
+        simply unresolved.
+        """
         if method_name in cs.CSHARP_OBJECT_VIRTUALS:
             return CSHARP_EXTERNAL_TARGET
         if receiver_class_qn is None and self._externally_targeted(
-            receiver, method_name, local_var_types or {}, caller_qn
+            receiver, method_name, local_var_types, caller_qn
         ):
             return CSHARP_EXTERNAL_TARGET
         return None
+
+    def _resolve_non_member_call(
+        self,
+        func: Node,
+        call_node: Node,
+        module_qn: str,
+        caller_qn: str | None,
+    ) -> tuple[str, str] | None:
+        """Resolve a call whose callee is not a member access.
+
+        A bare `Foo(...)`/`Foo<T>(...)` follows C# simple-name lookup: an
+        in-scope local function first (it shadows same-name method overloads),
+        then an arity-matched member of the enclosing type. A miss falls to the
+        generic simple-name path. Anything else (an invoked expression, say) is
+        not resolvable here.
+        """
+        if func.type in (cs.TS_CSHARP_IDENTIFIER, cs.TS_CSHARP_GENERIC_NAME):
+            return self._resolve_bare_call(func, call_node, module_qn, caller_qn)
+        return None
+
+    def _method_or_property_target(self, hit: str) -> tuple[str, str]:
+        """A resolved qn as a call target, or external when it is a property.
+
+        Both the arity and the name lookup end this way, so the property check
+        lives here once rather than twice in the caller.
+        """
+        if self.function_registry.is_property(hit):
+            return CSHARP_EXTERNAL_TARGET
+        return cs.NodeLabel.METHOD.value, hit
 
     def _resolve_base_call(
         self, method_name: str, arg_count: int, caller_qn: str | None

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -62,6 +62,25 @@ def _arity(leaf: str) -> int:
     return count
 
 
+class _Sentinel:
+    """Distinct from every real result, including None."""
+
+    __slots__ = ()
+
+
+# A miss, as distinct from a cached None: None is a legitimate answer
+# ("unresolved"), and caching it is most of the win on a chain whose links
+# do not resolve.
+_MISSING = _Sentinel()
+# Set while a node's own resolution is on the stack; see the docstring on
+# resolve_csharp_method_call.
+_IN_PROGRESS = _Sentinel()
+
+# What the memo stores: a resolved (label, qn), an unresolved None, or the
+# in-progress marker.
+type _MemoEntry = tuple[str, str] | None | _Sentinel
+
+
 class CSharpTypeInferenceEngine:
     __slots__ = (
         "import_processor",
@@ -85,6 +104,7 @@ class CSharpTypeInferenceEngine:
         "method_return_types",
         "function_locations",
         "_rel_to_module",
+        "_call_memo",
     )
 
     def __init__(
@@ -111,6 +131,22 @@ class CSharpTypeInferenceEngine:
         method_return_types: dict[str, str] | None = None,
         function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
     ):
+        # Memo for `resolve_csharp_method_call` (issue #1800). A chained
+        # invocation types its receiver by resolving it, and THREE branches do
+        # that independently for the same receiver node (the class-qn path,
+        # the type-name path and the arity path), so an n-link fluent chain
+        # re-resolved its whole prefix 3^(n/2)-ish times: measured 58 calls at
+        # 4 links rising to 3,587,219 at 14, and a real Aspire file wedged
+        # Pass 3 at 100% CPU for over half an hour. Memoising the entry point
+        # collapses all three branches at once and makes the walk linear.
+        #
+        # Keyed by byte span rather than `id(node)`: CPython recycles ids of
+        # freed objects, and this repo has already been bitten by that (see
+        # `reset_resolution_caches`, "wildcard entries keyed by dict id, which
+        # recycles"). A span is unique within a file, and `module_qn` scopes it
+        # to one; `caller_qn` is included because the same node resolves
+        # differently per enclosing method (`this`, locals, imports).
+        self._call_memo: dict[tuple[str, str | None, int, int], _MemoEntry] = {}
         self.import_processor = import_processor
         self.function_registry = function_registry
         self.repo_path = repo_path
@@ -274,6 +310,36 @@ class CSharpTypeInferenceEngine:
     # --- typed method-call resolution ------------------------------------
 
     def resolve_csharp_method_call(
+        self,
+        call_node: Node,
+        local_var_types: dict[str, str] | None,
+        module_qn: str,
+        caller_qn: str | None = None,
+    ) -> tuple[str, str] | None:
+        """Memoising front for `_resolve_csharp_method_call` (issue #1800).
+
+        Wrapping the entry point rather than editing the three recursive
+        branches means every path in and every path back out shares one memo,
+        including future callers.
+
+        `_IN_PROGRESS` doubles as a cycle guard. A chain cannot be cyclic in
+        valid C#, but a malformed or recovered parse tree can present one, and
+        without this the recursion would not terminate. Returning None for a
+        re-entered node degrades that site to an unresolved call, which is what
+        the issue asks a pathological input to do instead of hanging.
+        """
+        key = (module_qn, caller_qn, call_node.start_byte, call_node.end_byte)
+        cached = self._call_memo.get(key, _MISSING)
+        if cached is not _MISSING:
+            return None if cached is _IN_PROGRESS else cached  # type: ignore[return-value]
+        self._call_memo[key] = _IN_PROGRESS
+        result = self._resolve_csharp_method_call(
+            call_node, local_var_types, module_qn, caller_qn
+        )
+        self._call_memo[key] = result
+        return result
+
+    def _resolve_csharp_method_call(
         self,
         call_node: Node,
         local_var_types: dict[str, str] | None,

--- a/codebase_rag/tests/test_csharp_chain_resolution_is_linear.py
+++ b/codebase_rag/tests/test_csharp_chain_resolution_is_linear.py
@@ -1,0 +1,195 @@
+"""A C# fluent chain resolves in linear work, not exponential (issue #1800).
+
+`resolve_csharp_method_call` types a chained invocation by resolving its
+receiver, and THREE branches did that independently for the same receiver
+node -- the class-qn path, the type-name path and the arity path -- so an
+n-link chain re-resolved its whole prefix once per branch per link. Measured
+on `main`: 58 resolver entries at 4 links, 4,916 at 8, 398,574 at 12 and
+3,587,219 at 14 (~9x per two links, i.e. 3^2). A real `microsoft/aspire`
+file wedged Pass 3 at 100% CPU for over half an hour.
+
+The entry point now memoises per (module_qn, caller_qn, byte span), which
+collapses all three branches at once.
+
+`test_chain_resolution_work_grows_linearly` is the regression test for
+#1800, and the only one here that fails on the pre-fix code: it asserts the
+COMPLEXITY rather than a wall-clock time, because a timing threshold is flaky
+on shared CI while the resolver-entry count is deterministic and is the
+quantity the fix changes. The old code resolved these chains CORRECTLY, just
+exponentially, so the resolution-coverage tests below pass with the memo
+removed; they exist to catch a memo that buys speed by returning wrong or
+missing answers, and they do fail if it is made to do so.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.parsers.csharp import type_inference as ti
+from codebase_rag.tests.conftest import (
+    create_and_run_updater,
+    get_relationships,
+    run_updater,
+)
+
+SKIP = "c_sharp"
+
+
+@pytest.fixture
+def csharp_project(temp_repo: Path) -> Path:
+    project = temp_repo / "csharp_chain"
+    project.mkdir()
+    return project
+
+
+def _chain_source(links: int) -> str:
+    chain = "".join(f'\n            .Step{i}("x")' for i in range(links))
+    exts = "\n".join(
+        f"    public static Builder Step{i}(this Builder b, string s) => b;"
+        for i in range(links)
+    )
+    return (
+        "namespace N {\n"
+        "  public class Builder { }\n"
+        f"  public static class Ext {{\n{exts}\n  }}\n"
+        "  public class Use {\n"
+        f"    public void Run(Builder stage) {{\n        stage{chain};\n    }}\n"
+        "  }\n"
+        "}\n"
+    )
+
+
+def _resolver_entries(
+    project: Path, mock_ingestor: MagicMock, links: int, monkeypatch: pytest.MonkeyPatch
+) -> int:
+    """Run one chain of `links` links and count entries into the resolver."""
+    (project / "A.cs").write_text(_chain_source(links), encoding="utf-8")
+    calls = {"n": 0}
+    original = ti.CSharpTypeInferenceEngine.resolve_csharp_method_call
+
+    def counting(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        calls["n"] += 1
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        ti.CSharpTypeInferenceEngine, "resolve_csharp_method_call", counting
+    )
+    run_updater(project, mock_ingestor, skip_if_missing=SKIP)
+    return calls["n"]
+
+
+def test_chain_resolution_work_grows_linearly(
+    csharp_project: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Doubling the chain must not square the work.
+
+    Before the memo this ratio was ~80x for 6 -> 12 links (543 -> 398,574).
+    The bound of 4x is far above the true linear ratio (45/21 = 2.1) and far
+    below the exponential one, so it discriminates without being brittle.
+    """
+    short = _resolver_entries(csharp_project, mock_ingestor, 6, monkeypatch)
+    mock_ingestor.reset_mock()
+    long = _resolver_entries(csharp_project, mock_ingestor, 12, monkeypatch)
+
+    assert short > 0, "fixture guard: the resolver was never entered"
+    assert long < short * 4, (
+        f"chain resolution is superlinear: {short} entries at 6 links, "
+        f"{long} at 12 (linear would be about {short * 2})"
+    )
+
+
+def test_long_chain_still_resolves_every_link(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    """The memo must not cost coverage: every link still binds.
+
+    A cache that returned a stale or empty answer would make the timing test
+    above pass while silently dropping edges, so the win is only real if the
+    chain still resolves completely.
+    """
+    links = 12
+    (csharp_project / "A.cs").write_text(_chain_source(links), encoding="utf-8")
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    targets = {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
+    missing = [
+        i for i in range(links) if not any(f"Ext.Step{i}(" in t for t in targets)
+    ]
+    assert not missing, f"links {missing} did not resolve; got {sorted(targets)}"
+
+
+def test_memo_does_not_leak_between_resolution_passes(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    """`reset_resolution_caches` clears the chain memo with the others.
+
+    The memo is keyed by byte span, so a re-parsed file whose code moved would
+    otherwise be served an answer computed for whatever used to occupy those
+    bytes.
+    """
+    (csharp_project / "A.cs").write_text(_chain_source(4), encoding="utf-8")
+    updater = create_and_run_updater(
+        csharp_project, mock_ingestor, skip_if_missing=SKIP
+    )
+
+    engine = updater.factory.type_inference._csharp_type_inference
+    assert engine is not None, "fixture guard: no C# engine was built"
+    assert engine._call_memo, "fixture guard: the memo was never populated"
+
+    updater.factory.call_processor.reset_resolution_caches()
+    assert not engine._call_memo, "the chain memo survived a cache reset"
+
+
+# The shape from the file that actually wedged a `microsoft/aspire` index:
+# `src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs`, 1540
+# lines, 253.6s on its own. Extension methods on a builder with MIXED
+# arities, including zero-argument links -- the uniform one-argument chain
+# above exercises the arity branch only incidentally.
+ASPIRE_SHAPE = """namespace Aspire.Hosting {
+  public class DockerfileBuilder { }
+  public static class DockerfileBuilderExtensions {
+    public static DockerfileBuilder Comment(this DockerfileBuilder b, string t) => b;
+    public static DockerfileBuilder Copy(this DockerfileBuilder b, string s, string d) => b;
+    public static DockerfileBuilder EmptyLine(this DockerfileBuilder b) => b;
+    public static DockerfileBuilder Run(this DockerfileBuilder b, string cmd) => b;
+  }
+  public class PythonAppResourceBuilder {
+    public void Write(DockerfileBuilder stage) {
+        stage
+            .Comment("Copy requirements.txt for dependency installation")
+            .Copy("requirements.txt", "/app/requirements.txt")
+            .EmptyLine()
+            .Comment("Install dependencies using pip")
+            .Run("apt-get update && pip install -r requirements.txt")
+            .EmptyLine()
+            .Comment("Copy application code")
+            .Copy(".", "/app")
+            .EmptyLine();
+    }
+  }
+}
+"""
+
+
+def test_real_world_mixed_arity_chain_resolves(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    """Every distinct extension in the reported aspire chain still binds.
+
+    Mixed arities matter: `_receiver_type_arity` is one of the three branches
+    that recursed, and a zero-argument link (`EmptyLine()`) is the case where
+    an arity-keyed answer is easiest to get wrong.
+    """
+    (csharp_project / "PythonAppResourceBuilder.cs").write_text(
+        ASPIRE_SHAPE, encoding="utf-8"
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    targets = {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
+    for method in ("Comment(", "Copy(", "EmptyLine(", "Run("):
+        assert any(f"DockerfileBuilderExtensions.{method}" in t for t in targets), (
+            f"{method} did not resolve in the aspire-shaped chain: {sorted(targets)}"
+        )


### PR DESCRIPTION
`resolve_csharp_method_call` types a chained invocation by resolving its
receiver, and nothing cached the answer, so an n-link fluent chain re-resolved
its whole prefix once per branch per link. A real `microsoft/aspire` file spent
253s on its own and a full index made no progress for 33+ minutes at 100% CPU.

Fixes #1800.

## Three recursive branches, not two

The issue names two sites; there are three, all descending into the same
receiver node:

| site | branch |
|---|---|
| `_invocation_return_type_name` (:803) | receiver type name |
| `_receiver_type_arity` (:891) | receiver generic arity |
| `_resolve_receiver_class_qn` (:1045) | receiver class qn |

That reconciles the issue's own numbers: the measured ~9x growth per two links
is 3², which two branches would not produce.

## The fix

The body becomes `_resolve_csharp_method_call`; the public name is a memoising
wrapper. Wrapping the entry point collapses all three branches at once, and any
future caller with it.

**Keyed on `(module_qn, caller_qn, start_byte, end_byte)`, not node id.** The
issue suggested node id; `id()` is recycled by CPython for freed objects, and
this repo already carries a scar from that — see `reset_resolution_caches`,
"wildcard entries keyed by dict id, which recycles". `local_var_types` is
deliberately absent from the key: for C# it is a pure function of the enclosing
method (`_overlay_span_binding` is Rust-gated), so one key cannot need two
answers.

**No separate depth cap.** An `_IN_PROGRESS` sentinel doubles as a cycle guard,
giving the "degrade to unresolved rather than hang" behaviour the issue asks
for on a malformed parse tree. A `_MISSING` sentinel keeps a cached `None`
distinct from a miss — `None` means "unresolved", which is a legitimate and
common answer, and caching it is most of the win on chains that do not resolve.

**Cleared in `reset_resolution_caches`**, via the private
`_csharp_type_inference` attribute so a project with no C# does not build an
engine just to clear an empty dict.

## Measured

Resolver entries, not seconds — deterministic, and the quantity the fix changes:

| links | calls before | calls after | secs before | secs after |
|---|---|---|---|---|
| 8 | 4,916 | 29 | 0.09 | 0.05 |
| 12 | 398,574 | 45 | 2.95 | 0.06 |
| 14 | 3,587,219 | 53 | 29.57 | 0.06 |

Growth is now +4 calls per +2 links. End to end, 200 files x 14 links indexes
in 1.08s; on `main` a single 14-link file took 29.57s, so that corpus was
roughly 100 minutes. The memo holds 2,000 entries (~74 KB) for 200 files and
clears to 0 on reset.

## Correctness

Speed alone proves nothing — a memo returning wrong answers is just as fast. A
harness captured every emitted relationship with and without the memo across
fluent, generic, inheritance and cast fixtures: **58 identical relationships**.
That harness was validated with a known-positive (poisoning the memo drops
exactly the 7 chained CALLS edges), because an equivalence check that cannot
fail is not evidence.

The memo key was audited the same way: 10 distinct keys, 0 locals/result
conflicts, and the audit demonstrably reports conflicts when the key is
weakened to collide.

## Tests

`test_chain_resolution_work_grows_linearly` is the regression test and the only
one that fails on pre-fix code — the old code resolved these chains correctly,
just exponentially. The other three are correctness guards on the memo itself
and fail when it is made to return wrong answers:

* `test_long_chain_still_resolves_every_link` — all 12 links still bind.
* `test_real_world_mixed_arity_chain_resolves` — the reported aspire shape
  (`Comment().Copy().EmptyLine().Run()`), whose zero-argument links exercise the
  arity branch directly rather than incidentally.
* `test_memo_does_not_leak_between_resolution_passes` — reddens if the cache
  clear is removed.

995 passed, 1 skipped across the C#, resolution and type-inference modules, on
a settled tree under the host suite lock. `ruff check` and `ruff format` clean.

## Not covered

A full `microsoft/aspire` index is the real acceptance test and is not run
here: it needs memgraph and a 5000-file clone, and cannot run in CI. Worth a
follow-up for a periodic large-repo indexing benchmark — this class of
regression is invisible to a unit suite by construction, which is how it
survived.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved C# fluent method-chain resolution for more consistent performance, especially on long chains.

- **Bug Fixes**
  - C# method chains now resolve reliably without missing links, including mixed-arity extension-method chains.
  - Resolution results refresh after files are re-parsed, preventing stale analysis across passes.
  - Circular or repeated resolution paths are handled safely without interrupting analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->