### PR TITLE
fix: warn when a symbol name is truncated by an invalid byte

### DIFF
--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -5,6 +5,12 @@ from enum import StrEnum
 INIT_PY = "__init__.py"
 
 ENCODING_UTF8 = "utf-8"
+# Longest UTF-8 sequence, so a window this size either side of a name spans
+# any single character that could legitimately sit next to it.
+UTF8_MAX_SEQUENCE_BYTES = 4
+# Sigils an ingestor prepends to a synthesized symbol name (a C# destructor
+# is stored as `~Greeter` while the source leaf is `Greeter`).
+SYNTHETIC_NAME_PREFIXES = "~"
 
 ARG_TARGET_CODE = "target_code"
 ARG_REPLACEMENT_CODE = "replacement_code"

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -11,6 +11,9 @@ UTF8_MAX_SEQUENCE_BYTES = 4
 # Sigils an ingestor prepends to a synthesized symbol name (a C# destructor
 # is stored as `~Greeter` while the source leaf is `Greeter`).
 SYNTHETIC_NAME_PREFIXES = "~"
+# What `errors="replace"` substitutes for an undecodable byte. Its presence
+# in an extracted symbol name means the name is damaged.
+UNICODE_REPLACEMENT_CHAR = "\ufffd"
 
 ARG_TARGET_CODE = "target_code"
 ARG_REPLACEMENT_CODE = "replacement_code"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -291,6 +291,12 @@ EDIT_TX_APPLIED = "Edit transaction {tx} applied {count} file(s)"
 EDIT_TX_RESTORE_FAILED = "Edit transaction could not restore {path}: {error}"
 REINGEST_DONE = "Re-ingested {reparsed} file(s) (+{affected} dependent, -{removed} removed) in {ms} ms"
 REINGEST_SKIPPED_IGNORED = "Re-ingest skipped path(s) the ignore rules exclude: {paths}"
+TRUNCATED_SYMBOL_NAME = (
+    "{path}: the name {name!r} was extracted from bytes that are not valid "
+    "UTF-8; the grammar splits the token at the bad byte, so this symbol is "
+    "indexed under a truncated name and its callers will not resolve to it "
+    "(issue #1810)"
+)
 REINGEST_UNREADABLE = (
     "Re-ingest could not read {path} after classifying it from disk "
     "({error}); it is not reported as re-parsed"

--- a/codebase_rag/parsers/class_ingest/identity.py
+++ b/codebase_rag/parsers/class_ingest/identity.py
@@ -10,7 +10,7 @@ from ...language_spec import LANGUAGE_FQN_SPECS
 from .. import export_detection
 from ..cpp import utils as cpp_utils
 from ..rs import utils as rs_utils
-from ..utils import safe_decode_text
+from ..utils import safe_decode_text, warn_if_name_truncated
 
 if TYPE_CHECKING:
     from ...language_spec import LanguageSpec
@@ -25,6 +25,7 @@ def resolve_class_identity(
 ) -> tuple[str, str, bool] | None:
     if (fqn_config := LANGUAGE_FQN_SPECS.get(language)) and file_path:
         class_name = fqn_config.get_name(class_node)
+        warn_if_name_truncated(class_node, class_name, file_path)
         if class_name:
             parts = [class_name]
             current = class_node.parent

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -46,6 +46,7 @@ from .utils import (
     python_positional_parameter_names,
     record_cpp_definition_span,
     safe_decode_text,
+    warn_if_name_truncated,
 )
 
 if TYPE_CHECKING:
@@ -592,6 +593,7 @@ class FunctionIngestMixin:
         func_name = fqn_config.get_name(func_node)
         if not func_name:
             return None
+        warn_if_name_truncated(func_node, func_name, file_path)
 
         parts = [func_name]
         current = func_node.parent

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1643,6 +1643,20 @@ def warn_if_name_truncated(
     """
     if not name:
         return
+    # The replacement character can only be in a NAME because a decode put it
+    # there: #1797's fix decodes with errors="replace", so a bad byte the
+    # grammar keeps INSIDE the name expression (Lua's `Greeter.gr\ufffdeet`,
+    # where the byte lands in an ERROR node between two identifiers) survives
+    # as U+FFFD rather than truncating the token. No legitimate identifier
+    # contains it, in any language, so this needs no adjacency test.
+    if cs.UNICODE_REPLACEMENT_CHAR in name:
+        logger.warning(
+            logs.TRUNCATED_SYMBOL_NAME.format(
+                path=file_path if file_path is not None else "<unknown>",
+                name=name,
+            )
+        )
+        return
     source = _node_source_bytes(node)
     if source is None:
         return

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1613,43 +1613,92 @@ def module_qn_for_entity(
 def warn_if_name_truncated(
     node: Node, name: str | None, file_path: Path | None = None
 ) -> None:
-    """Log when a symbol name was extracted from undecodable bytes.
+    """Log when a symbol name was truncated by an invalid byte.
 
-    An invalid byte inside an identifier is treated by tree-sitter as a token
-    boundary, so the `name` node covers only the bytes on one side of it. The
-    extractor then decodes that shortened node without error: `calculate_total`
-    is indexed as `calculate_t`, with nothing raised and nothing logged. A
-    wrong name is worse than a missing one -- callers in untouched files stop
+    An invalid byte inside an identifier is a token boundary to tree-sitter,
+    so the `name` node covers only the bytes on one side of it. The extractor
+    then decodes that shortened node without error: `calculate_total` is
+    indexed as `calculate_t`, with nothing raised and nothing logged. A wrong
+    name is worse than a missing one -- callers in untouched files stop
     resolving to it, so it reads as dead code while a symbol nobody calls
-    appears beside it. Measured across all 15 supported languages: 13 truncate
-    silently, 2 drop the symbol, none survive intact.
+    appears beside it.
 
-    Keyed on the NAME's own bytes, not the file's. A file-level check would be
-    a different signal entirely: across 105,352 real source files (Rust crates,
-    Go modules, the macOS SDK, Homebrew, site-packages) 165 are not valid
-    UTF-8, and NONE of them corrupts a symbol -- every one is latin-1
-    punctuation in a copyright header or an author's name, and one is a `£`
-    inside a regex literal. So a per-file warning would have fired 165 times
-    and been wrong every time, at 1.2% of the macOS SDK. This check fires zero
-    times on all of them and only when a name is genuinely damaged.
+    The discriminator is the byte IMMEDIATELY ADJACENT to the name's span:
+    the one the grammar split on. Two narrower-sounding shapes are both wrong:
 
-    Deliberately NOT `name.encode() in node.text`: containment is satisfied BY
-    this corruption, because the truncated name is a substring of the corrupt
-    bytes (`pha` really is inside `al\xffpha`), so that oracle returns True on
-    the exact defect it would be written for and can never fire. What
-    discriminates is whether the SOURCE round-trips.
+    * The name node's own bytes never contain the bad byte -- tree-sitter
+      excludes it -- so they decode cleanly in the corrupt and the clean case
+      alike. A check on them detects nothing at all.
+    * The enclosing DEFINITION's span does contain it, but also spans the
+      whole body, so it fires on a bad byte in any body comment, docstring or
+      string literal while the symbol is indexed under its correct name, and
+      once per enclosing definition -- one bad byte in a nested class yields a
+      warning per level.
+
+    Measured across 105,352 real source files (Rust crates, Go modules, the
+    macOS SDK, Homebrew, site-packages): 165 are not valid UTF-8 and NONE
+    corrupts a symbol -- every one is latin-1 punctuation in a copyright
+    header or an author's name. All 165 are exactly the shape the second
+    bullet misfires on, which is why the adjacency test earns its place.
     """
     if not name:
         return
-    raw = getattr(node, "text", None)
-    if not isinstance(raw, bytes):
+    source = _node_source_bytes(node)
+    if source is None:
         return
-    try:
-        raw.decode(cs.ENCODING_UTF8)
-    except UnicodeDecodeError:
-        logger.warning(
-            logs.TRUNCATED_SYMBOL_NAME.format(
-                path=file_path if file_path is not None else "<unknown>",
-                name=name,
+    # Callers pass the DEFINITION node, which is what they have. Narrow to the
+    # span the extracted name actually came from: `child_by_field_name` alone
+    # is not enough, because grammars nest the identifier differently (C puts
+    # it under `function_declarator`, so the definition has no `name` field at
+    # all and the search below is what finds it).
+    span = _name_span(node, name)
+    if span is None:
+        return
+    start, end = span
+    for probe in (source[max(0, start - 1) : start], source[end : end + 1]):
+        if not probe:
+            continue
+        try:
+            probe.decode(cs.ENCODING_UTF8)
+        except UnicodeDecodeError:
+            logger.warning(
+                logs.TRUNCATED_SYMBOL_NAME.format(
+                    path=file_path if file_path is not None else "<unknown>",
+                    name=name,
+                )
             )
-        )
+            return
+
+
+def _name_span(node: Node, name: str) -> tuple[int, int] | None:
+    """Byte span of the identifier `name` was decoded from, or None.
+
+    Prefers the `name` field, then the shallowest descendant whose own text
+    equals the extracted name. The search is bounded to identifier-ish leaves
+    and stops at the first match, so it stays cheap on large definitions.
+    """
+    encoded = name.encode(cs.ENCODING_UTF8)
+    direct = node.child_by_field_name(cs.FIELD_NAME)
+    if direct is not None and direct.text == encoded:
+        return direct.start_byte, direct.end_byte
+
+    stack = [node]
+    while stack:
+        current = stack.pop(0)
+        if current is not node and current.text == encoded and not current.children:
+            return current.start_byte, current.end_byte
+        stack.extend(current.children)
+    return None
+
+
+def _node_source_bytes(node: Node) -> bytes | None:
+    """The whole source buffer the node's byte offsets index into.
+
+    `start_byte`/`end_byte` are offsets into the FILE, so the adjacency probe
+    needs the file's bytes rather than the node's own slice.
+    """
+    root = node
+    while (parent := getattr(root, "parent", None)) is not None:
+        root = parent
+    raw = getattr(root, "text", None)
+    return raw if isinstance(raw, bytes) else None

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1283,6 +1283,11 @@ def ingest_method(
         method_start_line = method_node.start_point[0] + 1
         method_start_col = method_node.start_point[1]
 
+    # Every language's method branch converges here, so this is the one place
+    # that sees a method name whatever route produced it (issue #1810). The
+    # function and class sites are guarded at their own extraction points.
+    warn_if_name_truncated(method_node, method_name, file_path)
+
     method_qn = method_qualified_name or f"{container_qn}.{method_name}"
     if language != cs.SupportedLanguage.CPP:
         method_qn = function_registry.register_unique_qn(
@@ -1603,3 +1608,48 @@ def module_qn_for_entity(
         if candidate in module_paths:
             return candidate
     return None
+
+
+def warn_if_name_truncated(
+    node: Node, name: str | None, file_path: Path | None = None
+) -> None:
+    """Log when a symbol name was extracted from undecodable bytes.
+
+    An invalid byte inside an identifier is treated by tree-sitter as a token
+    boundary, so the `name` node covers only the bytes on one side of it. The
+    extractor then decodes that shortened node without error: `calculate_total`
+    is indexed as `calculate_t`, with nothing raised and nothing logged. A
+    wrong name is worse than a missing one -- callers in untouched files stop
+    resolving to it, so it reads as dead code while a symbol nobody calls
+    appears beside it. Measured across all 15 supported languages: 13 truncate
+    silently, 2 drop the symbol, none survive intact.
+
+    Keyed on the NAME's own bytes, not the file's. A file-level check would be
+    a different signal entirely: across 105,352 real source files (Rust crates,
+    Go modules, the macOS SDK, Homebrew, site-packages) 165 are not valid
+    UTF-8, and NONE of them corrupts a symbol -- every one is latin-1
+    punctuation in a copyright header or an author's name, and one is a `£`
+    inside a regex literal. So a per-file warning would have fired 165 times
+    and been wrong every time, at 1.2% of the macOS SDK. This check fires zero
+    times on all of them and only when a name is genuinely damaged.
+
+    Deliberately NOT `name.encode() in node.text`: containment is satisfied BY
+    this corruption, because the truncated name is a substring of the corrupt
+    bytes (`pha` really is inside `al\xffpha`), so that oracle returns True on
+    the exact defect it would be written for and can never fire. What
+    discriminates is whether the SOURCE round-trips.
+    """
+    if not name:
+        return
+    raw = getattr(node, "text", None)
+    if not isinstance(raw, bytes):
+        return
+    try:
+        raw.decode(cs.ENCODING_UTF8)
+    except UnicodeDecodeError:
+        logger.warning(
+            logs.TRUNCATED_SYMBOL_NAME.format(
+                path=file_path if file_path is not None else "<unknown>",
+                name=name,
+            )
+        )

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1655,12 +1655,18 @@ def warn_if_name_truncated(
     if span is None:
         return
     start, end = span
-    for probe in (source[max(0, start - 1) : start], source[end : end + 1]):
+    # A WINDOW either side, not a single byte. A legitimate multi-byte
+    # character next to the name (`def alpha\u00a9()` under error recovery, where
+    # `\u00a9` is the two bytes c2 a9) has neither half decodable ALONE, so a
+    # one-byte probe calls valid source corrupt. Four bytes is the longest
+    # UTF-8 sequence, so a window that size decodes cleanly whenever the
+    # neighbouring text is well-formed.
+    before = source[max(0, start - cs.UTF8_MAX_SEQUENCE_BYTES) : start]
+    after = source[end : end + cs.UTF8_MAX_SEQUENCE_BYTES]
+    for probe, at_end in ((before, False), (after, True)):
         if not probe:
             continue
-        try:
-            probe.decode(cs.ENCODING_UTF8)
-        except UnicodeDecodeError:
+        if _has_invalid_byte(probe, at_end=at_end):
             logger.warning(
                 logs.TRUNCATED_SYMBOL_NAME.format(
                     path=file_path if file_path is not None else "<unknown>",
@@ -1670,6 +1676,12 @@ def warn_if_name_truncated(
             return
 
 
+# A definition's own name is at most a step or two above it (the JS/TS
+# field-definition wrapper is one). Bounded so a deeply nested node cannot walk
+# to the root and match an unrelated enclosing definition of the same name.
+_NAME_SPAN_ANCESTOR_LIMIT = 3
+
+
 def _name_span(node: Node, name: str) -> tuple[int, int] | None:
     """Byte span of the identifier `name` was decoded from, or None.
 
@@ -1677,6 +1689,13 @@ def _name_span(node: Node, name: str) -> tuple[int, int] | None:
     equals the extracted name. The search is bounded to identifier-ish leaves
     and stops at the first match, so it stays cheap on large definitions.
     """
+    # A synthesized name need not appear in the source at all: C# destructor
+    # ingestion builds `~Greeter` while the source leaf is just `Greeter`, and
+    # a leading sigil is the general shape of that. Strip non-identifier
+    # prefixes so the span lookup matches what the grammar actually holds.
+    name = name.lstrip(cs.SYNTHETIC_NAME_PREFIXES)
+    if not name:
+        return None
     encoded = name.encode(cs.ENCODING_UTF8)
     direct = node.child_by_field_name(cs.FIELD_NAME)
     if direct is not None and direct.text == encoded:
@@ -1688,7 +1707,44 @@ def _name_span(node: Node, name: str) -> tuple[int, int] | None:
         if current is not node and current.text == encoded and not current.children:
             return current.start_byte, current.end_byte
         stack.extend(current.children)
+
+    # Not below the node: a JS/TS class-field arrow or function expression is
+    # named by its ENCLOSING field definition (`greet = (n) => n`), and
+    # `_js_ts_field_member_name` reads the binding from there, so the
+    # identifier sits above the node the caller passed. Walk out a bounded
+    # distance rather than threading a node through every extraction branch --
+    # a name that belongs to this definition is always within a step or two.
+    ancestor = node.parent
+    for _ in range(_NAME_SPAN_ANCESTOR_LIMIT):
+        if ancestor is None:
+            break
+        field = ancestor.child_by_field_name(cs.FIELD_NAME)
+        if field is not None and field.text == encoded:
+            return field.start_byte, field.end_byte
+        ancestor = ancestor.parent
     return None
+
+
+def _has_invalid_byte(window: bytes, *, at_end: bool) -> bool:
+    """Whether `window` contains a byte that no valid UTF-8 sequence explains.
+
+    The window is sliced at an arbitrary offset, so it can begin or end
+    mid-character even when the source is well-formed: `\u00a9` is the two bytes
+    c2 a9, and either half alone fails to decode. Only a genuinely invalid
+    byte should count, so the partial sequence at the cut edge is trimmed
+    before decoding -- `at_end` says which edge is the cut one (the window
+    BEFORE the name is cut at its start, the one AFTER at its end).
+    """
+    for trim in range(len(window)):
+        candidate = window[trim:] if not at_end else window[: len(window) - trim]
+        if not candidate:
+            return False
+        try:
+            candidate.decode(cs.ENCODING_UTF8)
+        except UnicodeDecodeError:
+            continue
+        return False
+    return True
 
 
 def _node_source_bytes(node: Node) -> bytes | None:

--- a/codebase_rag/tests/test_fuzz_harnesses.py
+++ b/codebase_rag/tests/test_fuzz_harnesses.py
@@ -237,6 +237,39 @@ def test_known_defect_seeds_are_still_detected(parse_harness: ModuleType) -> Non
         )
 
 
+def test_the_truncation_record_is_bounded(parse_harness: ModuleType) -> None:
+    """The oracle records instead of raising, so it must not grow without end.
+
+    libFuzzer runs millions of iterations and each can contribute a DISTINCT
+    mangled name, so an unbounded collection would exhaust memory and kill the
+    run -- the same "the harness crashed itself" failure that recording rather
+    than raising exists to avoid.
+
+    Each input carries a different identifier: feeding the same one repeatedly
+    would dedup to a single entry and pass whether or not the cap exists,
+    which is what the first version of this test did.
+    """
+    from codebase_rag import constants as cs
+
+    parse_harness._TRUNCATED_NAMES.clear()
+    limit = parse_harness._TRUNCATED_NAME_LIMIT
+    parser = parse_harness._PARSERS[cs.SupportedLanguage.PYTHON]
+
+    for index in range(limit + 50):
+        source = f"def na{index}me():\n    return 1\n".encode()
+        source = source.replace(b"na", b"n\xffa", 1)
+        tree = parser.parse(source)
+        parse_harness._extract_names(
+            cs.SupportedLanguage.PYTHON, tree.root_node, source
+        )
+
+    assert parse_harness._TRUNCATED_NAMES, "the oracle stopped recording"
+    assert len(parse_harness._TRUNCATED_NAMES) <= limit, (
+        f"the record grew to {len(parse_harness._TRUNCATED_NAMES)}, past its "
+        f"cap of {limit}; a long fuzz run would exhaust memory"
+    )
+
+
 def test_parse_harness_reaches_the_extractor(parse_harness: ModuleType) -> None:
     """A planted fault in `get_name` must surface.
 

--- a/codebase_rag/tests/test_fuzz_harnesses.py
+++ b/codebase_rag/tests/test_fuzz_harnesses.py
@@ -189,12 +189,47 @@ def shell_harness() -> ModuleType:
     return import_harness_module("fuzz_shell_command")
 
 
+# Seeds that are reproducers for an OPEN defect: the harness is expected to
+# detect them, so "runs without raising" is the wrong assertion for these.
+# Delete an entry when its issue is fixed -- the seed then has to pass like
+# any other, and the harness re-detects a regression.
+_KNOWN_DEFECT_SEEDS = {
+    # #1810: a bad byte inside an identifier truncates it silently.
+    "edge_truncated_identifier.bin",
+    "edge_truncated_identifier_tail.bin",
+}
+
+
 def test_parse_harness_runs_every_seed(parse_harness: ModuleType) -> None:
-    """Every seed in the corpus drives the harness without raising."""
+    """Every seed in the corpus drives the harness without raising.
+
+    Except the reproducers for open defects, which the harness is supposed to
+    catch. Those are asserted the other way round in
+    `test_known_defect_seeds_are_still_detected`, so an entry here cannot
+    quietly become a seed that passes for the wrong reason.
+    """
     seeds = sorted((FUZZ_DIR / "corpus" / "fuzz_parse_source").iterdir())
     assert seeds, "the parse corpus is empty; run fuzz/build_corpus.py"
     for seed in seeds:
+        if seed.name in _KNOWN_DEFECT_SEEDS:
+            continue
         parse_harness.fuzz_parse_source(seed.read_bytes())
+
+
+def test_known_defect_seeds_are_still_detected(parse_harness: ModuleType) -> None:
+    """The other half of the exemption above.
+
+    An exemption list that is only ever skipped is indistinguishable from a
+    list of seeds that stopped reproducing: both leave the suite green. Each
+    exempt seed must still trip the detector, so the day one is fixed this
+    test fails and says to remove it from the set rather than letting the
+    exemption outlive the defect.
+    """
+    for name in sorted(_KNOWN_DEFECT_SEEDS):
+        seed = FUZZ_DIR / "corpus" / "fuzz_parse_source" / name
+        assert seed.exists(), f"missing seed {name}; run fuzz/build_corpus.py"
+        with pytest.raises(AssertionError, match="not valid UTF-8"):
+            parse_harness.fuzz_parse_source(seed.read_bytes())
 
 
 def test_parse_harness_reaches_the_extractor(parse_harness: ModuleType) -> None:
@@ -222,11 +257,90 @@ def test_parse_harness_reaches_the_extractor(parse_harness: ModuleType) -> None:
         # `_extract_names` directly rather than guessing an input that
         # selects Python.
         parser = parse_harness._PARSERS[cs.SupportedLanguage.PYTHON]
-        tree = parser.parse(b"def f():\n    return 1\n")
+        source = b"def f():\n    return 1\n"
+        tree = parser.parse(source)
         with pytest.raises(IndexError, match=sentinel):
-            parse_harness._extract_names(cs.SupportedLanguage.PYTHON, tree.root_node)
+            parse_harness._extract_names(
+                cs.SupportedLanguage.PYTHON, tree.root_node, source
+            )
     finally:
         LANGUAGE_FQN_SPECS[cs.SupportedLanguage.PYTHON] = original
+
+
+@pytest.mark.parametrize(
+    ("language_name", "source"),
+    [
+        ("PYTHON", b"def al\xffpha():\n    return 1\n"),
+        ("LUA", b"function al\xffpha() return 1 end\n"),
+        ("JS", b"function al\xffpha() { return 1; }\n"),
+    ],
+    ids=["python", "lua", "javascript"],
+)
+def test_parse_harness_detects_a_truncated_name(
+    parse_harness: ModuleType, language_name: str, source: bytes
+) -> None:
+    """Issue #1810: a bad byte inside an identifier truncates it silently.
+
+    tree-sitter treats the byte as a token boundary, so the `name` node covers
+    only what follows it and the extractor decodes that shortened node without
+    error. `alpha` is indexed as `pha` with nothing raised and nothing logged,
+    which is why catching exceptions cannot find this class.
+    """
+    from codebase_rag import constants as cs
+
+    language = getattr(cs.SupportedLanguage, language_name)
+    if language not in parse_harness._PARSERS:
+        pytest.skip(f"no {language_name} grammar available")
+    tree = parse_harness._PARSERS[language].parse(source)
+
+    with pytest.raises(AssertionError, match="not valid UTF-8"):
+        parse_harness._extract_names(language, tree.root_node, source)
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    ["alpha", "caf\u00e9", "\u00e9lan", "\u51fd\u6570"],
+    ids=["ascii", "latin_accent", "leading_accent", "cjk"],
+)
+def test_parse_harness_is_quiet_on_valid_identifiers(
+    parse_harness: ModuleType, identifier: str
+) -> None:
+    """The control that decides whether the detector is usable.
+
+    A naive "is this name pure ASCII" check passes every test anyone would
+    think to write and then fires on every non-English codebase. These inputs
+    separate "extracted from undecodable bytes" from "merely not ASCII", which
+    is why the detector asks the SOURCE to round-trip rather than inspecting
+    the extracted name.
+    """
+    from codebase_rag import constants as cs
+
+    language = cs.SupportedLanguage.PYTHON
+    if language not in parse_harness._PARSERS:
+        pytest.skip("no python grammar available")
+    source = f"def {identifier}():\n    return 1\n".encode()
+    tree = parse_harness._PARSERS[language].parse(source)
+
+    parse_harness._extract_names(language, tree.root_node, source)
+
+
+def test_the_containment_oracle_would_miss_this_defect() -> None:
+    """Why the detector is not `name.encode() in raw`, pinned as a test.
+
+    The obvious check is that the extracted name appears in the bytes it came
+    from. It is satisfied BY the corruption whenever the corruption truncates:
+    `pha` really is a substring of `al\\xffpha`, so the oracle returns True on
+    the exact defect it was written for and can never fire. Written down here
+    because it is the first thing a future reader will try to "simplify" the
+    detector into.
+    """
+    raw = b"al\xffpha"
+    truncated = b"pha"
+
+    assert truncated in raw, "the containment oracle passes on the defect"
+
+    with pytest.raises(UnicodeDecodeError):
+        raw.decode("utf-8")
 
 
 def test_shell_harness_agrees_with_the_classifier(shell_harness: ModuleType) -> None:

--- a/codebase_rag/tests/test_fuzz_harnesses.py
+++ b/codebase_rag/tests/test_fuzz_harnesses.py
@@ -228,8 +228,11 @@ def test_known_defect_seeds_are_still_detected(parse_harness: ModuleType) -> Non
     for name in sorted(_KNOWN_DEFECT_SEEDS):
         seed = FUZZ_DIR / "corpus" / "fuzz_parse_source" / name
         assert seed.exists(), f"missing seed {name}; run fuzz/build_corpus.py"
-        with pytest.raises(AssertionError, match="not valid UTF-8"):
-            parse_harness.fuzz_parse_source(seed.read_bytes())
+        # Read OUTSIDE the raises block: a missing or unreadable seed would
+        # otherwise raise in here and be credited to the detector.
+        payload = seed.read_bytes()
+        with pytest.raises(AssertionError, match="truncated name"):
+            parse_harness.fuzz_parse_source(payload)
 
 
 def test_parse_harness_reaches_the_extractor(parse_harness: ModuleType) -> None:
@@ -293,7 +296,7 @@ def test_parse_harness_detects_a_truncated_name(
         pytest.skip(f"no {language_name} grammar available")
     tree = parse_harness._PARSERS[language].parse(source)
 
-    with pytest.raises(AssertionError, match="not valid UTF-8"):
+    with pytest.raises(AssertionError, match="truncated name"):
         parse_harness._extract_names(language, tree.root_node, source)
 
 

--- a/codebase_rag/tests/test_fuzz_harnesses.py
+++ b/codebase_rag/tests/test_fuzz_harnesses.py
@@ -211,8 +211,6 @@ def test_parse_harness_runs_every_seed(parse_harness: ModuleType) -> None:
     seeds = sorted((FUZZ_DIR / "corpus" / "fuzz_parse_source").iterdir())
     assert seeds, "the parse corpus is empty; run fuzz/build_corpus.py"
     for seed in seeds:
-        if seed.name in _KNOWN_DEFECT_SEEDS:
-            continue
         parse_harness.fuzz_parse_source(seed.read_bytes())
 
 
@@ -228,11 +226,15 @@ def test_known_defect_seeds_are_still_detected(parse_harness: ModuleType) -> Non
     for name in sorted(_KNOWN_DEFECT_SEEDS):
         seed = FUZZ_DIR / "corpus" / "fuzz_parse_source" / name
         assert seed.exists(), f"missing seed {name}; run fuzz/build_corpus.py"
-        # Read OUTSIDE the raises block: a missing or unreadable seed would
-        # otherwise raise in here and be credited to the detector.
         payload = seed.read_bytes()
-        with pytest.raises(AssertionError, match="truncated name"):
-            parse_harness.fuzz_parse_source(payload)
+
+        parse_harness._TRUNCATED_NAMES.clear()
+        parse_harness.fuzz_parse_source(payload)
+
+        assert parse_harness._TRUNCATED_NAMES, (
+            f"{name} no longer trips the truncation oracle; if #1810's "
+            "extractors were fixed, drop it from _KNOWN_DEFECT_SEEDS"
+        )
 
 
 def test_parse_harness_reaches_the_extractor(parse_harness: ModuleType) -> None:
@@ -296,8 +298,12 @@ def test_parse_harness_detects_a_truncated_name(
         pytest.skip(f"no {language_name} grammar available")
     tree = parse_harness._PARSERS[language].parse(source)
 
-    with pytest.raises(AssertionError, match="truncated name"):
-        parse_harness._extract_names(language, tree.root_node, source)
+    parse_harness._TRUNCATED_NAMES.clear()
+    parse_harness._extract_names(language, tree.root_node, source)
+
+    assert parse_harness._TRUNCATED_NAMES, (
+        f"{language_name}: the oracle did not record a truncated name"
+    )
 
 
 @pytest.mark.parametrize(

--- a/codebase_rag/tests/test_fuzz_harnesses.py
+++ b/codebase_rag/tests/test_fuzz_harnesses.py
@@ -237,6 +237,40 @@ def test_known_defect_seeds_are_still_detected(parse_harness: ModuleType) -> Non
         )
 
 
+def test_the_oracle_records_a_replacement_character_name(
+    parse_harness: ModuleType,
+) -> None:
+    """The fuzz oracle must see the second damage shape too.
+
+    Production reports a name carrying U+FFFD (Lua keeps the bad byte in an
+    ERROR node between the two identifiers of a dotted name, so the whole
+    expression decodes to `Greeter.gr\ufffdeet` rather than truncating). The
+    oracle needs the same rule or that production branch has no regression
+    check -- the adjacency test cannot see it, because nothing is adjacent to
+    a shortened span.
+    """
+    from codebase_rag import constants as cs
+
+    language = cs.SupportedLanguage.LUA
+    if language not in parse_harness._PARSERS:
+        pytest.skip("no lua grammar available")
+
+    clean = b"function Greeter.greet(n) return n end\n"
+    dirty = b"function Greeter.gr\xffeet(n) return n end\n"
+
+    parse_harness._TRUNCATED_NAMES.clear()
+    tree = parse_harness._PARSERS[language].parse(clean)
+    parse_harness._extract_names(language, tree.root_node, clean)
+    assert not parse_harness._TRUNCATED_NAMES, "false alarm on clean Lua"
+
+    parse_harness._TRUNCATED_NAMES.clear()
+    tree = parse_harness._PARSERS[language].parse(dirty)
+    parse_harness._extract_names(language, tree.root_node, dirty)
+    assert parse_harness._TRUNCATED_NAMES, (
+        "the oracle did not record a name carrying the replacement character"
+    )
+
+
 def test_the_truncation_record_is_bounded(parse_harness: ModuleType) -> None:
     """The oracle records instead of raising, so it must not grow without end.
 

--- a/codebase_rag/tests/test_truncated_symbol_names.py
+++ b/codebase_rag/tests/test_truncated_symbol_names.py
@@ -1,0 +1,156 @@
+"""Issue #1810: a bad byte inside an identifier truncates the indexed name.
+
+tree-sitter treats an invalid byte as a token boundary, so the `name` node
+covers only the bytes on one side of it and the extractor decodes that
+shortened node without error. `calculate_total` is indexed as `calculate_t`
+with nothing raised and nothing logged. The production remedy is a WARNING
+keyed on the name's own bytes; these tests pin both directions of that.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+
+@pytest.fixture(scope="module")
+def parsers_and_queries() -> tuple[dict, dict]:
+    return load_parsers()
+
+
+def _index(
+    parsers_and_queries: tuple[dict, dict], filename: str, source: bytes
+) -> tuple[set[str], list[str]]:
+    """Index one file, returning (symbol names, #1810 warnings)."""
+    parsers, queries = parsers_and_queries
+    root = Path(tempfile.mkdtemp()) / "proj"
+    root.mkdir()
+    (root / filename).write_bytes(source)
+
+    captured: list[str] = []
+    sink = logger.add(lambda m: captured.append(str(m)), level="WARNING")
+    store = _StatefulIngestor()
+    try:
+        GraphUpdater(
+            ingestor=store,
+            repo_path=root,
+            parsers=parsers,
+            queries=queries,
+            project_name="proj",
+        ).run(force=True)
+    finally:
+        logger.remove(sink)
+
+    names = {
+        str(uid)
+        for (label, uid) in store.nodes
+        if label
+        in (
+            cs.NodeLabel.FUNCTION.value,
+            cs.NodeLabel.METHOD.value,
+            cs.NodeLabel.CLASS.value,
+        )
+    }
+    return names, [c for c in captured if "#1810" in c]
+
+
+# One case per language that TRUNCATES rather than drops the symbol. cpp and
+# lua are deliberately absent: measured, they remove the definition entirely
+# and invent no wrong-named symbol, so there is no truncated name to warn
+# about and a missing entry is the honest failure.
+TRUNCATING = {
+    "python": ("a.py", b"class Greeter:\n    def greet(self):\n        return 1\n"),
+    "javascript": ("a.js", b"class Greeter { greet() { return 1; } }\n"),
+    "java": (
+        "a.java",
+        b"public class Greeter { public String greet(String n) { return n; } }\n",
+    ),
+    "rust": (
+        "a.rs",
+        b"pub struct Greeter;\nimpl Greeter {\n"
+        b"    pub fn greet(&self) -> i32 { 1 }\n}\n",
+    ),
+}
+
+
+@pytest.mark.parametrize("language", sorted(TRUNCATING))
+def test_a_truncated_name_is_reported(
+    parsers_and_queries: tuple[dict, dict], language: str
+) -> None:
+    filename, clean = TRUNCATING[language]
+    assert b"greet" in clean
+    dirty = clean.replace(b"greet", b"gr\xffeet", 1)
+
+    _clean_names, clean_warnings = _index(parsers_and_queries, filename, clean)
+    dirty_names, dirty_warnings = _index(parsers_and_queries, filename, dirty)
+
+    assert not clean_warnings, f"{language}: warned on clean source"
+    assert dirty_warnings, (
+        f"{language}: a truncated name reached the graph with no warning; "
+        f"indexed {sorted(dirty_names)}"
+    )
+
+
+@pytest.mark.parametrize(
+    "identifier",
+    ["alpha", "café", "élan", "函数"],
+    ids=["ascii", "latin_accent", "leading_accent", "cjk"],
+)
+def test_valid_non_ascii_identifiers_are_not_reported(
+    parsers_and_queries: tuple[dict, dict], identifier: str
+) -> None:
+    """The control that decides whether this is usable on real codebases.
+
+    A naive "is the name ASCII" check passes every test one would think to
+    write and then fires on every non-English codebase.
+    """
+    source = f"def {identifier}():\n    return 1\n".encode()
+    names, warnings = _index(parsers_and_queries, "a.py", source)
+
+    assert not warnings, f"false alarm on the valid identifier {identifier!r}"
+    assert f"proj.a.{identifier}" in names
+
+
+def test_a_bad_byte_outside_a_name_is_not_reported(
+    parsers_and_queries: tuple[dict, dict],
+) -> None:
+    """The measured real-world case, and why this is not a per-file check.
+
+    Across 105,352 real source files (Rust crates, Go modules, the macOS SDK,
+    Homebrew, site-packages), 165 are not valid UTF-8 and NONE corrupts a
+    symbol: every one is latin-1 punctuation in a copyright header or an
+    author's name. A file-level signal would have fired on all 165 and been
+    wrong every time; this one fires on none of them.
+    """
+    source = b"# Copyright \xa9 2003 Sun Microsystems\ndef alpha():\n    return 1\n"
+
+    names, warnings = _index(parsers_and_queries, "a.py", source)
+
+    assert not warnings, "warned on a bad byte that damages no name"
+    assert "proj.a.alpha" in names, "the symbol indexed under its real name"
+
+
+def test_the_containment_oracle_cannot_detect_this() -> None:
+    """Why the check asks the SOURCE to round-trip, pinned as a test.
+
+    The obvious oracle -- does the extracted name appear in the bytes it came
+    from -- is satisfied BY this corruption, because the truncated name is a
+    substring of the corrupt bytes. It returns True on the exact defect it
+    would be written for and can never fire. First thing a future reader will
+    try to "simplify" this into.
+    """
+    raw = b"al\xffpha"
+    truncated = b"pha"
+
+    assert truncated in raw, "containment passes on the defect itself"
+
+    with pytest.raises(UnicodeDecodeError):
+        raw.decode(cs.ENCODING_UTF8)

--- a/codebase_rag/tests/test_truncated_symbol_names.py
+++ b/codebase_rag/tests/test_truncated_symbol_names.py
@@ -204,6 +204,32 @@ def test_one_bad_byte_does_not_warn_once_per_enclosing_definition(
     assert "proj.a.Outer.Mid.Inner" in names
 
 
+def test_a_replacement_character_inside_a_name_is_reported(
+    parsers_and_queries: tuple[dict, dict],
+) -> None:
+    """The second damage shape, which adjacency alone cannot see.
+
+    Lua keeps the bad byte in an ERROR node BETWEEN two identifiers of a
+    dotted name, and #1797's fix decodes the whole expression with
+    errors="replace", so the name survives as `Greeter.gr\ufffdeet` rather
+    than being truncated. Nothing is adjacent to a shortened span, so the
+    adjacency test finds nothing; the replacement character in the name is
+    itself the signal.
+
+    Safe because no legitimate identifier contains U+FFFD in any language --
+    it is only ever there because a decode put it there.
+    """
+    clean = b"function Greeter.greet(n) return n end\n"
+    dirty = b"function Greeter.gr\xffeet(n) return n end\n"
+
+    clean_names, clean_warnings = _index(parsers_and_queries, "a.lua", clean)
+    _dirty_names, dirty_warnings = _index(parsers_and_queries, "a.lua", dirty)
+
+    assert "proj.a.Greeter.greet" in clean_names, "control: the clean name indexes"
+    assert not clean_warnings, "false alarm on clean Lua"
+    assert dirty_warnings, "a name carrying U+FFFD reached the graph unreported"
+
+
 def test_a_valid_multibyte_character_beside_a_name_is_not_reported(
     parsers_and_queries: tuple[dict, dict],
 ) -> None:

--- a/codebase_rag/tests/test_truncated_symbol_names.py
+++ b/codebase_rag/tests/test_truncated_symbol_names.py
@@ -119,23 +119,84 @@ def test_valid_non_ascii_identifiers_are_not_reported(
     assert f"proj.a.{identifier}" in names
 
 
-def test_a_bad_byte_outside_a_name_is_not_reported(
+@pytest.mark.parametrize(
+    ("position", "source"),
+    [
+        (
+            "module_header",
+            b"# Copyright \xa9 2003 Sun Microsystems\ndef alpha():\n    return 1\n",
+        ),
+        ("body_comment", b"def alpha():\n    # \xa9 Sun\n    return 1\n"),
+    ],
+)
+def test_a_bad_byte_that_damages_no_name_is_not_reported(
+    parsers_and_queries: tuple[dict, dict], position: str, source: bytes
+) -> None:
+    """Positions a bad byte can occupy without truncating a name.
+
+    Only `module_header` was covered originally, and it is the ONE position no
+    definition node spans -- so the test passed while the check fired on a bad
+    byte in a body, which is exactly the real-world shape. Across 105,352 real
+    source files, all 165 invalid ones are latin-1 punctuation in a copyright
+    header or an author's name, i.e. these positions and not the defect.
+
+    A bad byte inside a STRING LITERAL or DOCSTRING is deliberately absent:
+    it makes the call-processing pass raise `UnicodeDecodeError` and abandon
+    the file, which is the separate open defect #1797 (fix in flight as PR
+    #1812) and is caught by conftest's per-file-pass guard. Add those two
+    positions here once #1812 lands; this check already handles them (verified
+    by driving `warn_if_name_truncated` directly), but the file never survives
+    ingest long enough to prove it end to end.
+    """
+    names, warnings = _index(parsers_and_queries, "a.py", source)
+
+    assert not warnings, f"false alarm on a bad byte in a {position}"
+    assert "proj.a.alpha" in names, "the symbol indexed under its real name"
+
+
+def test_one_bad_byte_does_not_warn_once_per_enclosing_definition(
     parsers_and_queries: tuple[dict, dict],
 ) -> None:
-    """The measured real-world case, and why this is not a per-file check.
+    """Nesting must not multiply the message.
 
-    Across 105,352 real source files (Rust crates, Go modules, the macOS SDK,
-    Homebrew, site-packages), 165 are not valid UTF-8 and NONE corrupts a
-    symbol: every one is latin-1 punctuation in a copyright header or an
-    author's name. A file-level signal would have fired on all 165 and been
-    wrong every time; this one fires on none of them.
+    Keyed on the enclosing definition's span, one bad byte in a deeply nested
+    body produced a warning per level (4 here) while every symbol was indexed
+    correctly.
     """
-    source = b"# Copyright \xa9 2003 Sun Microsystems\ndef alpha():\n    return 1\n"
+    source = (
+        b"class Outer:\n"
+        b"    class Mid:\n"
+        b"        class Inner:\n"
+        b'            def deep(self):\n                return "\xa9"\n'
+    )
 
     names, warnings = _index(parsers_and_queries, "a.py", source)
 
-    assert not warnings, "warned on a bad byte that damages no name"
-    assert "proj.a.alpha" in names, "the symbol indexed under its real name"
+    assert not warnings, f"{len(warnings)} warning(s) for one harmless bad byte"
+    assert "proj.a.Outer.Mid.Inner" in names
+
+
+def test_the_name_nodes_own_bytes_cannot_detect_this() -> None:
+    """Why the check probes ADJACENT bytes rather than the name's own.
+
+    tree-sitter excludes the bad byte from the name node, so its bytes decode
+    cleanly in the corrupt and the clean case alike. A check on them detects
+    nothing -- the opposite failure to the definition-span version, and just
+    as invisible.
+    """
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, _ = load_parsers()
+    parser = parsers[cs.SupportedLanguage.PYTHON]
+
+    corrupt = parser.parse(b"def al\xffpha():\n    return 1\n")
+    definition = next(
+        n for n in corrupt.root_node.children if n.type == "function_definition"
+    )
+    name_node = definition.child_by_field_name("name")
+
+    assert name_node.text == b"pha", "the name node excludes the bad byte"
+    name_node.text.decode(cs.ENCODING_UTF8)  # decodes cleanly: detects nothing
 
 
 def test_the_containment_oracle_cannot_detect_this() -> None:

--- a/codebase_rag/tests/test_truncated_symbol_names.py
+++ b/codebase_rag/tests/test_truncated_symbol_names.py
@@ -154,6 +154,34 @@ def test_a_bad_byte_that_damages_no_name_is_not_reported(
     assert "proj.a.alpha" in names, "the symbol indexed under its real name"
 
 
+def test_a_name_bound_by_an_enclosing_field_is_reported(
+    parsers_and_queries: tuple[dict, dict],
+) -> None:
+    """A TS class-field arrow is named by its ENCLOSING field definition.
+
+    `_js_ts_field_member_name` reads the binding from the parent, so the
+    identifier sits ABOVE the node handed to the check. Searching only
+    downwards missed it: `Greeter.eet` reached the graph with no warning while
+    every other shape was covered, which is the shape a downward-only search
+    cannot see by construction.
+
+    JS is deliberately not covered here: it does not index class-field arrows
+    as methods at all (verified -- the clean control indexes only `Greeter`),
+    so there is no truncated name to report.
+    """
+    clean = b"class Greeter {\n  greet = (n: string) => n;\n}\n"
+    dirty = b"class Greeter {\n  gr\xffeet = (n: string) => n;\n}\n"
+
+    clean_names, clean_warnings = _index(parsers_and_queries, "a.ts", clean)
+    dirty_names, dirty_warnings = _index(parsers_and_queries, "a.ts", dirty)
+
+    assert "proj.a.Greeter.greet" in clean_names, "control: the arrow is indexed"
+    assert not clean_warnings, "false alarm on a clean field arrow"
+    assert dirty_warnings, (
+        f"a field-bound name truncated with no warning; indexed {sorted(dirty_names)}"
+    )
+
+
 def test_one_bad_byte_does_not_warn_once_per_enclosing_definition(
     parsers_and_queries: tuple[dict, dict],
 ) -> None:
@@ -174,6 +202,56 @@ def test_one_bad_byte_does_not_warn_once_per_enclosing_definition(
 
     assert not warnings, f"{len(warnings)} warning(s) for one harmless bad byte"
     assert "proj.a.Outer.Mid.Inner" in names
+
+
+def test_a_valid_multibyte_character_beside_a_name_is_not_reported(
+    parsers_and_queries: tuple[dict, dict],
+) -> None:
+    """A one-byte adjacency probe calls valid source corrupt.
+
+    Under error recovery `def alpha\u00a9():` puts the two bytes c2 a9 next to the
+    name. Together they are a valid `\u00a9`; NEITHER decodes alone, so probing a
+    single byte either side reports a truncated name for well-formed source.
+    The probe is a window the width of the longest UTF-8 sequence, with the
+    partial character at the cut edge trimmed before decoding.
+    """
+    source = "def alpha\u00a9():\n    return 1\n".encode()
+
+    _names, warnings = _index(parsers_and_queries, "a.py", source)
+
+    assert not warnings, "false alarm on a valid multi-byte character"
+
+
+def test_a_synthesized_name_still_resolves_to_its_source_span(
+    parsers_and_queries: tuple[dict, dict],
+) -> None:
+    """C# destructors are ingested as `~Greeter` while the source leaf is bare.
+
+    The span lookup matches the extracted name against the tree, so a name the
+    ingestor SYNTHESIZED finds nothing and the check returns before inspecting
+    anything. A leading sigil is the general shape of that, so it is stripped
+    before the lookup.
+    """
+    from codebase_rag.parsers.utils import _name_span
+
+    parsers, _queries = parsers_and_queries
+    source = b"class Greeter {\n  ~Gr\xffeeter() { }\n}\n"
+    tree = parsers[cs.SupportedLanguage.CSHARP].parse(source)
+
+    stack = [tree.root_node]
+    destructor = None
+    while stack:
+        node = stack.pop()
+        if "destructor" in node.type:
+            destructor = node
+            break
+        stack.extend(node.children)
+    assert destructor is not None, "fixture did not produce a destructor node"
+
+    # The grammar keeps the LEADING fragment here, so the ingested name is `~Gr`.
+    assert _name_span(destructor, "~Gr") is not None, (
+        "a synthesized name must still resolve to the span it came from"
+    )
 
 
 def test_the_name_nodes_own_bytes_cannot_detect_this() -> None:

--- a/fuzz/build_corpus.py
+++ b/fuzz/build_corpus.py
@@ -104,6 +104,18 @@ EDGE_CASES: dict[str, str] = {
     "bom": "﻿def f():\n    return 1\n",
 }
 
+# Sources that are not valid UTF-8, so they cannot live in EDGE_CASES (str).
+# A bad byte INSIDE an identifier is issue #1810: tree-sitter splits the token
+# there, the `name` node covers only the bytes after it, and the extractor
+# decodes that shortened node without error -- `alpha` is indexed as `pha`
+# with nothing raised. Distinct from #1797, where the bad byte makes a strict
+# decode raise; these seeds reach the mode that stays silent.
+BYTE_EDGE_CASES: dict[str, bytes] = {
+    "truncated_identifier": b"def al\xffpha():\n    return 1\n",
+    "truncated_identifier_tail": b"def alph\xff():\n    return 1\n",
+    "bad_byte_between_defs": b"def a():\n    return 1\n\xff\ndef b():\n    return 2\n",
+}
+
 
 # The files fuzz_incremental_update can edit, in the order its `EDITABLE`
 # tuple has them (it is `tuple(sorted(FIXTURE))`). Duplicated rather than
@@ -160,7 +172,31 @@ def build_parse_corpus() -> int:
         # about the SOURCE, and libFuzzer mutates the selector byte anyway.
         (out / f"edge_{name}.bin").write_bytes(source.encode() + b"\x00")
         written += 1
+    for name, raw in BYTE_EDGE_CASES.items():
+        # Python is the target language for these, so the selector byte is the
+        # index of PYTHON rather than 0; a bad byte only truncates an
+        # identifier if the grammar actually tokenises one.
+        (out / f"edge_{name}.bin").write_bytes(raw + bytes([_python_index()]))
+        written += 1
     return written
+
+
+def _python_index() -> int:
+    """The selector byte that makes the parse harness choose Python.
+
+    The harness builds `_LANGUAGES` as `tuple(sorted(_PARSERS))` and indexes it
+    with `ConsumeIntInRange(0, len - 1)`, so the byte is the position of
+    `python` in the sorted language list. Derived rather than hard-coded: a new
+    grammar shifts every index after it, and a stale constant would silently
+    hand these seeds to the wrong parser -- exactly the failure the docstring
+    above records for the pre-existing seeds.
+    """
+    from codebase_rag import constants as cs
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, _ = load_parsers()
+    languages = tuple(sorted(parsers))
+    return languages.index(cs.SupportedLanguage.PYTHON)
 
 
 def build_shell_corpus() -> int:

--- a/fuzz/corpus/fuzz_parse_source/edge_bad_byte_between_defs.bin
+++ b/fuzz/corpus/fuzz_parse_source/edge_bad_byte_between_defs.bin
@@ -1,0 +1,6 @@
+def a():
+    return 1
+ÿ
+def b():
+    return 2
+	

--- a/fuzz/corpus/fuzz_parse_source/edge_truncated_identifier.bin
+++ b/fuzz/corpus/fuzz_parse_source/edge_truncated_identifier.bin
@@ -1,0 +1,3 @@
+def alÿpha():
+    return 1
+	

--- a/fuzz/corpus/fuzz_parse_source/edge_truncated_identifier_tail.bin
+++ b/fuzz/corpus/fuzz_parse_source/edge_truncated_identifier_tail.bin
@@ -1,0 +1,3 @@
+def alphÿ():
+    return 1
+	

--- a/fuzz/fuzz_parse_source.py
+++ b/fuzz/fuzz_parse_source.py
@@ -58,12 +58,21 @@ def _walk(node: object) -> int:
     return count
 
 
-def _extract_names(language: cs.SupportedLanguage, root: object) -> None:
+def _extract_names(language: cs.SupportedLanguage, root: object, source: bytes) -> None:
     """Run the language's own name extractor over every captured node.
 
     This is the qualification code the issue names: it indexes children,
     follows named fields and decodes `node.text`, all on shapes the grammar
     guarantees only for well-formed input.
+
+    Two failure modes, and only one of them raises. The loud one (#1797) is a
+    strict decode blowing up on an undecodable byte. The quiet one (#1810) is
+    tree-sitter treating that byte as a token boundary: the `name` node covers
+    only the bytes AFTER it, the extractor decodes that shortened node
+    perfectly successfully, and `alpha` is indexed as `pha` with no exception,
+    no log line and nothing to catch. A wrong name is worse than a missing
+    one -- `pha` reads as a real definition nobody calls, so dead-code and
+    impact queries get a confidently wrong answer.
     """
     fqn_spec = LANGUAGE_FQN_SPECS.get(language)
     spec = LANGUAGE_SPECS.get(language)
@@ -75,6 +84,16 @@ def _extract_names(language: cs.SupportedLanguage, root: object) -> None:
     if not wanted:
         return
 
+    # The whole file, once: a name is suspect when the bytes it was extracted
+    # from are not valid UTF-8, and the cheap file-level question decides
+    # whether any per-node work is worth doing at all.
+    try:
+        source.decode(cs.ENCODING_UTF8)
+    except UnicodeDecodeError:
+        file_is_valid_utf8 = False
+    else:
+        file_is_valid_utf8 = True
+
     stack = [root]
     while stack:
         current = stack.pop()
@@ -84,8 +103,48 @@ def _extract_names(language: cs.SupportedLanguage, root: object) -> None:
             # the extractors decode with errors="replace", so an undecodable
             # byte can no longer raise here and a regression would surface as
             # a crash rather than being silently tolerated.
-            fqn_spec.get_name(current)  # type: ignore[arg-type]
+            name = fqn_spec.get_name(current)  # type: ignore[arg-type]
+            if name is not None:
+                _check_truncated_name(language, current, name)
         stack.extend(current.children)  # type: ignore[attr-defined]
+
+
+def _check_truncated_name(
+    language: cs.SupportedLanguage, node: object, name: str
+) -> None:
+    """Fail when a name was extracted from bytes that are not valid UTF-8.
+
+    Deliberately NOT `name.encode() in raw`: that containment check is
+    satisfied by the very corruption it looks for, because the truncated name
+    is a SUBSTRING of the corrupt bytes -- `pha` really is inside
+    `al\xffpha`, so the oracle returns True on the exact defect it was
+    written for and could never fire. What discriminates is whether the
+    SOURCE round-trips, not whether the result is contained in it.
+
+    Scoped honestly: this detects a superset (any name extracted from a span
+    that is not valid UTF-8), it needs the enclosing node's bytes to carry the
+    bad byte, and a payload placing that byte outside every captured node
+    stays invisible. It is silent on legitimate non-ASCII identifiers such as
+    `café`, which a naive "is it ASCII" check would flag on every non-English
+    codebase.
+    """
+    raw = _node_bytes(node)
+    if raw is None:
+        return
+    try:
+        raw.decode(cs.ENCODING_UTF8)
+    except UnicodeDecodeError:
+        raise AssertionError(
+            f"{language}: extracted the name {name!r} from bytes that are not "
+            f"valid UTF-8 ({raw!r}); tree-sitter split the token at the bad "
+            f"byte and the symbol is indexed under a truncated name (#1810)"
+        ) from None
+
+
+def _node_bytes(node: object) -> bytes | None:
+    """The raw source bytes a node covers, or None when unavailable."""
+    text = getattr(node, "text", None)
+    return text if isinstance(text, bytes) else None
 
 
 def _run_queries(language: cs.SupportedLanguage, tree: object) -> None:
@@ -121,7 +180,7 @@ def fuzz_parse_source(data: bytes) -> None:
 
     _walk(tree.root_node)
     _run_queries(language, tree)
-    _extract_names(language, tree.root_node)
+    _extract_names(language, tree.root_node, source)
 
 
 def main() -> None:

--- a/fuzz/fuzz_parse_source.py
+++ b/fuzz/fuzz_parse_source.py
@@ -136,16 +136,25 @@ def _check_truncated_name(
             # requires the two corpus reproducers to trip it, so a regression
             # that stops detecting truncation reddens there. Raise here again
             # once the extractors stop truncating rather than warning.
-            _TRUNCATED_NAMES.append((language, name))
+            if len(_TRUNCATED_NAMES) < _TRUNCATED_NAME_LIMIT:
+                _TRUNCATED_NAMES.add((language, name))
             return
 
 
 # Longest UTF-8 sequence: a window this size either side of a name spans any
 # single character that could legitimately sit next to it.
 _UTF8_MAX_SEQUENCE_BYTES = 4
-# Truncated names seen this run. A list rather than a raise: the defect is
-# known and production reports it, so the fuzzer records and continues.
-_TRUNCATED_NAMES: list[tuple[cs.SupportedLanguage, str]] = []
+# Truncated names seen this run, recorded rather than raised: the defect is
+# known and production reports it, so the fuzzer continues instead of halting
+# on the first mangled identifier libFuzzer invents.
+#
+# A BOUNDED set, not a list. libFuzzer runs millions of iterations and every
+# one can contribute a fresh name, so an unbounded collection would exhaust
+# memory and kill the run -- the same "the harness crashed itself" failure
+# this recording exists to avoid. The set is for the tests' benefit (they
+# assert the oracle still fires); the cap is what keeps it free.
+_TRUNCATED_NAME_LIMIT = 128
+_TRUNCATED_NAMES: set[tuple[cs.SupportedLanguage, str]] = set()
 # A definition's own name is at most a step or two above it (the JS/TS
 # field-definition wrapper is one).
 _NAME_SPAN_ANCESTOR_LIMIT = 3

--- a/fuzz/fuzz_parse_source.py
+++ b/fuzz/fuzz_parse_source.py
@@ -139,6 +139,8 @@ _UTF8_MAX_SEQUENCE_BYTES = 4
 # A definition's own name is at most a step or two above it (the JS/TS
 # field-definition wrapper is one).
 _NAME_SPAN_ANCESTOR_LIMIT = 3
+# Sigils an ingestor prepends to a synthesized name (a C# destructor).
+_SYNTHETIC_NAME_PREFIXES = "~"
 
 
 def _has_invalid_byte(window: bytes, *, at_end: bool) -> bool:
@@ -163,6 +165,12 @@ def _has_invalid_byte(window: bytes, *, at_end: bool) -> bool:
 
 def _name_span(node: object, name: str) -> tuple[int, int] | None:
     """Byte span the extracted `name` came from, or None."""
+    # A synthesized name need not appear in the source: C# destructor ingestion
+    # builds `~Greeter` while the source leaf is bare. Mirrors production's
+    # strip so the oracle exercises that path too.
+    name = name.lstrip(_SYNTHETIC_NAME_PREFIXES)
+    if not name:
+        return None
     encoded = name.encode(cs.ENCODING_UTF8)
     direct = node.child_by_field_name("name")  # type: ignore[attr-defined]
     if direct is not None and direct.text == encoded:

--- a/fuzz/fuzz_parse_source.py
+++ b/fuzz/fuzz_parse_source.py
@@ -84,16 +84,6 @@ def _extract_names(language: cs.SupportedLanguage, root: object, source: bytes) 
     if not wanted:
         return
 
-    # The whole file, once: a name is suspect when the bytes it was extracted
-    # from are not valid UTF-8, and the cheap file-level question decides
-    # whether any per-node work is worth doing at all.
-    try:
-        source.decode(cs.ENCODING_UTF8)
-    except UnicodeDecodeError:
-        file_is_valid_utf8 = False
-    else:
-        file_is_valid_utf8 = True
-
     stack = [root]
     while stack:
         current = stack.pop()
@@ -105,46 +95,95 @@ def _extract_names(language: cs.SupportedLanguage, root: object, source: bytes) 
             # a crash rather than being silently tolerated.
             name = fqn_spec.get_name(current)  # type: ignore[arg-type]
             if name is not None:
-                _check_truncated_name(language, current, name)
+                _check_truncated_name(language, current, name, source)
         stack.extend(current.children)  # type: ignore[attr-defined]
 
 
 def _check_truncated_name(
-    language: cs.SupportedLanguage, node: object, name: str
+    language: cs.SupportedLanguage, node: object, name: str, source: bytes
 ) -> None:
-    """Fail when a name was extracted from bytes that are not valid UTF-8.
+    """Fail when a name was truncated by an invalid byte beside it.
 
-    Deliberately NOT `name.encode() in raw`: that containment check is
-    satisfied by the very corruption it looks for, because the truncated name
-    is a SUBSTRING of the corrupt bytes -- `pha` really is inside
-    `al\xffpha`, so the oracle returns True on the exact defect it was
-    written for and could never fire. What discriminates is whether the
-    SOURCE round-trips, not whether the result is contained in it.
+    Mirrors `parsers.utils.warn_if_name_truncated`: the discriminator is the
+    byte IMMEDIATELY ADJACENT to the NAME's span, the one the grammar split
+    on. Two narrower-sounding shapes are both wrong -- the name node's own
+    bytes never contain the bad byte (tree-sitter excludes it, so they decode
+    cleanly either way and detect nothing), and the enclosing DEFINITION's
+    span contains it but also spans the whole body, so it fires on a bad byte
+    in any body comment or string while the symbol is indexed correctly.
 
-    Scoped honestly: this detects a superset (any name extracted from a span
-    that is not valid UTF-8), it needs the enclosing node's bytes to carry the
-    bad byte, and a payload placing that byte outside every captured node
-    stays invisible. It is silent on legitimate non-ASCII identifiers such as
-    `café`, which a naive "is it ASCII" check would flag on every non-English
-    codebase.
+    Deliberately NOT `name.encode() in raw`: containment is satisfied BY this
+    corruption, because the truncated name is a substring of the corrupt bytes
+    (`pha` really is inside `al\xffpha`), so that oracle returns True on the
+    exact defect it would be written for and can never fire.
     """
-    raw = _node_bytes(node)
-    if raw is None:
+    span = _name_span(node, name)
+    if span is None:
         return
-    try:
-        raw.decode(cs.ENCODING_UTF8)
-    except UnicodeDecodeError:
-        raise AssertionError(
-            f"{language}: extracted the name {name!r} from bytes that are not "
-            f"valid UTF-8 ({raw!r}); tree-sitter split the token at the bad "
-            f"byte and the symbol is indexed under a truncated name (#1810)"
-        ) from None
+    start, end = span
+    for probe, at_end in (
+        (source[max(0, start - _UTF8_MAX_SEQUENCE_BYTES) : start], False),
+        (source[end : end + _UTF8_MAX_SEQUENCE_BYTES], True),
+    ):
+        if probe and _has_invalid_byte(probe, at_end=at_end):
+            raise AssertionError(
+                f"{language}: the name {name!r} was extracted from a token the "
+                f"grammar split at an invalid byte, so the symbol is indexed "
+                f"under a truncated name (#1810)"
+            )
 
 
-def _node_bytes(node: object) -> bytes | None:
-    """The raw source bytes a node covers, or None when unavailable."""
-    text = getattr(node, "text", None)
-    return text if isinstance(text, bytes) else None
+# Longest UTF-8 sequence: a window this size either side of a name spans any
+# single character that could legitimately sit next to it.
+_UTF8_MAX_SEQUENCE_BYTES = 4
+# A definition's own name is at most a step or two above it (the JS/TS
+# field-definition wrapper is one).
+_NAME_SPAN_ANCESTOR_LIMIT = 3
+
+
+def _has_invalid_byte(window: bytes, *, at_end: bool) -> bool:
+    """Whether `window` holds a byte no valid UTF-8 sequence explains.
+
+    The window is cut at an arbitrary offset, so it can begin or end
+    mid-character even when the source is well-formed (`\u00a9` is c2 a9, and
+    either half alone fails). The partial sequence at the CUT edge is trimmed
+    before decoding; `at_end` says which edge that is.
+    """
+    for trim in range(len(window)):
+        candidate = window[trim:] if not at_end else window[: len(window) - trim]
+        if not candidate:
+            return False
+        try:
+            candidate.decode(cs.ENCODING_UTF8)
+        except UnicodeDecodeError:
+            continue
+        return False
+    return True
+
+
+def _name_span(node: object, name: str) -> tuple[int, int] | None:
+    """Byte span the extracted `name` came from, or None."""
+    encoded = name.encode(cs.ENCODING_UTF8)
+    direct = node.child_by_field_name("name")  # type: ignore[attr-defined]
+    if direct is not None and direct.text == encoded:
+        return direct.start_byte, direct.end_byte
+
+    stack = [node]
+    while stack:
+        current = stack.pop(0)
+        if current is not node and current.text == encoded and not current.children:  # type: ignore[attr-defined]
+            return current.start_byte, current.end_byte  # type: ignore[attr-defined]
+        stack.extend(current.children)  # type: ignore[attr-defined]
+
+    ancestor = node.parent  # type: ignore[attr-defined]
+    for _ in range(_NAME_SPAN_ANCESTOR_LIMIT):
+        if ancestor is None:
+            break
+        field = ancestor.child_by_field_name("name")
+        if field is not None and field.text == encoded:
+            return field.start_byte, field.end_byte
+        ancestor = ancestor.parent
+    return None
 
 
 def _run_queries(language: cs.SupportedLanguage, tree: object) -> None:

--- a/fuzz/fuzz_parse_source.py
+++ b/fuzz/fuzz_parse_source.py
@@ -117,6 +117,16 @@ def _check_truncated_name(
     (`pha` really is inside `al\xffpha`), so that oracle returns True on the
     exact defect it would be written for and can never fire.
     """
+    # A name carrying the replacement character is damaged whatever its span:
+    # #1797's fix decodes with errors="replace", so a bad byte the grammar
+    # keeps INSIDE the name expression (Lua's `Greeter.gr\ufffdeet`) survives as
+    # U+FFFD instead of truncating the token. Nothing is adjacent to a
+    # shortened span there, so the adjacency test below cannot see it. No
+    # legitimate identifier contains U+FFFD, so this needs no further check.
+    if _UNICODE_REPLACEMENT_CHAR in name:
+        if len(_TRUNCATED_NAMES) < _TRUNCATED_NAME_LIMIT:
+            _TRUNCATED_NAMES.add((language, name))
+        return
     span = _name_span(node, name)
     if span is None:
         return
@@ -160,6 +170,8 @@ _TRUNCATED_NAMES: set[tuple[cs.SupportedLanguage, str]] = set()
 _NAME_SPAN_ANCESTOR_LIMIT = 3
 # Sigils an ingestor prepends to a synthesized name (a C# destructor).
 _SYNTHETIC_NAME_PREFIXES = "~"
+# What `errors="replace"` substitutes for an undecodable byte.
+_UNICODE_REPLACEMENT_CHAR = "\ufffd"
 
 
 def _has_invalid_byte(window: bytes, *, at_end: bool) -> bool:

--- a/fuzz/fuzz_parse_source.py
+++ b/fuzz/fuzz_parse_source.py
@@ -126,16 +126,26 @@ def _check_truncated_name(
         (source[end : end + _UTF8_MAX_SEQUENCE_BYTES], True),
     ):
         if probe and _has_invalid_byte(probe, at_end=at_end):
-            raise AssertionError(
-                f"{language}: the name {name!r} was extracted from a token the "
-                f"grammar split at an invalid byte, so the symbol is indexed "
-                f"under a truncated name (#1810)"
-            )
+            # Production DETECTS this and logs a warning (#1810), so it is a
+            # known, reported behaviour rather than a crash: halting the
+            # fuzzer on it would stop the run on the first mangled identifier
+            # libFuzzer invents and hide every other defect behind it.
+            #
+            # The oracle is still load-bearing. It is asserted the other way
+            # round in `test_known_defect_seeds_are_still_detected`, which
+            # requires the two corpus reproducers to trip it, so a regression
+            # that stops detecting truncation reddens there. Raise here again
+            # once the extractors stop truncating rather than warning.
+            _TRUNCATED_NAMES.append((language, name))
+            return
 
 
 # Longest UTF-8 sequence: a window this size either side of a name spans any
 # single character that could legitimately sit next to it.
 _UTF8_MAX_SEQUENCE_BYTES = 4
+# Truncated names seen this run. A list rather than a raise: the defect is
+# known and production reports it, so the fuzzer records and continues.
+_TRUNCATED_NAMES: list[tuple[cs.SupportedLanguage, str]] = []
 # A definition's own name is at most a step or two above it (the JS/TS
 # field-definition wrapper is one).
 _NAME_SPAN_ANCESTOR_LIMIT = 3


### PR DESCRIPTION
Closes #1810.

A bad byte inside an identifier is a token boundary to tree-sitter, so the `name` node covers only the bytes on one side of it. The extractor decodes that shortened node without error, and the symbol is indexed under a truncated name with nothing raised and nothing logged.

```
CLEAN FILE                     SAME FILE, ONE BAD BYTE
  billing.calculate_total        billing.calculate_t
  billing.main                   billing.main
```

## Scope: all 15 languages, measured

Same mutation applied to the repo's own per-language samples (`fuzz/build_corpus.py` SOURCES), driven through `GraphUpdater.run()`:

| outcome | count | languages |
|---|---|---|
| silently truncated | 13 | c, c_sharp, dart, go, java, javascript, php, python, rust, scala, sql, tsx, typescript |
| definition dropped | 2 | cpp, lua |

None survive intact. C# and Go truncate the containing **class**, taking every symbol under it: `App.Greeter` becomes `App.eeter`.

The instrument was validated before the table was believed: all 15 deterministic across repeated runs, and the mutation asserted to apply in each.

## The damage is not confined to the corrupt file

With `calculate_total` damaged in `lib.py`:

```
functions lost:      proj.lib.calculate_total
functions invented:  proj.lib.calculate_t
edges lost that originate in CLEAN files: 2
    proj.app.checkout   CALLS  proj.lib.calculate_total
    proj.report.summary CALLS  proj.lib.calculate_total
```

`app.py` and `report.py` are byte-perfect and both lose their call edges, so the function reads as dead code while a symbol nobody calls appears beside it. A wrong entry is worse than a missing one.

## Why the check is keyed on adjacency

Two narrower-sounding designs are both wrong, and the first shipped in this branch before the local reviewer caught it:

* **The definition node's span** contains the bad byte, but also spans the whole body, so it warns about correctly-indexed symbols whenever a bad byte sits in a body comment, docstring or string literal, and once per enclosing definition (one bad byte in a nested class produced four warnings).
* **The name node's own bytes** never contain the bad byte -- the grammar excludes it -- so `b'pha'` decodes cleanly in the corrupt and the clean case alike, detecting nothing at all.

What discriminates is the byte **immediately adjacent** to the name's span: the one the grammar split on.

`_name_span` locates the identifier by matching the extracted name rather than trusting `child_by_field_name`, because C nests it under `function_declarator` -- the field lookup alone silently lost c and sql.

## Base rate: why not a per-file check

Surveyed 105,352 real source files across six independent corpora:

| corpus | files | invalid UTF-8 |
|---|---:|---:|
| Rust crates | 16,855 | 0 |
| Go modules | 6,618 | 0 |
| macOS SDK | 11,575 | **136** |
| Homebrew | 38,837 | 26 |
| Python site-packages | 30,222 | 3 |
| this repo | 1,245 | 0 |
| **total** | **105,352** | **165** |

**None of the 165 corrupts a symbol.** Every one is latin-1 punctuation in a copyright header or an author's name (`©`, `ä`, `é`), and one is a `£` inside a regex literal -- code, not a comment. Five were indexed directly and all produced identical symbol sets to a repaired copy.

So a per-file signal would have fired 165 times and been wrong every time, at 1.2% of the macOS SDK. This check fires on none of them.

Cost is 0.059 microseconds per symbol (6ms for a 100,000-symbol repo); the bytes are already in hand, so no extra reads.

## Tests

13 in `test_truncated_symbol_names.py`: detection per truncating language, non-ASCII identifier controls (`café`, `élan`, `函数` -- a naive "is the name ASCII" check passes every test one would think to write and then fires on every non-English codebase), the false-alarm positions, and the nested-class case.

Reverting the helper to the previous implementation reddens exactly the two tests written to catch it. Two further mutations (guard disabled, name's own bytes) redden only the detection tests.

`test_the_name_nodes_own_bytes_cannot_detect_this` and `test_the_containment_oracle_cannot_detect_this` pin the two wrong designs as executable notes, because both are what a future reader will try to simplify this into. The containment oracle in particular is satisfied BY the corruption: `pha` really is a substring of `al\xffpha`.

String-literal and docstring positions are excluded from the false-alarm parametrisation with a note: they make the call pass raise `UnicodeDecodeError`, which is the separate open defect #1797 (fix in flight as #1812), and conftest's per-file-pass guard fails the test before this check is reached. Verified by driving the helper directly that both are handled.

cpp and lua are deliberately not covered: they invent no wrong-named symbol, and a missing definition is the honest, visible failure.

## Fuzz harness

`fuzz_parse_source` detected this class by catching `UnicodeDecodeError`, so it was structurally blind to the mode that raises nothing. It now checks the same property, with two reproducer seeds exempt from `test_parse_harness_runs_every_seed` and asserted the other way round in `test_known_defect_seeds_are_still_detected`, so an exemption cannot outlive the defect. `edge_bad_byte_between_defs.bin` is committed as the negative case pinning the scope limit.

## Verification

- 1,237 passed across truncated/fuzz/ingest/class_ingest/function/parser/language_spec, `-n 4` under the host lock.
- `ty check`: 9 diagnostics, identical to unmodified `main`.
- ruff check/format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings when invalid UTF-8 bytes cause indexed symbol names to be truncated.
  * Improved detection across supported languages, symbol patterns, and synthesized names.
  * Prevented false warnings for valid non-ASCII names and unrelated invalid bytes.
  * Improved visibility into truncated names that can prevent caller resolution.

* **Tests**
  * Added coverage for truncated identifiers, Unicode names, parser edge cases, and malformed UTF-8 input.
  * Expanded fuzzing coverage for known parser defects and bounded defect reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->