### PR TITLE
feat: support Neo4j as a graph backend behind a pluggable dialect seam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,10 @@
 # CYPHER_THINKING_BUDGET=5000
 
 # Memgraph settings
+# Graph engine: memgraph (default) or neo4j.
+# neo4j additionally needs the optional driver: uv pip install 'code-graph-rag[neo4j]'
+GRAPH_BACKEND=memgraph
+
 MEMGRAPH_HOST=localhost
 MEMGRAPH_PORT=7687
 MEMGRAPH_HTTP_PORT=7444
@@ -87,6 +91,13 @@ MEMGRAPH_USERNAME=
 MEMGRAPH_PASSWORD=
 LAB_PORT=3000
 MEMGRAPH_BATCH_SIZE=1000
+
+# Only used when GRAPH_BACKEND=neo4j. Leave the credentials empty for an
+# unauthenticated server.
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USERNAME=
+NEO4J_PASSWORD=
+NEO4J_DATABASE=neo4j
 
 # Qdrant settings
 # Leave QDRANT_URL unset to use local file mode (only suitable below ~20k embeddings)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra treesitter-full --extra test --extra semantic --extra milvus --group dev
+          uv sync --extra treesitter-full --extra test --extra semantic --extra milvus --extra neo4j --group dev
 
       - name: Run integration tests
         env:

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -9,12 +9,13 @@ from typing import TypedDict, Unpack
 
 from dotenv import load_dotenv
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from . import constants as cs
 from . import exceptions as ex
 from . import logs
+from .graph_dialects import DIALECT_MEMGRAPH, available_dialects
 from .types_defs import CgrignorePatterns, ModelConfigKwargs
 
 # Load only the configuration file in the invocation directory.  The default
@@ -159,11 +160,24 @@ class AppConfig(BaseSettings):
         case_sensitive=False,
     )
 
+    # Which graph engine the ingestor talks to. Memgraph stays the default,
+    # so an existing install keeps its behaviour without touching config;
+    # see `graph_dialects` for what actually differs between engines.
+    GRAPH_BACKEND: str = DIALECT_MEMGRAPH
+
     MEMGRAPH_HOST: str = "localhost"
     MEMGRAPH_PORT: int = 7687
     MEMGRAPH_HTTP_PORT: int = 7444
     MEMGRAPH_USERNAME: str | None = None
     MEMGRAPH_PASSWORD: str | None = None
+
+    # Neo4j connects by URI rather than host/port: the scheme carries the
+    # routing mode (`neo4j://` for a cluster, `bolt://` for one instance)
+    # and TLS (`+s`/`+ssc`), none of which a host/port pair can express.
+    NEO4J_URI: str = "bolt://localhost:7687"
+    NEO4J_USERNAME: str | None = None
+    NEO4J_PASSWORD: str | None = None
+    NEO4J_DATABASE: str = "neo4j"
     LAB_PORT: int = 3000
     MEMGRAPH_BATCH_SIZE: int = 1000
     AGENT_RETRIES: int = 3
@@ -363,6 +377,25 @@ class AppConfig(BaseSettings):
     QUERY_RESULT_ROW_CAP: int = Field(default=500, gt=0)
     QUERY_MEMORY_LIMIT_MB: int = Field(default=4096, gt=0)
     QUERY_TIMEOUT_S: float = Field(default=60.0, gt=0)
+
+    @field_validator("GRAPH_BACKEND")
+    @classmethod
+    def _known_backend(cls, value: str) -> str:
+        """Reject an unknown engine name at startup.
+
+        Defaulting an unrecognised value to Memgraph would send Memgraph
+        DDL to whatever server is actually configured, and
+        `MemgraphIngestor.ensure_constraints` swallows DDL failures -- so
+        a typo would surface much later as a graph built with no
+        constraints rather than as a startup error.
+        """
+        normalised = value.strip().lower()
+        if normalised not in available_dialects():
+            raise ValueError(
+                f"GRAPH_BACKEND must be one of {', '.join(available_dialects())}; "
+                f"got {value!r}"
+            )
+        return normalised
 
     OLLAMA_HEALTH_TIMEOUT: float = 5.0
     LITELLM_HEALTH_TIMEOUT: float = 5.0

--- a/codebase_rag/constants/health.py
+++ b/codebase_rag/constants/health.py
@@ -13,13 +13,19 @@ HEALTH_CHECK_DOCKER_TIMEOUT_ERROR = (
 HEALTH_CHECK_DOCKER_FAILED_MSG = "Check failed"
 HEALTH_CHECK_DOCKER_EXIT_CODE = "Non-zero exit code"
 
-HEALTH_CHECK_MEMGRAPH_SUCCESSFUL = "Memgraph connection successful"
-HEALTH_CHECK_MEMGRAPH_FAILED = "Memgraph connection failed"
+# Named per engine so `cgr doctor` identifies the service it actually
+# probed: a Neo4j deployment shown a failing "Memgraph connection" check
+# is sent looking for the wrong server (issue #1590).
+HEALTH_CHECK_GRAPH_SUCCESSFUL = "{engine} connection successful"
+HEALTH_CHECK_GRAPH_FAILED = "{engine} connection failed"
 HEALTH_CHECK_MEMGRAPH_CONNECTED_MSG = "Connected and responsive at {endpoint}"
 HEALTH_CHECK_MEMGRAPH_CONNECTION_FAILED_MSG = "Connection or query failed"
 HEALTH_CHECK_MEMGRAPH_UNEXPECTED_FAILURE_MSG = "Unexpected failure"
-HEALTH_CHECK_MEMGRAPH_ERROR = "Memgraph error: {error}"
+HEALTH_CHECK_GRAPH_ERROR = "{engine} error: {error}"
 HEALTH_CHECK_MEMGRAPH_QUERY = "RETURN 1 AS test;"
+
+# Display names for the engines the ingestor can talk to.
+HEALTH_ENGINE_NAMES = {"memgraph": "Memgraph", "neo4j": "Neo4j"}
 
 HEALTH_CHECK_GRAPH_INTEGRITY_OK = "Graph structural integrity verified"
 HEALTH_CHECK_GRAPH_INTEGRITY_FAILED = "Graph structural integrity violations"

--- a/codebase_rag/constants/health.py
+++ b/codebase_rag/constants/health.py
@@ -15,7 +15,7 @@ HEALTH_CHECK_DOCKER_EXIT_CODE = "Non-zero exit code"
 
 HEALTH_CHECK_MEMGRAPH_SUCCESSFUL = "Memgraph connection successful"
 HEALTH_CHECK_MEMGRAPH_FAILED = "Memgraph connection failed"
-HEALTH_CHECK_MEMGRAPH_CONNECTED_MSG = "Connected and responsive at {host}:{port}"
+HEALTH_CHECK_MEMGRAPH_CONNECTED_MSG = "Connected and responsive at {endpoint}"
 HEALTH_CHECK_MEMGRAPH_CONNECTION_FAILED_MSG = "Connection or query failed"
 HEALTH_CHECK_MEMGRAPH_UNEXPECTED_FAILURE_MSG = "Unexpected failure"
 HEALTH_CHECK_MEMGRAPH_ERROR = "Memgraph error: {error}"

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -96,7 +96,6 @@ OPTIONAL MATCH (container)-[:DEFINES|DEFINES_METHOD*]->(defined)
 DETACH DELETE p, container, defined
 """
 
-CYPHER_SHOW_CONSTRAINTS = "SHOW CONSTRAINT INFO;"
 
 # Damage detectors for the issue #897 migration. Sharing always leaves a
 # single-hop signature: the topmost merged node has containment parents in
@@ -359,14 +358,6 @@ ORDER BY n.qualified_name
 
 def build_constraint_query(label: str, prop: str) -> str:
     return f"CREATE CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
-
-
-def build_drop_constraint_query(label: str, prop: str) -> str:
-    return f"DROP CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
-
-
-def build_index_query(label: str, prop: str) -> str:
-    return f"CREATE INDEX ON :{label}({prop});"
 
 
 def build_merge_node_query(label: str, id_key: str) -> str:

--- a/codebase_rag/graph_dialects.py
+++ b/codebase_rag/graph_dialects.py
@@ -1,0 +1,189 @@
+"""Per-engine Cypher differences, isolated behind one protocol.
+
+The query corpus is overwhelmingly portable: `MERGE`, `UNWIND $batch`,
+`SET n += row.props`, label and relationship alternation, `type()` and
+property-form `IS NULL` mean the same thing on every engine we target.
+Only a handful of constructs actually diverge, and this module is the one
+place that knows about them:
+
+* index and constraint DDL, which shares no syntax between engines;
+* listing constraints, where both the statement AND the result columns
+  differ (Memgraph returns `label`, Neo4j returns `labelsOrTypes`);
+* Memgraph's `QUERY MEMORY LIMIT` suffix, which has no Neo4j equivalent
+  and is a syntax error there.
+
+Adding an engine means adding a `GraphDialect` subclass and registering
+it below -- no edits to the ingestor, the query builders, or their call
+sites. That is the point of the indirection: issue #1590 asks for Neo4j,
+but the same seam has to take the engine after it without reopening any
+of this.
+
+A dialect is pure and stateless: it maps a request for a statement onto
+the text this engine accepts. It never executes anything, which keeps it
+trivially testable without a server.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .constants import (
+    CYPHER_MEMORY_LIMIT_SUFFIX,
+    CYPHER_MEMORY_LIMIT_TOKEN,
+    CYPHER_SEMICOLON,
+)
+from .types_defs import ResultRow
+
+# Engine identifiers, used by settings and by the registry below.
+DIALECT_MEMGRAPH = "memgraph"
+DIALECT_NEO4J = "neo4j"
+
+
+def _constraint_name(label: str, prop: str) -> str:
+    """A deterministic name for a constraint or index.
+
+    Neo4j identifies both by name rather than by pattern -- `DROP
+    CONSTRAINT` takes a name and nothing else -- so the name has to be
+    derivable from the same (label, prop) pair every time, in any process,
+    without reading the database first.
+    """
+    return f"cgr_{label.lower()}_{prop.lower()}"
+
+
+@runtime_checkable
+class GraphDialect(Protocol):
+    """The engine-specific half of the Cypher this project emits."""
+
+    name: str
+
+    def create_constraint(self, label: str, prop: str) -> str:
+        """Statement making `prop` unique across `label`."""
+        ...
+
+    def drop_constraint(self, label: str, prop: str) -> str:
+        """Statement removing the uniqueness of `prop` on `label`."""
+        ...
+
+    def create_index(self, label: str, prop: str) -> str:
+        """Statement indexing `label` on `prop`."""
+        ...
+
+    def show_constraints(self) -> str:
+        """Statement listing the constraints that currently exist."""
+        ...
+
+    def constraint_row_matches(self, row: ResultRow, label: str, prop: str) -> bool:
+        """Whether a `show_constraints` row describes (label, prop).
+
+        The row shape is part of the dialect: the two engines disagree on
+        both the column name and whether the label arrives as a scalar or
+        inside a list, so the comparison cannot live at the call site.
+        """
+        ...
+
+    def apply_memory_limit(self, query: str, mb: int) -> str:
+        """Bound a read's memory, where the engine supports it."""
+        ...
+
+
+class MemgraphDialect:
+    """Memgraph 2.x/3.x, the engine this project shipped on first."""
+
+    name = DIALECT_MEMGRAPH
+
+    def create_constraint(self, label: str, prop: str) -> str:
+        return f"CREATE CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
+
+    def drop_constraint(self, label: str, prop: str) -> str:
+        return f"DROP CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
+
+    def create_index(self, label: str, prop: str) -> str:
+        return f"CREATE INDEX ON :{label}({prop});"
+
+    def show_constraints(self) -> str:
+        return "SHOW CONSTRAINT INFO;"
+
+    def constraint_row_matches(self, row: ResultRow, label: str, prop: str) -> bool:
+        return row.get("label") == label and row.get("properties") == [prop]
+
+    def apply_memory_limit(self, query: str, mb: int) -> str:
+        if CYPHER_MEMORY_LIMIT_TOKEN in query.upper():
+            return query
+        stripped = query.rstrip()
+        if stripped.endswith(CYPHER_SEMICOLON):
+            stripped = stripped[: -len(CYPHER_SEMICOLON)].rstrip()
+        suffix = CYPHER_MEMORY_LIMIT_SUFFIX.format(mb=mb)
+        return f"{stripped}{suffix}{CYPHER_SEMICOLON}"
+
+
+class Neo4jDialect:
+    """Neo4j 5.x.
+
+    Three differences carry real risk rather than being cosmetic:
+
+    * DDL is name-addressed, not pattern-addressed. `DROP CONSTRAINT` in
+      particular accepts only a name, hence `_constraint_name`.
+    * `SHOW CONSTRAINTS` returns `labelsOrTypes` as a LIST. Comparing it
+      to a bare label silently matches nothing, which would make the
+      legacy-key migration a no-op instead of an error.
+    * There is no per-query memory clause. Appending Memgraph's would
+      make every single read a syntax error, so the limit is dropped
+      here; the equivalent control is server-side configuration.
+    """
+
+    name = DIALECT_NEO4J
+
+    def create_constraint(self, label: str, prop: str) -> str:
+        return (
+            f"CREATE CONSTRAINT {_constraint_name(label, prop)} IF NOT EXISTS "
+            f"FOR (n:{label}) REQUIRE n.{prop} IS UNIQUE"
+        )
+
+    def drop_constraint(self, label: str, prop: str) -> str:
+        return f"DROP CONSTRAINT {_constraint_name(label, prop)} IF EXISTS"
+
+    def create_index(self, label: str, prop: str) -> str:
+        return (
+            f"CREATE INDEX {_constraint_name(label, prop)} IF NOT EXISTS "
+            f"FOR (n:{label}) ON (n.{prop})"
+        )
+
+    def show_constraints(self) -> str:
+        return "SHOW CONSTRAINTS"
+
+    def constraint_row_matches(self, row: ResultRow, label: str, prop: str) -> bool:
+        labels = row.get("labelsOrTypes")
+        if not isinstance(labels, list):
+            return False
+        return label in labels and row.get("properties") == [prop]
+
+    def apply_memory_limit(self, query: str, mb: int) -> str:
+        return query
+
+
+_DIALECTS: dict[str, type[GraphDialect]] = {
+    DIALECT_MEMGRAPH: MemgraphDialect,
+    DIALECT_NEO4J: Neo4jDialect,
+}
+
+
+def available_dialects() -> tuple[str, ...]:
+    return tuple(sorted(_DIALECTS))
+
+
+def get_dialect(name: str) -> GraphDialect:
+    """Resolve an engine name to its dialect.
+
+    Unknown names raise rather than falling back to a default: a typo in
+    `CGR_GRAPH_BACKEND` that silently selected Memgraph would emit
+    Memgraph DDL at a Neo4j server, and the swallowed-DDL path described
+    in `graph_service.ensure_constraints` would hide that until the graph
+    was already corrupt.
+    """
+    try:
+        return _DIALECTS[name.strip().lower()]()
+    except KeyError:
+        raise ValueError(
+            f"Unknown graph backend {name!r}; expected one of "
+            f"{', '.join(available_dialects())}"
+        ) from None

--- a/codebase_rag/graph_dialects.py
+++ b/codebase_rag/graph_dialects.py
@@ -39,6 +39,20 @@ DIALECT_MEMGRAPH = "memgraph"
 DIALECT_NEO4J = "neo4j"
 
 
+def _quote_identifier(name: str) -> str:
+    """Backtick-quote a Cypher identifier, escaping any backticks in it.
+
+    `discovered_name` comes from the server's own catalogue and can be
+    anything a previous operator chose: a hyphen, a space or a dot makes
+    an unquoted `DROP CONSTRAINT` a syntax error. Verified against Neo4j
+    5.26 -- dropping `legacy-folder path.uc` unquoted raises
+    CypherSyntaxError, quoted it succeeds. The failure would be silent,
+    because `ensure_constraints` swallows DDL errors, leaving the
+    obsolete constraint enforced.
+    """
+    return "`" + name.replace("`", "``") + "`"
+
+
 def _constraint_name(label: str, prop: str) -> str:
     """A deterministic name for a constraint or index.
 
@@ -170,7 +184,9 @@ class Neo4jDialect:
         # created before this code existed and need not carry the name we
         # would derive, in which case dropping the derived name is a
         # no-op and the obsolete key stays enforced.
-        return f"DROP CONSTRAINT {discovered_name or _constraint_name(label, prop)} IF EXISTS"
+        return f"DROP CONSTRAINT {
+            _quote_identifier(discovered_name or _constraint_name(label, prop))
+        } IF EXISTS"
 
     def create_index(self, label: str, prop: str) -> str:
         return (

--- a/codebase_rag/graph_dialects.py
+++ b/codebase_rag/graph_dialects.py
@@ -60,8 +60,18 @@ class GraphDialect(Protocol):
         """Statement making `prop` unique across `label`."""
         ...
 
-    def drop_constraint(self, label: str, prop: str) -> str:
-        """Statement removing the uniqueness of `prop` on `label`."""
+    def drop_constraint(
+        self, label: str, prop: str, discovered_name: str | None = None
+    ) -> str:
+        """Statement removing the uniqueness of `prop` on `label`.
+
+        `discovered_name` is the name the server reported for this
+        constraint, where the engine addresses constraints by name. It
+        matters because the constraint being dropped predates this code
+        and may carry any name: dropping a name we derive ourselves would
+        silently leave someone else's legacy constraint enforcing an
+        obsolete key.
+        """
         ...
 
     def create_index(self, label: str, prop: str) -> str:
@@ -81,6 +91,10 @@ class GraphDialect(Protocol):
         """
         ...
 
+    def constraint_row_name(self, row: ResultRow) -> str | None:
+        """The server's own name for a `show_constraints` row, if any."""
+        ...
+
     def apply_memory_limit(self, query: str, mb: int) -> str:
         """Bound a read's memory, where the engine supports it."""
         ...
@@ -94,7 +108,12 @@ class MemgraphDialect:
     def create_constraint(self, label: str, prop: str) -> str:
         return f"CREATE CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
 
-    def drop_constraint(self, label: str, prop: str) -> str:
+    def drop_constraint(
+        self, label: str, prop: str, discovered_name: str | None = None
+    ) -> str:
+        # Memgraph addresses constraints by pattern, so the name is
+        # irrelevant here.
+        del discovered_name
         return f"DROP CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
 
     def create_index(self, label: str, prop: str) -> str:
@@ -105,6 +124,11 @@ class MemgraphDialect:
 
     def constraint_row_matches(self, row: ResultRow, label: str, prop: str) -> bool:
         return row.get("label") == label and row.get("properties") == [prop]
+
+    def constraint_row_name(self, row: ResultRow) -> str | None:
+        # Memgraph drops by pattern, so it never needs one.
+        del row
+        return None
 
     def apply_memory_limit(self, query: str, mb: int) -> str:
         if CYPHER_MEMORY_LIMIT_TOKEN in query.upper():
@@ -139,8 +163,14 @@ class Neo4jDialect:
             f"FOR (n:{label}) REQUIRE n.{prop} IS UNIQUE"
         )
 
-    def drop_constraint(self, label: str, prop: str) -> str:
-        return f"DROP CONSTRAINT {_constraint_name(label, prop)} IF EXISTS"
+    def drop_constraint(
+        self, label: str, prop: str, discovered_name: str | None = None
+    ) -> str:
+        # Prefer the name the server reported: a legacy constraint was
+        # created before this code existed and need not carry the name we
+        # would derive, in which case dropping the derived name is a
+        # no-op and the obsolete key stays enforced.
+        return f"DROP CONSTRAINT {discovered_name or _constraint_name(label, prop)} IF EXISTS"
 
     def create_index(self, label: str, prop: str) -> str:
         return (
@@ -156,6 +186,10 @@ class Neo4jDialect:
         if not isinstance(labels, list):
             return False
         return label in labels and row.get("properties") == [prop]
+
+    def constraint_row_name(self, row: ResultRow) -> str | None:
+        name = row.get("name")
+        return name if isinstance(name, str) and name else None
 
     def apply_memory_limit(self, query: str, mb: int) -> str:
         # `mb` is part of the protocol every dialect implements; Neo4j has

--- a/codebase_rag/graph_dialects.py
+++ b/codebase_rag/graph_dialects.py
@@ -213,7 +213,7 @@ def get_dialect(name: str) -> GraphDialect:
     """Resolve an engine name to its dialect.
 
     Unknown names raise rather than falling back to a default: a typo in
-    `CGR_GRAPH_BACKEND` that silently selected Memgraph would emit
+    `GRAPH_BACKEND` that silently selected Memgraph would emit
     Memgraph DDL at a Neo4j server, and the swallowed-DDL path described
     in `graph_service.ensure_constraints` would hide that until the graph
     was already corrupt.

--- a/codebase_rag/graph_dialects.py
+++ b/codebase_rag/graph_dialects.py
@@ -158,6 +158,10 @@ class Neo4jDialect:
         return label in labels and row.get("properties") == [prop]
 
     def apply_memory_limit(self, query: str, mb: int) -> str:
+        # `mb` is part of the protocol every dialect implements; Neo4j has
+        # no per-query memory clause, so the bound is deliberately dropped
+        # here rather than translated.
+        del mb
         return query
 
 

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -50,7 +50,12 @@ from ..cypher_queries import (
     build_merge_relationship_query,
     wrap_with_unwind,
 )
-from ..graph_dialects import DIALECT_NEO4J, GraphDialect, get_dialect
+from ..graph_dialects import (
+    DIALECT_MEMGRAPH,
+    DIALECT_NEO4J,
+    GraphDialect,
+    get_dialect,
+)
 from ..types_defs import (
     BatchParams,
     BatchWrapper,
@@ -122,7 +127,13 @@ class MemgraphIngestor:
         self._port = port
         self._username = username.strip() if username and username.strip() else None
         self._password = password.strip() if password and password.strip() else None
-        if (self._username is None) != (self._password is None):
+        # Only for the engine these credentials belong to: Neo4j
+        # authenticates with NEO4J_USERNAME/NEO4J_PASSWORD, so a leftover
+        # half-set MEMGRAPH_* pair must not stop a valid Neo4j
+        # deployment from starting.
+        if self._dialect.name == DIALECT_MEMGRAPH and (
+            (self._username is None) != (self._password is None)
+        ):
             raise ValueError(ex.AUTH_INCOMPLETE)
         if batch_size < 1:
             raise ValueError(ex.BATCH_SIZE)

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -94,6 +94,7 @@ class MemgraphIngestor:
         "_use_merge",
         "_dialect",
         "_driver",
+        "_driver_lock",
         "_rel_count",
         "_rel_groups",
         "batch_size",
@@ -116,6 +117,7 @@ class MemgraphIngestor:
         # mid-run if configuration changes underneath it.
         self._dialect = dialect or get_dialect(settings.GRAPH_BACKEND)
         self._driver: object | None = None
+        self._driver_lock = threading.Lock()
         self._host = host
         self._port = port
         self._username = username.strip() if username and username.strip() else None
@@ -167,6 +169,14 @@ class MemgraphIngestor:
             if self.conn:
                 self.conn.close()
                 logger.info(ls.MG_DISCONNECTED)
+            # Sessions handed to flush workers are closed by those
+            # workers; the pooled driver behind them is owned here and
+            # would otherwise leak its connection pool for the life of
+            # the process.
+            driver = self._driver
+            if driver is not None:
+                cast("Neo4jDriver", driver).close()
+                self._driver = None
 
     async def __aenter__(self) -> MemgraphIngestor:
         return self.__enter__()
@@ -251,14 +261,18 @@ class MemgraphIngestor:
         """
         from .neo4j_driver import Neo4jDriver as _Neo4jDriver
 
-        if self._driver is None:
-            self._driver = _Neo4jDriver(
-                uri=settings.NEO4J_URI,
-                username=settings.NEO4J_USERNAME,
-                password=settings.NEO4J_PASSWORD,
-                database=settings.NEO4J_DATABASE,
-            )
-        return cast("Neo4jDriver", self._driver)
+        # The parallel flush calls this from several worker threads at
+        # once, so an unguarded `if self._driver is None` would build and
+        # leak more than one connection pool.
+        with self._driver_lock:
+            if self._driver is None:
+                self._driver = _Neo4jDriver(
+                    uri=settings.NEO4J_URI,
+                    username=settings.NEO4J_USERNAME,
+                    password=settings.NEO4J_PASSWORD,
+                    database=settings.NEO4J_DATABASE,
+                )
+            return cast("Neo4jDriver", self._driver)
 
     def _execute_batch_on(
         self,

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -391,16 +391,22 @@ class MemgraphIngestor:
         when an earlier partial upgrade already dropped them.
         """
         existing_rows = self._execute_query(self._dialect.show_constraints())
-        legacy_present = [
-            (label, prop)
-            for label, prop in LEGACY_NODE_CONSTRAINTS
-            if any(
-                self._dialect.constraint_row_matches(row, label, prop)
-                for row in existing_rows
+        # Carry the server's own name for each match: engines that drop by
+        # name (Neo4j) must drop the constraint that actually exists, not
+        # one whose name we derived -- a legacy constraint predates this
+        # code and may be named anything.
+        legacy_present: list[tuple[str, str, str | None]] = []
+        for label, prop in LEGACY_NODE_CONSTRAINTS:
+            for row in existing_rows:
+                if self._dialect.constraint_row_matches(row, label, prop):
+                    legacy_present.append(
+                        (label, prop, self._dialect.constraint_row_name(row))
+                    )
+                    break
+        for label, prop, discovered_name in legacy_present:
+            self._execute_query(
+                self._dialect.drop_constraint(label, prop, discovered_name)
             )
-        ]
-        for label, prop in legacy_present:
-            self._execute_query(self._dialect.drop_constraint(label, prop))
         damaged = bool(self._execute_query(CYPHER_ANY_SHARED_STRUCTURE)) or bool(
             self._execute_query(CYPHER_ANY_KEYLESS_STRUCTURE)
         )

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -173,10 +173,7 @@ class MemgraphIngestor:
             # workers; the pooled driver behind them is owned here and
             # would otherwise leak its connection pool for the life of
             # the process.
-            driver = self._driver
-            if driver is not None:
-                cast("Neo4jDriver", driver).close()
-                self._driver = None
+            self.close_driver()
 
     async def __aenter__(self) -> MemgraphIngestor:
         return self.__enter__()
@@ -251,6 +248,19 @@ class MemgraphIngestor:
             conn = mgclient.connect(host=self._host, port=self._port)
         conn.autocommit = True
         return conn
+
+    def close_driver(self) -> None:
+        """Release the Neo4j connection pool, if one was ever built.
+
+        Sessions handed to flush workers are closed by those workers; the
+        pooled driver behind them is owned by this object and would
+        otherwise outlive it. A Memgraph run never builds one, so this is
+        a no-op there.
+        """
+        driver = self._driver
+        if driver is not None:
+            cast("Neo4jDriver", driver).close()
+            self._driver = None
 
     def _neo4j_driver(self) -> Neo4jDriver:
         """The process-wide Neo4j driver, created on first use.

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -7,28 +7,24 @@ from collections.abc import Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager, nullcontext
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
 
 import mgclient  # ty: ignore[unresolved-import]
 from loguru import logger
 
 from codebase_rag.config import settings
-from codebase_rag.types_defs import CursorProtocol, ResultValue
+from codebase_rag.types_defs import ConnectionProtocol, CursorProtocol, ResultValue
 
 from .. import exceptions as ex
 from .. import logs as ls
 from ..constants import (
     CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES,
-    CYPHER_MEMORY_LIMIT_SUFFIX,
-    CYPHER_MEMORY_LIMIT_TOKEN,
-    CYPHER_SEMICOLON,
     ERR_SUBSTR_ALREADY_EXISTS,
     ERR_SUBSTR_CONSTRAINT,
     KEY_CREATED,
     KEY_FROM_VAL,
-    KEY_LABEL,
     KEY_NAME,
     KEY_PROJECT_NAME,
-    KEY_PROPERTIES,
     KEY_PROPS,
     KEY_PURGED,
     KEY_TO_VAL,
@@ -48,16 +44,13 @@ from ..cypher_queries import (
     CYPHER_LIST_PROJECTS,
     CYPHER_PURGE_CROSS_PROJECT_STRUCTURE,
     CYPHER_PURGE_KEYLESS_STRUCTURE,
-    CYPHER_SHOW_CONSTRAINTS,
-    build_constraint_query,
     build_create_node_query,
     build_create_relationship_query,
-    build_drop_constraint_query,
-    build_index_query,
     build_merge_node_query,
     build_merge_relationship_query,
     wrap_with_unwind,
 )
+from ..graph_dialects import DIALECT_NEO4J, GraphDialect, get_dialect
 from ..types_defs import (
     BatchParams,
     BatchWrapper,
@@ -72,16 +65,22 @@ from ..types_defs import (
 from ..utils.path_utils import project_roots_from_rows
 from .resource_cleanup import prune_unanchored_resources
 
+if TYPE_CHECKING:
+    from .neo4j_driver import Neo4jDriver
 
-def _apply_memory_limit(query: str, mb: int) -> str:
-    if CYPHER_MEMORY_LIMIT_TOKEN in query.upper():
-        return query
-    stripped = query.rstrip()
-    had_semicolon = stripped.endswith(CYPHER_SEMICOLON)
-    if had_semicolon:
-        stripped = stripped[: -len(CYPHER_SEMICOLON)].rstrip()
-    suffix = CYPHER_MEMORY_LIMIT_SUFFIX.format(mb=mb)
-    return f"{stripped}{suffix}{CYPHER_SEMICOLON}"
+
+def _apply_memory_limit(
+    query: str, mb: int, dialect: GraphDialect | None = None
+) -> str:
+    """Bound a read's memory using the configured engine's syntax.
+
+    Kept as a module-level function with a defaulted dialect because it is
+    imported and called directly by tests and by callers that have no
+    ingestor to hand.
+    """
+    return (dialect or get_dialect(settings.GRAPH_BACKEND)).apply_memory_limit(
+        query, mb
+    )
 
 
 class MemgraphIngestor:
@@ -93,6 +92,8 @@ class MemgraphIngestor:
         "_username",
         "_password",
         "_use_merge",
+        "_dialect",
+        "_driver",
         "_rel_count",
         "_rel_groups",
         "batch_size",
@@ -108,7 +109,13 @@ class MemgraphIngestor:
         username: str | None = None,
         password: str | None = None,
         use_merge: bool = True,
+        dialect: GraphDialect | None = None,
     ):
+        # The engine is resolved once here rather than read from settings at
+        # each call site, so a single ingestor cannot straddle two dialects
+        # mid-run if configuration changes underneath it.
+        self._dialect = dialect or get_dialect(settings.GRAPH_BACKEND)
+        self._driver: object | None = None
         self._host = host
         self._port = port
         self._username = username.strip() if username and username.strip() else None
@@ -121,7 +128,7 @@ class MemgraphIngestor:
         self._use_merge = use_merge
         self._conn_lock = threading.Lock()
         self._executor: ThreadPoolExecutor | None = None
-        self.conn: mgclient.Connection | None = None
+        self.conn: ConnectionProtocol | None = None
         self.node_buffer: list[tuple[str, dict[str, PropertyValue]]] = []
         self._rel_count = 0
         self._rel_groups: defaultdict[
@@ -213,7 +220,16 @@ class MemgraphIngestor:
                     logger.error(ls.MG_CYPHER_PARAMS.format(params=params))
                 raise
 
-    def _create_connection(self) -> mgclient.Connection:
+    def _create_connection(self) -> ConnectionProtocol:
+        """Open one connection for the configured engine.
+
+        The parallel flush calls this once per worker, so whatever comes
+        back must be safe to use from a single thread and cheap enough to
+        create per flush group. For Neo4j that is a session drawn from a
+        shared, pooled `Driver`; for Memgraph it is a real socket.
+        """
+        if self._dialect.name == DIALECT_NEO4J:
+            return self._neo4j_driver().connect()
         if self._username is not None:
             conn = mgclient.connect(
                 host=self._host,
@@ -226,9 +242,27 @@ class MemgraphIngestor:
         conn.autocommit = True
         return conn
 
+    def _neo4j_driver(self) -> Neo4jDriver:
+        """The process-wide Neo4j driver, created on first use.
+
+        One `Driver` pools connections for the whole ingestor; creating one
+        per flush group would defeat that pooling and open a new TCP
+        connection per label.
+        """
+        from .neo4j_driver import Neo4jDriver as _Neo4jDriver
+
+        if self._driver is None:
+            self._driver = _Neo4jDriver(
+                uri=settings.NEO4J_URI,
+                username=settings.NEO4J_USERNAME,
+                password=settings.NEO4J_PASSWORD,
+                database=settings.NEO4J_DATABASE,
+            )
+        return cast("Neo4jDriver", self._driver)
+
     def _execute_batch_on(
         self,
-        conn: mgclient.Connection,
+        conn: ConnectionProtocol,
         query: str,
         params_list: Sequence[BatchParams],
     ) -> None:
@@ -257,7 +291,7 @@ class MemgraphIngestor:
 
     def _execute_batch_with_return_on(
         self,
-        conn: mgclient.Connection,
+        conn: ConnectionProtocol,
         query: str,
         params_list: Sequence[BatchParams],
     ) -> list[ResultRow]:
@@ -302,7 +336,7 @@ class MemgraphIngestor:
         self._migrate_legacy_path_keys()
         for label, prop in NODE_UNIQUE_CONSTRAINTS.items():
             try:
-                self._execute_query(build_constraint_query(label, prop))
+                self._execute_query(self._dialect.create_constraint(label, prop))
             except Exception:
                 pass
         logger.info(ls.MG_CONSTRAINTS_DONE)
@@ -321,17 +355,17 @@ class MemgraphIngestor:
         keys off the data, not the constraints: damage outlives the schema
         when an earlier partial upgrade already dropped them.
         """
-        existing_rows = self._execute_query(CYPHER_SHOW_CONSTRAINTS)
+        existing_rows = self._execute_query(self._dialect.show_constraints())
         legacy_present = [
             (label, prop)
             for label, prop in LEGACY_NODE_CONSTRAINTS
             if any(
-                row.get(KEY_LABEL) == label and row.get(KEY_PROPERTIES) == [prop]
+                self._dialect.constraint_row_matches(row, label, prop)
                 for row in existing_rows
             )
         ]
         for label, prop in legacy_present:
-            self._execute_query(build_drop_constraint_query(label, prop))
+            self._execute_query(self._dialect.drop_constraint(label, prop))
         damaged = bool(self._execute_query(CYPHER_ANY_SHARED_STRUCTURE)) or bool(
             self._execute_query(CYPHER_ANY_KEYLESS_STRUCTURE)
         )
@@ -352,7 +386,7 @@ class MemgraphIngestor:
         logger.info(ls.MG_ENSURING_INDEXES)
         for label, prop in NODE_UNIQUE_CONSTRAINTS.items():
             try:
-                self._execute_query(build_index_query(label, prop))
+                self._execute_query(self._dialect.create_index(label, prop))
             except Exception:
                 pass
         # The unique-key indexes serve MERGE at write time; generated Cypher
@@ -360,7 +394,7 @@ class MemgraphIngestor:
         # or every lookup is a full label scan.
         for label in NODE_NAME_INDEXES:
             try:
-                self._execute_query(build_index_query(label, KEY_NAME))
+                self._execute_query(self._dialect.create_index(label, KEY_NAME))
             except Exception:
                 pass
         logger.info(ls.MG_INDEXES_DONE)
@@ -396,7 +430,7 @@ class MemgraphIngestor:
         self,
         label: str,
         props_list: list[dict[str, PropertyValue]],
-        conn: mgclient.Connection | None = None,
+        conn: ConnectionProtocol | None = None,
     ) -> tuple[int, int]:
         if not props_list:
             return 0, 0
@@ -522,7 +556,7 @@ class MemgraphIngestor:
         self,
         pattern: tuple[str, str, str, str, str],
         params_list: list[RelBatchRow],
-        conn: mgclient.Connection | None = None,
+        conn: ConnectionProtocol | None = None,
     ) -> tuple[int, int]:
         from_label, from_key, rel_type, to_label, to_key = pattern
         has_props = any(p[KEY_PROPS] for p in params_list)
@@ -656,7 +690,9 @@ class MemgraphIngestor:
     def fetch_all(
         self, query: str, params: dict[str, PropertyValue] | None = None
     ) -> list[ResultRow]:
-        bounded_query = _apply_memory_limit(query, settings.QUERY_MEMORY_LIMIT_MB)
+        bounded_query = _apply_memory_limit(
+            query, settings.QUERY_MEMORY_LIMIT_MB, self._dialect
+        )
         logger.debug(ls.MG_FETCH_QUERY, query=bounded_query, params=params)
         return self._execute_query(bounded_query, params)
 

--- a/codebase_rag/services/neo4j_driver.py
+++ b/codebase_rag/services/neo4j_driver.py
@@ -1,0 +1,163 @@
+"""A cursor-shaped adapter over the official Neo4j driver.
+
+`MemgraphIngestor` is written against a DB-API-ish surface: a connection
+with `.cursor()` and `.close()`, and a cursor with `.execute()`,
+`.description`, `.fetchall()` and `.close()` (`types_defs.CursorProtocol`).
+The Neo4j driver exposes sessions and `Result`/`Record` objects instead,
+with no cursor and no `description`.
+
+Rather than fork the ingestor -- 690 lines of batching, grouping,
+parallel-flush and error accounting that have nothing to do with the
+engine -- this module makes Neo4j *look* like that surface. The ingestor
+then works unchanged on either engine, and the only engine-aware code in
+the project stays split between here (transport) and `graph_dialects`
+(statement text).
+
+Two behaviours are deliberate and load-bearing:
+
+* Each `Neo4jConnection` owns one session, and the ingestor's parallel
+  flush already creates one connection per worker, so sessions are never
+  shared across threads -- which the Neo4j driver requires. The
+  underlying `Driver` is shared and pools connections, which is the
+  supported pattern.
+* Results are consumed eagerly inside `execute`. The ingestor closes
+  cursors in a `finally` and reads `fetchall()` afterwards, whereas a
+  Neo4j `Result` is invalid once its session moves on, so buffering at
+  execute time is what makes the two models compatible.
+"""
+
+from __future__ import annotations
+
+import types
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from ..types_defs import BatchParams, BatchWrapper, PropertyValue
+
+if TYPE_CHECKING:  # pragma: no cover - import cost only paid at type-check time
+    from neo4j import Driver, Session
+
+
+class _Column:
+    """The single attribute the ingestor reads off `cursor.description`."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Neo4jCursor:
+    """One statement's execution, buffered to look like a DB-API cursor."""
+
+    __slots__ = ("_session", "_rows", "_keys")
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._rows: list[tuple[PropertyValue, ...]] = []
+        self._keys: list[str] = []
+
+    def execute(
+        self,
+        query: str,
+        params: dict[str, PropertyValue]
+        | Sequence[BatchParams]
+        | BatchWrapper
+        | None = None,
+    ) -> None:
+        # `BatchWrapper` is a TypedDict (`{"batch": [...]}`), which is a
+        # plain dict at runtime and is exactly the parameter map the
+        # `UNWIND $batch AS row` idiom wants. A bare sequence would have
+        # no name to bind to, so it is rejected rather than guessed at.
+        if params is None:
+            parameters: dict[str, Any] = {}
+        elif isinstance(params, dict):
+            parameters = dict(params)
+        else:
+            raise TypeError(
+                "Neo4j parameters must be a mapping; "
+                f"got {type(params).__name__}. Batched writes pass "
+                "BatchWrapper({'batch': rows})."
+            )
+        result = self._session.run(query, parameters)
+        self._keys = list(result.keys())
+        # Materialise before the result is invalidated by the next
+        # statement on this session; the ingestor reads rows after the
+        # cursor has been closed.
+        self._rows = [tuple(record.values()) for record in result]
+
+    @property
+    def description(self) -> Sequence[_Column] | None:
+        return [_Column(k) for k in self._keys] if self._keys else None
+
+    def fetchall(self) -> list[tuple[PropertyValue, ...]]:
+        return self._rows
+
+    def close(self) -> None:
+        self._rows = []
+        self._keys = []
+
+
+class Neo4jConnection:
+    """A session dressed as a connection.
+
+    `autocommit` is accepted and ignored: every statement runs through
+    `Session.run`, which is Neo4j's auto-commit transaction, so the
+    ingestor's `conn.autocommit = True` is already the behaviour here.
+    Accepting the attribute keeps the ingestor engine-agnostic; silently
+    ignoring it is safe only because the semantics already match.
+    """
+
+    __slots__ = ("_session", "autocommit")
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self.autocommit = True
+
+    def cursor(self) -> Neo4jCursor:
+        return Neo4jCursor(self._session)
+
+    def close(self) -> None:
+        self._session.close()
+
+    def __enter__(self) -> Neo4jConnection:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+class Neo4jDriver:
+    """Owns the shared `Driver` and hands out per-thread connections."""
+
+    __slots__ = ("_driver", "_database")
+
+    def __init__(
+        self,
+        uri: str,
+        username: str | None,
+        password: str | None,
+        database: str,
+    ) -> None:
+        try:
+            from neo4j import GraphDatabase
+        except ImportError as exc:  # pragma: no cover - depends on extras
+            raise ImportError(
+                "The neo4j backend needs the `neo4j` package. "
+                "Install it with: pip install 'code-graph-rag[neo4j]'"
+            ) from exc
+
+        auth = (username, password) if username and password else None
+        self._driver: Driver = GraphDatabase.driver(uri, auth=auth)
+        self._database = database
+
+    def connect(self) -> Neo4jConnection:
+        return Neo4jConnection(self._driver.session(database=self._database))
+
+    def close(self) -> None:
+        self._driver.close()

--- a/codebase_rag/services/neo4j_driver.py
+++ b/codebase_rag/services/neo4j_driver.py
@@ -79,7 +79,16 @@ class Neo4jCursor:
                 f"got {type(params).__name__}. Batched writes pass "
                 "BatchWrapper({'batch': rows})."
             )
-        result = self._session.run(query, parameters)
+        # The driver types every query entry point as `LiteralString` to
+        # discourage string-built Cypher, and `Query()` demands one too,
+        # so there is no typed route for a statement assembled at
+        # runtime. Ours comes from the dialect and the query builders,
+        # never from user input; the parameters below are always bound,
+        # never interpolated.
+        result = self._session.run(
+            query,  # ty: ignore[invalid-argument-type]
+            parameters,
+        )
         self._keys = list(result.keys())
         # Materialise before the result is invalidated by the next
         # statement on this session; the ingestor reads rows after the

--- a/codebase_rag/services/neo4j_driver.py
+++ b/codebase_rag/services/neo4j_driver.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any
 from ..types_defs import BatchParams, BatchWrapper, PropertyValue
 
 if TYPE_CHECKING:  # pragma: no cover - import cost only paid at type-check time
-    from neo4j import Driver, Session
+    from neo4j import Driver, Session  # ty: ignore[unresolved-import]
 
 
 class _Column:
@@ -85,10 +85,14 @@ class Neo4jCursor:
         # runtime. Ours comes from the dialect and the query builders,
         # never from user input; the parameters below are always bound,
         # never interpolated.
-        result = self._session.run(
-            query,  # ty: ignore[invalid-argument-type]
-            parameters,
-        )
+        #
+        # Not suppressed with a `ty: ignore`: `neo4j` is an optional
+        # extra, so the environment CI type-checks in cannot resolve
+        # `Session` and reports any narrower directive here as unused.
+        # `run` is looked up through a local to keep that difference from
+        # turning into a checker error in one environment or the other.
+        session_run = self._session.run
+        result = session_run(query, parameters)
         self._keys = list(result.keys())
         # Materialise before the result is invalidated by the next
         # statement on this session; the ingestor reads rows after the
@@ -154,7 +158,7 @@ class Neo4jDriver:
         database: str,
     ) -> None:
         try:
-            from neo4j import GraphDatabase
+            from neo4j import GraphDatabase  # ty: ignore[unresolved-import]
         except ImportError as exc:  # pragma: no cover - depends on extras
             raise ImportError(
                 "The neo4j backend needs the `neo4j` package. "

--- a/codebase_rag/tests/integration/conftest.py
+++ b/codebase_rag/tests/integration/conftest.py
@@ -135,7 +135,7 @@ def neo4j_container() -> Generator[dict[str, str | int], None, None]:
     container.stop()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def neo4j_ingestor(
     neo4j_container: dict[str, str | int],
 ) -> Generator[MemgraphIngestor, None, None]:

--- a/codebase_rag/tests/integration/conftest.py
+++ b/codebase_rag/tests/integration/conftest.py
@@ -83,6 +83,86 @@ def memgraph_container() -> Generator[dict[str, str | int], None, None]:
     container.stop()
 
 
+@pytest.fixture(scope="session")
+def neo4j_container() -> Generator[dict[str, str | int], None, None]:
+    """A real Neo4j 5 server for the backend-parity tests (issue #1590).
+
+    Skipped rather than failed when the driver or Docker is unavailable:
+    `neo4j` is an optional extra, so a default install must still be able
+    to run the suite.
+    """
+    pytest.importorskip("testcontainers")
+    pytest.importorskip("neo4j")
+
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.docker_client import DockerClient
+    from testcontainers.core.wait_strategies import LogMessageWaitStrategy
+
+    reap_orphaned_containers(DockerClient().client)
+
+    container = DockerContainer("neo4j:5.26")
+    container.with_exposed_ports(7687)
+    container.with_kwargs(labels=cgr_container_labels())
+    # Auth off keeps the fixture in step with the unauthenticated Memgraph
+    # container above, so the parity tests differ only by engine.
+    container.with_env("NEO4J_AUTH", "none")
+    container.waiting_for(LogMessageWaitStrategy("Started."))
+    container.start()
+
+    host = container.get_container_host_ip()
+    port = int(container.get_exposed_port(7687))
+
+    # "Started." precedes Bolt actually accepting queries, so probe with a
+    # real statement rather than trusting the log line or a bare socket.
+    from neo4j import GraphDatabase
+
+    max_retries = 30
+    for attempt in range(max_retries):
+        try:
+            driver = GraphDatabase.driver(f"bolt://{host}:{port}", auth=None)
+            with driver.session() as session:
+                session.run("RETURN 1").consume()
+            driver.close()
+            break
+        except Exception as exc:
+            if attempt == max_retries - 1:
+                container.stop()
+                pytest.fail(f"Neo4j not ready after {max_retries} attempts: {exc}")
+            time.sleep(1.0)
+
+    yield {"host": host, "port": port}
+
+    container.stop()
+
+
+@pytest.fixture(scope="function")
+def neo4j_ingestor(
+    neo4j_container: dict[str, str | int],
+) -> Generator[MemgraphIngestor, None, None]:
+    """The ingestor pointed at Neo4j, wiped before and after each test."""
+    from codebase_rag.config import settings
+    from codebase_rag.graph_dialects import DIALECT_NEO4J, get_dialect
+
+    host = str(neo4j_container["host"])
+    port = int(neo4j_container["port"])
+
+    previous_uri = settings.NEO4J_URI
+    settings.NEO4J_URI = f"bolt://{host}:{port}"
+    ingestor = MemgraphIngestor(
+        host=host, port=port, dialect=get_dialect(DIALECT_NEO4J)
+    )
+    ingestor.__enter__()
+    try:
+        ingestor._execute_query("MATCH (n) DETACH DELETE n")
+        yield ingestor
+    finally:
+        try:
+            ingestor._execute_query("MATCH (n) DETACH DELETE n")
+        finally:
+            ingestor.__exit__(None, None, None)
+            settings.NEO4J_URI = previous_uri
+
+
 @pytest.fixture(scope="function")
 def memgraph_connection(
     memgraph_container: dict[str, str | int],

--- a/codebase_rag/tests/integration/test_backend_parity_e2e.py
+++ b/codebase_rag/tests/integration/test_backend_parity_e2e.py
@@ -87,8 +87,10 @@ class TestSchemaSetup:
         """
         legacy = ingestor._dialect.create_constraint("Folder", "path")
         if ingestor._dialect.name == DIALECT_NEO4J:
+            # Punctuation on purpose: an unquoted DROP of this name is a
+            # CypherSyntaxError, and `ensure_constraints` would swallow it.
             legacy = (
-                "CREATE CONSTRAINT someone_elses_folder_path IF NOT EXISTS "
+                "CREATE CONSTRAINT `someone-elses folder.path` IF NOT EXISTS "
                 "FOR (n:Folder) REQUIRE n.path IS UNIQUE"
             )
         ingestor._execute_query(legacy)

--- a/codebase_rag/tests/integration/test_backend_parity_e2e.py
+++ b/codebase_rag/tests/integration/test_backend_parity_e2e.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pytest
 
 from codebase_rag.constants import NODE_UNIQUE_CONSTRAINTS
+from codebase_rag.graph_dialects import DIALECT_NEO4J
 from codebase_rag.services.graph_service import MemgraphIngestor
 
 pytestmark = pytest.mark.integration
@@ -72,6 +73,34 @@ class TestSchemaSetup:
     def test_running_it_twice_is_idempotent(self, ingestor: MemgraphIngestor) -> None:
         ingestor.ensure_constraints()
         ingestor.ensure_constraints()
+
+    def test_a_legacy_constraint_under_another_name_is_dropped(
+        self, ingestor: MemgraphIngestor
+    ) -> None:
+        """The migration must drop the constraint that actually exists.
+
+        Neo4j addresses constraints by name only, so detecting a legacy
+        one by label and property but dropping a name derived here would
+        leave the obsolete key enforced -- and `ensure_constraints`
+        swallows DDL errors, so it would fail silently. The constraint is
+        created under a name this code would never derive.
+        """
+        legacy = ingestor._dialect.create_constraint("Folder", "path")
+        if ingestor._dialect.name == DIALECT_NEO4J:
+            legacy = (
+                "CREATE CONSTRAINT someone_elses_folder_path IF NOT EXISTS "
+                "FOR (n:Folder) REQUIRE n.path IS UNIQUE"
+            )
+        ingestor._execute_query(legacy)
+
+        ingestor.ensure_constraints()
+
+        rows = ingestor._execute_query(ingestor._dialect.show_constraints())
+        assert not [
+            row
+            for row in rows
+            if ingestor._dialect.constraint_row_matches(row, "Folder", "path")
+        ]
 
 
 @pytest.mark.parametrize("ingestor", BACKENDS, indirect=True)

--- a/codebase_rag/tests/integration/test_backend_parity_e2e.py
+++ b/codebase_rag/tests/integration/test_backend_parity_e2e.py
@@ -1,0 +1,196 @@
+"""The same graph, built and read back on each engine (issue #1590).
+
+Unit tests pin the statements the dialects emit; only a real server shows
+that those statements are ACCEPTED and mean the same thing. Each test
+takes the ingestor fixture by name and runs identical assertions, so a
+divergence shows up as one engine failing a test the other passes.
+
+The Neo4j tests skip without Docker or the optional `neo4j` package;
+`neo4j_container` handles both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.constants import NODE_UNIQUE_CONSTRAINTS
+from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = pytest.mark.integration
+
+BACKENDS = ("memgraph_ingestor", "neo4j_ingestor")
+
+
+@pytest.fixture
+def ingestor(request: pytest.FixtureRequest) -> MemgraphIngestor:
+    """Resolve whichever engine's ingestor this parametrisation names."""
+    return request.getfixturevalue(request.param)
+
+
+@pytest.mark.parametrize("ingestor", BACKENDS, indirect=True)
+class TestSchemaSetup:
+    def test_the_constraints_actually_exist_afterwards(
+        self, ingestor: MemgraphIngestor
+    ) -> None:
+        """The DDL must be ACCEPTED, not merely issued.
+
+        `ensure_constraints` wraps every statement in `except Exception:
+        pass`, so wrong-dialect DDL fails silently and the graph is built
+        with nothing enforced. Counting nodes cannot detect that -- MERGE
+        deduplicates on its own whether or not a constraint exists, which
+        is why an earlier version of this test passed against a
+        deliberately broken dialect. Read the server's own constraint
+        catalogue back instead.
+        """
+        ingestor.ensure_constraints()
+        # `_execute_query`, not `fetch_all`: the latter appends Memgraph's
+        # QUERY MEMORY LIMIT, which SHOW CONSTRAINT INFO rejects. This is
+        # the same path `_migrate_legacy_path_keys` uses in production.
+        rows = ingestor._execute_query(ingestor._dialect.show_constraints())
+        assert rows, "no constraints were created"
+        matched = [
+            (label, prop)
+            for label, prop in NODE_UNIQUE_CONSTRAINTS.items()
+            if any(
+                ingestor._dialect.constraint_row_matches(row, label, prop)
+                for row in rows
+            )
+        ]
+        assert len(matched) == len(NODE_UNIQUE_CONSTRAINTS)
+
+    def test_a_duplicate_unique_key_is_rejected(
+        self, ingestor: MemgraphIngestor
+    ) -> None:
+        # The parallel MERGE flush relies on the constraint for
+        # correctness, so prove the server enforces it rather than
+        # trusting that the DDL was accepted.
+        ingestor.ensure_constraints()
+        ingestor.execute_write("CREATE (n:Project {name: 'dup', path: '/a'})")
+        with pytest.raises(Exception, match="(?i)constraint|already exists"):
+            ingestor.execute_write("CREATE (n:Project {name: 'dup', path: '/b'})")
+
+    def test_running_it_twice_is_idempotent(self, ingestor: MemgraphIngestor) -> None:
+        ingestor.ensure_constraints()
+        ingestor.ensure_constraints()
+
+
+@pytest.mark.parametrize("ingestor", BACKENDS, indirect=True)
+class TestNodesAndRelationships:
+    def test_a_node_round_trips_with_its_properties(
+        self, ingestor: MemgraphIngestor
+    ) -> None:
+        ingestor.ensure_constraints()
+        ingestor.ensure_node_batch(
+            "Module", {"qualified_name": "a.b", "name": "b", "path": "a/b.py"}
+        )
+        ingestor.flush_all()
+        rows = ingestor.fetch_all(
+            "MATCH (m:Module {qualified_name: 'a.b'}) "
+            "RETURN m.name AS name, m.path AS path"
+        )
+        assert rows == [{"name": "b", "path": "a/b.py"}]
+
+    def test_merge_does_not_duplicate_on_re_ingest(
+        self, ingestor: MemgraphIngestor
+    ) -> None:
+        ingestor.ensure_constraints()
+        for _ in range(3):
+            ingestor.ensure_node_batch("Module", {"qualified_name": "a.b", "name": "b"})
+        ingestor.flush_all()
+        rows = ingestor.fetch_all("MATCH (m:Module) RETURN count(m) AS c")
+        assert rows[0]["c"] == 1
+
+    def test_a_relationship_links_two_nodes(self, ingestor: MemgraphIngestor) -> None:
+        ingestor.ensure_constraints()
+        ingestor.ensure_node_batch("Module", {"qualified_name": "a", "name": "a"})
+        ingestor.ensure_node_batch("Module", {"qualified_name": "b", "name": "b"})
+        ingestor.flush_all()
+        ingestor.ensure_relationship_batch(
+            ("Module", "qualified_name", "a"),
+            "IMPORTS",
+            ("Module", "qualified_name", "b"),
+        )
+        ingestor.flush_all()
+        rows = ingestor.fetch_all(
+            "MATCH (:Module {qualified_name: 'a'})-[r:IMPORTS]->"
+            "(:Module {qualified_name: 'b'}) RETURN count(r) AS c"
+        )
+        assert rows[0]["c"] == 1
+
+    def test_relationship_properties_survive(self, ingestor: MemgraphIngestor) -> None:
+        ingestor.ensure_constraints()
+        ingestor.ensure_node_batch("Module", {"qualified_name": "a", "name": "a"})
+        ingestor.ensure_node_batch("Module", {"qualified_name": "b", "name": "b"})
+        ingestor.flush_all()
+        ingestor.ensure_relationship_batch(
+            ("Module", "qualified_name", "a"),
+            "IMPORTS",
+            ("Module", "qualified_name", "b"),
+            {"line": 12},
+        )
+        ingestor.flush_all()
+        rows = ingestor.fetch_all("MATCH ()-[r:IMPORTS]->() RETURN r.line AS line")
+        assert rows == [{"line": 12}]
+
+    def test_a_batch_larger_than_batch_size_is_written_whole(
+        self, ingestor: MemgraphIngestor
+    ) -> None:
+        # Exercises the UNWIND $batch path and the mid-run auto-flush.
+        ingestor.ensure_constraints()
+        for i in range(250):
+            ingestor.ensure_node_batch(
+                "Module", {"qualified_name": f"m{i}", "name": f"m{i}"}
+            )
+        ingestor.flush_all()
+        rows = ingestor.fetch_all("MATCH (m:Module) RETURN count(m) AS c")
+        assert rows[0]["c"] == 250
+
+
+@pytest.mark.parametrize("ingestor", BACKENDS, indirect=True)
+class TestReadPath:
+    def test_fetch_all_returns_named_columns(self, ingestor: MemgraphIngestor) -> None:
+        # Column names come from `cursor.description`, which the Neo4j
+        # adapter has to synthesise; a regression there yields positional
+        # tuples or empty dicts rather than an error.
+        rows = ingestor.fetch_all("RETURN 1 AS one, 2 AS two")
+        assert rows == [{"one": 1, "two": 2}]
+
+    def test_a_query_with_no_rows_returns_an_empty_list(
+        self, ingestor: MemgraphIngestor
+    ) -> None:
+        assert ingestor.fetch_all("MATCH (n:NothingHere) RETURN n") == []
+
+    def test_parameters_are_bound(self, ingestor: MemgraphIngestor) -> None:
+        rows = ingestor.fetch_all("RETURN $value AS v", {"value": 7})
+        assert rows == [{"v": 7}]
+
+    def test_execute_write_persists(self, ingestor: MemgraphIngestor) -> None:
+        ingestor.execute_write("CREATE (n:Marker {id: $id})", {"id": "x"})
+        rows = ingestor.fetch_all("MATCH (n:Marker) RETURN n.id AS id")
+        assert rows == [{"id": "x"}]
+
+
+@pytest.mark.parametrize("ingestor", BACKENDS, indirect=True)
+class TestProjectLifecycle:
+    def test_a_project_is_listed_then_deleted(self, ingestor: MemgraphIngestor) -> None:
+        ingestor.ensure_constraints()
+        ingestor.ensure_node_batch("Project", {"name": "proj", "path": "/p"})
+        ingestor.flush_all()
+        assert "proj" in ingestor.list_projects()
+        ingestor.delete_project("proj")
+        assert "proj" not in ingestor.list_projects()
+
+    def test_clean_database_empties_the_graph(self, ingestor: MemgraphIngestor) -> None:
+        ingestor.ensure_constraints()
+        ingestor.ensure_node_batch("Module", {"qualified_name": "a", "name": "a"})
+        ingestor.flush_all()
+        ingestor.clean_database()
+        assert ingestor.fetch_all("MATCH (n) RETURN count(n) AS c")[0]["c"] == 0
+
+    def test_export_reports_what_was_written(self, ingestor: MemgraphIngestor) -> None:
+        ingestor.ensure_constraints()
+        ingestor.ensure_node_batch("Module", {"qualified_name": "a", "name": "a"})
+        ingestor.ensure_node_batch("Module", {"qualified_name": "b", "name": "b"})
+        ingestor.flush_all()
+        exported = ingestor.export_graph_to_dict()
+        assert exported["metadata"]["total_nodes"] == 2

--- a/codebase_rag/tests/test_graph_dialects.py
+++ b/codebase_rag/tests/test_graph_dialects.py
@@ -1,0 +1,182 @@
+"""Per-engine Cypher differences (issue #1590).
+
+Two properties matter more than the literal strings: the Memgraph output
+must be exactly what the project emitted before the dialect seam existed
+(or every current install regresses), and no engine's syntax may leak
+into another's statements.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.constants import (
+    KEY_NAME,
+    LEGACY_NODE_CONSTRAINTS,
+    NODE_NAME_INDEXES,
+    NODE_UNIQUE_CONSTRAINTS,
+)
+from codebase_rag.graph_dialects import (
+    DIALECT_MEMGRAPH,
+    DIALECT_NEO4J,
+    GraphDialect,
+    MemgraphDialect,
+    Neo4jDialect,
+    available_dialects,
+    get_dialect,
+)
+
+# Every (label, prop) pair the ingestor actually builds DDL for.
+REAL_PAIRS = (
+    list(NODE_UNIQUE_CONSTRAINTS.items())
+    + [(label, KEY_NAME) for label in NODE_NAME_INDEXES]
+    + list(LEGACY_NODE_CONSTRAINTS)
+)
+
+
+class TestRegistry:
+    def test_both_engines_are_registered(self) -> None:
+        assert available_dialects() == (DIALECT_MEMGRAPH, DIALECT_NEO4J)
+
+    def test_lookup_is_case_and_whitespace_insensitive(self) -> None:
+        assert get_dialect("  NEO4J ").name == DIALECT_NEO4J
+
+    def test_an_unknown_engine_is_rejected(self) -> None:
+        # Falling back to a default would send Memgraph DDL to another
+        # server, and the ingestor swallows DDL errors, so the mistake
+        # would only surface as a silently unconstrained graph.
+        with pytest.raises(ValueError, match="Unknown graph backend"):
+            get_dialect("postgres")
+
+    def test_the_error_names_the_valid_engines(self) -> None:
+        with pytest.raises(ValueError, match="memgraph, neo4j"):
+            get_dialect("postgres")
+
+    @pytest.mark.parametrize("name", available_dialects())
+    def test_every_registered_engine_satisfies_the_protocol(self, name: str) -> None:
+        assert isinstance(get_dialect(name), GraphDialect)
+
+
+class TestMemgraphIsUnchanged:
+    """The exact statements this project emitted before the seam existed."""
+
+    @pytest.mark.parametrize(("label", "prop"), REAL_PAIRS)
+    def test_create_constraint_text(self, label: str, prop: str) -> None:
+        assert (
+            MemgraphDialect().create_constraint(label, prop)
+            == f"CREATE CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
+        )
+
+    @pytest.mark.parametrize(("label", "prop"), REAL_PAIRS)
+    def test_drop_constraint_text(self, label: str, prop: str) -> None:
+        assert (
+            MemgraphDialect().drop_constraint(label, prop)
+            == f"DROP CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
+        )
+
+    @pytest.mark.parametrize(("label", "prop"), REAL_PAIRS)
+    def test_create_index_text(self, label: str, prop: str) -> None:
+        assert (
+            MemgraphDialect().create_index(label, prop)
+            == f"CREATE INDEX ON :{label}({prop});"
+        )
+
+    def test_show_constraints_text(self) -> None:
+        assert MemgraphDialect().show_constraints() == "SHOW CONSTRAINT INFO;"
+
+    def test_memory_limit_is_appended_before_the_semicolon(self) -> None:
+        assert (
+            MemgraphDialect().apply_memory_limit("MATCH (n) RETURN n;", 4096)
+            == "MATCH (n) RETURN n QUERY MEMORY LIMIT 4096 MB;"
+        )
+
+    def test_memory_limit_is_not_applied_twice(self) -> None:
+        once = MemgraphDialect().apply_memory_limit("MATCH (n) RETURN n;", 4096)
+        assert MemgraphDialect().apply_memory_limit(once, 4096) == once
+
+    def test_a_row_is_matched_by_label_and_properties(self) -> None:
+        row = {"label": "Folder", "properties": ["path"]}
+        assert MemgraphDialect().constraint_row_matches(row, "Folder", "path")
+
+    def test_a_different_label_does_not_match(self) -> None:
+        row = {"label": "File", "properties": ["path"]}
+        assert not MemgraphDialect().constraint_row_matches(row, "Folder", "path")
+
+
+class TestNeo4j:
+    def test_create_constraint_uses_require_and_is_idempotent(self) -> None:
+        assert Neo4jDialect().create_constraint("Folder", "path") == (
+            "CREATE CONSTRAINT cgr_folder_path IF NOT EXISTS "
+            "FOR (n:Folder) REQUIRE n.path IS UNIQUE"
+        )
+
+    def test_drop_constraint_addresses_by_name(self) -> None:
+        # Neo4j 5 has no pattern-based DROP CONSTRAINT at all, so the name
+        # has to be derivable from (label, prop) without a database read.
+        assert (
+            Neo4jDialect().drop_constraint("Folder", "path")
+            == "DROP CONSTRAINT cgr_folder_path IF EXISTS"
+        )
+
+    def test_create_index_uses_the_for_on_form(self) -> None:
+        assert Neo4jDialect().create_index("Class", "name") == (
+            "CREATE INDEX cgr_class_name IF NOT EXISTS FOR (n:Class) ON (n.name)"
+        )
+
+    def test_show_constraints_has_no_info_suffix(self) -> None:
+        assert Neo4jDialect().show_constraints() == "SHOW CONSTRAINTS"
+
+    def test_the_memory_limit_is_dropped_entirely(self) -> None:
+        # Neo4j has no per-query memory clause; appending Memgraph's would
+        # make every single read in the system a syntax error.
+        query = "MATCH (n) RETURN n;"
+        assert Neo4jDialect().apply_memory_limit(query, 4096) == query
+
+    def test_a_row_matches_through_the_labelsortypes_list(self) -> None:
+        row = {"labelsOrTypes": ["Folder"], "properties": ["path"], "name": "x"}
+        assert Neo4jDialect().constraint_row_matches(row, "Folder", "path")
+
+    def test_a_memgraph_shaped_row_does_not_match(self) -> None:
+        # The regression this guards: comparing Neo4j's list column to a
+        # bare label matches nothing, which would make the legacy-key
+        # migration silently no-op instead of failing loudly.
+        row = {"label": "Folder", "properties": ["path"]}
+        assert not Neo4jDialect().constraint_row_matches(row, "Folder", "path")
+
+    def test_a_different_property_does_not_match(self) -> None:
+        row = {"labelsOrTypes": ["Folder"], "properties": ["name"]}
+        assert not Neo4jDialect().constraint_row_matches(row, "Folder", "path")
+
+
+class TestNoCrossDialectLeakage:
+    @pytest.mark.parametrize(("label", "prop"), REAL_PAIRS)
+    def test_neo4j_never_emits_memgraph_syntax(self, label: str, prop: str) -> None:
+        d = Neo4jDialect()
+        statements = (
+            d.create_constraint(label, prop),
+            d.drop_constraint(label, prop),
+            d.create_index(label, prop),
+            d.show_constraints(),
+        )
+        for statement in statements:
+            assert "ASSERT" not in statement
+            assert "CONSTRAINT INFO" not in statement
+            assert "QUERY MEMORY LIMIT" not in statement
+
+    @pytest.mark.parametrize(("label", "prop"), REAL_PAIRS)
+    def test_memgraph_never_emits_neo4j_syntax(self, label: str, prop: str) -> None:
+        d = MemgraphDialect()
+        statements = (
+            d.create_constraint(label, prop),
+            d.drop_constraint(label, prop),
+            d.create_index(label, prop),
+        )
+        for statement in statements:
+            assert "REQUIRE" not in statement
+            assert "IF NOT EXISTS" not in statement
+
+    def test_constraint_names_are_unique_per_pair(self) -> None:
+        # A collision would make one DROP remove another label's constraint.
+        d = Neo4jDialect()
+        names = {d.create_constraint(label, prop) for label, prop in REAL_PAIRS}
+        assert len(names) == len(set(REAL_PAIRS))

--- a/codebase_rag/tests/test_graph_dialects.py
+++ b/codebase_rag/tests/test_graph_dialects.py
@@ -180,3 +180,52 @@ class TestNoCrossDialectLeakage:
         d = Neo4jDialect()
         names = {d.create_constraint(label, prop) for label, prop in REAL_PAIRS}
         assert len(names) == len(set(REAL_PAIRS))
+
+
+class TestLegacyConstraintIsDroppedByItsRealName:
+    """A legacy constraint predates this code and may be named anything.
+
+    Neo4j drops constraints by name only, so detecting one by label and
+    property but dropping a name we derived leaves the obsolete key
+    enforced -- silently, since `ensure_constraints` swallows DDL errors.
+    """
+
+    def test_neo4j_reads_the_servers_own_name(self) -> None:
+        row = {
+            "name": "legacy_folder_path_uc",
+            "labelsOrTypes": ["Folder"],
+            "properties": ["path"],
+        }
+        assert Neo4jDialect().constraint_row_name(row) == "legacy_folder_path_uc"
+
+    def test_neo4j_drops_the_discovered_name(self) -> None:
+        assert (
+            Neo4jDialect().drop_constraint("Folder", "path", "legacy_folder_path_uc")
+            == "DROP CONSTRAINT legacy_folder_path_uc IF EXISTS"
+        )
+
+    def test_neo4j_falls_back_to_the_derived_name(self) -> None:
+        assert (
+            Neo4jDialect().drop_constraint("Folder", "path", None)
+            == "DROP CONSTRAINT cgr_folder_path IF EXISTS"
+        )
+
+    def test_a_row_without_a_name_yields_none(self) -> None:
+        row = {"labelsOrTypes": ["Folder"], "properties": ["path"]}
+        assert Neo4jDialect().constraint_row_name(row) is None
+
+    def test_an_empty_name_yields_none(self) -> None:
+        # An empty string would produce `DROP CONSTRAINT  IF EXISTS`.
+        row = {"name": "", "labelsOrTypes": ["Folder"], "properties": ["path"]}
+        assert Neo4jDialect().constraint_row_name(row) is None
+
+    def test_memgraph_ignores_the_name_entirely(self) -> None:
+        # Memgraph addresses constraints by pattern, so passing a name
+        # must not change the statement it emits.
+        dialect = MemgraphDialect()
+        assert dialect.drop_constraint("Folder", "path", "anything") == (
+            dialect.drop_constraint("Folder", "path", None)
+        )
+
+    def test_memgraph_reports_no_name(self) -> None:
+        assert MemgraphDialect().constraint_row_name({"label": "Folder"}) is None

--- a/codebase_rag/tests/test_graph_dialects.py
+++ b/codebase_rag/tests/test_graph_dialects.py
@@ -115,7 +115,7 @@ class TestNeo4j:
         # has to be derivable from (label, prop) without a database read.
         assert (
             Neo4jDialect().drop_constraint("Folder", "path")
-            == "DROP CONSTRAINT cgr_folder_path IF EXISTS"
+            == "DROP CONSTRAINT `cgr_folder_path` IF EXISTS"
         )
 
     def test_create_index_uses_the_for_on_form(self) -> None:
@@ -201,13 +201,13 @@ class TestLegacyConstraintIsDroppedByItsRealName:
     def test_neo4j_drops_the_discovered_name(self) -> None:
         assert (
             Neo4jDialect().drop_constraint("Folder", "path", "legacy_folder_path_uc")
-            == "DROP CONSTRAINT legacy_folder_path_uc IF EXISTS"
+            == "DROP CONSTRAINT `legacy_folder_path_uc` IF EXISTS"
         )
 
     def test_neo4j_falls_back_to_the_derived_name(self) -> None:
         assert (
             Neo4jDialect().drop_constraint("Folder", "path", None)
-            == "DROP CONSTRAINT cgr_folder_path IF EXISTS"
+            == "DROP CONSTRAINT `cgr_folder_path` IF EXISTS"
         )
 
     def test_a_row_without_a_name_yields_none(self) -> None:
@@ -229,3 +229,37 @@ class TestLegacyConstraintIsDroppedByItsRealName:
 
     def test_memgraph_reports_no_name(self) -> None:
         assert MemgraphDialect().constraint_row_name({"label": "Folder"}) is None
+
+
+class TestNeo4jQuotesConstraintNames:
+    """A server-chosen name may contain characters Cypher cannot parse bare.
+
+    Verified against Neo4j 5.26: `DROP CONSTRAINT legacy-folder path.uc
+    IF EXISTS` raises CypherSyntaxError, the backtick-quoted form
+    succeeds. The failure would be silent, since `ensure_constraints`
+    swallows DDL errors and would leave the obsolete constraint enforced.
+    """
+
+    def test_a_punctuated_name_is_quoted(self) -> None:
+        assert (
+            Neo4jDialect().drop_constraint("Folder", "path", "legacy-folder path.uc")
+            == "DROP CONSTRAINT `legacy-folder path.uc` IF EXISTS"
+        )
+
+    def test_an_embedded_backtick_is_doubled(self) -> None:
+        # A single backtick would close the quoting early and change the
+        # statement's meaning.
+        assert (
+            Neo4jDialect().drop_constraint("Folder", "path", "weird`name")
+            == "DROP CONSTRAINT `weird``name` IF EXISTS"
+        )
+
+    def test_the_derived_fallback_is_quoted_too(self) -> None:
+        assert (
+            Neo4jDialect().drop_constraint("Folder", "path", None)
+            == "DROP CONSTRAINT `cgr_folder_path` IF EXISTS"
+        )
+
+    def test_memgraph_does_not_quote(self) -> None:
+        # Memgraph drops by pattern, so there is no identifier to quote.
+        assert "`" not in MemgraphDialect().drop_constraint("Folder", "path")

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -7,6 +7,7 @@ leaked driver shows up only as connection exhaustion much later.
 
 from __future__ import annotations
 
+import mgclient
 import pytest
 
 from codebase_rag.graph_dialects import (
@@ -19,6 +20,7 @@ from codebase_rag.tools.health_checker import (
     HealthChecker,
     _backend_connection,
     _backend_endpoint,
+    _connection_error_types,
 )
 
 
@@ -215,3 +217,86 @@ class TestDriverIsReleased:
 
         source = inspect.getsource(health_checker.HealthChecker.check_graph_integrity)
         assert "connection.__exit__(None, None, None)" in source
+
+
+class TestConnectionFailureClassification:
+    """An unreachable server must read as a connection failure, per engine."""
+
+    def test_memgraph_errors_are_connection_failures(self) -> None:
+        assert mgclient.Error in _connection_error_types()
+
+    def test_neo4j_errors_are_connection_failures(self, monkeypatch) -> None:
+        # ServiceUnavailable is neither an mgclient.Error nor an OSError,
+        # so without this it lands in the generic "unexpected failure"
+        # branch and an unreachable server reads as a mystery.
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND", DIALECT_NEO4J
+        )
+        from neo4j.exceptions import ServiceUnavailable
+
+        assert issubclass(ServiceUnavailable, _connection_error_types())
+
+    def test_memgraph_does_not_pull_in_neo4j_types(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND",
+            DIALECT_MEMGRAPH,
+        )
+        assert _connection_error_types() == (mgclient.Error,)
+
+    def test_an_unreachable_neo4j_reads_as_a_connection_failure(
+        self, monkeypatch
+    ) -> None:
+        from neo4j.exceptions import ServiceUnavailable
+
+        class ExplodingConn:
+            def cursor(self):  # type: ignore[no-untyped-def]
+                raise ServiceUnavailable("cannot reach server")
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND", DIALECT_NEO4J
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: ExplodingConn(),
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor.close_driver",
+            lambda self: None,
+        )
+        result = HealthChecker().check_memgraph_connection()
+        assert not result.passed
+        assert result.message == "Connection or query failed"
+
+
+class TestCleanupDoesNotMaskTheAuditResult:
+    def test_a_close_failure_keeps_a_successful_audit(self, monkeypatch) -> None:
+        """A completed audit must not be reported as failed by cleanup."""
+
+        class BadCloseConn(FakeConn):
+            def close(self) -> None:
+                raise RuntimeError("close blew up")
+
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: BadCloseConn(),
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor.close_driver",
+            lambda self: None,
+        )
+        results = HealthChecker().check_graph_integrity()
+        assert len(results) == 1
+        assert results[0].passed, results[0].error
+
+    def test_an_unreachable_server_still_yields_no_results(self, monkeypatch) -> None:
+        def explode(self):  # type: ignore[no-untyped-def]
+            raise ConnectionError("down")
+
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            explode,
+        )
+        assert HealthChecker().check_graph_integrity() == []

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -139,13 +139,10 @@ class TestCredentialValidationIsPerEngine:
         )
 
     def test_memgraph_still_rejects_a_half_set_credential(self) -> None:
+        dialect = get_dialect(DIALECT_MEMGRAPH)
         with pytest.raises(ValueError, match="(?i)both"):
             MemgraphIngestor(
-                host="h",
-                port=7687,
-                username="u",
-                password=None,
-                dialect=get_dialect(DIALECT_MEMGRAPH),
+                host="h", port=7687, username="u", password=None, dialect=dialect
             )
 
 

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -229,12 +229,13 @@ class TestConnectionFailureClassification:
         # ServiceUnavailable is neither an mgclient.Error nor an OSError,
         # so without this it lands in the generic "unexpected failure"
         # branch and an unreachable server reads as a mystery.
+        # `neo4j` is an optional extra, so a base install must skip rather
+        # than fail: this test is about the driver's exception hierarchy.
+        exceptions = pytest.importorskip("neo4j.exceptions")
         monkeypatch.setattr(
             "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND", DIALECT_NEO4J
         )
-        from neo4j.exceptions import ServiceUnavailable
-
-        assert issubclass(ServiceUnavailable, _connection_error_types())
+        assert issubclass(exceptions.ServiceUnavailable, _connection_error_types())
 
     def test_memgraph_does_not_pull_in_neo4j_types(self, monkeypatch) -> None:
         monkeypatch.setattr(
@@ -246,11 +247,12 @@ class TestConnectionFailureClassification:
     def test_an_unreachable_neo4j_reads_as_a_connection_failure(
         self, monkeypatch
     ) -> None:
-        from neo4j.exceptions import ServiceUnavailable
+        exceptions = pytest.importorskip("neo4j.exceptions")
+        service_unavailable = exceptions.ServiceUnavailable
 
         class ExplodingConn:
             def cursor(self):  # type: ignore[no-untyped-def]
-                raise ServiceUnavailable("cannot reach server")
+                raise service_unavailable("cannot reach server")
 
             def close(self) -> None:
                 pass

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -237,6 +237,25 @@ class TestConnectionFailureClassification:
         )
         assert issubclass(exceptions.ServiceUnavailable, _connection_error_types())
 
+    def test_a_query_error_is_not_a_connection_failure(self, monkeypatch) -> None:
+        """The classification answers "can we reach the server", nothing more.
+
+        `Neo4jError` would also cover a Cypher syntax error, which is a
+        query problem: reporting it as a connectivity failure sends the
+        operator to check a server that is answering perfectly well.
+        """
+        exceptions = pytest.importorskip("neo4j.exceptions")
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND", DIALECT_NEO4J
+        )
+        types = _connection_error_types()
+        assert issubclass(exceptions.ServiceUnavailable, types)
+        assert issubclass(exceptions.SessionExpired, types)
+        # Authentication still means "cannot connect".
+        assert issubclass(exceptions.AuthError, types)
+        # A query failure does not.
+        assert not issubclass(exceptions.CypherSyntaxError, types)
+
     def test_memgraph_does_not_pull_in_neo4j_types(self, monkeypatch) -> None:
         monkeypatch.setattr(
             "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND",

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -1,0 +1,161 @@
+"""`cgr health` must describe the engine it actually connected to.
+
+Both failures here are silent: a wrong endpoint in the success message
+reads as a healthy Memgraph while the tool is talking to Neo4j, and a
+leaked driver shows up only as connection exhaustion much later.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.graph_dialects import DIALECT_MEMGRAPH, DIALECT_NEO4J
+from codebase_rag.tools.health_checker import (
+    HealthChecker,
+    _backend_connection,
+    _backend_endpoint,
+)
+
+
+class FakeCursor:
+    def execute(self, query: str, params: object = None) -> None:
+        pass
+
+    @property
+    def description(self) -> None:
+        return None
+
+    def fetchall(self) -> list[tuple]:
+        return []
+
+    def close(self) -> None:
+        pass
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestReportedEndpoint:
+    def test_memgraph_reports_its_host_and_port(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND",
+            DIALECT_MEMGRAPH,
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.MEMGRAPH_HOST", "mg-host"
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.MEMGRAPH_PORT", 7687
+        )
+        assert _backend_endpoint() == "mg-host:7687"
+
+    def test_neo4j_reports_its_uri(self, monkeypatch) -> None:
+        # The regression: reporting MEMGRAPH_HOST here names a server the
+        # Neo4j install never talks to, while claiming it is responsive.
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND", DIALECT_NEO4J
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.NEO4J_URI",
+            "bolt://neo-server.example:7999",
+        )
+        assert _backend_endpoint() == "bolt://neo-server.example:7999"
+
+    def test_the_success_message_carries_the_neo4j_endpoint(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND", DIALECT_NEO4J
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.NEO4J_URI",
+            "bolt://neo-server.example:7999",
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.MEMGRAPH_HOST", "mg-host"
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: FakeConn(),
+        )
+        result = HealthChecker().check_memgraph_connection()
+        assert result.passed
+        assert "neo-server.example:7999" in result.message
+        assert "mg-host" not in result.message
+
+
+class TestDriverIsReleased:
+    def test_the_driver_is_closed_when_the_context_exits(self, monkeypatch) -> None:
+        # Each health check builds its own ingestor, so without this every
+        # call leaks a whole Neo4j connection pool.
+        closed: list[str] = []
+        conn = FakeConn()
+
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: conn,
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor.close_driver",
+            lambda self: closed.append("driver"),
+        )
+
+        with _backend_connection() as handed_out:
+            assert handed_out is conn
+
+        assert conn.closed
+        assert closed == ["driver"]
+
+    def test_the_driver_is_closed_even_when_the_body_raises(self, monkeypatch) -> None:
+        closed: list[str] = []
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: FakeConn(),
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor.close_driver",
+            lambda self: closed.append("driver"),
+        )
+
+        with pytest.raises(RuntimeError):  # noqa: PT012
+            with _backend_connection():
+                raise RuntimeError("boom")
+
+        assert closed == ["driver"]
+
+    def test_the_integrity_audit_releases_its_driver(self, monkeypatch) -> None:
+        closed: list[str] = []
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: FakeConn(),
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor.close_driver",
+            lambda self: closed.append("driver"),
+        )
+        HealthChecker().check_graph_integrity()
+        assert closed == ["driver"]
+
+    def test_the_integrity_audit_releases_explicitly_not_via_gc(self) -> None:
+        """The release must not depend on the garbage collector.
+
+        Dropping the last reference to an abandoned generator-based
+        context manager runs its `finally` anyway under CPython's
+        refcounting, so asserting that `close_driver` was called cannot
+        tell an explicit release from an accidental one -- a mutation
+        removing the release passes. On a non-refcounting runtime (PyPy)
+        the same code leaks a connection pool per health check until a
+        collection happens. Assert the call exists in the source instead.
+        """
+        import inspect
+
+        from codebase_rag.tools import health_checker
+
+        source = inspect.getsource(health_checker.HealthChecker.check_graph_integrity)
+        assert "connection.__exit__(None, None, None)" in source

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 
 import pytest
 
-from codebase_rag.graph_dialects import DIALECT_MEMGRAPH, DIALECT_NEO4J
+from codebase_rag.graph_dialects import (
+    DIALECT_MEMGRAPH,
+    DIALECT_NEO4J,
+    get_dialect,
+)
+from codebase_rag.services.graph_service import MemgraphIngestor
 from codebase_rag.tools.health_checker import (
     HealthChecker,
     _backend_connection,
@@ -90,6 +95,60 @@ class TestReportedEndpoint:
         assert "mg-host" not in result.message
 
 
+class TestReportedEngineName:
+    """`cgr doctor` renders `result.name`, so the label names the service."""
+
+    def _probe(self, monkeypatch, backend: str, uri: str = ""):
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.settings.GRAPH_BACKEND", backend
+        )
+        monkeypatch.setattr("codebase_rag.tools.health_checker.settings.NEO4J_URI", uri)
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: FakeConn(),
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor.close_driver",
+            lambda self: None,
+        )
+        return HealthChecker().check_memgraph_connection()
+
+    def test_memgraph_keeps_its_label(self, monkeypatch) -> None:
+        assert self._probe(monkeypatch, DIALECT_MEMGRAPH).name == (
+            "Memgraph connection successful"
+        )
+
+    def test_neo4j_is_labelled_neo4j(self, monkeypatch) -> None:
+        # The regression: a Neo4j deployment shown a "Memgraph connection"
+        # check is sent looking for a server it does not run.
+        result = self._probe(monkeypatch, DIALECT_NEO4J, "bolt://neo:7999")
+        assert result.name == "Neo4j connection successful"
+        assert "Memgraph" not in result.name
+
+
+class TestCredentialValidationIsPerEngine:
+    def test_neo4j_ignores_a_half_set_memgraph_credential(self) -> None:
+        # Neo4j authenticates with NEO4J_USERNAME/NEO4J_PASSWORD, so a
+        # leftover MEMGRAPH_USERNAME must not block startup.
+        MemgraphIngestor(
+            host="h",
+            port=7687,
+            username="legacy",
+            password=None,
+            dialect=get_dialect(DIALECT_NEO4J),
+        )
+
+    def test_memgraph_still_rejects_a_half_set_credential(self) -> None:
+        with pytest.raises(ValueError, match="(?i)both"):
+            MemgraphIngestor(
+                host="h",
+                port=7687,
+                username="u",
+                password=None,
+                dialect=get_dialect(DIALECT_MEMGRAPH),
+            )
+
+
 class TestDriverIsReleased:
     def test_the_driver_is_closed_when_the_context_exits(self, monkeypatch) -> None:
         # Each health check builds its own ingestor, so without this every
@@ -123,9 +182,9 @@ class TestDriverIsReleased:
             lambda self: closed.append("driver"),
         )
 
-        with pytest.raises(RuntimeError):  # noqa: PT012
-            with _backend_connection():
-                raise RuntimeError("boom")
+        connection = _backend_connection()
+        with pytest.raises(RuntimeError), connection:
+            raise RuntimeError("boom")
 
         assert closed == ["driver"]
 

--- a/codebase_rag/tests/test_ingestor_backend_selection.py
+++ b/codebase_rag/tests/test_ingestor_backend_selection.py
@@ -1,0 +1,170 @@
+"""The ingestor's engine wiring (issue #1590).
+
+The dialect object being correct is not enough: these tests assert the
+statements that reach the connection, because the failure this guards
+against is silent. `ensure_constraints` and `_ensure_indexes` wrap every
+DDL statement in `except Exception: pass`, so an engine sent the wrong
+syntax builds a graph with no constraints and no indexes rather than
+raising -- and the parallel MERGE flush depends on those constraints.
+"""
+
+from __future__ import annotations
+
+from codebase_rag.graph_dialects import DIALECT_MEMGRAPH, DIALECT_NEO4J, get_dialect
+from codebase_rag.services.graph_service import MemgraphIngestor, _apply_memory_limit
+
+
+class RecordingCursor:
+    def __init__(self, log: list[str], rows: list[tuple]) -> None:
+        self._log, self._rows = log, rows
+
+    def execute(self, query: str, params=None) -> None:
+        self._log.append(query)
+
+    @property
+    def description(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def fetchall(self) -> list[tuple]:
+        return self._rows
+
+    def close(self) -> None:
+        pass
+
+
+class RecordingConn:
+    """A connection that records statements without needing a server."""
+
+    def __init__(self, rows: list[tuple] | None = None) -> None:
+        self.log: list[str] = []
+        self._rows = rows or []
+
+    def cursor(self) -> RecordingCursor:
+        return RecordingCursor(self.log, self._rows)
+
+    def close(self) -> None:
+        pass
+
+
+def _ingestor(dialect_name: str) -> tuple[MemgraphIngestor, RecordingConn]:
+    ingestor = MemgraphIngestor(
+        host="localhost", port=7687, dialect=get_dialect(dialect_name)
+    )
+    conn = RecordingConn()
+    ingestor.conn = conn
+    return ingestor, conn
+
+
+class TestConstraintsReachTheConnection:
+    def test_memgraph_emits_assert_form_constraints(self) -> None:
+        ingestor, conn = _ingestor(DIALECT_MEMGRAPH)
+        ingestor.ensure_constraints()
+        assert any("ASSERT" in q and "IS UNIQUE" in q for q in conn.log)
+
+    def test_neo4j_emits_require_form_constraints(self) -> None:
+        ingestor, conn = _ingestor(DIALECT_NEO4J)
+        ingestor.ensure_constraints()
+        assert any("REQUIRE" in q and "IS UNIQUE" in q for q in conn.log)
+
+    def test_neo4j_never_emits_memgraph_ddl(self) -> None:
+        ingestor, conn = _ingestor(DIALECT_NEO4J)
+        ingestor.ensure_constraints()
+        assert not [q for q in conn.log if "ASSERT" in q]
+
+    def test_memgraph_never_emits_neo4j_ddl(self) -> None:
+        ingestor, conn = _ingestor(DIALECT_MEMGRAPH)
+        ingestor.ensure_constraints()
+        assert not [q for q in conn.log if "REQUIRE" in q]
+
+    def test_neo4j_uses_the_plain_show_constraints_statement(self) -> None:
+        ingestor, conn = _ingestor(DIALECT_NEO4J)
+        ingestor.ensure_constraints()
+        assert "SHOW CONSTRAINTS" in conn.log
+        assert "SHOW CONSTRAINT INFO;" not in conn.log
+
+    def test_memgraph_uses_the_info_form(self) -> None:
+        ingestor, conn = _ingestor(DIALECT_MEMGRAPH)
+        ingestor.ensure_constraints()
+        assert "SHOW CONSTRAINT INFO;" in conn.log
+
+    def test_both_engines_issue_the_same_number_of_statements(self) -> None:
+        # The engines must cover the same schema; a shortfall on one side
+        # would mean a label silently left unconstrained.
+        memgraph, mg_conn = _ingestor(DIALECT_MEMGRAPH)
+        memgraph.ensure_constraints()
+        neo4j, neo_conn = _ingestor(DIALECT_NEO4J)
+        neo4j.ensure_constraints()
+        assert len(mg_conn.log) == len(neo_conn.log)
+
+    def test_indexes_are_created_for_both_engines(self) -> None:
+        for name in (DIALECT_MEMGRAPH, DIALECT_NEO4J):
+            ingestor, conn = _ingestor(name)
+            ingestor.ensure_constraints()
+            assert [q for q in conn.log if "INDEX" in q], name
+
+
+class TestMemoryLimit:
+    def test_memgraph_reads_carry_the_limit(self) -> None:
+        ingestor, conn = _ingestor(DIALECT_MEMGRAPH)
+        ingestor.fetch_all("MATCH (n) RETURN n")
+        assert "QUERY MEMORY LIMIT" in conn.log[0]
+
+    def test_neo4j_reads_do_not(self) -> None:
+        # Every read goes through fetch_all, so leaking this suffix would
+        # make the entire read path a syntax error on Neo4j.
+        ingestor, conn = _ingestor(DIALECT_NEO4J)
+        ingestor.fetch_all("MATCH (n) RETURN n")
+        assert "QUERY MEMORY LIMIT" not in conn.log[0]
+        assert conn.log[0] == "MATCH (n) RETURN n"
+
+    def test_the_module_helper_defaults_to_the_configured_engine(self) -> None:
+        assert "QUERY MEMORY LIMIT" in _apply_memory_limit("MATCH (n) RETURN n", 512)
+
+    def test_the_module_helper_honours_an_explicit_dialect(self) -> None:
+        assert (
+            _apply_memory_limit("MATCH (n) RETURN n", 512, get_dialect(DIALECT_NEO4J))
+            == "MATCH (n) RETURN n"
+        )
+
+
+class TestDialectResolution:
+    def test_the_default_engine_is_memgraph(self) -> None:
+        # An existing install must keep working with no configuration.
+        assert MemgraphIngestor(host="h", port=1)._dialect.name == DIALECT_MEMGRAPH
+
+    def test_an_explicit_dialect_wins(self) -> None:
+        ingestor = MemgraphIngestor(
+            host="h", port=1, dialect=get_dialect(DIALECT_NEO4J)
+        )
+        assert ingestor._dialect.name == DIALECT_NEO4J
+
+    def test_the_engine_is_fixed_at_construction(self, monkeypatch) -> None:
+        # Re-reading settings per call would let one run straddle two
+        # dialects if configuration changed underneath it.
+        ingestor = MemgraphIngestor(host="h", port=1)
+        monkeypatch.setattr(
+            "codebase_rag.services.graph_service.settings.GRAPH_BACKEND",
+            DIALECT_NEO4J,
+        )
+        assert ingestor._dialect.name == DIALECT_MEMGRAPH
+
+    def test_writes_do_not_carry_a_memory_limit_on_either_engine(self) -> None:
+        for name in (DIALECT_MEMGRAPH, DIALECT_NEO4J):
+            ingestor, conn = _ingestor(name)
+            ingestor.execute_write("CREATE (n:Thing)")
+            assert "QUERY MEMORY LIMIT" not in conn.log[0], name
+
+
+class TestNeo4jDriverIsNotRequiredForMemgraph:
+    def test_memgraph_never_builds_a_neo4j_driver(self, monkeypatch) -> None:
+        # The neo4j package is an optional extra; a Memgraph install must
+        # not import it.
+        def explode(*args: object, **kwargs: object) -> None:
+            raise AssertionError("neo4j driver must not be constructed")
+
+        monkeypatch.setattr(
+            "codebase_rag.services.graph_service.MemgraphIngestor._neo4j_driver",
+            explode,
+        )
+        ingestor, _ = _ingestor(DIALECT_MEMGRAPH)
+        ingestor.ensure_constraints()

--- a/codebase_rag/tests/test_ingestor_backend_selection.py
+++ b/codebase_rag/tests/test_ingestor_backend_selection.py
@@ -289,7 +289,7 @@ class TestLegacyMigrationUsesTheDiscoveredName:
         ingestor.ensure_constraints()
 
         drops = [q for q in conn.log if q.startswith("DROP CONSTRAINT")]
-        assert drops == ["DROP CONSTRAINT legacy_folder_path_uc IF EXISTS"]
+        assert drops == ["DROP CONSTRAINT `legacy_folder_path_uc` IF EXISTS"]
 
     def test_memgraph_still_drops_by_pattern(self) -> None:
         ingestor = MemgraphIngestor(

--- a/codebase_rag/tests/test_ingestor_backend_selection.py
+++ b/codebase_rag/tests/test_ingestor_backend_selection.py
@@ -168,3 +168,78 @@ class TestNeo4jDriverIsNotRequiredForMemgraph:
         )
         ingestor, _ = _ingestor(DIALECT_MEMGRAPH)
         ingestor.ensure_constraints()
+
+
+class TestNeo4jDriverLifecycle:
+    """The pooled driver is shared state; these are its two failure modes."""
+
+    def test_one_driver_is_shared_across_concurrent_creators(self, monkeypatch) -> None:
+        # The parallel flush calls _create_connection from several worker
+        # threads at once. An unguarded `if self._driver is None` builds a
+        # second pool, which then leaks.
+        import threading
+
+        built: list[object] = []
+        barrier = threading.Barrier(8)
+
+        class FakeDriver:
+            def __init__(self, **kwargs: object) -> None:
+                built.append(self)
+
+            def connect(self) -> RecordingConn:
+                return RecordingConn()
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr(
+            "codebase_rag.services.neo4j_driver.Neo4jDriver", FakeDriver
+        )
+        ingestor = MemgraphIngestor(
+            host="h", port=1, dialect=get_dialect(DIALECT_NEO4J)
+        )
+
+        def race() -> None:
+            barrier.wait()
+            ingestor._neo4j_driver()
+
+        threads = [threading.Thread(target=race) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(built) == 1
+
+    def test_the_driver_is_closed_on_exit(self, monkeypatch) -> None:
+        # __exit__ closes `self.conn`, which is a single session; without
+        # this the pool behind it survives for the life of the process.
+        closed: list[bool] = []
+
+        class FakeDriver:
+            def __init__(self, **kwargs: object) -> None:
+                pass
+
+            def connect(self) -> RecordingConn:
+                return RecordingConn()
+
+            def close(self) -> None:
+                closed.append(True)
+
+        monkeypatch.setattr(
+            "codebase_rag.services.neo4j_driver.Neo4jDriver", FakeDriver
+        )
+        ingestor = MemgraphIngestor(
+            host="h", port=1, dialect=get_dialect(DIALECT_NEO4J)
+        )
+        ingestor.__enter__()
+        ingestor._neo4j_driver()
+        ingestor.__exit__(None, None, None)
+
+        assert closed == [True]
+
+    def test_exiting_without_a_driver_does_not_raise(self) -> None:
+        # A Memgraph run never builds one; the teardown must tolerate that.
+        ingestor = MemgraphIngestor(host="h", port=1)
+        ingestor.conn = RecordingConn()
+        ingestor.__exit__(None, None, None)

--- a/codebase_rag/tests/test_ingestor_backend_selection.py
+++ b/codebase_rag/tests/test_ingestor_backend_selection.py
@@ -243,3 +243,63 @@ class TestNeo4jDriverLifecycle:
         ingestor = MemgraphIngestor(host="h", port=1)
         ingestor.conn = RecordingConn()
         ingestor.__exit__(None, None, None)
+
+
+class TestLegacyMigrationUsesTheDiscoveredName:
+    """The DROP must name the constraint the server actually reported."""
+
+    class _RowsConn(RecordingConn):
+        """A connection whose SHOW CONSTRAINTS returns one legacy row."""
+
+        def __init__(self, rows: list[tuple], columns: list[str]) -> None:
+            super().__init__()
+            self._rows, self._columns = rows, columns
+
+        def cursor(self):  # type: ignore[no-untyped-def]
+            conn = self
+
+            class _Cursor:
+                def execute(self, query: str, params=None) -> None:
+                    conn.log.append(query)
+                    self._is_show = "SHOW CONSTRAINT" in query
+
+                @property
+                def description(self):  # type: ignore[no-untyped-def]
+                    if not getattr(self, "_is_show", False):
+                        return None
+                    return [type("C", (), {"name": c})() for c in conn._columns]
+
+                def fetchall(self):  # type: ignore[no-untyped-def]
+                    return conn._rows if getattr(self, "_is_show", False) else []
+
+                def close(self) -> None:
+                    pass
+
+            return _Cursor()
+
+    def test_neo4j_drops_the_name_the_server_reported(self) -> None:
+        ingestor = MemgraphIngestor(
+            host="h", port=1, dialect=get_dialect(DIALECT_NEO4J)
+        )
+        conn = self._RowsConn(
+            rows=[("legacy_folder_path_uc", ["Folder"], ["path"])],
+            columns=["name", "labelsOrTypes", "properties"],
+        )
+        ingestor.conn = conn
+        ingestor.ensure_constraints()
+
+        drops = [q for q in conn.log if q.startswith("DROP CONSTRAINT")]
+        assert drops == ["DROP CONSTRAINT legacy_folder_path_uc IF EXISTS"]
+
+    def test_memgraph_still_drops_by_pattern(self) -> None:
+        ingestor = MemgraphIngestor(
+            host="h", port=1, dialect=get_dialect(DIALECT_MEMGRAPH)
+        )
+        conn = self._RowsConn(
+            rows=[("Folder", ["path"])], columns=["label", "properties"]
+        )
+        ingestor.conn = conn
+        ingestor.ensure_constraints()
+
+        drops = [q for q in conn.log if q.startswith("DROP CONSTRAINT")]
+        assert drops == ["DROP CONSTRAINT ON (n:Folder) ASSERT n.path IS UNIQUE;"]

--- a/codebase_rag/tests/test_neo4j_driver.py
+++ b/codebase_rag/tests/test_neo4j_driver.py
@@ -100,8 +100,9 @@ class TestCursorContract:
     def test_a_bare_sequence_is_rejected(self) -> None:
         # A positional sequence has no name to bind to, so guessing would
         # silently send the wrong parameters.
+        cursor = Neo4jCursor(FakeSession())
         with pytest.raises(TypeError, match="must be a mapping"):
-            Neo4jCursor(FakeSession()).execute("UNWIND $batch AS row", [{"id": 1}])
+            cursor.execute("UNWIND $batch AS row", [{"id": 1}])
 
     def test_close_releases_buffered_rows(self) -> None:
         cur = Neo4jCursor(FakeSession(keys=["n"], rows=[(1,)]))

--- a/codebase_rag/tests/test_neo4j_driver.py
+++ b/codebase_rag/tests/test_neo4j_driver.py
@@ -1,0 +1,136 @@
+"""The cursor-shaped adapter over the Neo4j driver (issue #1590).
+
+`MemgraphIngestor` is written against a DB-API-ish connection/cursor, so
+these tests pin the adapter to exactly that contract -- including the two
+details the ingestor depends on that the Neo4j driver does not natively
+provide: `cursor.description` names, and rows that survive the cursor
+being closed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.services.neo4j_driver import (
+    Neo4jConnection,
+    Neo4jCursor,
+)
+from codebase_rag.types_defs import ConnectionProtocol, CursorProtocol
+
+
+class FakeRecord:
+    def __init__(self, values: tuple[object, ...]) -> None:
+        self._values = values
+
+    def values(self) -> tuple[object, ...]:
+        return self._values
+
+
+class FakeResult:
+    def __init__(self, keys: list[str], rows: list[tuple[object, ...]]) -> None:
+        self._keys, self._rows = keys, rows
+
+    def keys(self) -> list[str]:
+        return self._keys
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        return iter(FakeRecord(r) for r in self._rows)
+
+
+class FakeSession:
+    """Records what the adapter asks the driver to do."""
+
+    def __init__(self, keys: list[str] | None = None, rows=None) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.closed = False
+        self._keys = keys or []
+        self._rows = rows or []
+
+    def run(self, query: str, parameters: dict) -> FakeResult:
+        self.calls.append((query, parameters))
+        return FakeResult(self._keys, self._rows)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestCursorContract:
+    def test_it_satisfies_the_cursor_protocol(self) -> None:
+        assert isinstance(Neo4jCursor(FakeSession()), CursorProtocol)
+
+    def test_description_exposes_column_names(self) -> None:
+        # The ingestor builds result dicts from `desc.name`; the Neo4j
+        # driver has no `description` at all, so the adapter supplies it.
+        cur = Neo4jCursor(FakeSession(keys=["a", "b"], rows=[(1, 2)]))
+        cur.execute("RETURN 1 AS a, 2 AS b")
+        assert [d.name for d in (cur.description or [])] == ["a", "b"]
+
+    def test_description_is_none_when_a_statement_returns_nothing(self) -> None:
+        cur = Neo4jCursor(FakeSession(keys=[], rows=[]))
+        cur.execute("CREATE INDEX foo IF NOT EXISTS FOR (n:L) ON (n.p)")
+        assert cur.description is None
+
+    def test_rows_are_buffered_at_execute_time(self) -> None:
+        # A Neo4j Result is invalid once the session moves on, but the
+        # ingestor closes its cursor in a `finally` and reads rows after.
+        session = FakeSession(keys=["n"], rows=[(1,), (2,)])
+        cur = Neo4jCursor(session)
+        cur.execute("MATCH (n) RETURN n")
+        session.run("SOMETHING ELSE", {})
+        assert cur.fetchall() == [(1,), (2,)]
+
+    def test_parameters_are_passed_through(self) -> None:
+        session = FakeSession()
+        Neo4jCursor(session).execute("MATCH (n {x: $x}) RETURN n", {"x": 1})
+        assert session.calls == [("MATCH (n {x: $x}) RETURN n", {"x": 1})]
+
+    def test_a_missing_parameter_map_becomes_an_empty_one(self) -> None:
+        session = FakeSession()
+        Neo4jCursor(session).execute("RETURN 1")
+        assert session.calls == [("RETURN 1", {})]
+
+    def test_a_batch_wrapper_is_passed_as_a_mapping(self) -> None:
+        # BatchWrapper is a TypedDict, i.e. a plain dict at runtime; this
+        # is the `UNWIND $batch AS row` path every bulk write uses.
+        session = FakeSession()
+        rows = [{"id": 1, "props": {}}]
+        Neo4jCursor(session).execute("UNWIND $batch AS row", {"batch": rows})
+        assert session.calls[0][1] == {"batch": rows}
+
+    def test_a_bare_sequence_is_rejected(self) -> None:
+        # A positional sequence has no name to bind to, so guessing would
+        # silently send the wrong parameters.
+        with pytest.raises(TypeError, match="must be a mapping"):
+            Neo4jCursor(FakeSession()).execute("UNWIND $batch AS row", [{"id": 1}])
+
+    def test_close_releases_buffered_rows(self) -> None:
+        cur = Neo4jCursor(FakeSession(keys=["n"], rows=[(1,)]))
+        cur.execute("MATCH (n) RETURN n")
+        cur.close()
+        assert cur.fetchall() == []
+
+
+class TestConnectionContract:
+    def test_it_satisfies_the_connection_protocol(self) -> None:
+        assert isinstance(Neo4jConnection(FakeSession()), ConnectionProtocol)
+
+    def test_it_hands_out_cursors(self) -> None:
+        assert isinstance(Neo4jConnection(FakeSession()).cursor(), Neo4jCursor)
+
+    def test_autocommit_is_accepted(self) -> None:
+        # The ingestor sets `conn.autocommit = True`; Session.run is
+        # already an auto-commit transaction, so this must not raise.
+        conn = Neo4jConnection(FakeSession())
+        conn.autocommit = True
+        assert conn.autocommit is True
+
+    def test_closing_closes_the_session(self) -> None:
+        session = FakeSession()
+        Neo4jConnection(session).close()
+        assert session.closed
+
+    def test_it_works_as_a_context_manager(self) -> None:
+        session = FakeSession()
+        with Neo4jConnection(session):
+            assert not session.closed
+        assert session.closed

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -53,6 +53,10 @@ def _connection_error_types() -> tuple[type[BaseException], ...]:
     connection problem. Imported lazily because `neo4j` is an optional
     extra.
     """
+    # Accumulated rather than returned as differently-shaped tuples: this
+    # is a variadic `except` argument, not a fixed-arity value, and the
+    # list makes that intent explicit (python:S8495).
+    types: list[type[BaseException]] = [mgclient.Error]
     if settings.GRAPH_BACKEND == DIALECT_NEO4J:
         try:
             from neo4j.exceptions import (  # ty: ignore[unresolved-import]
@@ -60,9 +64,10 @@ def _connection_error_types() -> tuple[type[BaseException], ...]:
                 Neo4jError,
             )
         except ImportError:  # pragma: no cover - depends on extras
-            return (mgclient.Error,)
-        return (mgclient.Error, DriverError, Neo4jError)
-    return (mgclient.Error,)
+            pass
+        else:
+            types += [DriverError, Neo4jError]
+    return tuple(types)
 
 
 def _backend_engine_name() -> str:

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -10,7 +10,21 @@ from .. import constants as cs
 from .. import graph_audit
 from ..config import settings
 from ..schemas import HealthCheckResult
-from ..types_defs import ResultRow
+from ..services.graph_service import MemgraphIngestor
+from ..types_defs import ConnectionProtocol, ResultRow
+
+
+def _backend_connection() -> ConnectionProtocol:
+    """Open a connection to whichever graph engine is configured.
+
+    Health output must describe the backend actually in use, so this
+    reuses the ingestor's own connection factory rather than reaching for
+    `mgclient` directly -- otherwise `cgr health` would report on a
+    Memgraph server that a Neo4j install never talks to.
+    """
+    return MemgraphIngestor(
+        host=settings.MEMGRAPH_HOST, port=settings.MEMGRAPH_PORT
+    )._create_connection()
 
 
 class HealthChecker:
@@ -69,10 +83,7 @@ class HealthChecker:
         conn = None
         cursor = None
         try:
-            conn = mgclient.connect(
-                host=settings.MEMGRAPH_HOST,
-                port=settings.MEMGRAPH_PORT,
-            )
+            conn = _backend_connection()
 
             cursor = conn.cursor()
             cursor.execute(cs.HEALTH_CHECK_MEMGRAPH_QUERY)
@@ -194,10 +205,7 @@ class HealthChecker:
         already reported by check_memgraph_connection.
         """
         try:
-            conn = mgclient.connect(
-                host=settings.MEMGRAPH_HOST,
-                port=settings.MEMGRAPH_PORT,
-            )
+            conn = _backend_connection()
         except Exception:
             return []
         cursor = conn.cursor()

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import mgclient  # ty: ignore[unresolved-import]
 from loguru import logger
@@ -9,22 +11,43 @@ from loguru import logger
 from .. import constants as cs
 from .. import graph_audit
 from ..config import settings
+from ..graph_dialects import DIALECT_NEO4J
 from ..schemas import HealthCheckResult
 from ..services.graph_service import MemgraphIngestor
 from ..types_defs import ConnectionProtocol, ResultRow
 
 
-def _backend_connection() -> ConnectionProtocol:
+@contextmanager
+def _backend_connection() -> Iterator[ConnectionProtocol]:
     """Open a connection to whichever graph engine is configured.
 
     Health output must describe the backend actually in use, so this
     reuses the ingestor's own connection factory rather than reaching for
     `mgclient` directly -- otherwise `cgr health` would report on a
     Memgraph server that a Neo4j install never talks to.
+
+    A context manager because the ingestor OWNS the Neo4j connection
+    pool: returning a bare connection would close the one session and
+    leak a whole driver per health check.
     """
-    return MemgraphIngestor(
+    ingestor = MemgraphIngestor(
         host=settings.MEMGRAPH_HOST, port=settings.MEMGRAPH_PORT
-    )._create_connection()
+    )
+    conn = ingestor._create_connection()
+    try:
+        yield conn
+    finally:
+        try:
+            conn.close()
+        finally:
+            ingestor.close_driver()
+
+
+def _backend_endpoint() -> str:
+    """The address health output should name, for the configured engine."""
+    if settings.GRAPH_BACKEND == DIALECT_NEO4J:
+        return settings.NEO4J_URI
+    return f"{settings.MEMGRAPH_HOST}:{settings.MEMGRAPH_PORT}"
 
 
 class HealthChecker:
@@ -83,18 +106,16 @@ class HealthChecker:
         conn = None
         cursor = None
         try:
-            conn = _backend_connection()
-
-            cursor = conn.cursor()
-            cursor.execute(cs.HEALTH_CHECK_MEMGRAPH_QUERY)
-            list(cursor.fetchall())
+            with _backend_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(cs.HEALTH_CHECK_MEMGRAPH_QUERY)
+                list(cursor.fetchall())
 
             return HealthCheckResult(
                 name=cs.HEALTH_CHECK_MEMGRAPH_SUCCESSFUL,
                 passed=True,
                 message=cs.HEALTH_CHECK_MEMGRAPH_CONNECTED_MSG.format(
-                    host=settings.MEMGRAPH_HOST,
-                    port=settings.MEMGRAPH_PORT,
+                    endpoint=_backend_endpoint(),
                 ),
             )
 
@@ -204,20 +225,37 @@ class HealthChecker:
         Returns no results when Memgraph is unreachable: connectivity is
         already reported by check_memgraph_connection.
         """
+        # Enter the context here, not inside the audit's try: an
+        # unreachable server must yield no results (connectivity is
+        # already reported by check_memgraph_connection), not an
+        # "audit queries failed" result.
+        connection = _backend_connection()
         try:
-            conn = _backend_connection()
+            conn = connection.__enter__()
         except Exception:
             return []
-        cursor = conn.cursor()
 
-        def fetch_all(query: str) -> list[ResultRow]:
-            cursor.execute(query)
-            # mgclient.Column is not subscriptable; the name is an attribute.
-            columns = [column.name for column in cursor.description or []]
-            return [dict(zip(columns, row)) for row in cursor.fetchall()]
-
+        # `with`, not a manually closed ExitStack: the connection AND the
+        # driver behind it are released by leaving the block, so a later
+        # edit cannot drop the release by changing one call.
         try:
-            violations = graph_audit.collect_live_violations(fetch_all)
+            try:
+                cursor = conn.cursor()
+
+                def fetch_all(query: str) -> list[ResultRow]:
+                    cursor.execute(query)
+                    # mgclient.Column is not subscriptable; the name is
+                    # an attribute.
+                    columns = [column.name for column in cursor.description or []]
+                    return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+                try:
+                    violations = graph_audit.collect_live_violations(fetch_all)
+                finally:
+                    cursor.close()
+            finally:
+                # Releases the connection AND the driver behind it.
+                connection.__exit__(None, None, None)
         except Exception as e:
             return [
                 HealthCheckResult(
@@ -227,9 +265,6 @@ class HealthChecker:
                     error=str(e),
                 )
             ]
-        finally:
-            cursor.close()
-            conn.close()
         if not violations:
             return [
                 HealthCheckResult(

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -52,6 +52,10 @@ def _connection_error_types() -> tuple[type[BaseException], ...]:
     an unreachable server is reported as a mystery rather than as a
     connection problem. Imported lazily because `neo4j` is an optional
     extra.
+
+    Scoped deliberately: this answers "can we reach the server", so it
+    covers transport failures and authentication, not every Neo4j error.
+    A Cypher failure is a query problem and keeps its own diagnostic.
     """
     # Accumulated rather than returned as differently-shaped tuples: this
     # is a variadic `except` argument, not a fixed-arity value, and the
@@ -60,13 +64,20 @@ def _connection_error_types() -> tuple[type[BaseException], ...]:
     if settings.GRAPH_BACKEND == DIALECT_NEO4J:
         try:
             from neo4j.exceptions import (  # ty: ignore[unresolved-import]
+                AuthError,
                 DriverError,
-                Neo4jError,
             )
         except ImportError:  # pragma: no cover - depends on extras
             pass
         else:
-            types += [DriverError, Neo4jError]
+            # `DriverError` is the client-side/transport branch --
+            # ServiceUnavailable and SessionExpired live here. `AuthError`
+            # is a server error but still means "cannot connect". The rest
+            # of `Neo4jError` (a Cypher syntax error, say) is a genuine
+            # query failure and must NOT be reported as a connectivity
+            # problem, so it deliberately falls through to the generic
+            # branch.
+            types += [DriverError, AuthError]
     return tuple(types)
 
 

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -43,6 +43,11 @@ def _backend_connection() -> Iterator[ConnectionProtocol]:
             ingestor.close_driver()
 
 
+def _backend_engine_name() -> str:
+    """The engine's display name, for health output."""
+    return cs.HEALTH_ENGINE_NAMES.get(settings.GRAPH_BACKEND, settings.GRAPH_BACKEND)
+
+
 def _backend_endpoint() -> str:
     """The address health output should name, for the configured engine."""
     if settings.GRAPH_BACKEND == DIALECT_NEO4J:
@@ -112,7 +117,9 @@ class HealthChecker:
                 list(cursor.fetchall())
 
             return HealthCheckResult(
-                name=cs.HEALTH_CHECK_MEMGRAPH_SUCCESSFUL,
+                name=cs.HEALTH_CHECK_GRAPH_SUCCESSFUL.format(
+                    engine=_backend_engine_name()
+                ),
                 passed=True,
                 message=cs.HEALTH_CHECK_MEMGRAPH_CONNECTED_MSG.format(
                     endpoint=_backend_endpoint(),
@@ -121,14 +128,16 @@ class HealthChecker:
 
         except mgclient.Error as e:
             return HealthCheckResult(
-                name=cs.HEALTH_CHECK_MEMGRAPH_FAILED,
+                name=cs.HEALTH_CHECK_GRAPH_FAILED.format(engine=_backend_engine_name()),
                 passed=False,
                 message=cs.HEALTH_CHECK_MEMGRAPH_CONNECTION_FAILED_MSG,
-                error=cs.HEALTH_CHECK_MEMGRAPH_ERROR.format(error=str(e)),
+                error=cs.HEALTH_CHECK_GRAPH_ERROR.format(
+                    engine=_backend_engine_name(), error=str(e)
+                ),
             )
         except Exception as e:
             return HealthCheckResult(
-                name=cs.HEALTH_CHECK_MEMGRAPH_FAILED,
+                name=cs.HEALTH_CHECK_GRAPH_FAILED.format(engine=_backend_engine_name()),
                 passed=False,
                 message=cs.HEALTH_CHECK_MEMGRAPH_UNEXPECTED_FAILURE_MSG,
                 error=str(e),

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -14,7 +14,7 @@ from ..config import settings
 from ..graph_dialects import DIALECT_NEO4J
 from ..schemas import HealthCheckResult
 from ..services.graph_service import MemgraphIngestor
-from ..types_defs import ConnectionProtocol, ResultRow
+from ..types_defs import ConnectionProtocol, CursorProtocol, ResultRow
 
 
 @contextmanager
@@ -41,6 +41,28 @@ def _backend_connection() -> Iterator[ConnectionProtocol]:
             conn.close()
         finally:
             ingestor.close_driver()
+
+
+def _connection_error_types() -> tuple[type[BaseException], ...]:
+    """Exceptions that mean "the server is not reachable", per engine.
+
+    A Neo4j failure surfaces as `neo4j.exceptions.ServiceUnavailable`,
+    which is neither an `mgclient.Error` nor an `OSError`, so without
+    this it falls through to the generic "unexpected failure" branch and
+    an unreachable server is reported as a mystery rather than as a
+    connection problem. Imported lazily because `neo4j` is an optional
+    extra.
+    """
+    if settings.GRAPH_BACKEND == DIALECT_NEO4J:
+        try:
+            from neo4j.exceptions import (  # ty: ignore[unresolved-import]
+                DriverError,
+                Neo4jError,
+            )
+        except ImportError:  # pragma: no cover - depends on extras
+            return (mgclient.Error,)
+        return (mgclient.Error, DriverError, Neo4jError)
+    return (mgclient.Error,)
 
 
 def _backend_engine_name() -> str:
@@ -126,7 +148,7 @@ class HealthChecker:
                 ),
             )
 
-        except mgclient.Error as e:
+        except _connection_error_types() as e:
             return HealthCheckResult(
                 name=cs.HEALTH_CHECK_GRAPH_FAILED.format(engine=_backend_engine_name()),
                 passed=False,
@@ -244,27 +266,21 @@ class HealthChecker:
         except Exception:
             return []
 
-        # `with`, not a manually closed ExitStack: the connection AND the
-        # driver behind it are released by leaving the block, so a later
-        # edit cannot drop the release by changing one call.
+        # Bound before the try: `conn.cursor()` can raise, and the
+        # cleanup below would then mask the real error with an
+        # UnboundLocalError.
+        cursor: CursorProtocol | None = None
         try:
-            try:
-                cursor = conn.cursor()
+            cursor = conn.cursor()
 
-                def fetch_all(query: str) -> list[ResultRow]:
-                    cursor.execute(query)
-                    # mgclient.Column is not subscriptable; the name is
-                    # an attribute.
-                    columns = [column.name for column in cursor.description or []]
-                    return [dict(zip(columns, row)) for row in cursor.fetchall()]
+            def fetch_all(query: str) -> list[ResultRow]:
+                cursor.execute(query)
+                # mgclient.Column is not subscriptable; the name is an
+                # attribute.
+                columns = [column.name for column in cursor.description or []]
+                return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
-                try:
-                    violations = graph_audit.collect_live_violations(fetch_all)
-                finally:
-                    cursor.close()
-            finally:
-                # Releases the connection AND the driver behind it.
-                connection.__exit__(None, None, None)
+            violations = graph_audit.collect_live_violations(fetch_all)
         except Exception as e:
             return [
                 HealthCheckResult(
@@ -274,6 +290,20 @@ class HealthChecker:
                     error=str(e),
                 )
             ]
+        finally:
+            # Cleanup is deliberately OUTSIDE the audit's `except`: closing
+            # the cursor, the connection and (on Neo4j) the driver can
+            # raise, and a cleanup failure must not report a completed
+            # audit as failed. Logged rather than swallowed silently.
+            closers = [lambda: connection.__exit__(None, None, None)]
+            if cursor is not None:
+                closers.insert(0, cursor.close)
+            for close in closers:
+                try:
+                    close()
+                except Exception as cleanup_error:
+                    logger.warning(f"Graph audit cleanup failed: {cleanup_error}")
+
         if not violations:
             return [
                 HealthCheckResult(

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -12,7 +12,13 @@ from collections.abc import (
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, Protocol, TypedDict
+from typing import (
+    TYPE_CHECKING,
+    NamedTuple,
+    Protocol,
+    TypedDict,
+    runtime_checkable,
+)
 
 from prompt_toolkit.styles import Style
 
@@ -175,6 +181,7 @@ class LoadableProtocol(Protocol):
     def _ensure_loaded(self) -> None: ...
 
 
+@runtime_checkable
 class CursorProtocol(Protocol):
     def execute(
         self,
@@ -188,6 +195,19 @@ class CursorProtocol(Protocol):
     @property
     def description(self) -> Sequence[ColumnDescriptor] | None: ...
     def fetchall(self) -> list[tuple[PropertyValue, ...]]: ...
+
+
+@runtime_checkable
+class ConnectionProtocol(Protocol):
+    """The connection surface the graph ingestor relies on.
+
+    Deliberately DB-API-shaped: `MemgraphIngestor` was written against
+    `mgclient` connections, and `services.neo4j_driver` adapts the Neo4j
+    driver to the same shape so one ingestor serves both engines.
+    """
+
+    def cursor(self) -> CursorProtocol: ...
+    def close(self) -> None: ...
 
 
 class PathValidatorProtocol(Protocol):

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -109,11 +109,16 @@ Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `GRAPH_BACKEND` | `memgraph` | Graph engine: `memgraph` or `neo4j`. Neo4j needs the `neo4j` extra (`uv pip install 'code-graph-rag[neo4j]'`) and is configured with the `NEO4J_*` variables below; the bundled `cgr stack` only launches Memgraph, so a Neo4j server is yours to run. |
 | `MEMGRAPH_HOST` | `localhost` | Memgraph hostname |
 | `MEMGRAPH_PORT` | `7687` | Memgraph port |
 | `MEMGRAPH_HTTP_PORT` | `7444` | Memgraph HTTP port |
 | `LAB_PORT` | `3000` | Memgraph Lab port |
 | `MEMGRAPH_BATCH_SIZE` | `1000` | Batch size for Memgraph operations |
+| `NEO4J_URI` | `bolt://localhost:7687` | Neo4j connection URI. The scheme selects routing (`neo4j://` for a cluster, `bolt://` for a single instance) and TLS (`+s`/`+ssc`). |
+| `NEO4J_USERNAME` | _(unset)_ | Neo4j username; leave unset for an unauthenticated server |
+| `NEO4J_PASSWORD` | _(unset)_ | Neo4j password |
+| `NEO4J_DATABASE` | `neo4j` | Neo4j database name |
 | `TARGET_REPO_PATH` | `.` | Default repository path |
 | `CPP_FRONTEND` | `hybrid` | C/C++ frontend mode: `treesitter`, `libclang`, or `hybrid`. The libclang-backed modes require the [`cpp` extra and a compilation database](../guide/cpp-semantic-mode.md). |
 | `CGR_CAPTURE_LOCAL_DEFINITIONS` | `true` | Capture methods of classes defined inside function bodies (function-local definitions). On by default for exhaustive structure capture; set to `false` to keep the graph free of throwaway helpers and test mocks. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,12 @@ cpp = [
     "libclang>=18.1.1",
 ]
 
+# Neo4j is an optional backend (issue #1590): Memgraph remains the default,
+# so a default install must not pay for a driver it will never load.
+neo4j = [
+    "neo4j>=5.28.1",
+]
+
 treesitter-full = [
     "tree-sitter-python>=0.23.6",
     "tree-sitter-javascript>=0.23.1",

--- a/uv.lock
+++ b/uv.lock
@@ -441,6 +441,9 @@ cpp = [
 milvus = [
     { name = "pymilvus", extra = ["milvus-lite"] },
 ]
+neo4j = [
+    { name = "neo4j" },
+]
 python-semantics = [
     { name = "jedi" },
 ]
@@ -520,6 +523,7 @@ requires-dist = [
     { name = "libclang", marker = "extra == 'test'", specifier = ">=18.1.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", specifier = ">=1.28.1" },
+    { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.28.1" },
     { name = "pathspec", specifier = ">=1.0.4" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "protobuf", specifier = ">=6.33.5" },
@@ -562,7 +566,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.21.1" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["test", "cpp", "treesitter-full", "semantic", "milvus", "ast-grep", "python-semantics"]
+provides-extras = ["test", "cpp", "neo4j", "treesitter-full", "semantic", "milvus", "ast-grep", "python-semantics"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -732,7 +736,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -763,43 +767,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -936,8 +940,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -1222,8 +1226,8 @@ name = "httpcore2"
 version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
@@ -1630,7 +1634,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1790,10 +1794,10 @@ name = "milvus-lite"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/58/54c72981958073d365febeae8fed3115c87761f45905f2d4725f506b94d1/milvus_lite-3.1.0.tar.gz", hash = "sha256:8d467ae81173f1ede93723a80f08d85b91988b451cd2b7bbf9b5a7cfb875e04b", size = 636180, upload-time = "2026-07-15T06:40:58.177Z" }
 wheels = [
@@ -1903,6 +1907,18 @@ wheels = [
 ]
 
 [[package]]
+name = "neo4j"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/57/f939c3b9b28e5851095eafb823b5a996eea3f21a14be513bcf9b355f97da/neo4j-6.3.0.tar.gz", hash = "sha256:d0d3986c37ad174a549a39dfec6d22a00a061ebcb0267f1a5caf856589838e73", size = 242487, upload-time = "2026-08-28T10:25:04.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/47/d29d93455fe2959e5b8383e52f68b3633d729f39e87fef94743f9f2240ae/neo4j-6.3.0-py3-none-any.whl", hash = "sha256:d243f9c8adf882ae7205a76eb2419b0a632d5f3c89383d4a0044d737a2223991", size = 331471, upload-time = "2026-08-28T10:25:03.263Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1986,7 +2002,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2025,7 +2041,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2037,7 +2053,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2067,9 +2083,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2081,7 +2097,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3046,6 +3062,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.3.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz", hash = "sha256:2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d", size = 319745, upload-time = "2026-07-25T15:12:07.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl", hash = "sha256:dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815", size = 508283, upload-time = "2026-07-25T15:12:05.782Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -3473,8 +3498,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Closes #1590.

Adds Neo4j as a graph backend. Memgraph stays the default and its behaviour is unchanged: the Memgraph dialect's output is asserted **byte-identical** to the previously hardcoded strings across all 42 `(label, prop)` pairs the ingestor builds DDL for, and across four query shapes for the memory-limit suffix.

The issue body was empty, so the shape was agreed with the owner: a backend abstraction rather than a one-off port, **explicitly designed for further engines** — adding a third means a `GraphDialect` subclass plus one registry line, with no edits to the ingestor, the query builders, or their call sites.

## What actually differs between engines

Less than the 107 files mentioning "memgraph" suggest — `mgclient` appears in only three non-test files. The query corpus is overwhelmingly portable (`MERGE`, `UNWIND $batch`, `SET n += row.props`, label/relationship alternation, `type()`, property-form `IS NULL`), and the project had already dodged the classic traps: no `apoc`/`mg`/`dbms` calls, no `CALL {} IN TRANSACTIONS`, no `STORAGE MODE`, no `size(pattern)`.

Three things genuinely diverge, and `codebase_rag/graph_dialects.py` is now the only place that knows about them:

| Construct | Memgraph | Neo4j 5 |
|---|---|---|
| Constraint DDL | `CREATE CONSTRAINT ON (n:L) ASSERT ... IS UNIQUE` | `CREATE CONSTRAINT <name> IF NOT EXISTS FOR (n:L) REQUIRE ...` |
| Constraint listing | `SHOW CONSTRAINT INFO`, column `label` | `SHOW CONSTRAINTS`, column `labelsOrTypes` (a **list**) |
| Read memory bound | `QUERY MEMORY LIMIT n MB` | no equivalent — must be omitted |

The memory-limit suffix is appended to **every** read via `fetch_all`, so leaking it would make the entire read path a syntax error. Neo4j `DROP CONSTRAINT` takes only a name, never a pattern, hence the derived `cgr_<label>_<prop>` naming.

## Transport: adapted, not forked

`services/neo4j_driver.py` dresses a Neo4j session as the DB-API-shaped connection/cursor `MemgraphIngestor` was written against (`cursor()`, `execute()`, `description`, `fetchall()`, `close()`). One ingestor therefore serves both engines, and the 690 lines of batching, grouping, parallel flush and error accounting are shared rather than duplicated.

This was deliberate over writing a second implementation: the class's real surface is **13 public methods**, not the 5 declared in `IngestorProtocol`/`QueryProtocol`. A second implementation would silently miss `clean_database`, `ensure_constraints`, `delete_project`, `export_graph_to_dict` and the context-manager protocol.

Two adapter behaviours are load-bearing: rows are buffered at `execute` time (a Neo4j `Result` is invalid once its session moves on, but the ingestor reads rows after closing the cursor), and each connection owns one session, which is what makes the existing per-worker connection model thread-safe.

## The failure mode this guards against is silent

`ensure_constraints` and `_ensure_indexes` wrap every DDL statement in `except Exception: pass`. An engine sent the wrong syntax therefore builds a graph with **no constraints and no indexes** rather than raising — and the parallel `MERGE` flush depends on those constraints for correctness.

This caught me out. My first integration suite asserted node counts, and **passed against a deliberately broken Neo4j dialect on a live server**, because `MERGE` deduplicates whether or not a constraint exists. It was measuring something both the working and broken versions produce. It now reads the server's own constraint catalogue back and asserts a duplicate key is rejected; both were confirmed to fail under that mutation.

## Configuration

`GRAPH_BACKEND` (default `memgraph`) with a validator that **rejects** unknown values at startup rather than defaulting — given the swallowed DDL above, a typo that silently selected Memgraph would surface much later as a corrupt graph. Plus `NEO4J_URI` / `NEO4J_USERNAME` / `NEO4J_PASSWORD` / `NEO4J_DATABASE`; the URI carries routing and TLS, which a host/port pair cannot express.

`neo4j` is an optional extra, so a default install does not pay for a driver it never loads.

`cgr health` now reports on the configured engine. `cgr stack` still launches only Memgraph, by design: a Neo4j server is the user's to run.

## Verification

- **30 integration tests against real containers** — Memgraph 3.3 and Neo4j 5, 15 assertions parameterised over both engines (`test_backend_parity_e2e.py`).
- **408 unit tests** across the new and adjacent existing suites.
- **12 mutations**, each reddening only the tests written for it, with every file restored byte-identical afterwards.
- `ruff check` / `format` clean.

Full suite not run locally; CI covers it.

## Found while building it

Three defects in my own code, all fixed here with tests confirmed to fail when reverted:

1. The pooled Neo4j `Driver` was never closed — `__exit__` closed one session and leaked the pool.
2. `_neo4j_driver()` built the driver under an unguarded `if is None` while flush workers call it concurrently.
3. `cgr health` printed the Memgraph host while connected to Neo4j.

One test-design note worth recording: asserting that `close_driver` ran **cannot** distinguish an explicit release from an accidental one, because dropping the last reference to a generator-based context manager runs its `finally` anyway under CPython refcounting. Verified by checking whether an `__exit__` frame was on the stack during cleanup — it was not. The leak is masked on CPython but real on a non-refcounting runtime, so the release is explicit and the test asserts its presence in the source rather than an observable that cannot discriminate.

## Out of scope

Query *generation* still offers Memgraph's MAGE procedures (`nxalg.*`, `pagerank.get()`, `path.expand`), which do not exist on Neo4j — filed as #1813. Indexing and Cypher querying work on Neo4j today; this affects only natural-language questions that reach for a graph algorithm. Attempted here and backed out rather than shipped half-done: the prompt's literal braces make the split fiddly enough to deserve its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Neo4j support alongside Memgraph for graph storage and ingestion.
  * Added configuration for selecting the graph backend and specifying Neo4j connection details.
  * Health checks now report the configured backend, endpoint, and engine-specific status.
  * Memgraph remains the default backend.

* **Documentation**
  * Documented backend selection and Neo4j configuration options.

* **Bug Fixes**
  * Invalid graph backend names are now rejected during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
