### PR TITLE
test: stop gating the per-language module-doc tests on tree-sitter-python

### DIFF
--- a/codebase_rag/tests/test_module_docstring.py
+++ b/codebase_rag/tests/test_module_docstring.py
@@ -613,6 +613,7 @@ class TestModuleDocstringPerLanguageIsExercised:
         ("dart", "dart"),
         ("lua", "lua"),
         ("php", "php"),
+        ("sql", "sql"),
     )
 
     def test_per_language_class_is_not_gated_on_the_python_grammar(self) -> None:

--- a/codebase_rag/tests/test_module_docstring.py
+++ b/codebase_rag/tests/test_module_docstring.py
@@ -176,9 +176,13 @@ class TestModuleDocSpecCoverage:
         assert not undecided, f"languages with no module-doc decision: {undecided}"
 
 
-@pytest.mark.skipif(not PY_AVAILABLE, reason="tree-sitter-python not available")
 class TestModuleDocstringPerLanguage:
-    """Each language's own module-doc convention, and what must NOT match."""
+    """Each language's own module-doc convention, and what must NOT match.
+
+    Deliberately not gated on ``tree-sitter-python``: ``load_parsers`` loads
+    each grammar independently, and none of the languages below is Python, so
+    a missing Python grammar must not silently skip all of them (#1817).
+    """
 
     def _extract(self, lang_name: str, source: bytes) -> str | None:
         from codebase_rag.constants import SupportedLanguage
@@ -590,3 +594,42 @@ class TestModuleDocstringPerLanguage:
         of it. Left there, that slash became the file's documentation.
         """
         assert self._extract("java", source) is None
+
+
+class TestModuleDocstringPerLanguageIsExercised:
+    """Guard against ``TestModuleDocstringPerLanguage`` going green by collecting nothing (#1817)."""
+
+    # (language, prefix of the test methods that exercise it)
+    LANGUAGES = (
+        ("rust", "rust"),
+        ("go", "go"),
+        ("java", "java"),
+        ("javascript", "javascript"),
+        ("typescript", "typescript"),
+        ("c", "c"),
+        ("cpp", "cpp"),
+        ("c_sharp", "csharp"),
+        ("scala", "scala"),
+        ("dart", "dart"),
+        ("lua", "lua"),
+        ("php", "php"),
+    )
+
+    def test_per_language_class_is_not_gated_on_the_python_grammar(self) -> None:
+        marks = getattr(TestModuleDocstringPerLanguage, "pytestmark", [])
+        assert not [m for m in marks if m.name == "skipif"], (
+            "the per-language module-doc tests must not be skipped as a block; "
+            "each language loads its own grammar"
+        )
+
+    @pytest.mark.parametrize(("lang_name", "prefix"), LANGUAGES)
+    def test_each_language_is_exercised(self, lang_name: str, prefix: str) -> None:
+        from codebase_rag.constants import SupportedLanguage
+
+        SupportedLanguage(lang_name)  # the language exists
+        names = [
+            n
+            for n in dir(TestModuleDocstringPerLanguage)
+            if n.startswith(f"test_{prefix}_")
+        ]
+        assert names, f"no per-language module-doc test exercises {lang_name}"

--- a/codebase_rag/tests/test_module_docstring.py
+++ b/codebase_rag/tests/test_module_docstring.py
@@ -617,7 +617,7 @@ class TestModuleDocstringPerLanguageIsExercised:
 
     def test_per_language_class_is_not_gated_on_the_python_grammar(self) -> None:
         marks = getattr(TestModuleDocstringPerLanguage, "pytestmark", [])
-        assert not [m for m in marks if m.name == "skipif"], (
+        assert not [m for m in marks if m.name in {"skip", "skipif"}], (
             "the per-language module-doc tests must not be skipped as a block; "
             "each language loads its own grammar"
         )


### PR DESCRIPTION
## Summary

- Drop the class-level `@pytest.mark.skipif(not PY_AVAILABLE, ...)` from `TestModuleDocstringPerLanguage`: it tests Rust, Go, Java, JavaScript, TypeScript, C, C++, C#, Scala, Dart, Lua and PHP, never Python, and `load_parsers()` loads each grammar lazily and independently. With a partial local install (no `tree-sitter-python`) the whole class was skipped and the suite went green having collected almost nothing from it. The two Python-specific classes keep their gate. A language whose grammar really is missing is still skipped individually by the existing conftest hook (`<lang> parser not available`).
- Add `TestModuleDocstringPerLanguageIsExercised`, so the class cannot quietly go back to collecting nothing: one test fails if the per-language class ever carries a block-level `skipif` again, and one parametrized test per language fails if that language loses its `test_<lang>_*` cases.

## Type of Change

- [x] Bug fix
- [x] CI/CD or tooling

## Related Issues

Fixes #1817

## Test Plan

- [x] Unit tests pass (`uv run pytest codebase_rag/tests/test_module_docstring.py`)
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

`pytest --collect-only -q codebase_rag/tests/test_module_docstring.py`: 98 tests before, 111 after (the 13 new guard cases; the per-language class collects the same 40 tests either way, the difference is whether they run). With the `treesitter-full` extra installed the per-language tests run and pass; without `tree-sitter-python` only the two Python classes skip, the eleven other languages still run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Per-language module documentation tests now run independently, even when the Python grammar is unavailable.
  * Added coverage to verify that every supported language, including SQL, has at least one corresponding test.
  * Added safeguards to ensure the per-language test suite is not inadvertently skipped or conditionally disabled.
  * Updated test documentation to clarify that language grammars are loaded independently and tested separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->