### PR TITLE
fix: say whether a missing check is still coming or never arriving (#1827)

### DIFF
--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -938,6 +938,90 @@ class TestEntryFinishedHandlesBothRollupShapes:
         assert "YET" not in reason
 
 
+class TestOnlyDependenciesExplainAnAbsentAggregate:
+    """An unrelated pending check must not suppress "investigate".
+
+    `All Checks Pass` waits on AGGREGATED_JOBS and nothing else, so only
+    those being unfinished can explain its absence. Counting every
+    unfinished entry meant one unrelated pending check flipped the verdict
+    from "investigate" to "wait" -- and CodeRabbit is pending on nearly
+    every PR here, so the wrong branch was the common case. Reported by
+    Greptile on #1831.
+    """
+
+    @staticmethod
+    def _concluded() -> list[dict[str, object]]:
+        return [
+            {
+                "__typename": "CheckRun",
+                "name": job,
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+            for job in AGGREGATED_JOBS
+        ]
+
+    @staticmethod
+    def _pending(name: str) -> dict[str, object]:
+        return {
+            "__typename": "CheckRun",
+            "name": name,
+            "status": "IN_PROGRESS",
+            "conclusion": "",
+        }
+
+    def test_an_unrelated_pending_check_does_not_say_wait(self) -> None:
+        rollup = [*self._concluded(), self._pending("CodeRabbit")]
+
+        reason = absent_context_reason("All Checks Pass", rollup)
+
+        assert "re-check rather than investigate" not in reason
+        assert "not going to appear" in reason
+
+    def test_a_pending_dependency_still_says_wait(self) -> None:
+        rollup = [*self._concluded()[:-1], self._pending("Binary Smoke Test")]
+
+        reason = absent_context_reason("All Checks Pass", rollup)
+
+        assert "re-check rather than investigate" in reason
+
+    def test_a_pending_matrix_dependency_is_matched_by_prefix(self) -> None:
+        """Matrix jobs carry a platform suffix, so exact matching finds none."""
+        rollup = [
+            *self._concluded()[:-1],
+            self._pending("Unit Tests (ubuntu-latest, py3.12)"),
+        ]
+
+        reason = absent_context_reason("All Checks Pass", rollup)
+
+        assert "re-check rather than investigate" in reason
+
+    def test_a_pending_dependency_wins_over_unrelated_noise(self) -> None:
+        rollup = [
+            *self._concluded()[:-1],
+            self._pending("Binary Smoke Test"),
+            self._pending("CodeRabbit"),
+        ]
+
+        reason = absent_context_reason("All Checks Pass", rollup)
+
+        assert "re-check rather than investigate" in reason
+        assert "Binary Smoke Test" in reason
+
+    def test_the_count_names_only_dependencies(self) -> None:
+        """The number must not include checks the aggregate does not await."""
+        rollup = [
+            *self._concluded()[:-1],
+            self._pending("Binary Smoke Test"),
+            self._pending("CodeRabbit"),
+            self._pending("Fuzz (address)"),
+        ]
+
+        reason = absent_context_reason("All Checks Pass", rollup)
+
+        assert "1 check(s)" in reason
+
+
 class TestPendingNamesReadHonestly:
     """The parenthetical must not claim names it does not have."""
 
@@ -947,17 +1031,29 @@ class TestPendingNamesReadHonestly:
         assert "(Type Check)" in absent_context_reason("X", one)
 
     def test_ellipsis_only_once_names_are_omitted(self) -> None:
+        """Names must be jobs the aggregate waits on, or they are filtered.
+
+        Synthetic names (`Check 0`) no longer reach the parenthetical:
+        only unfinished AGGREGATED_JOBS entries can explain the
+        aggregate's absence, so the fixture uses four real ones.
+        """
         four = [
-            {"__typename": "CheckRun", "name": f"Check {n}", "conclusion": ""}
-            for n in range(4)
+            {"__typename": "CheckRun", "name": name, "conclusion": ""}
+            for name in AGGREGATED_JOBS[:4]
         ]
 
         assert "..." in absent_context_reason("X", four)
 
     def test_no_empty_parentheses_when_no_name_is_known(self) -> None:
+        """A dependency-shaped entry whose name cannot be read.
+
+        `context_name` returns "" for a shape carrying neither `name` nor
+        `context`, so such an entry is filtered out with the unrelated
+        ones and cannot produce an empty parenthetical.
+        """
         nameless = [{"conclusion": ""}, {"conclusion": ""}]
 
         reason = absent_context_reason("X", nameless)
 
-        assert "2 check(s)" in reason
         assert "()" not in reason
+        assert "still running" not in reason

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -896,4 +896,68 @@ class TestCheckDistinguishesPendingFromNeverRan:
 
         reasons, _ = check_pr_gated.check("1547")
 
-        assert reasons
+        assert any("required context absent at the head" in r for r in reasons)
+
+
+class TestEntryFinishedHandlesBothRollupShapes:
+    """A `StatusContext` carries `state`, never `conclusion`.
+
+    Judged by `is_concluded` alone, every third-party status is unfinished
+    forever, so a rollup containing one can never reach the all-concluded
+    branch: #1582 then reports as "still running, re-check" -- the
+    reassuring reading, in the one case that needs investigating. The
+    older `is_concluded` call site filters to a name only a `CheckRun`
+    ever has, which is why the gap stayed latent.
+    """
+
+    def test_a_finished_status_context_is_finished(self) -> None:
+        assert check_pr_gated.entry_finished(REAL_STATUS_CONTEXT) is True
+
+    def test_a_pending_status_context_is_not_finished(self) -> None:
+        pending = {"__typename": "StatusContext", "context": "X", "state": "PENDING"}
+
+        assert check_pr_gated.entry_finished(pending) is False
+
+    def test_a_queued_check_run_is_not_finished(self) -> None:
+        """The empty-STRING conclusion trap, still handled."""
+        queued = {"__typename": "CheckRun", "name": "X", "conclusion": ""}
+
+        assert check_pr_gated.entry_finished(queued) is False
+
+    def test_a_finished_status_context_does_not_block_the_verdict(self) -> None:
+        """The bug this predicate exists for, at the level that matters.
+
+        With the real captured fixture in an otherwise-concluded rollup,
+        the all-concluded branch must still be reachable.
+        """
+        rollup = [*REAL_ROLLUP_ALL_CONCLUDED, REAL_STATUS_CONTEXT]
+
+        reason = absent_context_reason("All Checks Pass", rollup)
+
+        assert "not going to appear" in reason
+        assert "YET" not in reason
+
+
+class TestPendingNamesReadHonestly:
+    """The parenthetical must not claim names it does not have."""
+
+    def test_no_ellipsis_when_every_pending_check_is_named(self) -> None:
+        one = [{"__typename": "CheckRun", "name": "Type Check", "conclusion": ""}]
+
+        assert "(Type Check)" in absent_context_reason("X", one)
+
+    def test_ellipsis_only_once_names_are_omitted(self) -> None:
+        four = [
+            {"__typename": "CheckRun", "name": f"Check {n}", "conclusion": ""}
+            for n in range(4)
+        ]
+
+        assert "..." in absent_context_reason("X", four)
+
+    def test_no_empty_parentheses_when_no_name_is_known(self) -> None:
+        nameless = [{"conclusion": ""}, {"conclusion": ""}]
+
+        reason = absent_context_reason("X", nameless)
+
+        assert "2 check(s)" in reason
+        assert "()" not in reason

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -32,6 +32,7 @@ from scripts import check_pr_gated
 from scripts.check_pr_gated import (
     AGGREGATED_JOBS,
     BLOCKED_VALIDATION_MARKERS,
+    absent_context_reason,
     context_name,
     is_concluded,
     is_real_review,
@@ -754,3 +755,145 @@ class TestEveryCheckReturnPathIsATuple:
         self._gh_is_broken(monkeypatch)
 
         assert check_pr_gated.main(["check_pr_gated.py", "9999"]) == 1
+
+
+# Captured from #1547 at 41ad9750 on 2026-09-10, the run that motivated
+# #1827: `CI Ran At Head` had passed and twenty jobs were mid-flight, and
+# the tool reported the same sentence it prints when nothing ran at all.
+REAL_ROLLUP_MID_RUN = [
+    {"__typename": "CheckRun", "name": "CI Ran At Head", "conclusion": "SUCCESS"},
+    {"__typename": "CheckRun", "name": "Analyze (python)", "conclusion": "SUCCESS"},
+    {"__typename": "CheckRun", "name": "Lint & Format", "conclusion": ""},
+    {"__typename": "CheckRun", "name": "Type Check", "conclusion": ""},
+    {
+        "__typename": "CheckRun",
+        "name": "Unit Tests (ubuntu-latest, py3.13)",
+        "conclusion": "",
+    },
+]
+
+# The #1582 shape: everything concluded, the aggregate never appeared.
+REAL_ROLLUP_ALL_CONCLUDED = [
+    {"__typename": "CheckRun", "name": "CodeQL", "conclusion": "SKIPPED"},
+    {"__typename": "CheckRun", "name": "Analyze (actions)", "conclusion": "SUCCESS"},
+]
+
+
+class TestAbsentContextReason:
+    """ "Absent" hides three states, two of which need opposite action.
+
+    `All Checks Pass` is an aggregate that reports only once its
+    dependencies finish, so it is legitimately missing for a whole run.
+    The same sentence also covers #1582, where every job concluded and it
+    never arrived. One means wait; the other means investigate.
+    """
+
+    def test_mid_run_says_the_checks_are_still_coming(self) -> None:
+        reason = absent_context_reason("All Checks Pass", REAL_ROLLUP_MID_RUN)
+
+        assert "has not reported YET" in reason
+        assert "3 check(s)" in reason
+
+    def test_mid_run_names_the_checks_still_running(self) -> None:
+        """A count alone leaves the reader to go and look anyway."""
+        reason = absent_context_reason("All Checks Pass", REAL_ROLLUP_MID_RUN)
+
+        assert "Lint & Format" in reason
+
+    def test_mid_run_does_not_name_a_finished_check_as_pending(self) -> None:
+        reason = absent_context_reason("All Checks Pass", REAL_ROLLUP_MID_RUN)
+
+        assert "CI Ran At Head" not in reason
+
+    def test_all_concluded_says_it_is_never_arriving(self) -> None:
+        reason = absent_context_reason("All Checks Pass", REAL_ROLLUP_ALL_CONCLUDED)
+
+        assert "not going to appear" in reason
+        assert "YET" not in reason
+
+    def test_an_empty_rollup_says_nothing_ran(self) -> None:
+        reason = absent_context_reason("All Checks Pass", [])
+
+        assert "no check reported at the head at all" in reason
+
+    def test_the_three_states_are_mutually_distinguishable(self) -> None:
+        """The whole point is that a reader can tell them apart.
+
+        Asserting each in isolation would pass if two returned the same
+        sentence, which is precisely the defect being fixed.
+        """
+        said = {
+            absent_context_reason("All Checks Pass", REAL_ROLLUP_MID_RUN),
+            absent_context_reason("All Checks Pass", REAL_ROLLUP_ALL_CONCLUDED),
+            absent_context_reason("All Checks Pass", []),
+        }
+
+        assert len(said) == 3
+
+    def test_a_queued_check_counts_as_pending(self) -> None:
+        """A queued check reports `conclusion: ""`, an empty STRING.
+
+        Read as concluded, a fully-queued run reports as "not going to
+        appear" -- the alarming wording, for the most ordinary state.
+        """
+        queued = [{"__typename": "CheckRun", "name": "Type Check", "conclusion": ""}]
+
+        assert "has not reported YET" in absent_context_reason("X", queued)
+
+
+class TestCheckDistinguishesPendingFromNeverRan:
+    """`check` must consult the helper, not merely be able to.
+
+    The class above stays green when the call site is deleted. This one
+    stubs the I/O seam and asserts on `check`'s own return, so removing
+    the call reddens it.
+    """
+
+    @staticmethod
+    def _stub(monkeypatch: pytest.MonkeyPatch, rollup: list[dict[str, object]]) -> None:
+        view = {
+            "headRefOid": "e" * 40,
+            "baseRefName": "main",
+            "statusCheckRollup": rollup,
+            "comments": [],
+            "reviews": [],
+        }
+
+        def fake(*args: str) -> str:
+            if args[:2] == ("pr", "view"):
+                return json.dumps(view)
+            return ""
+
+        monkeypatch.setattr(check_pr_gated, "_gh_stdout_or_empty", fake)
+
+    def test_check_says_in_flight_for_a_mid_run_pr(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._stub(monkeypatch, REAL_ROLLUP_MID_RUN)
+
+        reasons, _ = check_pr_gated.check("1547")
+
+        assert any("has not reported YET" in r for r in reasons)
+
+    def test_check_does_not_say_in_flight_once_everything_concluded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._stub(monkeypatch, REAL_ROLLUP_ALL_CONCLUDED)
+
+        reasons, _ = check_pr_gated.check("1582")
+
+        assert not any("has not reported YET" in r for r in reasons)
+        assert any("not going to appear" in r for r in reasons)
+
+    def test_a_mid_run_pr_is_still_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Wording only. A PR mid-run is not verifiably gated, and the
+        tool is right to refuse it -- the defect was that it could not say
+        why, not that it refused.
+        """
+        self._stub(monkeypatch, REAL_ROLLUP_MID_RUN)
+
+        reasons, _ = check_pr_gated.check("1547")
+
+        assert reasons

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -216,12 +216,14 @@ def absent_context_reason(context: str, rollup: list[dict[str, object]]) -> str:
     """
     if not rollup:
         return f"no check reported at the head at all, so '{context}' cannot appear"
-    pending = [context_name(entry) for entry in rollup if not is_concluded(entry)]
+    pending = [entry for entry in rollup if not entry_finished(entry)]
     if pending:
-        shown = ", ".join(sorted(name for name in pending if name)[:3])
+        names = sorted(name for name in map(context_name, pending) if name)
+        shown = ", ".join(names[:3]) + ("..." if len(names) > 3 else "")
+        named = f" ({shown})" if names else ""
         return (
             f"'{context}' has not reported YET: {len(pending)} check(s) at the "
-            f"head are still running ({shown}...). This is CI in flight, not a "
+            f"head are still running{named}. This is CI in flight, not a "
             "missing run -- re-check rather than investigate"
         )
     return (
@@ -239,6 +241,25 @@ def is_concluded(entry: dict[str, object]) -> bool:
     """
     conclusion = entry.get("conclusion")
     return isinstance(conclusion, str) and conclusion != ""
+
+
+def entry_finished(entry: dict[str, object]) -> bool:
+    """Whether a rollup entry has finished, whichever shape it is.
+
+    `is_concluded` reads `conclusion`, which a `StatusContext` does not
+    have -- it carries `state`. Judged by that predicate every third-party
+    status is unfinished forever, so a rollup containing one can never
+    reach the all-concluded branch and #1582 reports as "still running":
+    the reassuring reading, in the one case that needs investigating.
+
+    The older call site is guarded by a name test that only ever matches a
+    `CheckRun`, so the gap was latent until `absent_context_reason` began
+    judging EVERY entry (Greptile-local, PR for #1827).
+    """
+    if "conclusion" in entry or entry.get("__typename") == "CheckRun":
+        return is_concluded(entry)
+    state = entry.get("state")
+    return isinstance(state, str) and state not in ("", "PENDING", "EXPECTED")
 
 
 def unit_test_contexts(rollup: list[dict[str, object]]) -> list[str]:

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -200,6 +200,36 @@ def context_name(entry: dict[str, object]) -> str:
     return ""
 
 
+def absent_context_reason(context: str, rollup: list[dict[str, object]]) -> str:
+    """Why `context` is missing: still coming, never arriving, or no run.
+
+    "Absent" collapses two states needing opposite responses. `All Checks
+    Pass` is an aggregate that reports only once its dependencies finish,
+    so it is legitimately missing for the whole run -- yet the same
+    sentence covers the #1582 case, where every job concluded and the
+    aggregate never appeared. One says wait, the other says investigate,
+    and the reassuring reading is the one a reader defaults to (#1827).
+
+    The three are separable from the rollup already fetched, so this costs
+    no extra API call. Measured on #1547: 20 unconcluded entries alongside
+    a passing `CI Ran At Head`, reported as though nothing had run.
+    """
+    if not rollup:
+        return f"no check reported at the head at all, so '{context}' cannot appear"
+    pending = [context_name(entry) for entry in rollup if not is_concluded(entry)]
+    if pending:
+        shown = ", ".join(sorted(name for name in pending if name)[:3])
+        return (
+            f"'{context}' has not reported YET: {len(pending)} check(s) at the "
+            f"head are still running ({shown}...). This is CI in flight, not a "
+            "missing run -- re-check rather than investigate"
+        )
+    return (
+        f"'{context}' is absent although every check at the head has "
+        "concluded, so it is not going to appear"
+    )
+
+
 def is_concluded(entry: dict[str, object]) -> bool:
     """Whether a check has finished.
 
@@ -470,7 +500,10 @@ def check(pr: str) -> tuple[list[str], list[str]]:
 
     missing = required_contexts_present(rollup, [REQUIRED_CONTEXT])
     if missing:
-        reasons.append(f"required context absent at the head: {missing}")
+        reasons.append(
+            f"required context absent at the head: {missing}; "
+            + absent_context_reason(REQUIRED_CONTEXT, rollup)
+        )
     else:
         for entry in rollup:
             if context_name(entry) != REQUIRED_CONTEXT:

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -200,6 +200,16 @@ def context_name(entry: dict[str, object]) -> str:
     return ""
 
 
+def aggregated_job_for(name: str) -> str | None:
+    """The `AGGREGATED_JOBS` entry `name` belongs to, or None.
+
+    Prefix-matched for the same reason `missing_aggregated_jobs` is: the
+    matrix jobs carry their platform in the name (`Unit Tests
+    (ubuntu-latest, py3.12)`), so an exact comparison matches none of them.
+    """
+    return next((job for job in AGGREGATED_JOBS if name.startswith(job)), None)
+
+
 def absent_context_reason(context: str, rollup: list[dict[str, object]]) -> str:
     """Why `context` is missing: still coming, never arriving, or no run.
 
@@ -216,7 +226,17 @@ def absent_context_reason(context: str, rollup: list[dict[str, object]]) -> str:
     """
     if not rollup:
         return f"no check reported at the head at all, so '{context}' cannot appear"
-    pending = [entry for entry in rollup if not entry_finished(entry)]
+    # Only the jobs the aggregate WAITS ON can explain its absence. Any
+    # unfinished entry used to count, so a single unrelated pending check --
+    # CodeRabbit is pending on nearly every PR here -- flipped the verdict
+    # from "investigate" to "wait" while every dependency had concluded.
+    # That is the #1582 case reported as its opposite, which is the exact
+    # confusion this function exists to remove.
+    pending = [
+        entry
+        for entry in rollup
+        if not entry_finished(entry) and aggregated_job_for(context_name(entry))
+    ]
     if pending:
         names = sorted(name for name in map(context_name, pending) if name)
         shown = ", ".join(names[:3]) + ("..." if len(names) > 3 else "")


### PR DESCRIPTION
Closes #1827.

**Stacked on #1826** (base is `fix/1824-flag-unexecuted-reviews`, not `main`). Both change `check()` in the same file; basing on main would conflict. Merge #1826 first and GitHub will retarget this.

## The bug

`required context absent at the head: ['All Checks Pass']` was printed for two states needing opposite responses.

`All Checks Pass` is an aggregate that reports only once its dependencies finish, so it is legitimately missing for an entire run. The same sentence also covers #1582, where every job concluded and the aggregate never appeared. One means wait; the other means investigate.

Measured on #1547 while running the gate: `CI Ran At Head` had passed with twenty jobs in flight, reported as though no run existed. I could only tell the two apart by running `gh pr checks` myself — the work this tool exists to remove.

## The fix

`absent_context_reason` separates three cases from the rollup already fetched, so no extra API call:

- some entries unconcluded → CI in flight, with the count and up to three names
- all concluded, context still absent → the #1582 case, not going to appear
- no entries at all → no run exists

A mid-run PR is still refused. The defect was that it could not say **why** it refused, not that it refused.

## What the local review caught, and why it mattered

The first commit had a P1 that inverted the fix. `is_concluded` reads `conclusion`; a `StatusContext` carries `state` and has no `conclusion` key. Judged by that predicate every third-party status is unfinished forever, so a rollup containing one could never reach the all-concluded branch — and #1582 reported as *"still running, re-check rather than investigate"*. The reassuring reading, in the one case that needs investigating.

Reproduced with the repo's own captured fixture before fixing:

```
'All Checks Pass' has not reported YET: 1 check(s) at the head are
still running (CodeRabbit...). This is CI in flight, not a missing run
```

`entry_finished` now judges by shape. The pre-existing `is_concluded` call site is guarded by a name test that only ever matches a `CheckRun`, which is why the gap was latent — that site is deliberately left alone, and making the predicate shape-aware everywhere is a follow-up rather than scope here.

Also fixed from the same round: an assertion that could not fail (it asserted `reasons` was non-empty, which the stub satisfies with five unrelated reasons, and it stayed green under the very mutation it names), an unconditional trailing `...` that made one pending check look like several, and empty parentheses when no name was known.

## Verification

- 67 tests pass; 17 are new.
- Mutation, not just green: reverting `entry_finished` to the shape-blind predicate reddens exactly the two StatusContext tests. Moving the append from `reasons` to `caveats` reddens four, including the assertion that was previously vacuous. Removing the call site reddens only the two wiring tests and leaves all seven helper tests green — which is the check that the helper tests alone would not have caught a deleted call site.
- Demonstrated on live data: run against #1826, the tool now reports `20 check(s) at the head are still running` where it previously said only `absent`.
