### PR TITLE
ci: validate .coderabbit.yaml in pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,14 @@ jobs:
         run: |
           uv run python scripts/validate_labels.py
 
+      # Neither check-yaml nor the vendor schema can catch a misspelt key
+      # nested under reviews.auto_review: additionalProperties is set on the
+      # root object only, so the typo validates clean and auto-review
+      # silently reverts to the default branch (issues #1581, #1823).
+      - name: Validate .coderabbit.yaml
+        run: |
+          uv run python scripts/validate_coderabbit_config.py
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,14 @@ repos:
         pass_filenames: false
   - repo: local
     hooks:
+      - id: validate-coderabbit-config
+        name: validate .coderabbit.yaml
+        entry: uv run --frozen --no-sync python scripts/validate_coderabbit_config.py
+        language: system
+        files: ^\.coderabbit\.yaml$
+        pass_filenames: false
+  - repo: local
+    hooks:
       - id: generate-readme
         name: generate README sections
         entry: uv run --frozen --no-sync python scripts/hooks/generate_readme.py

--- a/codebase_rag/tests/test_validate_coderabbit_config.py
+++ b/codebase_rag/tests/test_validate_coderabbit_config.py
@@ -262,21 +262,23 @@ class TestSchemaAloneIsInsufficient:
 
     def test_the_validator_catches_what_the_schema_misses(self) -> None:
         """The discriminating assertion: same input, opposite verdicts."""
+        # Both built before the raises block, so only the call under test can
+        # throw: otherwise a failure in the fixture would satisfy the
+        # assertion and the test would pass for the wrong reason.
+        schema = self._schema()
+        text = shipped().replace("base_branches:", "base_branchez:")
         with pytest.raises(ConfigError):
-            validate_coderabbit_config(
-                shipped().replace("base_branches:", "base_branchez:"),
-                schema=self._schema(),
-            )
+            validate_coderabbit_config(text, schema=schema)
 
     def test_the_shipped_config_passes_the_vendor_schema_too(self) -> None:
         assert validate_coderabbit_config(shipped(), schema=self._schema()) >= 1
 
     def test_a_schema_violation_is_reported_when_a_schema_is_given(self) -> None:
         """An unknown ROOT key is what the schema does catch."""
+        schema = self._schema()
+        text = VALID + "\nnonsense_root_key: 1\n"
         with pytest.raises(ConfigError, match="schema violation"):
-            validate_coderabbit_config(
-                VALID + "\nnonsense_root_key: 1\n", self._schema()
-            )
+            validate_coderabbit_config(text, schema)
 
 
 class TestWiring:

--- a/codebase_rag/tests/test_validate_coderabbit_config.py
+++ b/codebase_rag/tests/test_validate_coderabbit_config.py
@@ -17,6 +17,8 @@ from typing import Any
 import pytest
 
 from scripts.validate_coderabbit_config import (
+    ROOT_KEY_SCHEMA,
+    VENDOR_ROOT_KEYS,
     ConfigError,
     validate_coderabbit_config,
 )
@@ -75,6 +77,23 @@ class TestDocstringsMode:
 
         data = yaml.safe_load(VALID.replace('mode: "off"', "mode: off"))
         assert data["reviews"]["pre_merge_checks"]["docstrings"]["mode"] is False
+
+    def test_a_non_string_mode_names_the_type(self) -> None:
+        """A YAML typing accident gets its own message, not the value one.
+
+        Without this the `isinstance` branch is unreachable under mutation:
+        the value comparison below catches the same inputs, so deleting the
+        type check leaves the suite green.
+        """
+        text = VALID.replace('mode: "off"', "mode: 3")
+        with pytest.raises(ConfigError, match="got int"):
+            validate_coderabbit_config(text)
+
+    def test_a_null_mode_names_the_type(self) -> None:
+        """`mode:` with nothing after it parses as None, not as absent."""
+        text = VALID.replace('mode: "off"', "mode:")
+        with pytest.raises(ConfigError, match="got NoneType"):
+            validate_coderabbit_config(text)
 
     def test_a_different_mode_is_rejected(self) -> None:
         """Only 'off' clears the check; 'warning' silently restores #1617."""
@@ -217,11 +236,17 @@ class TestSchemaAloneIsInsufficient:
         try:
             with urlopen(SCHEMA_URL, timeout=10) as response:
                 live = json.loads(response.read().decode("utf-8"))
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
+            # JSONDecodeError subclasses ValueError, not OSError: a proxy or
+            # captive portal returning HTML must skip, not redden the build.
             pytest.skip(f"vendor schema unreachable: {exc}")
         assert live.get("additionalProperties") is False
         auto_review = live["properties"]["reviews"]["properties"]["auto_review"]
         assert "additionalProperties" not in auto_review
+        assert set(live["properties"]) == set(VENDOR_ROOT_KEYS), (
+            "the vendor's root key set has changed; update VENDOR_ROOT_KEYS "
+            "or the shipped check will reject a newly valid setting"
+        )
 
     def test_the_typo_passes_the_vendor_schema(self) -> None:
         """A schema check alone would report `base_branchez` as valid."""
@@ -269,3 +294,39 @@ class TestWiring:
             encoding="utf-8"
         )
         assert "scripts/validate_coderabbit_config.py" in text
+
+
+class TestShippedEntrypointEnforcesTheSchema:
+    """The schema check must run in pre-commit and CI, not only in tests.
+
+    It was reachable only from tests in the first cut of this script: `main()`
+    passed no schema, so an unknown root key that CodeRabbit itself rejects
+    went through the hook and CI clean. A check that exists but is never
+    called is the same defect as a check that cannot fail.
+    """
+
+    def test_an_unknown_root_key_is_rejected_by_the_shipped_schema(self) -> None:
+        with pytest.raises(ConfigError, match="schema violation"):
+            validate_coderabbit_config(
+                VALID + "\nnonsense_root_key: 1\n", schema=ROOT_KEY_SCHEMA
+            )
+
+    def test_every_known_root_key_is_accepted(self) -> None:
+        """The check must not reject a setting the vendor allows."""
+        for key in sorted(VENDOR_ROOT_KEYS):
+            if key == "reviews":
+                continue
+            assert (
+                validate_coderabbit_config(f"{VALID}\n{key}: {{}}\n", ROOT_KEY_SCHEMA)
+                == 2
+            ), f"root key {key!r} should be accepted"
+
+    def test_main_passes_a_schema(self) -> None:
+        """Pin the wiring: the entrypoint must supply the schema."""
+        source = (
+            REPO_ROOT / "scripts" / "validate_coderabbit_config.py"
+        ).read_text(encoding="utf-8")
+        assert "schema=ROOT_KEY_SCHEMA" in source
+
+    def test_the_shipped_config_passes_the_shipped_schema(self) -> None:
+        assert validate_coderabbit_config(shipped(), ROOT_KEY_SCHEMA) >= 1

--- a/codebase_rag/tests/test_validate_coderabbit_config.py
+++ b/codebase_rag/tests/test_validate_coderabbit_config.py
@@ -1,0 +1,271 @@
+"""Validation for `.coderabbit.yaml` (issue #1823).
+
+Nothing checked this file before: `check-yaml` in pre-commit covers syntax
+only, and the vendor schema sets `additionalProperties: false` at the root
+object alone, so a key misspelt under `reviews.auto_review` validates with
+zero errors. Both settings the file exists for fail silently, so a test that
+merely asserts the shipped file is valid would not discriminate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.validate_coderabbit_config import (
+    ConfigError,
+    validate_coderabbit_config,
+)
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+CONFIG_PATH = REPO_ROOT / ".coderabbit.yaml"
+# Note the 301: this URL needs redirect-following if fetched by hand.
+SCHEMA_URL = "https://coderabbit.ai/integrations/schema.v2.json"
+
+VALID = """
+reviews:
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+  auto_review:
+    base_branches:
+      - "^feat/.*"
+      - "^fix/.*"
+"""
+
+
+def shipped() -> str:
+    return CONFIG_PATH.read_text(encoding="utf-8")
+
+
+class TestAcceptsValid:
+    def test_well_formed_config_passes(self) -> None:
+        """A config meeting every rule raises nothing."""
+        assert validate_coderabbit_config(VALID) == 2
+
+    def test_the_shipped_config_is_valid(self) -> None:
+        """The real file must satisfy its own validator."""
+        assert validate_coderabbit_config(shipped()) >= 1
+
+    def test_extra_unknown_settings_are_not_rejected(self) -> None:
+        """Without the vendor schema, unrecognised keys are not our business.
+
+        The script guards two specific settings; failing on anything else
+        would make every upstream feature addition a local build break.
+        """
+        assert validate_coderabbit_config(VALID + "\n  poem: false\n") == 2
+
+
+class TestDocstringsMode:
+    """`mode` must be the string 'off', not the YAML boolean (#1617)."""
+
+    def test_unquoted_off_is_rejected_naming_the_cause(self) -> None:
+        """Bare `off` is a YAML boolean, so the exemption stops applying."""
+        text = VALID.replace('mode: "off"', "mode: off")
+        with pytest.raises(ConfigError, match="boolean False"):
+            validate_coderabbit_config(text)
+
+    def test_unquoted_off_really_does_parse_as_false(self) -> None:
+        """Pin the premise, so the test above cannot pass for another reason."""
+        import yaml
+
+        data = yaml.safe_load(VALID.replace('mode: "off"', "mode: off"))
+        assert data["reviews"]["pre_merge_checks"]["docstrings"]["mode"] is False
+
+    def test_a_different_mode_is_rejected(self) -> None:
+        """Only 'off' clears the check; 'warning' silently restores #1617."""
+        text = VALID.replace('mode: "off"', 'mode: "warning"')
+        with pytest.raises(ConfigError, match="must be"):
+            validate_coderabbit_config(text)
+
+    def test_a_misspelt_docstrings_key_is_rejected(self) -> None:
+        """The block is ignored rather than rejected, so it must be named."""
+        text = VALID.replace("docstrings:", "docstringz:")
+        with pytest.raises(ConfigError, match="no 'docstrings' key"):
+            validate_coderabbit_config(text)
+
+    def test_a_missing_pre_merge_checks_block_is_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="pre_merge_checks"):
+            validate_coderabbit_config(
+                "reviews:\n  auto_review:\n    base_branches: ['^feat/.*']\n"
+            )
+
+
+class TestBaseBranches:
+    """`base_branches` drives whether stacked PRs get reviewed at all (#1581)."""
+
+    def test_the_misspelt_key_from_the_issue_is_rejected(self) -> None:
+        """`base_branchez` is the exact typo the vendor schema accepts."""
+        text = VALID.replace("base_branches:", "base_branchez:")
+        with pytest.raises(ConfigError, match="no 'base_branches' key"):
+            validate_coderabbit_config(text)
+
+    def test_an_empty_list_is_rejected(self) -> None:
+        """Empty parses cleanly and reviews only the default branch."""
+        text = VALID.replace('      - "^feat/.*"\n      - "^fix/.*"\n', "      []\n")
+        with pytest.raises(ConfigError, match="empty"):
+            validate_coderabbit_config(text)
+
+    def test_a_scalar_instead_of_a_list_is_rejected(self) -> None:
+        text = VALID.replace(
+            '      - "^feat/.*"\n      - "^fix/.*"\n', '    base_branches: "^feat/.*"\n'
+        ).replace("    base_branches:\n", "")
+        with pytest.raises(ConfigError, match="must be a list"):
+            validate_coderabbit_config(text)
+
+    def test_an_uncompilable_regex_is_rejected(self) -> None:
+        """CodeRabbit matches these as regexes; a broken one is dropped."""
+        text = VALID.replace('"^feat/.*"', '"^feat/([.*"')
+        with pytest.raises(ConfigError, match="invalid regex"):
+            validate_coderabbit_config(text)
+
+    def test_an_empty_pattern_string_is_rejected(self) -> None:
+        text = VALID.replace('"^feat/.*"', '""')
+        with pytest.raises(ConfigError, match="non-empty string"):
+            validate_coderabbit_config(text)
+
+
+class TestMalformedDocument:
+    def test_empty_file_is_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="empty"):
+            validate_coderabbit_config("")
+
+    def test_a_list_document_is_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="must be a mapping"):
+            validate_coderabbit_config("- a\n- b\n")
+
+    def test_unparseable_yaml_is_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="could not parse"):
+            validate_coderabbit_config("reviews:\n  - [unclosed\n")
+
+    def test_a_scalar_where_a_mapping_belongs_is_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="expected a mapping"):
+            validate_coderabbit_config("reviews: 3\n")
+
+
+class TestSchemaAloneIsInsufficient:
+    """The reason this script exists rather than a plain schema check.
+
+    `additionalProperties: false` is set on the ROOT object only, so an
+    unknown key nested under `reviews.auto_review` validates clean. These
+    pin that, so if the vendor ever tightens the schema the redundancy is
+    reported rather than assumed.
+    """
+
+    @staticmethod
+    def _schema() -> Any:
+        """The vendor schema, reduced to the structure these tests assert.
+
+        Deliberately not the real 93KB document: vendoring it would freeze a
+        copy that drifts silently, and fetching it would make the suite need
+        the network. What is reproduced here is the shape the script depends
+        on -- `additionalProperties: false` at the root and absent below it --
+        which is the property under test. `test_the_real_schema_is_still_root_only`
+        checks the live document when it is reachable.
+        """
+        pytest.importorskip("jsonschema")
+        return {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "reviews": {
+                    "type": "object",
+                    "properties": {
+                        "pre_merge_checks": {
+                            "type": "object",
+                            "properties": {
+                                "docstrings": {
+                                    "type": "object",
+                                    "properties": {"mode": {"type": "string"}},
+                                }
+                            },
+                        },
+                        "auto_review": {
+                            "type": "object",
+                            "properties": {
+                                "base_branches": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                }
+                            },
+                        },
+                    },
+                }
+            },
+        }
+
+    def test_additional_properties_is_root_only(self) -> None:
+        """The structural fact the whole script rests on."""
+        schema = self._schema()
+        assert schema.get("additionalProperties") is False
+        auto_review = schema["properties"]["reviews"]["properties"]["auto_review"]
+        assert "additionalProperties" not in auto_review
+
+    @pytest.mark.slow
+    def test_the_real_schema_is_still_root_only(self) -> None:
+        """Guard the reduced fixture above against vendor drift.
+
+        Skipped without network. If this ever fails, the vendor has tightened
+        the schema and the key checks may have become redundant.
+        """
+        pytest.importorskip("jsonschema")
+        urlopen = pytest.importorskip("urllib.request").urlopen
+        try:
+            with urlopen(SCHEMA_URL, timeout=10) as response:
+                live = json.loads(response.read().decode("utf-8"))
+        except OSError as exc:
+            pytest.skip(f"vendor schema unreachable: {exc}")
+        assert live.get("additionalProperties") is False
+        auto_review = live["properties"]["reviews"]["properties"]["auto_review"]
+        assert "additionalProperties" not in auto_review
+
+    def test_the_typo_passes_the_vendor_schema(self) -> None:
+        """A schema check alone would report `base_branchez` as valid."""
+        import yaml
+        from jsonschema import Draft202012Validator
+
+        broken = yaml.safe_load(shipped().replace("base_branches:", "base_branchez:"))
+        errors = list(Draft202012Validator(self._schema()).iter_errors(broken))
+        assert errors == [], (
+            "the vendor schema now rejects the typo; if that is permanent, "
+            "this script's key checks are redundant and should be revisited"
+        )
+
+    def test_the_validator_catches_what_the_schema_misses(self) -> None:
+        """The discriminating assertion: same input, opposite verdicts."""
+        with pytest.raises(ConfigError):
+            validate_coderabbit_config(
+                shipped().replace("base_branches:", "base_branchez:"),
+                schema=self._schema(),
+            )
+
+    def test_the_shipped_config_passes_the_vendor_schema_too(self) -> None:
+        assert validate_coderabbit_config(shipped(), schema=self._schema()) >= 1
+
+    def test_a_schema_violation_is_reported_when_a_schema_is_given(self) -> None:
+        """An unknown ROOT key is what the schema does catch."""
+        with pytest.raises(ConfigError, match="schema violation"):
+            validate_coderabbit_config(
+                VALID + "\nnonsense_root_key: 1\n", self._schema()
+            )
+
+
+class TestWiring:
+    """The script must actually run, or it is a check that never fires."""
+
+    def test_pre_commit_runs_it_on_the_config(self) -> None:
+        text = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+        assert "scripts/validate_coderabbit_config.py" in text
+        assert re.search(r"files:\s*\^\\\.coderabbit\\\.yaml\$", text), (
+            "the hook must be scoped to .coderabbit.yaml"
+        )
+
+    def test_ci_runs_it(self) -> None:
+        text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        assert "scripts/validate_coderabbit_config.py" in text

--- a/codebase_rag/tests/test_validate_coderabbit_config.py
+++ b/codebase_rag/tests/test_validate_coderabbit_config.py
@@ -311,21 +311,40 @@ class TestShippedEntrypointEnforcesTheSchema:
                 VALID + "\nnonsense_root_key: 1\n", schema=ROOT_KEY_SCHEMA
             )
 
-    def test_every_known_root_key_is_accepted(self) -> None:
+    # Written out rather than derived from VENDOR_ROOT_KEYS on purpose. A test
+    # that iterates the same tuple it is checking cannot see a key being
+    # dropped from it: the deletion removes the case as well as the schema
+    # entry, and the loop stays green over a shorter list. Measured -- deleting
+    # `knowledge_base` from the shipped set left the derived version passing.
+    EXPECTED_ROOT_KEYS = (
+        "chat",
+        "code_generation",
+        "early_access",
+        "enable_free_tier",
+        "inheritance",
+        "issue_enrichment",
+        "knowledge_base",
+        "language",
+        "reviews",
+        "tone_instructions",
+    )
+
+    def test_the_shipped_root_key_set_is_complete(self) -> None:
+        """An independent copy, so dropping a key from the real set reddens."""
+        assert set(VENDOR_ROOT_KEYS) == set(self.EXPECTED_ROOT_KEYS)
+
+    @pytest.mark.parametrize("key", [k for k in EXPECTED_ROOT_KEYS if k != "reviews"])
+    def test_every_known_root_key_is_accepted(self, key: str) -> None:
         """The check must not reject a setting the vendor allows."""
-        for key in sorted(VENDOR_ROOT_KEYS):
-            if key == "reviews":
-                continue
-            assert (
-                validate_coderabbit_config(f"{VALID}\n{key}: {{}}\n", ROOT_KEY_SCHEMA)
-                == 2
-            ), f"root key {key!r} should be accepted"
+        assert (
+            validate_coderabbit_config(f"{VALID}\n{key}: {{}}\n", ROOT_KEY_SCHEMA) == 2
+        ), f"root key {key!r} should be accepted"
 
     def test_main_passes_a_schema(self) -> None:
         """Pin the wiring: the entrypoint must supply the schema."""
-        source = (
-            REPO_ROOT / "scripts" / "validate_coderabbit_config.py"
-        ).read_text(encoding="utf-8")
+        source = (REPO_ROOT / "scripts" / "validate_coderabbit_config.py").read_text(
+            encoding="utf-8"
+        )
         assert "schema=ROOT_KEY_SCHEMA" in source
 
     def test_the_shipped_config_passes_the_shipped_schema(self) -> None:

--- a/codebase_rag/tests/test_validate_coderabbit_config.py
+++ b/codebase_rag/tests/test_validate_coderabbit_config.py
@@ -40,7 +40,8 @@ reviews:
 """
 
 
-def shipped() -> str:
+def read_shipped_config_text() -> str:
+    """Return the contents of the repository's own `.coderabbit.yaml`."""
     return CONFIG_PATH.read_text(encoding="utf-8")
 
 
@@ -51,7 +52,7 @@ class TestAcceptsValid:
 
     def test_the_shipped_config_is_valid(self) -> None:
         """The real file must satisfy its own validator."""
-        assert validate_coderabbit_config(shipped()) >= 1
+        assert validate_coderabbit_config(read_shipped_config_text()) >= 1
 
     def test_extra_unknown_settings_are_not_rejected(self) -> None:
         """Without the vendor schema, unrecognised keys are not our business.
@@ -253,7 +254,9 @@ class TestSchemaAloneIsInsufficient:
         import yaml
         from jsonschema import Draft202012Validator
 
-        broken = yaml.safe_load(shipped().replace("base_branches:", "base_branchez:"))
+        broken = yaml.safe_load(
+            read_shipped_config_text().replace("base_branches:", "base_branchez:")
+        )
         errors = list(Draft202012Validator(self._schema()).iter_errors(broken))
         assert errors == [], (
             "the vendor schema now rejects the typo; if that is permanent, "
@@ -266,12 +269,17 @@ class TestSchemaAloneIsInsufficient:
         # throw: otherwise a failure in the fixture would satisfy the
         # assertion and the test would pass for the wrong reason.
         schema = self._schema()
-        text = shipped().replace("base_branches:", "base_branchez:")
+        text = read_shipped_config_text().replace("base_branches:", "base_branchez:")
         with pytest.raises(ConfigError):
             validate_coderabbit_config(text, schema=schema)
 
     def test_the_shipped_config_passes_the_vendor_schema_too(self) -> None:
-        assert validate_coderabbit_config(shipped(), schema=self._schema()) >= 1
+        assert (
+            validate_coderabbit_config(
+                read_shipped_config_text(), schema=self._schema()
+            )
+            >= 1
+        )
 
     def test_a_schema_violation_is_reported_when_a_schema_is_given(self) -> None:
         """An unknown ROOT key is what the schema does catch."""
@@ -350,4 +358,6 @@ class TestShippedEntrypointEnforcesTheSchema:
         assert "schema=ROOT_KEY_SCHEMA" in source
 
     def test_the_shipped_config_passes_the_shipped_schema(self) -> None:
-        assert validate_coderabbit_config(shipped(), ROOT_KEY_SCHEMA) >= 1
+        assert (
+            validate_coderabbit_config(read_shipped_config_text(), ROOT_KEY_SCHEMA) >= 1
+        )

--- a/scripts/validate_coderabbit_config.py
+++ b/scripts/validate_coderabbit_config.py
@@ -21,6 +21,12 @@ because both failure modes above leave everything looking green.
 So this asserts the keys it cares about are PRESENT and correctly SHAPED,
 and treats the schema as an additional check rather than the only one.
 `check-yaml` in pre-commit covers syntax and nothing else.
+
+The root key set is reproduced here rather than vendored from the 77KB
+vendor document, which would drift silently against upstream. Only the
+root matters: that is the one level the vendor marks
+`additionalProperties: false`, so it is the only level where a schema
+check adds anything the key checks above do not already cover.
 """
 
 from __future__ import annotations
@@ -35,6 +41,34 @@ from typing import Any
 DOCSTRINGS_MODE_PATH = "reviews.pre_merge_checks.docstrings.mode"
 DOCSTRINGS_MODE_EXPECTED = "off"
 BASE_BRANCHES_PATH = "reviews.auto_review.base_branches"
+
+# The vendor schema's root key set, as published at
+# https://coderabbit.ai/integrations/schema.v2.json (note the 301: fetching
+# it by hand needs `curl -L`). `additionalProperties: false` is set on the
+# root object ALONE -- absent under `reviews`, `reviews.auto_review`,
+# `reviews.pre_merge_checks` and `docstrings` -- so this is exactly the level
+# at which a schema check catches something the key checks cannot.
+# `test_the_real_schema_is_still_root_only` fails if upstream changes either
+# the flag or this key set.
+VENDOR_ROOT_KEYS = frozenset(
+    {
+        "chat",
+        "code_generation",
+        "early_access",
+        "enable_free_tier",
+        "inheritance",
+        "issue_enrichment",
+        "knowledge_base",
+        "language",
+        "reviews",
+        "tone_instructions",
+    }
+)
+ROOT_KEY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": dict.fromkeys(sorted(VENDOR_ROOT_KEYS), {}),
+}
 
 
 class ConfigError(ValueError):
@@ -81,6 +115,9 @@ def _check_docstrings_mode(data: Any) -> None:
             f"string the schema requires (issue #1617)."
         )
     if not isinstance(mode, str):
+        # Distinct from the value check below: a non-string here is a YAML
+        # typing accident (a number, a list, a null), and saying which type
+        # arrived points at the line rather than at the setting.
         raise ConfigError(
             f"{DOCSTRINGS_MODE_PATH}: must be the string "
             f'"{DOCSTRINGS_MODE_EXPECTED}", got {type(mode).__name__} {mode!r}'
@@ -173,7 +210,9 @@ def main() -> int:
     """Validate the shipped config, printing the failure and returning 1."""
     config = Path(__file__).parent.parent / ".coderabbit.yaml"
     try:
-        count = validate_coderabbit_config(config.read_text(encoding="utf-8"))
+        count = validate_coderabbit_config(
+            config.read_text(encoding="utf-8"), schema=ROOT_KEY_SCHEMA
+        )
     except ConfigError as exc:
         sys.stderr.write(f"{config.name}: {exc}\n")
         return 1

--- a/scripts/validate_coderabbit_config.py
+++ b/scripts/validate_coderabbit_config.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Validate `.coderabbit.yaml` before it can reach main (issue #1823).
+
+Two settings in that file are load-bearing and both fail silently:
+
+* `reviews.pre_merge_checks.docstrings.mode` must be the STRING `"off"`
+  (issue #1617). Unquoted, YAML yields the boolean `False`, the exemption
+  stops applying, and every PR touching a test warns again.
+* `reviews.auto_review.base_branches` must be a non-empty list of valid
+  regular expressions (issue #1581). Misspell the key and the block is
+  ignored, auto-review silently reverts to the default branch only, and
+  stacked PRs go unreviewed -- 14 of 18 open PRs, when that was measured.
+
+Validating against the vendor schema is not sufficient on its own, which is
+the part worth recording. The schema sets `additionalProperties: false` at
+the ROOT object only, so an unknown key nested under `reviews.auto_review`
+validates clean: `base_branchez` is reported as valid. A schema check alone
+would therefore be a check that cannot fail in the direction it exists for,
+because both failure modes above leave everything looking green.
+
+So this asserts the keys it cares about are PRESENT and correctly SHAPED,
+and treats the schema as an additional check rather than the only one.
+`check-yaml` in pre-commit covers syntax and nothing else.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Both are quoted here for the same reason the file must quote them: bare
+# `off` is a YAML boolean.
+DOCSTRINGS_MODE_PATH = "reviews.pre_merge_checks.docstrings.mode"
+DOCSTRINGS_MODE_EXPECTED = "off"
+BASE_BRANCHES_PATH = "reviews.auto_review.base_branches"
+
+
+class ConfigError(ValueError):
+    """A config CodeRabbit would reject, or would silently read differently."""
+
+
+def _walk(data: Any, path: str) -> Any:
+    """Return the value at a dotted path, raising if a segment is missing.
+
+    Reports the deepest segment that did resolve, because the common failure
+    is a single misspelt key in an otherwise correct block and naming the
+    whole path leaves you comparing it against the file by eye.
+    """
+    node = data
+    walked: list[str] = []
+    for segment in path.split("."):
+        if not isinstance(node, dict):
+            where = ".".join(walked) or "the document root"
+            raise ConfigError(
+                f"{path}: expected a mapping at {where}, got {type(node).__name__}"
+            )
+        if segment not in node:
+            where = ".".join(walked) or "the document root"
+            near = ", ".join(sorted(map(str, node))) or "nothing"
+            raise ConfigError(
+                f"{path}: {where} has no '{segment}' key. It defines: {near}. "
+                f"A misspelt key is ignored rather than rejected, so the "
+                f"setting silently reverts to its default."
+            )
+        node = node[segment]
+        walked.append(segment)
+    return node
+
+
+def _check_docstrings_mode(data: Any) -> None:
+    """Require the docstring pre-merge check to be the string 'off'."""
+    mode = _walk(data, DOCSTRINGS_MODE_PATH)
+    if mode is False:
+        # `mode: off` unquoted is the YAML 1.1 boolean, and the schema wants
+        # a string, so name the cause rather than reporting 'False'.
+        raise ConfigError(
+            f"{DOCSTRINGS_MODE_PATH}: parsed as the boolean False. Bare 'off' "
+            f'is a YAML boolean; quote it (mode: "off") so it stays the '
+            f"string the schema requires (issue #1617)."
+        )
+    if not isinstance(mode, str):
+        raise ConfigError(
+            f"{DOCSTRINGS_MODE_PATH}: must be the string "
+            f'"{DOCSTRINGS_MODE_EXPECTED}", got {type(mode).__name__} {mode!r}'
+        )
+    if mode != DOCSTRINGS_MODE_EXPECTED:
+        raise ConfigError(
+            f"{DOCSTRINGS_MODE_PATH}: must be "
+            f'"{DOCSTRINGS_MODE_EXPECTED}", got {mode!r} (issue #1617)'
+        )
+
+
+def _check_base_branches(data: Any) -> int:
+    """Require a non-empty list of compilable regexes, returning its length."""
+    patterns = _walk(data, BASE_BRANCHES_PATH)
+    if not isinstance(patterns, list):
+        raise ConfigError(
+            f"{BASE_BRANCHES_PATH}: must be a list, got "
+            f"{type(patterns).__name__} {patterns!r}"
+        )
+    if not patterns:
+        # An empty list parses cleanly and reviews nothing beyond the default
+        # branch, which is the exact behaviour issue #1581 was filed about.
+        raise ConfigError(
+            f"{BASE_BRANCHES_PATH}: is empty, so auto-review covers only the "
+            f"default branch and every stacked PR is skipped (issue #1581)."
+        )
+    for index, pattern in enumerate(patterns):
+        where = f"{BASE_BRANCHES_PATH}[{index}]"
+        if not isinstance(pattern, str) or not pattern.strip():
+            raise ConfigError(f"{where}: must be a non-empty string, got {pattern!r}")
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            # CodeRabbit matches these as regexes; one that cannot compile is
+            # dropped rather than reported back to us.
+            raise ConfigError(f"{where}: invalid regex {pattern!r}: {exc}") from exc
+    return len(patterns)
+
+
+def _check_against_vendor_schema(data: Any, schema: Any) -> None:
+    """Report vendor-schema violations, if a schema was supplied.
+
+    This runs in addition to the key checks above, never instead of them:
+    the schema's `additionalProperties: false` applies to the root object
+    only, so it accepts an unknown key nested anywhere below it.
+    """
+    from jsonschema import Draft202012Validator
+
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(data),
+        key=lambda err: list(err.absolute_path),
+    )
+    if errors:
+        first = errors[0]
+        where = ".".join(str(part) for part in first.absolute_path) or "root"
+        raise ConfigError(
+            f"{where}: {first.message} ({len(errors)} schema violation(s) in total)"
+        )
+
+
+def validate_coderabbit_config(text: str, schema: Any | None = None) -> int:
+    """Check a CodeRabbit config, returning how many base branches it lists.
+
+    Raises `ConfigError` naming the setting at fault. `schema`, when given,
+    is the parsed vendor JSON schema; it is optional so the checks that
+    matter still run with no network access.
+    """
+    import yaml
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"could not parse .coderabbit.yaml: {exc}") from exc
+
+    if data is None:
+        raise ConfigError(".coderabbit.yaml is empty")
+    if not isinstance(data, dict):
+        raise ConfigError(
+            f".coderabbit.yaml must be a mapping, got {type(data).__name__}"
+        )
+
+    _check_docstrings_mode(data)
+    count = _check_base_branches(data)
+    if schema is not None:
+        _check_against_vendor_schema(data, schema)
+    return count
+
+
+def main() -> int:
+    """Validate the shipped config, printing the failure and returning 1."""
+    config = Path(__file__).parent.parent / ".coderabbit.yaml"
+    try:
+        count = validate_coderabbit_config(config.read_text(encoding="utf-8"))
+    except ConfigError as exc:
+        sys.stderr.write(f"{config.name}: {exc}\n")
+        return 1
+    sys.stdout.write(f"{config.name}: {count} auto-review base branch(es) OK\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1823.

`.coderabbit.yaml` had no pre-merge validation. `check-yaml` checks syntax only, and validating against the vendor schema is **not sufficient on its own** — `additionalProperties: false` is set on the root object alone, so an unknown key nested under `reviews.auto_review` validates clean.

Measured against the live vendor schema before writing anything:

| input | vendor schema | this script |
|---|---|---|
| `.coderabbit.yaml` as written | 0 errors | OK, 2 base branches |
| `base_branches` → `base_branchez` | **0 errors** | rejected, names the key |
| `mode: "off"` → `mode: off` | 2 errors | rejected, names the YAML-boolean cause |

Both failure modes are silent and both restore a bug whose whole symptom is that everything still looks green: the misspelt key reverts auto-review to the default branch only (#1581 — 14 of 18 open PRs unreviewed), and bare `off` parses as the boolean `False` so the docstring exemption stops applying (#1617).

## What this adds

`scripts/validate_coderabbit_config.py`, mirroring the existing `scripts/validate_labels.py`, wired into pre-commit (scoped to `^\.coderabbit\.yaml$`) and into `ci.yml` beside `Validate labels.yml`. It asserts the keys it cares about are **present and correctly shaped** rather than only that the document validates, and enforces the vendor root key set on top.

## Two decisions worth reviewing

**The vendor schema is not vendored.** A committed 77KB copy drifts from upstream silently. Only the root level is marked `additionalProperties: false`, so that is the only level where a schema check adds anything the key checks do not already cover — the script ships the 10-key root set and nothing else. A `slow`-marked test checks the live document when reachable and fails if upstream changes either the flag or the key set.

**Error messages name causes, not values.** Bare `off` reports "parsed as the boolean False. Bare 'off' is a YAML boolean; quote it", not "got False".

## Verification

40 tests on the new file, 75 with the two pre-existing files that read `.pre-commit-config.yaml` and `ci.yml`. Every check was mutated one at a time and reddens exactly its own test, with the tree restored from the committed baseline each time.

Two of those mutations found real defects, which is the reason for the last two commits:

- The vendor-schema check was **dead code in the shipped path** — reachable only from tests, so `main()` accepted an unknown root key and exited 0. Now the entrypoint passes the schema and that input exits 1.
- The root-key test **derived its cases from the set it was checking**, so dropping a key removed the case along with the entry and the test stayed green over a shorter list. It now compares against an independent copy, and three tests catch the deletion, two of them offline.

Local review returned 4/5; all three findings are fixed in `e26dba8b` and `d31d1d5f`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Required review configuration settings are now validated, including pre-merge documentation checks and branch patterns.
  * Invalid, malformed, or misspelled configuration entries now produce clear validation failures instead of being silently accepted.

* **Chores**
  * Configuration validation now runs automatically during pre-commit checks and continuous integration.
  * Added automated coverage for valid, invalid, malformed, and incorrectly structured configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->