### PR TITLE
ci: auto-review stacked PRs whose base is a feat/ or fix/ branch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,3 +10,18 @@ reviews:
   pre_merge_checks:
     docstrings:
       mode: "off"
+  auto_review:
+    # Auto-review defaults to the default branch only, so on a stacked chain
+    # every layer above the bottom is skipped and only the bottom PR is ever
+    # read (issue #1581: 14 of 18 open PRs had never been reviewed). The skip
+    # is easy to misread as a clean result -- the same "Review skipped"
+    # headline covers "already reviewed the last commit", which means the head
+    # IS covered, so the notice cannot be judged without opening its body.
+    #
+    # These patterns are anchored and cover the two prefixes stacks are cut
+    # from here. Deliberately not ".*": a base that is neither the default
+    # branch nor a recognised stack layer should keep the default behaviour
+    # rather than silently opting in.
+    base_branches:
+      - "^feat/.*"
+      - "^fix/.*"


### PR DESCRIPTION
Closes #1581.

CodeRabbit auto-review defaults to the default branch only, so on a stacked
chain every layer above the bottom is skipped and only the bottom PR is ever
read. The issue measured 14 of 18 open PRs never reviewed, each carrying a
skip notice that is easy to read as a clean result.

`reviews.auto_review.base_branches` accepts regex patterns and defaults to
`[]`, which is precisely why every stacked PR was skipped.

## One correction to the issue

#1581 states the repo has no `.coderabbit.yaml` and the fix is a pure
addition. It has one now, added by 9320c7cf for #1617 to turn off the
docstring pre-merge check. So this is an edit, and that setting had to be
preserved. Verified it still parses as the string `off` after the change --
the quotes are load-bearing, since unquoted `mode: off` yields boolean
`False`, which is schema-invalid.

## Why two anchored prefixes rather than `.*`

A base that is neither the default branch nor a recognised stack layer should
keep default behaviour rather than silently opting in.

The `^` is load-bearing. Unanchored, under search semantics, `feat/.*` and
`fix/.*` would also match `notfeat/x`, `release/feat/x`, `myfix/x` and
`hotfix/urgent`. Anchored, all four correctly do not match. The trailing `.*`
is redundant under search semantics but required under fullmatch, and the
vendor docs do not say which is used, so it is kept.

## Verification

- Validated against the live vendor schema with `Draft202012Validator` (the
  dialect the schema declares): 0 errors. Four controls confirm the validator
  can fail -- string-not-array, a root typo key, `mode: false`, a bad enum.
- Prefix coverage is 9 of 9: every PR ever opened against a non-`main` base
  (#1548-#1551, #1274, #1260, #1114, #1112, #1111) used a `feat/` or `fix/`
  base. The 64 `chore/docs/test/ci/refactor/perf` PRs were all based on
  `main`.
- Patterns tested against real bases: `feat/postcondition-contract`,
  `feat/move-op`, `fix/incremental-init-package` all match; `main` does not.

Note when re-deriving that coverage: PRs retargeted to `main` before merging
now REPORT `base=main`, so recent history understates which prefixes were
stack bases. #1571-#1576 read as `main` today and were `fix/...` when the
issue was written.

## Known gap, not introduced here

Nothing validates `.coderabbit.yaml` before merge. `check-yaml` checks syntax
only, and the vendor schema sets `additionalProperties: false` at the ROOT
only -- so a `base_branchez` typo under `auto_review` validates with 0 errors
and silently restores the bug this PR fixes. Measured, not assumed.

The repo has the right precedent in `scripts/validate_labels.py`, wired into
pre-commit and `ci.yml`. A follow-up doing the same for `.coderabbit.yaml`
would close it. Filing separately rather than widening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automatic reviews for recognized feature and fix branch bases.
  * Existing behavior for other branch bases remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->