### PR TITLE
fix: one invalid UTF-8 byte no longer drops a whole file's definitions

### DIFF
--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -14,13 +14,25 @@ if TYPE_CHECKING:
     from tree_sitter import Node
 
 
+def decode_node_text(raw: bytes) -> str:
+    """Decode node text without letting one bad byte delete a whole file.
+
+    `node.text` is a slice of the raw file bytes, which are never validated
+    as UTF-8. A strict decode raises `UnicodeDecodeError`, and the per-file
+    handler in `graph_updater` catches it and abandons the file, so a single
+    undecodable byte drops EVERY definition in that file from the graph --
+    including definitions nowhere near the bad byte (issue #1797).
+
+    `errors="replace"` keeps the rest of the file indexable and leaves a
+    visibly mangled identifier, matching what `document_tier`, `java_lombok`
+    and `build_lock` already do with the same class of input.
+    """
+    return raw.decode(cs.ENCODING_UTF8, errors="replace")
+
+
 def _python_get_name(node: Node) -> str | None:
     name_node = node.child_by_field_name("name")
-    return (
-        name_node.text.decode(cs.ENCODING_UTF8)
-        if name_node and name_node.text
-        else None
-    )
+    return decode_node_text(name_node.text) if name_node and name_node.text else None
 
 
 def _file_to_module(
@@ -60,9 +72,7 @@ def _js_get_name(node: Node) -> str | None:
     if node.type in cs.JS_NAME_NODE_TYPES:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         return (
-            name_node.text.decode(cs.ENCODING_UTF8)
-            if name_node and name_node.text
-            else None
+            decode_node_text(name_node.text) if name_node and name_node.text else None
         )
     return None
 
@@ -73,12 +83,12 @@ _js_file_to_module = partial(_file_to_module, package_marker=cs.INDEX_INDEX)
 def _generic_get_name(node: Node) -> str | None:
     name_node = node.child_by_field_name("name")
     if name_node and name_node.text:
-        return name_node.text.decode(cs.ENCODING_UTF8)
+        return decode_node_text(name_node.text)
 
     for field_name in cs.NAME_FIELDS:
         name_node = node.child_by_field_name(field_name)
         if name_node and name_node.text:
-            return name_node.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(name_node.text)
 
     return None
 
@@ -96,7 +106,7 @@ def _sql_get_name(node: Node) -> str | None:
             continue
         if not child.text:
             break
-        reference = child.text.decode(cs.ENCODING_UTF8).strip()
+        reference = decode_node_text(child.text).strip()
         # The shared normalizer applies PostgreSQL's folding rules (unquoted
         # lowercases, quoted keeps case); the string-call side uses the SAME
         # one, or a definition and the call naming it would never connect.
@@ -122,11 +132,11 @@ def _rust_get_name(node: Node) -> str | None:
     if node.type in cs.RS_TYPE_NODE_TYPES:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         if name_node and name_node.type == cs.TS_TYPE_IDENTIFIER and name_node.text:
-            return name_node.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(name_node.text)
     elif node.type in cs.RS_IDENT_NODE_TYPES:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         if name_node and name_node.type == cs.TS_IDENTIFIER and name_node.text:
-            return name_node.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(name_node.text)
     elif node.type == cs.TS_IMPL_ITEM:
         # An `impl Foo` block is an FQN scope but has no `name` field; its
         # target type anchors its methods' qns (owner_module.Foo.method).
@@ -155,14 +165,14 @@ def _c_get_name(node: Node) -> str | None:
     if node.type in cs.C_NAME_NODE_TYPES:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         if name_node and name_node.text:
-            return name_node.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(name_node.text)
     elif node.type == cs.TS_CPP_FUNCTION_DEFINITION:
         declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
         declarator = _c_unwrap_declarator(declarator)
         if declarator and declarator.type == cs.TS_CPP_FUNCTION_DECLARATOR:
             name_node = declarator.child_by_field_name(cs.FIELD_DECLARATOR)
             if name_node and name_node.type == cs.TS_IDENTIFIER and name_node.text:
-                return name_node.text.decode(cs.ENCODING_UTF8)
+                return decode_node_text(name_node.text)
     return _generic_get_name(node)
 
 
@@ -178,13 +188,13 @@ def _cpp_get_name(node: Node) -> str | None:
     if node.type in cs.CPP_NAME_NODE_TYPES:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         if name_node and name_node.text:
-            return name_node.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(name_node.text)
     elif node.type == cs.TS_CPP_FUNCTION_DEFINITION:
         declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
         if declarator and declarator.type == cs.TS_CPP_FUNCTION_DECLARATOR:
             name_node = declarator.child_by_field_name(cs.FIELD_DECLARATOR)
             if name_node and name_node.type == cs.TS_IDENTIFIER and name_node.text:
-                return name_node.text.decode(cs.ENCODING_UTF8)
+                return decode_node_text(name_node.text)
 
     return _generic_get_name(node)
 
@@ -200,7 +210,7 @@ def _csharp_get_name(node: Node) -> str | None:
             if child.type == cs.TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION:
                 name_node = child.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
                 if name_node and name_node.text:
-                    return name_node.text.decode(cs.ENCODING_UTF8)
+                    return decode_node_text(name_node.text)
         return None
     # Operators expose no `name` field and a destructor's `name` collides
     # with the constructor; delegate to the shared synthesizer so the FQN

--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -23,6 +23,12 @@ def decode_node_text(raw: bytes) -> str:
     undecodable byte drops EVERY definition in that file from the graph --
     including definitions nowhere near the bad byte (issue #1797).
 
+    Several passes decode node text independently -- the name extractors
+    below, the call pass, and `parsers.utils.safe_decode_text` (decorators,
+    modifiers, import paths) -- and each one abandons the file on its own.
+    Every such site must route through here; fixing one leaves the rest
+    losing data on the same input.
+
     `errors="replace"` keeps the rest of the file indexable and leaves a
     visibly mangled identifier, matching what `document_tier`, `java_lombok`
     and `build_lock` already do with the same class of input.

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -13,7 +13,7 @@ from tree_sitter import Node, QueryCursor
 from .. import constants as cs
 from .. import logs as ls
 from ..capture import ALL_ENABLED, CaptureSelection
-from ..language_spec import LanguageSpec
+from ..language_spec import LanguageSpec, decode_node_text
 from ..parser_loader import COMBINED_FUNC_CLASS_QUERIES
 from ..services import IngestorProtocol
 from ..types_defs import (
@@ -1294,7 +1294,10 @@ class CallProcessor:
         if not name_node:
             return None
         text = name_node.text
-        return None if text is None else text.decode(cs.ENCODING_UTF8)
+        # Replacement decode, not strict: one undecodable byte in this file
+        # must not abort the whole call pass and strand the file's CALLS
+        # edges (issue #1797, same class as the definition-side extractors).
+        return None if text is None else decode_node_text(text)
 
     def _collect_all_call_nodes(
         self,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1296,7 +1296,9 @@ class CallProcessor:
         text = name_node.text
         # Replacement decode, not strict: one undecodable byte in this file
         # must not abort the whole call pass and strand the file's CALLS
-        # edges (issue #1797, same class as the definition-side extractors).
+        # edges (issue #1797). This is NOT the call pass's only name funnel
+        # -- `_get_call_target_name` decodes call targets separately and is
+        # routed through the same helper.
         return None if text is None else decode_node_text(text)
 
     def _collect_all_call_nodes(
@@ -2656,12 +2658,12 @@ class CallProcessor:
                     | cs.TS_PHP_NAME
                 ):
                     if func_child.text is not None:
-                        return func_child.text.decode(cs.ENCODING_UTF8)
+                        return decode_node_text(func_child.text)
                 case cs.TS_GENERIC_FUNCTION:
                     # turbofish: unwrap to the underlying callee identifier
                     inner = func_child.child_by_field_name(cs.TS_FIELD_FUNCTION)
                     if inner and inner.text:
-                        return inner.text.decode(cs.ENCODING_UTF8)
+                        return decode_node_text(inner.text)
                 case cs.TS_RS_FIELD_EXPRESSION if language == cs.SupportedLanguage.RUST:
                     # Rust member call `a.b.method()`: use the full dotted receiver
                     # chain as the call name so the resolver can map the receiver to
@@ -2670,11 +2672,11 @@ class CallProcessor:
                     # path; a paren-free chain ends at the bare-method trie fallback
                     # when the receiver type is unknown.
                     if (text := func_child.text) is not None:
-                        return text.decode(cs.ENCODING_UTF8)
+                        return decode_node_text(text)
                 case cs.TS_CPP_FIELD_EXPRESSION:
                     field_node = func_child.child_by_field_name(cs.FIELD_FIELD)
                     if field_node and field_node.text:
-                        method = field_node.text.decode(cs.ENCODING_UTF8)
+                        method = decode_node_text(field_node.text)
                         # Prepend a simple-identifier receiver (`obj->m`/`obj.m`
                         # -> `obj.m`) so the resolver can map obj to its type and
                         # bind the correct class method; a `.`-joined two-part name
@@ -2687,7 +2689,7 @@ class CallProcessor:
                             and arg.type == cs.TS_IDENTIFIER
                             and arg.text
                         ):
-                            receiver = arg.text.decode(cs.ENCODING_UTF8)
+                            receiver = decode_node_text(arg.text)
                             return f"{receiver}{cs.SEPARATOR_DOT}{method}"
                         # A factory-call receiver (`parser(ia, cb).parse(...)`,
                         # nlohmann's basic_json::parse) is a call_expression on a
@@ -2712,7 +2714,7 @@ class CallProcessor:
                             )
                             and arg.text
                         ):
-                            receiver = arg.text.decode(cs.ENCODING_UTF8)
+                            receiver = decode_node_text(arg.text)
                             return f"{receiver}{cs.SEPARATOR_DOT}{method}"
                         return method
                 case cs.TS_CSHARP_GENERIC_NAME if (
@@ -2725,7 +2727,7 @@ class CallProcessor:
                     # graph (Polly's parameterless HandleInner overload
                     # delegating to its Func sibling).
                     if func_child.text is not None:
-                        full = func_child.text.decode(cs.ENCODING_UTF8)
+                        full = decode_node_text(func_child.text)
                         return full.split(cs.CHAR_ANGLE_OPEN, 1)[0]
                 case cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION if (
                     language == cs.SupportedLanguage.CSHARP
@@ -2740,13 +2742,13 @@ class CallProcessor:
                         cs.TS_CSHARP_FIELD_EXPRESSION
                     )
                     if name_node and name_node.text:
-                        method = name_node.text.decode(cs.ENCODING_UTF8)
+                        method = decode_node_text(name_node.text)
                         # A generic member (`recv.Handle<T>`) registers
                         # generic-free; strip the type arguments so the
                         # name-keyed fallbacks can match.
                         method = method.split(cs.CHAR_ANGLE_OPEN, 1)[0]
                         if expr_node and expr_node.text:
-                            receiver = expr_node.text.decode(cs.ENCODING_UTF8)
+                            receiver = decode_node_text(expr_node.text)
                             return f"{receiver}{cs.SEPARATOR_DOT}{method}"
                         return method
                 case cs.TS_CSHARP_CONDITIONAL_ACCESS_EXPRESSION if (
@@ -2770,7 +2772,7 @@ class CallProcessor:
                         else None
                     )
                     if name_node and name_node.text:
-                        method = name_node.text.decode(cs.ENCODING_UTF8)
+                        method = decode_node_text(name_node.text)
                         receiver_node = (
                             func_child.named_children[0]
                             if (func_child.named_children)
@@ -2781,7 +2783,7 @@ class CallProcessor:
                             and receiver_node is not binding
                             and receiver_node.text
                         ):
-                            receiver = receiver_node.text.decode(cs.ENCODING_UTF8)
+                            receiver = decode_node_text(receiver_node.text)
                             return f"{receiver}{cs.SEPARATOR_DOT}{method}"
                         return method
                 case cs.TS_CALL_EXPRESSION if language in _JS_TS_LANGUAGES:
@@ -2796,7 +2798,7 @@ class CallProcessor:
                     if self._unwrap_bound_function(func_child) is not None:
                         peeled = self._peel_bound_callable(func_child)
                         if peeled.text is not None:
-                            return peeled.text.decode(cs.ENCODING_UTF8)
+                            return decode_node_text(peeled.text)
                 case cs.TS_PARENTHESIZED_EXPRESSION:
                     return self._get_iife_target_name(func_child)
                 case cs.TS_FUNCTION_EXPRESSION | cs.TS_GENERATOR_FUNCTION if (
@@ -2824,7 +2826,7 @@ class CallProcessor:
                 # it is not reported as dead.
                 ctor = call_node.child_by_field_name(cs.FIELD_CONSTRUCTOR)
                 if ctor is not None and ctor.text is not None:
-                    return ctor.text.decode(cs.ENCODING_UTF8)
+                    return decode_node_text(ctor.text)
             case cs.TS_OBJECT_CREATION_EXPRESSION if language in (
                 cs.SupportedLanguage.JAVA,
                 cs.SupportedLanguage.CSHARP,
@@ -2836,7 +2838,7 @@ class CallProcessor:
                 # -> ArrayList); a scoped name (`Outer.Inner`) is left for the resolver.
                 type_node = call_node.child_by_field_name(cs.FIELD_TYPE)
                 if type_node is not None and type_node.text is not None:
-                    return type_node.text.decode(cs.ENCODING_UTF8).split(
+                    return decode_node_text(type_node.text).split(
                         cs.CHAR_ANGLE_OPEN, 1
                     )[0]
             case cs.TS_NEW_EXPRESSION if language == cs.SupportedLanguage.CPP:
@@ -2867,16 +2869,16 @@ class CallProcessor:
             ):
                 operator_node = call_node.child_by_field_name(cs.FIELD_OPERATOR)
                 if operator_node and operator_node.text:
-                    operator_text = operator_node.text.decode(cs.ENCODING_UTF8)
+                    operator_text = decode_node_text(operator_node.text)
                     return cpp_utils.convert_operator_symbol_to_name(operator_text)
             case cs.TS_METHOD_INVOCATION:
                 object_node = call_node.child_by_field_name(cs.FIELD_OBJECT)
                 name_node = call_node.child_by_field_name(cs.FIELD_NAME)
                 if name_node and name_node.text:
-                    method_name = name_node.text.decode(cs.ENCODING_UTF8)
+                    method_name = decode_node_text(name_node.text)
                     if not object_node or not object_node.text:
                         return method_name
-                    object_text = object_node.text.decode(cs.ENCODING_UTF8)
+                    object_text = decode_node_text(object_node.text)
                     return f"{object_text}{cs.SEPARATOR_DOT}{method_name}"
             # Scala infix operator call (`a ~> b`, `xs map f`): the callee is the
             # `operator` field's method name. tree-sitter has no `function` field
@@ -2890,7 +2892,7 @@ class CallProcessor:
             case cs.TS_SCALA_INFIX_EXPRESSION if language == cs.SupportedLanguage.SCALA:
                 operator_node = call_node.child_by_field_name(cs.FIELD_OPERATOR)
                 if operator_node and operator_node.text:
-                    return operator_node.text.decode(cs.ENCODING_UTF8)
+                    return decode_node_text(operator_node.text)
             # Rust `square!(3)`: the callee lives in the `macro` field (no
             # `function`/`name` field), so the invocation was captured as a
             # call but dropped nameless here; unresolvable even now that
@@ -2898,11 +2900,11 @@ class CallProcessor:
             case cs.TS_RS_MACRO_INVOCATION if language == cs.SupportedLanguage.RUST:
                 macro_node = call_node.child_by_field_name(cs.FIELD_MACRO)
                 if macro_node is not None and macro_node.text is not None:
-                    return macro_node.text.decode(cs.ENCODING_UTF8)
+                    return decode_node_text(macro_node.text)
 
         if name_node := call_node.child_by_field_name(cs.FIELD_NAME):
             if name_node.text is not None:
-                return name_node.text.decode(cs.ENCODING_UTF8)
+                return decode_node_text(name_node.text)
 
         return None
 

--- a/codebase_rag/parsers/dart/utils.py
+++ b/codebase_rag/parsers/dart/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from tree_sitter import Node
 
 from ... import constants as cs
+from ...language_spec import decode_node_text
 
 
 def dart_get_name(node: Node) -> str | None:
@@ -18,14 +19,14 @@ def dart_get_name(node: Node) -> str | None:
     if node.type in cs.DART_CONSTRUCTOR_SIGNATURE_TYPES:
         ids = [c for c in node.named_children if c.type == cs.TS_IDENTIFIER and c.text]
         if ids:
-            return ids[-1].text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(ids[-1].text)
         return None
     name_node = node.child_by_field_name(cs.FIELD_NAME)
     if name_node and name_node.text:
-        return name_node.text.decode(cs.ENCODING_UTF8)
+        return decode_node_text(name_node.text)
     ids = [c for c in node.named_children if c.type == cs.TS_IDENTIFIER and c.text]
     if ids:
-        return ids[-1].text.decode(cs.ENCODING_UTF8)
+        return decode_node_text(ids[-1].text)
     return None
 
 
@@ -80,7 +81,7 @@ def _selector_member_name(selector: Node) -> str | None:
         ):
             for inner in child.named_children:
                 if inner.type == cs.TS_IDENTIFIER and inner.text:
-                    return inner.text.decode(cs.ENCODING_UTF8)
+                    return decode_node_text(inner.text)
             return None
     return None
 
@@ -88,7 +89,7 @@ def _selector_member_name(selector: Node) -> str | None:
 def _first_identifier_text(node: Node) -> str | None:
     for inner in node.named_children:
         if inner.type == cs.TS_IDENTIFIER and inner.text:
-            return inner.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(inner.text)
     return None
 
 
@@ -184,7 +185,7 @@ def _chain_part(node: Node) -> str | None:
         case cs.TS_DART_IDENTIFIER:
             if node.text is None:
                 return None
-            return node.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(node.text)
         case cs.TS_DART_THIS | cs.TS_DART_SUPER:
             return _CHAIN_STOP
         case _:
@@ -274,11 +275,11 @@ def dart_return_type_name(node: Node) -> str | None:
     if node.type in cs.DART_CONSTRUCTOR_SIGNATURE_TYPES:
         for child in node.named_children:
             if child.type == cs.TS_DART_IDENTIFIER and child.text:
-                return child.text.decode(cs.ENCODING_UTF8)
+                return decode_node_text(child.text)
         return None
     for child in node.named_children:
         if child.type == cs.TS_DART_TYPE_IDENTIFIER and child.text:
-            return child.text.decode(cs.ENCODING_UTF8)
+            return decode_node_text(child.text)
         if child.type == cs.TS_DART_IDENTIFIER:
             return None
     return None
@@ -290,7 +291,7 @@ def dart_extract_uri(node: Node) -> str | None:
     while stack:
         current = stack.pop()
         if current.type == cs.TS_DART_URI and current.text:
-            return current.text.decode(cs.ENCODING_UTF8).strip(cs.DART_QUOTE_CHARS)
+            return decode_node_text(current.text).strip(cs.DART_QUOTE_CHARS)
         stack.extend(current.children)
     return None
 

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -10,6 +10,7 @@ from tree_sitter import Language, Node, Query, QueryCursor
 
 from .. import constants as cs
 from .. import logs
+from ..language_spec import decode_node_text
 from ..types_defs import (
     ASTNode,
     CppDefinitionSpan,
@@ -242,7 +243,11 @@ def extract_modifiers_and_decorators(
 
 @lru_cache(maxsize=50000)
 def _cached_decode_bytes(text_bytes: bytes) -> str:
-    return text_bytes.decode(cs.ENCODING_UTF8)
+    # Replacement decode, not strict. `safe_decode_text` feeds decorators,
+    # modifiers and import paths, and a strict decode here raised
+    # UnicodeDecodeError and abandoned the whole file -- one bad byte in a
+    # Python decorator dropped every definition in it (issue #1797).
+    return decode_node_text(text_bytes)
 
 
 def node_site_properties(node: Node) -> PropertyDict:

--- a/codebase_rag/tests/test_invalid_utf8_keeps_file_indexed.py
+++ b/codebase_rag/tests/test_invalid_utf8_keeps_file_indexed.py
@@ -1,0 +1,88 @@
+"""One undecodable byte must not delete a whole file's definitions.
+
+`node.text` is a slice of the raw file bytes, which are never validated as
+UTF-8. The name extractors in `language_spec` decoded them strictly, so a
+single bad byte raised `UnicodeDecodeError`; the per-file handler in
+`graph_updater` caught it, logged `INCREMENTAL_FILE_FAILED` and abandoned the
+file. The result was total and silent: every definition in that file vanished
+from the graph, including pure-ASCII ones nowhere near the bad byte, with
+nothing in the graph to say the file had been skipped (issue #1797).
+
+The bytes sit in the file CONTENT, not in a filename, so these fixtures are
+portable to the Windows runners: NTFS restricts the characters a path may
+contain, not the bytes a file may hold.
+
+What each test pins:
+
+* `test_a_bad_byte_does_not_drop_the_rest_of_the_file` is the regression. It
+  asserts on the UNTOUCHED sibling function, which is the definition the
+  defect actually lost -- asserting on the damaged name instead would pass
+  against a fix that dropped the file and reported nothing.
+* `test_the_damaged_name_survives_as_a_replacement_char` pins the choice of
+  `errors="replace"` over dropping the node, so a later switch to a silent
+  skip is a red test rather than a quiet regression to invisible loss.
+* `test_a_clean_file_is_unchanged_by_the_fix` is the control: it fails if the
+  replacement decode has altered ordinary well-formed input.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import create_and_run_updater, get_node_names
+from codebase_rag.types_defs import NodeType
+
+# The bad bytes precede the dot, so they land inside the node
+# `_generic_get_name` decodes AS A WHOLE. That is what makes the decode raise
+# rather than merely truncate: with the bytes after the dot, tree-sitter
+# splits them out of the identifier token and the decode quietly succeeds on
+# a shortened name. Only this placement reproduces #1797's total loss.
+_BAD = (
+    b"function Greeter\xff\xff.greet(n) return 1 end\nfunction other() return 2 end\n"
+)
+_CLEAN = b"function Greeter.greet(n) return 1 end\nfunction other() return 2 end\n"
+
+_UNTOUCHED_SIBLING = "proj.a.other"
+
+
+def _definitions(mock_ingestor: MagicMock) -> set[str]:
+    """Every Function/Method qualified name written to the graph."""
+    return get_node_names(mock_ingestor, NodeType.FUNCTION.value) | get_node_names(
+        mock_ingestor, NodeType.METHOD.value
+    )
+
+
+def _index(tmp: Path, ingestor: MagicMock, payload: bytes) -> set[str]:
+    project = tmp / "proj"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "a.lua").write_bytes(payload)
+    create_and_run_updater(project, ingestor, skip_if_missing=cs.SupportedLanguage.LUA)
+    return _definitions(ingestor)
+
+
+def test_a_bad_byte_does_not_drop_the_rest_of_the_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The regression. `other` is pure ASCII on its own line and has nothing to
+    # do with the bad byte; before the fix it was lost with the whole file.
+    assert _UNTOUCHED_SIBLING in _index(temp_repo, mock_ingestor, _BAD)
+
+
+def test_the_damaged_name_survives_as_a_replacement_char(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The damaged definition is kept and visibly mangled, not silently
+    # discarded: a reader sees U+FFFD and knows the source byte was invalid.
+    damaged = {qn for qn in _index(temp_repo, mock_ingestor, _BAD) if "�" in qn}
+    assert damaged, "the damaged definition was dropped instead of replaced"
+
+
+def test_a_clean_file_is_unchanged_by_the_fix(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Control: well-formed input must decode exactly as before, with no
+    # replacement characters anywhere.
+    found = _index(temp_repo, mock_ingestor, _CLEAN)
+    assert found == {"proj.a.Greeter.greet", _UNTOUCHED_SIBLING}

--- a/codebase_rag/tests/test_invalid_utf8_keeps_file_indexed.py
+++ b/codebase_rag/tests/test_invalid_utf8_keeps_file_indexed.py
@@ -31,8 +31,12 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from codebase_rag import constants as cs
-from codebase_rag.tests.conftest import create_and_run_updater, get_node_names
-from codebase_rag.types_defs import NodeType
+from codebase_rag.tests.conftest import (
+    create_and_run_updater,
+    get_node_names,
+    get_relationships,
+)
+from codebase_rag.types_defs import NodeType, RelationshipType
 
 # The bad bytes precede the dot, so they land inside the node
 # `_generic_get_name` decodes AS A WHOLE. That is what makes the decode raise
@@ -40,9 +44,15 @@ from codebase_rag.types_defs import NodeType
 # splits them out of the identifier token and the decode quietly succeeds on
 # a shortened name. Only this placement reproduces #1797's total loss.
 _BAD = (
-    b"function Greeter\xff\xff.greet(n) return 1 end\nfunction other() return 2 end\n"
+    b"function Greeter\xff\xff.greet(n) return 1 end\n"
+    b"function other() return 2 end\n"
+    b"function caller() return other() end\n"
 )
-_CLEAN = b"function Greeter.greet(n) return 1 end\nfunction other() return 2 end\n"
+_CLEAN = (
+    b"function Greeter.greet(n) return 1 end\n"
+    b"function other() return 2 end\n"
+    b"function caller() return other() end\n"
+)
 
 _UNTOUCHED_SIBLING = "proj.a.other"
 
@@ -85,4 +95,24 @@ def test_a_clean_file_is_unchanged_by_the_fix(
     # Control: well-formed input must decode exactly as before, with no
     # replacement characters anywhere.
     found = _index(temp_repo, mock_ingestor, _CLEAN)
-    assert found == {"proj.a.Greeter.greet", _UNTOUCHED_SIBLING}
+    assert found == {
+        "proj.a.Greeter.greet",
+        _UNTOUCHED_SIBLING,
+        "proj.a.caller",
+    }
+
+
+def test_the_call_pass_still_links_the_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The definition pass and the call pass decode names independently, so
+    # fixing only `language_spec` left this pass raising and the file's CALLS
+    # edges stranded. Without this, nothing in THIS module goes red for that
+    # half of the fix -- only the conftest per-pass guard catches it, and a
+    # guard living outside the test file is easy to silence by accident.
+    _index(temp_repo, mock_ingestor, _BAD)
+    edges = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(mock_ingestor, RelationshipType.CALLS.value)
+    }
+    assert ("proj.a.caller", _UNTOUCHED_SIBLING) in edges

--- a/codebase_rag/tests/test_invalid_utf8_keeps_file_indexed.py
+++ b/codebase_rag/tests/test_invalid_utf8_keeps_file_indexed.py
@@ -116,3 +116,25 @@ def test_the_call_pass_still_links_the_file(
         for call in get_relationships(mock_ingestor, RelationshipType.CALLS.value)
     }
     assert ("proj.a.caller", _UNTOUCHED_SIBLING) in edges
+
+
+# The bad byte is in a DECORATOR, not in any name the extractors read. It
+# reaches `parsers.utils.safe_decode_text`, a third pass that decodes
+# independently of the two above -- and Python is the repo's primary
+# language, so this is the most likely way a real repository hits #1797.
+_BAD_DECORATOR = b"@deco\xffr\ndef f(): pass\ndef other(): pass\n"
+
+
+def test_a_bad_byte_in_a_decorator_does_not_drop_the_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Fixing only the name extractors and the call pass left this raising:
+    # decorators, modifiers and import paths all go through
+    # `safe_decode_text`, whose name suggests it already handled this and
+    # whose cached decode was strict.
+    project = temp_repo / "pyproj"
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "a.py").write_bytes(_BAD_DECORATOR)
+    create_and_run_updater(project, mock_ingestor)
+    found = get_node_names(mock_ingestor, NodeType.FUNCTION.value)
+    assert {"pyproj.a.f", "pyproj.a.other"} <= found

--- a/fuzz/fuzz_parse_source.py
+++ b/fuzz/fuzz_parse_source.py
@@ -80,16 +80,11 @@ def _extract_names(language: cs.SupportedLanguage, root: object) -> None:
         current = stack.pop()
         if current.type in wanted:  # type: ignore[attr-defined]
             # A None return is a legitimate "no name here"; a raise is not.
-            try:
-                fqn_spec.get_name(current)  # type: ignore[arg-type]
-            except UnicodeDecodeError:
-                # Known defect #1798's sibling, #1797: the extractors decode
-                # node text as strict UTF-8, so one undecodable byte raises
-                # and production drops the whole file from the graph. Caught
-                # narrowly -- only this exception type, only here -- so every
-                # other failure in the extractor still surfaces. Remove this
-                # handler when #1797 is fixed; the harness then re-detects it.
-                pass
+            # #1797's UnicodeDecodeError suppression was removed with the fix:
+            # the extractors decode with errors="replace", so an undecodable
+            # byte can no longer raise here and a regression would surface as
+            # a crash rather than being silently tolerated.
+            fqn_spec.get_name(current)  # type: ignore[arg-type]
         stack.extend(current.children)  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
Closes #1797.

`node.text` is a slice of the raw file bytes, which are never validated as UTF-8. The name extractors decoded them strictly, so one undecodable byte raised `UnicodeDecodeError`; the per-file handler in `graph_updater` caught it, logged `INCREMENTAL_FILE_FAILED` and abandoned the file. Every definition in that file left the graph, including pure-ASCII ones nowhere near the bad byte, with nothing recorded to say the file had been skipped.

```
clean file   -> ['proj.a.Greeter.greet', 'proj.a.other']
one bad byte -> []
```

## Three passes, not one

The issue scopes the fix to the `_*_get_name` helpers in `language_spec`. That is not enough — three passes decode node text independently and each abandons the file on its own:

| pass | site | what is lost |
|---|---|---|
| definitions | `language_spec`, 12 extractors | every definition in the file |
| calls | `call_processor._get_node_name` and `_get_call_target_name` | the file's CALLS edges |
| decorators, modifiers, imports | `parsers/utils._cached_decode_bytes` | every definition in the file |

All three now route through one helper, `language_spec.decode_node_text`, whose docstring names them so the next reader does not have to rediscover that fixing one leaves the others losing data.

The third was the one that mattered. Fixing the first two left a bad byte in a **Python decorator** still dropping the whole file, byte-identical to base, in the repo's primary language:

```
@deco\xffr  ->  defs=[]        before
@deco\xffr  ->  ['proj.a.f', 'proj.a.other']   after
```

It sits behind `safe_decode_text` (553 call sites), whose name reads as though it already handled this. That naming is filed separately as #1811.

`errors="replace"` follows `document_tier`, `java_lombok` and `build_lock`, which already take that route with the same class of input. The damaged identifier survives visibly mangled (`proj.a.Greeter��.greet`) rather than being deleted — greppable, and module-scoped so it cannot collide across files.

## Tests

Five, each verified to fail without the fix by mutating its own site in isolation:

| test | reddens when |
|---|---|
| `test_a_bad_byte_does_not_drop_the_rest_of_the_file` | `language_spec` reverted to strict |
| `test_the_damaged_name_survives_as_a_replacement_char` | `language_spec` reverted to strict |
| `test_the_call_pass_still_links_the_file` | `call_processor` reverted to strict |
| `test_a_bad_byte_in_a_decorator_does_not_drop_the_file` | `parsers/utils` reverted to strict |
| `test_a_clean_file_is_unchanged_by_the_fix` | control; reddens when the decode corrupts valid input |

The control was itself mutated to confirm it can fail, so its green is evidence rather than decoration.

The fuzz harness's `except UnicodeDecodeError: pass` suppression is removed, so a regression surfaces there instead of being silently tolerated. Verified by driving `fuzz_parse_source` against the in-tree seed `repro_1797_invalid_utf8.bin` through the repo's atheris stub: it passes with the suppression gone, and a planted `RuntimeError` in `decode_node_text` still surfaces.

The bad bytes are in file **content**, not filenames, so the fixtures are portable to the Windows runners.

## Scope check

Swept 18 payloads across py/js/go/java/rust/cpp/lua/cs — decorators, imports, type hints, class bases, annotations, call sites, docstrings. No remaining loss from the raising mode.

Two residual losses are a different defect and are **not** fixed here: they raise nothing at all (confirmed by tracing exception events), so `errors="replace"` cannot reach them. tree-sitter splits the token at the bad byte and the symbol is silently indexed under a truncated name. Filed as #1810, which now carries both, including a Java case where a mangled annotation deletes `C.m()` and invents `C.void()` in its place.

Related: #1810 (truncation mode), #1811 (`safe_decode_text` naming).

## Verification

- Full suite green on the first two commits: 10892 passed, 131 skipped, 1 xfailed, 0 failed.
- The final commit is verified by the 5 tests above (`-n 4`), per-site mutation, the 18-payload sweep, and ruff check/format clean. It has not had a full-suite run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved indexing for files containing invalid UTF-8 bytes.
  - Files are no longer abandoned when damaged text appears in names, decorators, call targets, or related source elements.
  - Undecodable characters are preserved as replacement characters, keeping definitions and call relationships available.
  - Clean text continues to decode as before.

- **Tests**
  - Added regression coverage for invalid UTF-8 handling across indexing and call processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->