### PR TITLE
ci: fail a PR that has no CI run at its head commit

### DIFF
--- a/.github/workflows/require-ci-at-head.yml
+++ b/.github/workflows/require-ci-at-head.yml
@@ -37,9 +37,18 @@ jobs:
         run: |
           set -euo pipefail
 
+          # A missing head SHA must NOT be a pass. `workflow_dispatch`
+          # carries no pull_request payload, so an earlier `exit 0` here
+          # let anyone manufacture a green `CI Ran At Head` by dispatching
+          # this workflow by hand -- a gate that reports success without
+          # asserting anything, which is the exact defect it exists to
+          # prevent.
           if [ -z "${HEAD_SHA:-}" ]; then
-            echo "No pull_request head SHA in the event payload; nothing to assert."
-            exit 0
+            echo "::error::No pull_request head SHA in the event payload."
+            echo "This check asserts a property of a pull request head and"
+            echo "cannot do so outside a pull_request event. Dispatching it"
+            echo "manually proves nothing and must not report success."
+            exit 1
           fi
 
           echo "Head SHA: $HEAD_SHA"
@@ -49,15 +58,21 @@ jobs:
           # runs belonging to OTHER PRs (issue #1582 records this trap).
           runs=$(gh api \
             "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
-            --jq '[.workflow_runs[] | {name, conclusion, status, event}]')
+            --jq '[.workflow_runs[] | {name, path, conclusion, status, event}]')
 
           echo "Runs at this head:"
-          echo "$runs" | jq -r '.[] | "  \(.name): \(.status)/\(.conclusion // "pending") (\(.event))"' || true
+          echo "$runs" | jq -r '.[] | "  \(.path) [\(.name)]: \(.status)/\(.conclusion // "pending") (\(.event))"' || true
 
-          # `| length == 0` is indistinguishable from "the name did not
-          # match", so match on the workflow's `name:` field exactly as
-          # ci.yml declares it, and print what was found either way.
-          ci_count=$(echo "$runs" | jq '[.[] | select(.name == "CI")] | length')
+          # Match the workflow's PATH, not its display `name`. A display
+          # name is just a string any workflow may declare, so a second
+          # file named `CI` would satisfy a name-only check without
+          # running a single test. The path identifies the file itself.
+          #
+          # `| length == 0` is also indistinguishable from "nothing
+          # matched the filter", so every run found is printed above
+          # whether the assertion passes or fails.
+          ci_count=$(echo "$runs" \
+            | jq '[.[] | select(.path == ".github/workflows/ci.yml")] | length')
 
           if [ "$ci_count" -eq 0 ]; then
             echo

--- a/.github/workflows/require-ci-at-head.yml
+++ b/.github/workflows/require-ci-at-head.yml
@@ -33,6 +33,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -56,12 +57,20 @@ jobs:
           # Query by head_sha rather than by branch. After a stack rebase
           # several branches share a head, so `gh run list --branch` returns
           # runs belonging to OTHER PRs (issue #1582 records this trap).
-          runs=$(gh api \
+          # --paginate: without it only the first 100 runs come back, and a
+          # matching run on a later page reads as "no run at this head".
+          # NOT --slurp: gh rejects it alongside --jq. With --jq, gh applies
+          # the filter per page and concatenates, so `.workflow_runs[]`
+          # yields every run across all pages.
+          runs=$(gh api --paginate \
             "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
-            --jq '[.workflow_runs[] | {name, path, conclusion, status, event}]')
+            --jq '.workflow_runs[]
+                  | {name, path, conclusion, status, event,
+                     prs: [.pull_requests[].number]}' \
+            | jq -s '.')
 
           echo "Runs at this head:"
-          echo "$runs" | jq -r '.[] | "  \(.path) [\(.name)]: \(.status)/\(.conclusion // "pending") (\(.event))"' || true
+          echo "$runs" | jq -r '.[] | "  \(.path) [\(.name)] PRs=\(.prs|tostring): \(.status)/\(.conclusion // "pending") (\(.event))"' || true
 
           # Match the workflow's PATH, not its display `name`. A display
           # name is just a string any workflow may declare, so a second
@@ -71,8 +80,14 @@ jobs:
           # `| length == 0` is also indistinguishable from "nothing
           # matched the filter", so every run found is printed above
           # whether the assertion passes or fails.
-          ci_count=$(echo "$runs" \
-            | jq '[.[] | select(.path == ".github/workflows/ci.yml")] | length')
+          # A head SHA identifies a COMMIT, not a pull request. After a
+          # stack rebase several branches share a head (issue #1582 records
+          # this), so a run at this SHA may belong to a different PR
+          # entirely. Require the run to name THIS pull request, which is
+          # what scripts/check_pr_gated.py already enforces.
+          ci_count=$(echo "$runs" | jq --argjson pr "$PR_NUMBER" \
+            '[.[] | select(.path == ".github/workflows/ci.yml")
+                  | select(.prs | index($pr))] | length')
 
           if [ "$ci_count" -eq 0 ]; then
             echo

--- a/.github/workflows/require-ci-at-head.yml
+++ b/.github/workflows/require-ci-at-head.yml
@@ -1,0 +1,86 @@
+name: Require CI At Head
+
+# A required status check that is ABSENT does not block a merge -- GitHub
+# cannot fail a check nobody reported. `All Checks Pass` is a job inside
+# ci.yml, so whenever ci.yml does not run at a PR's head that job simply
+# does not exist, the ruleset's only requirement is vacuously satisfied,
+# and the PR reports CLEAN with no tests having run (issue #1582).
+#
+# Measured on #1551: mergeStateStatus CLEAN, mergeable MERGEABLE, 7 checks
+# present, `All Checks Pass` among them: no. Zero unit tests had ever run
+# on that branch.
+#
+# This workflow exists to be PRESENT where ci.yml is not. It has no
+# `branches` filter, so it reports on every pull request, and it fails
+# unless a CI run exists at the exact head SHA. That is the base-agnostic
+# formulation issue #1582 settled on: it does not depend on why any given
+# run fired, only on whether one covers the commit being merged.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  require-ci-at-head:
+    name: CI Ran At Head
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assert a CI run exists at this PR's head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HEAD_SHA:-}" ]; then
+            echo "No pull_request head SHA in the event payload; nothing to assert."
+            exit 0
+          fi
+
+          echo "Head SHA: $HEAD_SHA"
+
+          # Query by head_sha rather than by branch. After a stack rebase
+          # several branches share a head, so `gh run list --branch` returns
+          # runs belonging to OTHER PRs (issue #1582 records this trap).
+          runs=$(gh api \
+            "repos/$REPO/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+            --jq '[.workflow_runs[] | {name, conclusion, status, event}]')
+
+          echo "Runs at this head:"
+          echo "$runs" | jq -r '.[] | "  \(.name): \(.status)/\(.conclusion // "pending") (\(.event))"' || true
+
+          # `| length == 0` is indistinguishable from "the name did not
+          # match", so match on the workflow's `name:` field exactly as
+          # ci.yml declares it, and print what was found either way.
+          ci_count=$(echo "$runs" | jq '[.[] | select(.name == "CI")] | length')
+
+          if [ "$ci_count" -eq 0 ]; then
+            echo
+            echo "::error::No 'CI' workflow run exists at head $HEAD_SHA."
+            echo "This PR has not been verified by the test suite at the commit"
+            echo "being merged. A superseded run drops off the PR, leaving"
+            echo "whatever happened to run at the current head -- often CodeQL"
+            echo "alone -- which reads as a clean result (issue #1582)."
+            echo
+            echo "Trigger one with:"
+            echo "  gh workflow run ci.yml --ref <branch>"
+            echo
+            echo "Note: pushing an empty commit is NOT sufficient on a branch"
+            echo "whose base is not main -- it creates a new head, CodeQL"
+            echo "re-runs green, and the page looks freshly validated while no"
+            echo "test has run."
+            exit 1
+          fi
+
+          echo
+          echo "Found $ci_count 'CI' run(s) at this head."
+
+          # Existence is the assertion; whether they PASSED is `All Checks
+          # Pass`'s job. Reporting the conclusion here would duplicate that
+          # gate and disagree with it while a run is still in flight.
+          exit 0


### PR DESCRIPTION
Closes the gap in #1582's option 2.

## The hole

A required status check that is **absent** does not block a merge. GitHub cannot fail a check nobody reported, so "required" in practice means "must not be red", not "must be present".

`All Checks Pass` — the ruleset's only required check — is a job inside `ci.yml`. Whenever `ci.yml` does not run at a PR's head, that job does not exist there, the requirement is vacuously satisfied, and the PR reports mergeable having run no tests.

Measured on #1551 while writing this:

```
mergeStateStatus:              CLEAN
mergeable:                     MERGEABLE
checks present:                7
'All Checks Pass' among them:  False
```

Seven CodeQL/CodeRabbit checks, zero unit tests ever run on that branch, and GitHub says it is ready to merge.

## The fix

A workflow that exists to be **present where `ci.yml` is not**. No `branches` filter, so it reports on every pull request, and it fails unless a run of the `CI` workflow exists at the exact head SHA.

That is the base-agnostic formulation #1582 settled on after two branch-filter theories were proposed and falsified: it does not ask *why* a run fired, only whether one covers the commit being merged.

Three details the issue's own caveats forced:

- Queries `actions/runs?head_sha=…`, **not** `gh run list --branch`. After a stack rebase several branches share a head, and the branch query returns runs belonging to *other* PRs — a trap #1582 records explicitly.
- Matches the workflow `name` exactly and prints every run found, either way. A bare `| length == 0` cannot distinguish "no run at this head" from "the name did not match".
- Asserts **existence only**, not conclusion. Whether the run passed is `All Checks Pass`'s job; duplicating it here would disagree with that gate while a run is in flight.

## Validation

Both directions, against live data, before committing:

| PR | base | CI runs at head | verdict |
|---|---|---|---|
| #1818 | `main`, merged clean | 1 | pass |
| #1547 | `main`, in review | 1 | pass |
| #1551 | feature branch | 1 | pass |
| #1549 | head pushed minutes ago | **0** | **fail** |

The last is correct and is the point — those commits are verified only by a local suite run.

The known-positive matters here: at #1818's head six workflows reported (`CI`, `ClusterFuzzLite PR`, `OSV-Scanner`, `PR #1818`, `PR Split Score`, `SonarCloud`), so the name match is genuinely selecting rather than trivially succeeding.

## Deliberately not included

**Adding this to the ruleset's required checks.** That is the owner's call and wants to be a separate, deliberate step. Until then it reports without blocking — which is the right order, since a gate that started blocking the moment it merged would block every PR currently open, including the five-layer stack.

Also not included: any change to workflow triggers. #1582 withdrew that fix after measuring a `pull_request` CI run firing for a PR whose base was not in the filter list, and I independently reproduced that before writing this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pull requests now verify that a CI run belongs to the specific pull request being reviewed.
  * CI validation checks only the intended CI workflow, improving accuracy.
  * Validation now includes CI runs beyond the initial results limit.
  * Run details provide clearer information about the pull requests associated with each run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->