### PR TITLE
docs: pin why a reachability probe must query, not just connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --python ${{ matrix.python-version }} --extra treesitter-full --extra test --extra semantic --extra milvus --group dev
+          uv sync --python ${{ matrix.python-version }} --extra treesitter-full --extra test --extra semantic --extra milvus --extra neo4j --group dev
 
       # Three unit tests embed for real. Without a cache each job pulled
       # microsoft/unixcoder-base from HuggingFace mid-suite, so a 429 or an

--- a/codebase_rag/services/neo4j_driver.py
+++ b/codebase_rag/services/neo4j_driver.py
@@ -170,6 +170,20 @@ class Neo4jDriver:
         self._database = database
 
     def connect(self) -> Neo4jConnection:
+        """Open a session.
+
+        This does NOT prove the server is reachable. The Neo4j driver
+        connects lazily: `GraphDatabase.driver()` and `session()` touch
+        no socket, and an unreachable server first surfaces as
+        `ServiceUnavailable` when a query runs. `mgclient.connect()` by
+        contrast fails immediately.
+
+        So a reachability probe that only opens a connection detects a
+        dead Memgraph and reports a dead Neo4j as HEALTHY -- silently, and
+        in the reassuring direction. Any such check must issue a query;
+        `HealthChecker.check_memgraph_connection` runs `RETURN 1` for
+        exactly this reason.
+        """
         return Neo4jConnection(self._driver.session(database=self._database))
 
     def close(self) -> None:

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import mgclient
 import pytest
 
+from codebase_rag import constants as cs
 from codebase_rag.graph_dialects import (
     DIALECT_MEMGRAPH,
     DIALECT_NEO4J,
@@ -321,3 +322,45 @@ class TestCleanupDoesNotMaskTheAuditResult:
             explode,
         )
         assert HealthChecker().check_graph_integrity() == []
+
+
+class TestReachabilityNeedsAQuery:
+    """Opening a connection does not prove a Neo4j server is reachable.
+
+    The Neo4j driver connects lazily, so `session()` succeeds against a
+    dead server and the failure only surfaces when a query runs.
+    `mgclient.connect()` fails immediately. A probe that merely opens a
+    connection therefore detects a dead Memgraph and reports a dead Neo4j
+    as healthy -- silently, and in the reassuring direction.
+    """
+
+    def test_the_health_check_issues_a_query(self) -> None:
+        # Pinned structurally: a future edit that drops the query in
+        # favour of "the connection opened, so we are fine" would pass
+        # every behavioural test using a fake connection, because a fake
+        # cannot reproduce the driver's laziness.
+        import inspect
+
+        source = inspect.getsource(HealthChecker.check_memgraph_connection)
+        assert "cursor.execute(" in source
+        assert "HEALTH_CHECK_MEMGRAPH_QUERY" in source
+
+    def test_the_probe_query_is_trivial(self) -> None:
+        # It must exercise the round trip without depending on any data.
+        assert cs.HEALTH_CHECK_MEMGRAPH_QUERY.upper().startswith("RETURN 1")
+
+    def test_opening_a_session_does_not_touch_the_network(self) -> None:
+        """The asymmetry itself, against a port with nothing listening."""
+        pytest.importorskip("neo4j")
+        from codebase_rag.services.neo4j_driver import Neo4jDriver
+
+        driver = Neo4jDriver(
+            uri="bolt://127.0.0.1:9", username=None, password=None, database="neo4j"
+        )
+        try:
+            conn = driver.connect()  # lazy: must NOT raise
+            with pytest.raises(Exception, match="(?i)unavailable|connect"):
+                cursor = conn.cursor()
+                cursor.execute("RETURN 1")
+        finally:
+            driver.close()

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -389,8 +389,10 @@ class TestReachabilityNeedsAQuery:
         )
         try:
             conn = driver.connect()  # lazy: must NOT raise
+            cursor = conn.cursor()  # also lazy: still no socket
+            # Only the query reaches the network, so only it belongs in
+            # the raises block (python:S5778).
             with pytest.raises(Exception, match="(?i)unavailable|connect"):
-                cursor = conn.cursor()
                 cursor.execute("RETURN 1")
         finally:
             driver.close()

--- a/codebase_rag/tests/test_health_backend_reporting.py
+++ b/codebase_rag/tests/test_health_backend_reporting.py
@@ -334,16 +334,46 @@ class TestReachabilityNeedsAQuery:
     as healthy -- silently, and in the reassuring direction.
     """
 
-    def test_the_health_check_issues_a_query(self) -> None:
-        # Pinned structurally: a future edit that drops the query in
-        # favour of "the connection opened, so we are fine" would pass
-        # every behavioural test using a fake connection, because a fake
-        # cannot reproduce the driver's laziness.
-        import inspect
+    def test_the_health_check_sends_the_probe_query(self, monkeypatch) -> None:
+        """Assert the statement that reaches the server, not that a call exists.
 
-        source = inspect.getsource(HealthChecker.check_memgraph_connection)
-        assert "cursor.execute(" in source
-        assert "HEALTH_CHECK_MEMGRAPH_QUERY" in source
+        A source-text check would pass against a probe that executed the
+        wrong statement, or an empty one.
+        """
+        sent: list[str] = []
+
+        class RecordingCursor:
+            def execute(self, query: str, params: object = None) -> None:
+                sent.append(query)
+
+            @property
+            def description(self) -> None:
+                return None
+
+            def fetchall(self) -> list[tuple]:
+                return []
+
+            def close(self) -> None:
+                pass
+
+        class RecordingConn(FakeConn):
+            def cursor(self) -> RecordingCursor:
+                return RecordingCursor()
+
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor._create_connection",
+            lambda self: RecordingConn(),
+        )
+        monkeypatch.setattr(
+            "codebase_rag.tools.health_checker.MemgraphIngestor.close_driver",
+            lambda self: None,
+        )
+        result = HealthChecker().check_memgraph_connection()
+
+        assert result.passed
+        # The probe must actually round-trip a statement: opening the
+        # connection is not evidence a Neo4j server is reachable.
+        assert sent == [cs.HEALTH_CHECK_MEMGRAPH_QUERY]
 
     def test_the_probe_query_is_trivial(self) -> None:
         # It must exercise the round trip without depending on any data.


### PR DESCRIPTION
Follow-up to #1814 (Neo4j backend). No behaviour change — this records a backend asymmetry that is silent in the reassuring direction, and pins the code that already handles it correctly.

## The asymmetry

Measured against `127.0.0.1:9`, a port with nothing listening:

| Backend | connection-only probe | query probe |
|---|---|---|
| Memgraph | detects down (`OperationalError`) | — |
| Neo4j | **REPORTS HEALTHY** | detects down (`ServiceUnavailable`) |

`GraphDatabase.driver()` and `session()` touch no socket — the Neo4j driver connects lazily, and an unreachable server first surfaces when a query runs. `mgclient.connect()` fails immediately.

So a reachability check that only opens a connection is correct on Memgraph and wrong on Neo4j. It would be written, reviewed and tested successfully against the default backend, then silently stop working the day someone sets `GRAPH_BACKEND=neo4j`. Nothing in the code would look different.

## What this adds

`HealthChecker.check_memgraph_connection` already runs `RETURN 1` and is correct today. This records **why** at the place someone would plausibly "simplify" it, and adds two tests:

- `test_the_health_check_issues_a_query` — structural, on purpose. A fake connection cannot reproduce the driver's laziness, so a behavioural test using one would pass against a connection-only probe. Asserting the query is issued is the only check that discriminates here.
- `test_opening_a_session_does_not_touch_the_network` — demonstrates the asymmetry directly, skipped without the optional `neo4j` extra.

Plus a docstring on `Neo4jDriver.connect` stating that it does not prove reachability.

## Verification

- Removing the query from the health check reddens `test_the_health_check_issues_a_query` and nothing else.
- 302 tests pass with the driver installed; 17 pass and 4 skip on a base install (both directions checked — gating wrongly makes tests skip everywhere, which reads identically to passing).

## Credit

A peer session noticed their own `_persisted_incomplete` guard probes by issuing a query rather than opening a connection, and flagged that this was accidental rather than designed. That is what prompted measuring it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that opening a database session does not confirm server reachability; a query is required.

* **Tests**
  * Added coverage verifying health checks execute the expected lightweight reachability query.
  * Replaced implementation-detail checks with executable health-check validation.
  * Added validation that session creation alone does not contact an unavailable server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->