### PR TITLE
fix: fuzz the rm-path guard the shell harness was skipping (#1731)

### DIFF
--- a/codebase_rag/tests/test_fuzz_harnesses.py
+++ b/codebase_rag/tests/test_fuzz_harnesses.py
@@ -245,6 +245,18 @@ def test_shell_harness_agrees_with_the_classifier(shell_harness: ModuleType) -> 
         ("bash script.sh", True),
         ("python3 script.py", True),
         ("make install", True),
+        # Decided ONLY by the subshell guard, which runs before pipeline
+        # patterns. Nothing else in `_classify` refuses these, so they go red
+        # if that call is dropped or moved after segmentation.
+        ("echo $(whoami)", True),
+        ("echo `id`", True),
+        # Decided ONLY by `_is_dangerous_rm_path`. `rm -rf /` above is caught
+        # by `_check_segment_patterns` regardless, so it cannot stand in for
+        # these: each needs the guard the harness calls explicitly, because
+        # `_validate_segment` does not call it.
+        ("rm /tmp/zzz", True),
+        ("rm *", True),
+        ("rm -r -- -x/../../outside/victim", True),
     ):
         dangerous, _reason = shell_harness._classify(command)
         assert dangerous is expected, f"{command!r} classified {dangerous}"

--- a/codebase_rag/tests/test_fuzz_harnesses.py
+++ b/codebase_rag/tests/test_fuzz_harnesses.py
@@ -257,6 +257,10 @@ def test_shell_harness_agrees_with_the_classifier(shell_harness: ModuleType) -> 
         ("rm /tmp/zzz", True),
         ("rm *", True),
         ("rm -r -- -x/../../outside/victim", True),
+        # No executable segment: production returns COMMAND_EMPTY, so these
+        # are refused, not allowed. Only the no-groups branch decides them.
+        ("", True),
+        ("| && ;", True),
     ):
         dangerous, _reason = shell_harness._classify(command)
         assert dangerous is expected, f"{command!r} classified {dangerous}"

--- a/fuzz/fuzz_incremental_update.py
+++ b/fuzz/fuzz_incremental_update.py
@@ -250,6 +250,14 @@ def _package_demotion_residue(
         ("Project", "CONTAINS_PACKAGE"),
         ("Project", "CONTAINS_FOLDER"),
     }
+    # Measured on both #1798 shapes (init deleted with the directory gone, and
+    # init deleted with a sibling keeping it alive), the containment rows land
+    # on the MISSING side only -- no extra containment edge was produced by
+    # either. The extra side is kept anyway because two shapes are not the
+    # whole defect, and a clause that is merely unused costs nothing, while
+    # dropping one the defect does produce would turn a known bug red. Unlike
+    # the phantom rule in `_resurrected_file_residue`, no lost row is known to
+    # be swallowed here; narrow this the moment one is.
     for edges in (extra_edges, missing_edges):
         for edge in {
             e

--- a/fuzz/fuzz_shell_command.py
+++ b/fuzz/fuzz_shell_command.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import os
 import shlex
 import sys
+from pathlib import Path
 
 # `shell_command` imports pydantic_ai, which reaches logfire's pydantic plugin.
 # That plugin patches pydantic at import time via `inspect.getsource`, which
@@ -40,7 +41,9 @@ with atheris.instrument_imports():
     from codebase_rag.tools.shell_command import (
         _check_pipeline_patterns,
         _check_segment_patterns,
+        _has_subshell,
         _is_dangerous_command,
+        _is_dangerous_rm_path,
         _parse_command,
         _validate_segment,
     )
@@ -72,13 +75,47 @@ ALWAYS_DANGEROUS = (
 )
 
 
+# The project root reaches the two root-aware guards by DIFFERENT routes, and
+# they are not interchangeable. `_validate_segment` calls
+# `_git_escapes_project` itself when given a root, so passing one is enough.
+# `_is_dangerous_rm_path` has a single call site -- inside
+# `ShellCommander.execute`, after `_validate_segment` -- so the harness has to
+# call it explicitly; passing a root does NOT reach it. An earlier version of
+# this file claimed it did, and `rm *`, `rm /` and
+# `rm -r -- -x/../../outside/victim` were classified safe while production
+# blocked them. The root is never written to and never chdir'd into: every
+# command is classified, none is executed.
+#
+# Deliberately a FIXED path rather than one derived from `__file__`. Under
+# PyInstaller -- which is how ClusterFuzzLite ships these targets -- `__file__`
+# resolves into the per-run `_MEIPASS` extraction directory, an ephemeral temp
+# path that nothing else lives under. Measured consequence: with such a root
+# `git -C . diff` flips from allowed to blocked, because `.` resolves against
+# the CWD and lands outside it. The classifier gets uniformly stricter, the
+# safe branch is reached far less often, and the properties asserted on safe
+# verdicts stop being exercised -- while the target still exits 0 and looks
+# like it is fuzzing. A fixed root keeps local and bundled runs identical.
+#
+# The path need not exist: `_git_escapes_project` and `_is_dangerous_rm_path`
+# only ask whether a resolved TARGET lies inside the root, which is pure path
+# arithmetic. Verified that this root and the real checkout give identical
+# verdicts for `git -C /etc status`, `git -C . diff`,
+# `git --git-dir=/tmp/x log` and `rm -rf /`.
+PROJECT_ROOT = Path("/fuzz-project-root")
+
+
 def _classify(command: str) -> tuple[bool, str]:
     """Return (is_dangerous, reason) the way the tool path decides it.
 
-    Mirrors the ordering in `ShellCommander`: a pipeline pattern rejects the
-    whole command before segmentation, then each segment is validated and
-    classified on its own.
+    Mirrors `ShellCommander.execute`'s ordering exactly: the subshell guard
+    runs FIRST on the whole command, then pipeline patterns, then each
+    segment is validated and classified on its own. Passing `project_root`
+    is what brings `_git_escapes_project` and `_is_dangerous_rm_path` into
+    coverage -- without it `_validate_segment` skips both.
     """
+    if pattern := _has_subshell(command):
+        return True, f"subshell: {pattern}"
+
     if reason := _check_pipeline_patterns(command):
         return True, reason
 
@@ -95,7 +132,7 @@ def _classify(command: str) -> tuple[bool, str]:
                 continue
             if reason := _check_segment_patterns(segment):
                 return True, reason
-            if err := _validate_segment(segment, available):
+            if err := _validate_segment(segment, available, project_root=PROJECT_ROOT):
                 return True, err
             try:
                 parts = shlex.split(segment)
@@ -104,6 +141,13 @@ def _classify(command: str) -> tuple[bool, str]:
                 return True, "invalid syntax"
             if not parts:
                 continue
+
+            # `execute` runs this guard here, on the split segment, after
+            # `_validate_segment` -- not from inside it. Mirrored rather than
+            # reached via `project_root`, which does not reach it.
+            dangerous, reason = _is_dangerous_rm_path(parts, PROJECT_ROOT)
+            if dangerous:
+                return True, reason
             dangerous, reason = _is_dangerous_command(parts, segment)
             if dangerous:
                 return True, reason

--- a/fuzz/fuzz_shell_command.py
+++ b/fuzz/fuzz_shell_command.py
@@ -121,8 +121,12 @@ def _classify(command: str) -> tuple[bool, str]:
 
     groups = _parse_command(command)
     if not groups:
-        # No executable segment: nothing runs, so nothing is dangerous.
-        return False, ""
+        # Production returns COMMAND_EMPTY here, before the segment loop, so
+        # the command is REFUSED rather than allowed. Modelling it as safe
+        # would leave the harness asserting its safe-verdict properties over
+        # a path the product never permits, and a regression that started
+        # executing empty commands would not show up as a mismatch.
+        return True, "empty command"
 
     available = ", ".join(sorted(cs.SHELL_LAUNCHER_COMMANDS))
     for group in groups:


### PR DESCRIPTION
Follow-up to #1796, which merged before these two commits were pushed.

## The gap

`fuzz_shell_command.py` on `main` never exercises `_is_dangerous_rm_path`. The harness passes `project_root` to `_validate_segment` on the assumption that this reaches both root-aware guards, but only `_git_escapes_project` is called from there. `_is_dangerous_rm_path` has a single call site, inside `ShellCommander.execute` **after** `_validate_segment`, so passing a root does not reach it.

Measured divergence on `main` today, harness verdict vs production:

| command | harness | production |
|---|---|---|
| `rm *` | safe | blocked |
| `rm /` | safe | blocked |
| `rm /tmp/zzz` | safe | blocked |
| `rm -r -- -x/../../outside/victim` | safe | blocked |

All one-directional: the harness is never stricter than production, only laxer. So the fuzzer cannot find a regression in this guard, which is the point of fuzzing it.

`rm -rf /` is NOT in that table, and that is why the gap survived an initial check: it is caught by `_check_segment_patterns` regardless, so its "dangerous" verdict says nothing about the rm guard. The reason string is the tell — `"rm with root path"` from the pattern matcher, not `"rm targeting ..."` from the guard.

## The fix

Call the guard where `execute` calls it: in the segment loop, on the split segment, after `_validate_segment`. A spy confirms it now runs (`guard_calls=1`) and returns its own reason strings. `ls -la` and `rm ./build` stay safe, so the widening did not simply make the classifier stricter.

## Coverage

Five parity cases, each decided by exactly one of the guards this touches:

- `echo $(whoami)`, `` echo `id` `` — the subshell ordering
- `rm /tmp/zzz`, `rm *`, `rm -r -- -x/../../outside/victim` — the rm guard

Verified by mutation that each half is genuinely pinned: deleting the subshell block reddens on `echo $(whoami)`; deleting the rm call reddens on the rm cases; the pre-existing parity cases stay green through both. Before this, either half could have been reverted with the suite staying green.

## Also here

A comment-only commit recording that both measured #1798 shapes produce containment rows on the missing side only, and why the extra-side clause was deliberately kept rather than narrowed. Zero non-comment lines.

## Verification

- `test_fuzz_harnesses.py`: 16 passed, on this branch rebased onto current `main`
- 15 seed corpus files and 400 random inputs through the widened path: 0 failures
- The frozen target previously did 119,393 runs in 61s in `clusterfuzzlite-run-fuzzers:v1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded shell-command safety coverage to include subshell syntax, dangerous `rm` paths, empty commands, and punctuation-only commands.
  * Improved fuzz testing to align more closely with production safety classification, including consistent project-root handling and explicit rejection of unsafe or incomplete commands.

* **Documentation**
  * Added explanatory notes clarifying containment behavior in incremental update fuzz testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->