### PR TITLE
fix: count context tokens for every provider, not only Anthropic (#1500)

### DIFF
--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -913,16 +913,27 @@ async def _refresh_context_tokens(messages: list[ModelMessage]) -> None:
     the context used", which is indistinguishable from a genuinely empty
     session and looks like abundant headroom. An approximate number is worth
     far more here than an exact absence.
+
+    The estimate runs in a THREAD. A coroutine runs synchronously until its
+    first await, so tokenising here inline blocked the interactive loop for as
+    long as it took -- measured at 3.3s on a twelve-message tool-call history,
+    with the whole UI frozen for the duration (Greptile, PR #1832). This is
+    a background refresh feeding a status line and a compaction trigger, so
+    it must never be the reason a keystroke waits.
     """
     try:
         config = settings.active_orchestrator_config
     except Exception:
         # No config at all still deserves a number: the estimate needs only
         # the messages, and the count drives compaction rather than billing.
-        app_context.session.context_tokens = estimate_message_tokens(messages)
+        app_context.session.context_tokens = await asyncio.to_thread(
+            estimate_message_tokens, messages
+        )
         return
 
-    app_context.session.context_tokens = estimate_message_tokens(messages)
+    app_context.session.context_tokens = await asyncio.to_thread(
+        estimate_message_tokens, messages
+    )
 
     # An exact count beats the estimate where it exists -- it accounts for
     # tool definitions and system-prompt overhead that tiktoken over a message

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -999,7 +999,13 @@ async def _estimate_off_loop(messages: list[ModelMessage]) -> int:
                 return
             try:
                 result = estimate_message_tokens(messages)
-            except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+            except Exception as exc:  # noqa: BLE001 - relayed to the awaiter
+                # `Exception`, not `BaseException` (SonarCloud S5754). A
+                # tokenisation failure belongs to the awaiter; a
+                # KeyboardInterrupt or SystemExit does not -- relaying one
+                # would report a shutdown signal as an estimation error, and
+                # this thread is a daemon that the interpreter is entitled to
+                # stop without ceremony.
                 _settle(loop, future, error=exc)
             else:
                 _settle(loop, future, value=result)

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -11,6 +11,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 import uuid
 from collections import deque
 from collections.abc import Callable, Coroutine
@@ -893,11 +894,63 @@ def _token_usage() -> tuple[int, int, float]:
 
 _background_tasks: set[asyncio.Task[None]] = set()
 
+# The context estimate runs on a DAEMON thread, not on `asyncio.to_thread`'s
+# default executor. That executor registers an atexit hook that JOINS its
+# threads, so a cancelled refresh still made shutdown wait out an in-flight
+# estimate -- seconds on a large history (Greptile, PR #1832). A daemon thread
+# is never joined, so an abandoned estimate cannot delay exit.
+#
+# Safe precisely because the estimate is pure and its result is discarded on
+# cancellation: it reads a message list and returns a number, touching no file
+# and no connection, so a thread killed at exit leaves nothing half-written.
+# Do NOT run anything that writes this way.
+
 
 def _spawn_background(coro: Coroutine[None, None, None]) -> None:
     task = asyncio.create_task(coro)
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
+
+
+def _settle(
+    loop: asyncio.AbstractEventLoop,
+    future: asyncio.Future[int],
+    *,
+    value: int | None = None,
+    error: BaseException | None = None,
+) -> None:
+    """Resolve `future` from another thread, ignoring an already-settled one.
+
+    A cancelled refresh leaves the future done before the daemon thread
+    finishes, and setting a result on a cancelled future raises.
+    """
+
+    def apply() -> None:
+        if future.done():
+            return
+        if error is not None:
+            future.set_exception(error)
+        else:
+            future.set_result(value or 0)
+
+    loop.call_soon_threadsafe(apply)
+
+
+async def _estimate_off_loop(messages: list[ModelMessage]) -> int:
+    """`estimate_message_tokens` on a daemon thread, awaited without blocking."""
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[int] = loop.create_future()
+
+    def run() -> None:
+        try:
+            result = estimate_message_tokens(messages)
+        except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+            _settle(loop, future, error=exc)
+        else:
+            _settle(loop, future, value=result)
+
+    threading.Thread(target=run, name="cgr-context-estimate", daemon=True).start()
+    return await future
 
 
 async def _refresh_context_tokens(messages: list[ModelMessage]) -> None:
@@ -926,14 +979,10 @@ async def _refresh_context_tokens(messages: list[ModelMessage]) -> None:
     except Exception:
         # No config at all still deserves a number: the estimate needs only
         # the messages, and the count drives compaction rather than billing.
-        app_context.session.context_tokens = await asyncio.to_thread(
-            estimate_message_tokens, messages
-        )
+        app_context.session.context_tokens = await _estimate_off_loop(messages)
         return
 
-    app_context.session.context_tokens = await asyncio.to_thread(
-        estimate_message_tokens, messages
-    )
+    app_context.session.context_tokens = await _estimate_off_loop(messages)
 
     # An exact count beats the estimate where it exists -- it accounts for
     # tool definitions and system-prompt overhead that tiktoken over a message

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -733,7 +733,7 @@ async def _run_agent_response_loop(
             # reachability check while doing nothing.
             message_history[:] = prune_old_tool_results(message_history)
 
-        _spawn_background(_refresh_context_tokens(list(message_history)))
+        _spawn_context_refresh(list(message_history))
 
         output_text = response.output
         if not isinstance(output_text, str):
@@ -906,6 +906,30 @@ _background_tasks: set[asyncio.Task[None]] = set()
 # Do NOT run anything that writes this way.
 
 
+_context_refresh_task: asyncio.Task[None] | None = None
+
+
+def _spawn_context_refresh(messages: list[ModelMessage]) -> None:
+    """Start a context refresh, superseding any still in flight.
+
+    Only the NEWEST count is wanted -- it is a percentage on a status line and
+    a compaction trigger, and an older history's total is stale the moment a
+    turn completes. Without this, several turns in quick succession each
+    started a full-history tokenisation and they ran CONCURRENTLY: measured at
+    5 simultaneous estimates from 5 refreshes (Greptile, PR #1832).
+
+    Cancelling is safe because the estimate is pure and its result is
+    discarded: `_settle` already ignores a future nobody holds.
+    """
+    global _context_refresh_task
+    if _context_refresh_task is not None and not _context_refresh_task.done():
+        _context_refresh_task.cancel()
+    task = asyncio.create_task(_refresh_context_tokens(messages))
+    _context_refresh_task = task
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
 def _spawn_background(coro: Coroutine[None, None, None]) -> None:
     task = asyncio.create_task(coro)
     _background_tasks.add(task)
@@ -933,21 +957,52 @@ def _settle(
         else:
             future.set_result(value or 0)
 
-    loop.call_soon_threadsafe(apply)
+    try:
+        loop.call_soon_threadsafe(apply)
+    except RuntimeError:
+        # The loop closed while the daemon thread was still estimating, which
+        # is the normal shape of shutdown: nothing is awaiting this future any
+        # more, and `call_soon_threadsafe` raises "Event loop is closed" on a
+        # thread with no handler, surfacing as an uncaught exception at exit
+        # (Greptile, PR #1832).
+        #
+        # Dropping the result is correct rather than merely quiet. The
+        # estimate is pure and its only consumer is the future nobody holds;
+        # there is nothing to retry, flush or report. This is the one case
+        # where "the answer no longer matters" is literally true.
+        return
+
+
+# One estimate at a time. Cancelling the awaiting TASK does not stop a daemon
+# thread already tokenising, so several turns in quick succession each started
+# a full-history walk and they ran concurrently -- measured at 5 simultaneous
+# estimates (Greptile, PR #1832). The lock makes a later estimate wait, and the
+# generation check below makes it exit instead: only the newest count is wanted.
+_estimate_lock = threading.Lock()
+_estimate_generation = 0
 
 
 async def _estimate_off_loop(messages: list[ModelMessage]) -> int:
     """`estimate_message_tokens` on a daemon thread, awaited without blocking."""
+    global _estimate_generation
     loop = asyncio.get_running_loop()
     future: asyncio.Future[int] = loop.create_future()
+    _estimate_generation += 1
+    mine = _estimate_generation
 
     def run() -> None:
-        try:
-            result = estimate_message_tokens(messages)
-        except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
-            _settle(loop, future, error=exc)
-        else:
-            _settle(loop, future, value=result)
+        with _estimate_lock:
+            if mine != _estimate_generation:
+                # Superseded while queued: a newer history is already the
+                # answer, so tokenising this one is pure waste. Left unsettled
+                # on purpose -- the awaiting task was cancelled with it.
+                return
+            try:
+                result = estimate_message_tokens(messages)
+            except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+                _settle(loop, future, error=exc)
+            else:
+                _settle(loop, future, value=result)
 
     threading.Thread(target=run, name="cgr-context-estimate", daemon=True).start()
     return await future
@@ -1022,7 +1077,7 @@ def _prime_context_token_counter(system_prompt: str) -> None:
     baseline_messages: list[ModelMessage] = [
         ModelRequest(parts=[SystemPromptPart(content=system_prompt)])
     ]
-    _spawn_background(_refresh_context_tokens(baseline_messages))
+    _spawn_context_refresh(baseline_messages)
 
 
 def _short_model_id() -> tuple[str, str]:

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -99,6 +99,7 @@ from .types_defs import (
     ToolArgs,
 )
 from .utils.rich_markdown import LeftAlignedMarkdown
+from .utils.token_utils import estimate_message_tokens
 
 if TYPE_CHECKING:
     from prompt_toolkit.key_binding import KeyPressEvent
@@ -713,12 +714,16 @@ async def _run_agent_response_loop(
         # line). Inheriting it means the shipped default is a decision the
         # repository made rather than one chosen to satisfy a review.
         #
-        # DELIBERATELY TIMID, and issue #1500 owns the policy. Two ways this
-        # declines to act: `_token_usage` reports 0 for every provider whose
-        # counter never runs (`_refresh_context_tokens` returns early unless
-        # Anthropic with a key), and `prune_old_tool_results` refuses below its
-        # own recovery floor. A mechanism that discards data should be inert
-        # where it cannot measure, so both silences are the wanted direction.
+        # DELIBERATELY TIMID, and issue #1500 owns the policy.
+        # `prune_old_tool_results` still refuses below its own recovery floor,
+        # so a mechanism that discards data stays inert until it would buy
+        # something real.
+        #
+        # It is no longer inert for want of a measurement, though. This used
+        # to read 0 for every provider whose counter never ran, which meant
+        # compaction was Anthropic-only without saying so; the counter now
+        # falls back to a local estimate, so the threshold is reachable
+        # whatever the session is talking to.
         _, _, context_pct = _token_usage()
         if context_pct >= cs.TOKEN_THRESHOLD_CRITICAL:
             # Assign THROUGH the slice: callers hold this same list and the
@@ -896,10 +901,33 @@ def _spawn_background(coro: Coroutine[None, None, None]) -> None:
 
 
 async def _refresh_context_tokens(messages: list[ModelMessage]) -> None:
+    """Update the session's context-token count, for ANY provider.
+
+    The local estimate is written FIRST and unconditionally, then upgraded to
+    the provider's exact count where one is obtainable. That order is the fix
+    for #1500: this function is the only writer of `context_tokens`, and the
+    pruning trigger reads a percentage derived from it, so every path that
+    returned without writing left compaction switched off.
+
+    Leaving the value at 0 is not a neutral failure. Zero renders as "0% of
+    the context used", which is indistinguishable from a genuinely empty
+    session and looks like abundant headroom. An approximate number is worth
+    far more here than an exact absence.
+    """
     try:
         config = settings.active_orchestrator_config
     except Exception:
+        # No config at all still deserves a number: the estimate needs only
+        # the messages, and the count drives compaction rather than billing.
+        app_context.session.context_tokens = estimate_message_tokens(messages)
         return
+
+    app_context.session.context_tokens = estimate_message_tokens(messages)
+
+    # An exact count beats the estimate where it exists -- it accounts for
+    # tool definitions and system-prompt overhead that tiktoken over a message
+    # list cannot see. Anthropic is the only provider exposing one today, so
+    # this is an upgrade to the line above, never a precondition for it.
     if config.provider != cs.Provider.ANTHROPIC or not config.api_key:
         return
     try:

--- a/codebase_rag/tests/test_context_count_any_provider.py
+++ b/codebase_rag/tests/test_context_count_any_provider.py
@@ -221,3 +221,86 @@ class TestTheCounterRunsForEveryProvider:
             "an unreadable config left the counter at 0 rather than falling "
             "back to the estimate, which needs no config at all"
         )
+
+
+class TestEveryPartTypeIsCounted:
+    """The axis the first version of this file left unvaried.
+
+    Every test above builds `ModelRequest(parts=[UserPromptPart(...)])` -- the
+    one shape the estimator handled correctly -- so all six passed while tool
+    calls counted as zero. A suite that only ever exercises the working shape
+    cannot see the defect, however many assertions it makes (greptile-local,
+    #1500).
+    """
+
+    def test_a_tool_call_is_not_free(self) -> None:
+        """`ToolCallPart` carries its payload in `args`, not `content`.
+
+        It is the only part type with no `content` field, so a loop reading
+        `content` alone scored it 0. Tool arguments carry whole file bodies
+        on this codebase, so this is the bulk of a long session's context,
+        not an edge case.
+        """
+        from pydantic_ai.messages import ModelResponse, ToolCallPart
+
+        from codebase_rag.utils.token_utils import (
+            count_tokens,
+            estimate_message_tokens,
+        )
+
+        body = "x = 1\n" * 5000
+        part = ToolCallPart(
+            tool_name="create_new_file",
+            args={"file_path": "big.py", "content": body},
+        )
+        counted = estimate_message_tokens([ModelResponse(parts=[part])])
+
+        assert counted > count_tokens(body) * 0.5, (
+            f"a tool call carrying {len(body)} characters of file content was "
+            f"counted as {counted} tokens, so a history of file writes reads "
+            "as an almost empty context and never triggers compaction"
+        )
+
+    def test_no_part_type_counts_as_zero(self) -> None:
+        """A sweep, so the next part type added cannot silently score zero.
+
+        Written as an enumeration rather than one assertion per type: the
+        failure mode is a NEW shape whose payload field nobody thought about,
+        and a test naming today's types would not catch it either -- but it
+        will catch a change to any of them, and it names the field each one
+        was counted through.
+        """
+        from pydantic_ai.messages import (
+            ModelRequest,
+            ModelResponse,
+            RetryPromptPart,
+            SystemPromptPart,
+            TextPart,
+            ToolCallPart,
+            ToolReturnPart,
+            UserPromptPart,
+        )
+
+        from codebase_rag.utils.token_utils import estimate_message_tokens
+
+        filler = "token " * 300
+        cases = {
+            "UserPromptPart": ModelRequest(parts=[UserPromptPart(content=filler)]),
+            "SystemPromptPart": ModelRequest(parts=[SystemPromptPart(content=filler)]),
+            "TextPart": ModelResponse(parts=[TextPart(content=filler)]),
+            "ToolCallPart": ModelResponse(
+                parts=[ToolCallPart(tool_name="t", args={"a": filler})]
+            ),
+            "ToolReturnPart": ModelRequest(
+                parts=[ToolReturnPart(tool_name="t", content=filler, tool_call_id="c1")]
+            ),
+            "RetryPromptPart": ModelRequest(
+                parts=[RetryPromptPart(content=filler, tool_call_id="c2")]
+            ),
+        }
+
+        zero = {name: estimate_message_tokens([m]) for name, m in cases.items()}
+        assert all(count > 0 for count in zero.values()), (
+            f"some part types contribute nothing to the context estimate: "
+            f"{ {n: c for n, c in zero.items() if c == 0} }"
+        )

--- a/codebase_rag/tests/test_context_count_any_provider.py
+++ b/codebase_rag/tests/test_context_count_any_provider.py
@@ -386,3 +386,119 @@ class TestTheRefreshDoesNotBlockTheEventLoop:
             f"the event loop was starved for {worst:.3f}s while the context "
             "estimate ran, so the whole UI freezes on a long history"
         )
+
+    @pytest.mark.asyncio
+    async def test_the_no_config_path_also_stays_off_the_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The second call site, which the test above does not reach.
+
+        `_refresh_context_tokens` estimates on TWO paths: the configured one,
+        and the fallback when the config cannot be read at all. Mutating the
+        fallback to run inline left every other test green -- it is only
+        reached when reading the config raises, which nothing else here does.
+
+        That path runs at startup, before a model is settled on, so blocking
+        the loop there freezes the UI at exactly the moment a user is waiting
+        for the first prompt.
+        """
+        import asyncio
+        import time
+
+        from codebase_rag import main as main_mod
+
+        def slow(_messages: object) -> int:
+            time.sleep(0.6)
+            return 4321
+
+        monkeypatch.setattr(main_mod, "estimate_message_tokens", slow)
+
+        def explode(self: object) -> object:
+            raise RuntimeError("no orchestrator configured")
+
+        monkeypatch.setattr(
+            type(main_mod.settings), "active_orchestrator_config", property(explode)
+        )
+        main_mod.app_context.session.context_tokens = 0
+
+        stop = asyncio.Event()
+        worst = 0.0
+
+        async def ticker() -> None:
+            nonlocal worst
+            last = time.perf_counter()
+            while not stop.is_set():
+                await asyncio.sleep(0.01)
+                now = time.perf_counter()
+                worst = max(worst, now - last)
+                last = now
+
+        task = asyncio.create_task(ticker())
+        await asyncio.sleep(0.05)
+        await main_mod._refresh_context_tokens(_messages())
+        stop.set()
+        await task
+
+        assert main_mod.app_context.session.context_tokens == 4321, (
+            "fixture guard: the fallback estimate must have run and been "
+            "written back, or a small gap proves nothing"
+        )
+        assert worst < 0.3, (
+            f"the event loop was starved for {worst:.3f}s on the no-config "
+            "path, which runs at startup while the user waits"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_refresh_does_not_hold_a_joined_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An abandoned estimate must not delay interpreter shutdown.
+
+        Moving the estimate off the loop fixed the UI freeze but introduced a
+        second cost: `asyncio.to_thread` uses an executor whose atexit hook
+        JOINS its threads, so a cancelled refresh still made shutdown wait out
+        an in-flight estimate -- seconds on a large history (Greptile, #1832).
+
+        The estimate now runs on a daemon thread, which is never joined. This
+        asserts the two properties that make that safe and observable: the
+        cancellation returns promptly rather than waiting for the work, and
+        the thread doing the work is a daemon.
+        """
+        import asyncio
+        import threading
+        import time
+
+        from codebase_rag import main as main_mod
+
+        started = threading.Event()
+        seen: dict[str, bool] = {}
+
+        def slow(_messages: object) -> int:
+            seen["daemon"] = threading.current_thread().daemon
+            started.set()
+            time.sleep(1.0)
+            return 99
+
+        monkeypatch.setattr(main_mod, "estimate_message_tokens", slow)
+        _use_config(monkeypatch, cs.Provider.OPENAI, "sk-whatever")
+
+        task = asyncio.create_task(main_mod._refresh_context_tokens(_messages()))
+        await asyncio.to_thread(started.wait, 5.0)
+        assert started.is_set(), (
+            "fixture guard: the estimate never started, so cancelling it proves nothing"
+        )
+
+        began = time.perf_counter()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        elapsed = time.perf_counter() - began
+
+        assert elapsed < 0.5, (
+            f"cancelling the refresh waited {elapsed:.2f}s for the estimate "
+            "to finish, so shutdown blocks on abandoned work"
+        )
+        assert seen.get("daemon") is True, (
+            "the estimate ran on a non-daemon thread, which the interpreter "
+            "joins at exit however promptly the await returned"
+        )

--- a/codebase_rag/tests/test_context_count_any_provider.py
+++ b/codebase_rag/tests/test_context_count_any_provider.py
@@ -1,0 +1,223 @@
+"""The context counter must work for every provider, not only Anthropic (#1500).
+
+`prune_old_tool_results` is triggered from a percentage derived from
+`session.context_tokens`, and only `_refresh_context_tokens` ever writes that
+value. It returned early unless the provider was Anthropic AND an API key was
+set, so `context_tokens` stayed 0 for OpenAI, Gemini, a local model, and for
+Anthropic with no key -- which makes the percentage 0, which is below every
+threshold, which means compaction never runs.
+
+The bug is silent and in the reassuring direction: the status line reads 0%,
+which looks like plenty of headroom rather than like a counter that never ran.
+This is the [[absence-vs-not-run]] shape -- "no context used" and "context
+never measured" rendered identically.
+
+The fix keeps the Anthropic path exactly as it was (an exact count from the
+provider beats an estimate) and adds a local tiktoken estimate for everyone
+else. The estimate is already trusted elsewhere in this codebase: it is what
+`QUERY_RESULT_MAX_TOKENS` and the pruning floor are measured in.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai.messages import ModelMessage, ModelRequest, UserPromptPart
+
+from codebase_rag import constants as cs
+
+
+def _messages(text: str = "hello " * 400) -> list[ModelMessage]:
+    """Enough text that a working counter cannot report 0.
+
+    The assertion below is `> 0`, so a fixture whose true count is 0 would
+    pass against broken code as readily as against fixed code. 400 words is
+    unambiguously non-zero under any tokeniser.
+    """
+    return [ModelRequest(parts=[UserPromptPart(content=text)])]
+
+
+def _use_config(
+    monkeypatch: pytest.MonkeyPatch, provider: object, api_key: str | None
+) -> None:
+    from codebase_rag import main as main_mod
+
+    class _Config:
+        pass
+
+    _Config.provider = provider  # type: ignore[attr-defined]
+    _Config.api_key = api_key  # type: ignore[attr-defined]
+    _Config.model_id = "some-model"  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(
+        type(main_mod.settings),
+        "active_orchestrator_config",
+        property(lambda self: _Config()),
+    )
+
+
+class TestTheCounterRunsForEveryProvider:
+    @pytest.mark.asyncio
+    async def test_a_non_anthropic_provider_gets_a_context_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The defect itself: OpenAI left the counter at 0 forever.
+
+        With the counter stuck at 0 the derived percentage is 0, so the
+        critical threshold is never crossed and `prune_old_tool_results` is
+        never called. Compaction was Anthropic-only without saying so.
+        """
+        from codebase_rag import main as main_mod
+
+        main_mod.app_context.session.context_tokens = 0
+        _use_config(monkeypatch, cs.Provider.OPENAI, "sk-whatever")
+
+        await main_mod._refresh_context_tokens(_messages())
+
+        assert main_mod.app_context.session.context_tokens > 0, (
+            "the context counter stayed at 0 for a non-Anthropic provider, so "
+            "the pruning threshold can never be crossed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_anthropic_without_a_key_gets_a_context_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The second half of the same early return.
+
+        `provider != ANTHROPIC or not api_key` has two ways to fire. Testing
+        only the provider half would leave a keyless Anthropic session with
+        the original bug and a green suite.
+        """
+        from codebase_rag import main as main_mod
+
+        main_mod.app_context.session.context_tokens = 0
+        _use_config(monkeypatch, cs.Provider.ANTHROPIC, None)
+
+        await main_mod._refresh_context_tokens(_messages())
+
+        assert main_mod.app_context.session.context_tokens > 0, (
+            "a keyless Anthropic session cannot reach the remote counter and "
+            "was left with no count at all"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_estimate_tracks_the_size_of_the_history(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A constant would satisfy `> 0` above while measuring nothing.
+
+        This is the discriminating assertion: the count has to be a function
+        of the input. A stub returning 1, or a counter reading a stale value
+        from a previous call, passes both tests above and fails this one.
+        """
+        from codebase_rag import main as main_mod
+
+        _use_config(monkeypatch, cs.Provider.OPENAI, "sk-whatever")
+
+        main_mod.app_context.session.context_tokens = 0
+        await main_mod._refresh_context_tokens(_messages("hi " * 50))
+        small = main_mod.app_context.session.context_tokens
+
+        main_mod.app_context.session.context_tokens = 0
+        await main_mod._refresh_context_tokens(_messages("hi " * 5000))
+        large = main_mod.app_context.session.context_tokens
+
+        assert small > 0 and large > small * 10, (
+            f"the estimate does not scale with the history: {small} then {large}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_anthropic_with_a_key_still_uses_the_exact_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control against over-correcting.
+
+        The obvious wrong fix is to replace the remote count with the local
+        estimate everywhere. The provider's own count is exact and accounts
+        for tool definitions and system prompt overhead that tiktoken over a
+        message list cannot see, so the Anthropic path must be untouched.
+
+        Asserts a sentinel the estimate could never produce.
+        """
+        from codebase_rag import main as main_mod
+
+        sentinel = 1234567
+
+        async def exact(*_args: object, **_kw: object) -> int:
+            return sentinel
+
+        monkeypatch.setattr(
+            "codebase_rag.services.anthropic_token_counter.count_anthropic_context",
+            exact,
+        )
+        main_mod.app_context.session.context_tokens = 0
+        _use_config(monkeypatch, cs.Provider.ANTHROPIC, "sk-real-key")
+
+        await main_mod._refresh_context_tokens(_messages())
+
+        assert main_mod.app_context.session.context_tokens == sentinel, (
+            "the exact provider count was replaced by the local estimate"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failed_remote_count_falls_back_rather_than_reporting_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A rate-limited Anthropic session must not read as empty context.
+
+        Before this, any exception left `context_tokens` at whatever it was
+        and logged at debug. On the first turn that is 0, so a transient
+        failure produced the same silent no-compaction state as the missing
+        provider support -- for the provider that DID have support.
+        """
+        from codebase_rag import main as main_mod
+        from codebase_rag.services.anthropic_token_counter import TokenCountError
+
+        async def boom(*_args: object, **_kw: object) -> int:
+            raise TokenCountError("503: unavailable")
+
+        monkeypatch.setattr(
+            "codebase_rag.services.anthropic_token_counter.count_anthropic_context",
+            boom,
+        )
+        monkeypatch.setattr(main_mod.logger, "debug", lambda msg, *a, **k: None)
+        main_mod.app_context.session.context_tokens = 0
+        _use_config(monkeypatch, cs.Provider.ANTHROPIC, "sk-real-key")
+
+        await main_mod._refresh_context_tokens(_messages())
+
+        assert main_mod.app_context.session.context_tokens > 0, (
+            "a transient remote failure left the counter at 0, which reads as "
+            "an empty context rather than an unmeasured one"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_config_still_produces_a_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The third early return, found by mutation rather than by reading.
+
+        Deleting the write on this path left every other test green. The
+        estimate needs only the messages, so a config that cannot be read is
+        no reason to report an empty context -- and this path runs at startup,
+        before a model is settled on, which is exactly when a stale 0 would
+        persist longest.
+        """
+        from codebase_rag import main as main_mod
+
+        def explode(self: object) -> object:
+            raise RuntimeError("no orchestrator configured")
+
+        monkeypatch.setattr(
+            type(main_mod.settings),
+            "active_orchestrator_config",
+            property(explode),
+        )
+        main_mod.app_context.session.context_tokens = 0
+
+        await main_mod._refresh_context_tokens(_messages())
+
+        assert main_mod.app_context.session.context_tokens > 0, (
+            "an unreadable config left the counter at 0 rather than falling "
+            "back to the estimate, which needs no config at all"
+        )

--- a/codebase_rag/tests/test_context_count_any_provider.py
+++ b/codebase_rag/tests/test_context_count_any_provider.py
@@ -304,3 +304,76 @@ class TestEveryPartTypeIsCounted:
             f"some part types contribute nothing to the context estimate: "
             f"{ {n: c for n, c in zero.items() if c == 0} }"
         )
+
+
+class TestTheRefreshDoesNotBlockTheEventLoop:
+    """The estimate must not freeze the UI while it runs (#1832 review).
+
+    A coroutine runs synchronously until its first await, so tokenising the
+    history inline stalled the interactive loop for as long as it took --
+    measured at 3.3 seconds on a twelve-message tool-call history, with every
+    keystroke and spinner frozen. This is a background refresh feeding a
+    status line; it must never be why the UI waits.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_large_history_does_not_stall_the_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Measures the LOOP, not the function.
+
+        Asserting the refresh is fast would be the wrong test: the work is
+        genuinely slow and is allowed to be. What must not happen is other
+        tasks being starved while it runs, so this times a concurrent ticker
+        and asserts its worst gap stays small.
+
+        The threshold is deliberately loose. A real regression here is
+        seconds, so the gap between pass and fail is two orders of magnitude
+        -- this is not a test that goes red because a laptop was busy.
+        """
+        import asyncio
+        import time
+
+        from codebase_rag import main as main_mod
+
+        slow_calls = 0
+
+        def slow_estimate(messages: object) -> int:
+            nonlocal slow_calls
+            slow_calls += 1
+            time.sleep(0.6)
+            return 4321
+
+        monkeypatch.setattr(main_mod, "estimate_message_tokens", slow_estimate)
+        _use_config(monkeypatch, cs.Provider.OPENAI, "sk-whatever")
+        main_mod.app_context.session.context_tokens = 0
+
+        stop = asyncio.Event()
+        worst = 0.0
+
+        async def ticker() -> None:
+            nonlocal worst
+            last = time.perf_counter()
+            while not stop.is_set():
+                await asyncio.sleep(0.01)
+                now = time.perf_counter()
+                worst = max(worst, now - last)
+                last = now
+
+        task = asyncio.create_task(ticker())
+        await asyncio.sleep(0.05)
+        await main_mod._refresh_context_tokens(_messages())
+        stop.set()
+        await task
+
+        assert slow_calls == 1, (
+            "fixture guard: the estimator must actually have run, or a gap of "
+            "zero proves nothing"
+        )
+        assert main_mod.app_context.session.context_tokens == 4321, (
+            "fixture guard: the estimate must have been written back"
+        )
+        assert worst < 0.3, (
+            f"the event loop was starved for {worst:.3f}s while the context "
+            "estimate ran, so the whole UI freezes on a long history"
+        )

--- a/codebase_rag/tests/test_context_count_any_provider.py
+++ b/codebase_rag/tests/test_context_count_any_provider.py
@@ -502,3 +502,111 @@ class TestTheRefreshDoesNotBlockTheEventLoop:
             "the estimate ran on a non-daemon thread, which the interpreter "
             "joins at exit however promptly the await returned"
         )
+
+    @pytest.mark.asyncio
+    async def test_a_late_estimate_does_not_raise_on_a_closed_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cost of the daemon thread: it outlives the loop it reports to.
+
+        A daemon thread is not joined at exit, which is what stops it delaying
+        shutdown -- and means it can finish AFTER the loop closes.
+        `call_soon_threadsafe` then raises "Event loop is closed" on a thread
+        with no handler, surfacing as an uncaught exception at exit
+        (Greptile, #1832).
+
+        Dropping the result is correct rather than merely quiet: the estimate
+        is pure and the only consumer is a future nobody holds.
+        """
+        import asyncio
+
+        from codebase_rag import main as main_mod
+
+        loop = asyncio.new_event_loop()
+        future: asyncio.Future[int] = loop.create_future()
+        loop.close()
+
+        # No raise, and nothing settled: the loop is gone.
+        main_mod._settle(loop, future, value=42)
+        assert not future.done(), (
+            "a future was settled through a closed loop, which cannot have "
+            "reached the awaiter"
+        )
+
+    @pytest.mark.asyncio
+    async def test_only_one_estimate_runs_at_a_time(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Several turns in quick succession must not tokenise in parallel.
+
+        Cancelling the awaiting TASK does not stop a daemon thread already
+        running, so five refreshes produced five simultaneous full-history
+        walks. Only the newest count is wanted -- it drives a status line and
+        a compaction trigger, and an older history's total is stale as soon as
+        a turn completes.
+
+        Asserts the PEAK concurrency, not the total count: serialising without
+        superseding would also reach a peak of one while doing all five walks,
+        so the second assertion checks the superseded ones exited instead.
+        """
+        import asyncio
+        import threading
+        import time
+
+        from codebase_rag import main as main_mod
+
+        live = 0
+        peak = 0
+        ran = 0
+        guard = threading.Lock()
+
+        def slow(_messages: object) -> int:
+            nonlocal live, peak, ran
+            with guard:
+                live += 1
+                ran += 1
+                peak = max(peak, live)
+            # Long enough that the next four refreshes are all queued behind
+            # this one. Too short and each finishes before the next arrives,
+            # so nothing is ever concurrent OR superseded and the test agrees
+            # with every implementation (measured: peak=1 ran=1 under the
+            # correct code AND under both mutations).
+            time.sleep(0.4)
+            with guard:
+                live -= 1
+            return 11
+
+        monkeypatch.setattr(main_mod, "estimate_message_tokens", slow)
+        _use_config(monkeypatch, cs.Provider.OPENAI, "sk-whatever")
+        # Reset the generation counter. It is module-global, so estimates from
+        # EARLIER TESTS leave it ahead and every refresh here then reads as
+        # superseded -- which passes this test for the wrong reason and made
+        # it blind to the generation check being removed. Found by mutating
+        # with the class scoped in, where it went green, and alone, where it
+        # went red: an order-dependent test that agreed with the code by
+        # accident.
+        monkeypatch.setattr(main_mod, "_estimate_generation", 0)
+        monkeypatch.setattr(main_mod, "_context_refresh_task", None)
+
+        # A SMALL GAP between refreshes, deliberately. With none, each task is
+        # cancelled before it reaches the estimator at all -- measured:
+        # 5 spawns, generation 1, ONE estimate -- so the test passes under
+        # every implementation and pins nothing. The gap lets each task start,
+        # which is what puts the generation check and the lock in play
+        # (5 spawns, generation 5, two estimates).
+        for _ in range(5):
+            main_mod._spawn_context_refresh(_messages())
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(2.5)
+
+        assert peak == 1, (
+            f"{peak} full-history estimates ran at once; only the newest "
+            "count is wanted, so the rest are pure waste"
+        )
+        # Measured: 1 unmutated, 5 with the generation check removed. The
+        # bound is deliberately loose enough to absorb scheduling jitter and
+        # still two orders of magnitude from the failure it catches.
+        assert ran <= 2, (
+            f"{ran} of 5 estimates ran; superseded ones must exit at the "
+            "generation check rather than tokenise a history nobody wants"
+        )

--- a/codebase_rag/tests/test_context_count_any_provider.py
+++ b/codebase_rag/tests/test_context_count_any_provider.py
@@ -122,8 +122,17 @@ class TestTheCounterRunsForEveryProvider:
         await main_mod._refresh_context_tokens(_messages("hi " * 5000))
         large = main_mod.app_context.session.context_tokens
 
-        assert small > 0 and large > small * 10, (
-            f"the estimate does not scale with the history: {small} then {large}"
+        # Split because the two halves fail for different reasons: the first
+        # says the estimator produced nothing at all, the second that it
+        # produced a constant. A composite assertion reports both as one
+        # message and leaves the reader to work out which (SonarCloud S9073).
+        assert small > 0, (
+            f"the estimator returned {small} for a non-empty history, so it "
+            "measured nothing rather than measuring something small"
+        )
+        assert large > small * 10, (
+            f"a history 100x larger estimated {large} against {small}, so the "
+            "count does not scale with the history and is effectively a constant"
         )
 
     @pytest.mark.asyncio

--- a/codebase_rag/tests/test_context_pruning.py
+++ b/codebase_rag/tests/test_context_pruning.py
@@ -622,27 +622,26 @@ def test_the_call_site_prunes_the_callers_list_and_precedes_the_counter() -> Non
         "rebinding the name prunes a copy and leaves the caller's list intact"
     )
 
+    # Matches `_spawn_context_refresh(list(...))`, which superseded
+    # `_spawn_background(_refresh_context_tokens(list(...)))` when refreshes
+    # were serialised so several turns cannot tokenise concurrently (#1832).
+    # The property under test is unchanged: the prune must precede the call
+    # that snapshots the history for the counter.
     spawn_lines = [
         node.lineno
         for node in ast.walk(tree)
         if isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
-        and node.func.id == "_spawn_background"
+        and node.func.id == "_spawn_context_refresh"
         and any(
             isinstance(a, ast.Call)
             and isinstance(a.func, ast.Name)
-            and a.func.id == "_refresh_context_tokens"
-            and any(
-                isinstance(inner, ast.Call)
-                and isinstance(inner.func, ast.Name)
-                and inner.func.id == "list"
-                for inner in ast.walk(a)
-            )
+            and a.func.id == "list"
             for a in node.args
         )
     ]
     assert spawn_lines, (
-        "found no _spawn_background(_refresh_context_tokens(list(...))); the "
+        "found no _spawn_context_refresh(list(...)); the "
         "counter's snapshot call changed shape and this guard has drifted"
     )
     assert min(assign.lineno for assign in slice_assignments) < max(spawn_lines), (

--- a/codebase_rag/utils/token_utils.py
+++ b/codebase_rag/utils/token_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from functools import cache
 
 import tiktoken
@@ -51,3 +52,26 @@ def truncate_results_by_tokens(
         total_tokens += row_tokens
 
     return kept, total_tokens, False
+
+
+def estimate_message_tokens(messages: Iterable[object]) -> int:
+    """A provider-independent estimate of what a message history costs.
+
+    Exists because the exact count is only available from Anthropic, and a
+    counter that runs for one provider is a counter that silently does not
+    bound anyone else's context (#1500). This is deliberately the same
+    tiktoken measure the rest of the codebase already budgets in, so the
+    pruning floor and this trigger speak one unit.
+
+    Content that is not a string is stringified rather than skipped. Skipping
+    would under-report exactly the structured tool payloads that dominate a
+    long session, and under-reporting is the direction that fails to compact.
+    """
+    total = 0
+    for message in messages:
+        for part in getattr(message, "parts", ()) or ():
+            content = getattr(part, "content", None)
+            if content is None:
+                continue
+            total += count_tokens(content if isinstance(content, str) else str(content))
+    return total

--- a/codebase_rag/utils/token_utils.py
+++ b/codebase_rag/utils/token_utils.py
@@ -70,8 +70,35 @@ def estimate_message_tokens(messages: Iterable[object]) -> int:
     total = 0
     for message in messages:
         for part in getattr(message, "parts", ()) or ():
-            content = getattr(part, "content", None)
-            if content is None:
-                continue
-            total += count_tokens(content if isinstance(content, str) else str(content))
+            total += _part_tokens(part)
+    return total
+
+
+def _part_tokens(part: object) -> int:
+    """One message part's cost, whichever field carries its payload.
+
+    `ToolCallPart` is the one part type with NO `content`: its payload lives
+    in `args`, so reading `content` alone counted every tool call as zero.
+    That is the under-reporting direction -- a history of file writes measured
+    0.1% of the window when it was really over 100% of it, so the compaction
+    this estimate exists to trigger never fired for exactly the tool-heavy
+    sessions that need it (greptile-local, #1500).
+
+    `args_as_json_str()` is preferred over `str(args)` because it is what
+    actually goes on the wire; the repr of a dict is a near-enough number by
+    accident rather than by construction.
+    """
+    if (as_json := getattr(part, "args_as_json_str", None)) is not None:
+        try:
+            return count_tokens(as_json())
+        except Exception:
+            # A malformed or unserialisable payload still occupies context;
+            # falling through to the fields below beats counting it as zero.
+            pass
+    total = 0
+    for field in ("content", "args"):
+        value = getattr(part, field, None)
+        if value is None:
+            continue
+        total += count_tokens(value if isinstance(value, str) else str(value))
     return total


### PR DESCRIPTION
Closes the second half of #1500. #1506 shipped `prune_old_tool_results` with no
caller; it is wired now, but only reachable for one provider, which is what
this fixes.

## The gap

`_refresh_context_tokens` is the ONLY writer of `session.context_tokens`, and
the compaction trigger fires on a percentage derived from it. It returned early
unless the provider was Anthropic AND an API key was set, so the count stayed 0
for OpenAI, Gemini, a local model, and for Anthropic without a key.

0 tokens renders as **0% of the context used**, which looks like abundant
headroom rather than like a gauge that never ran, so the threshold was never
crossed and compaction silently never happened. #1506's own body predicted
this ("a trigger built on it today would silently protect only Anthropic
users"); the trigger was built on it anyway.

## The fix

Write a local tiktoken estimate first and unconditionally, then upgrade to the
provider's exact count where one is obtainable. The estimate is the unit the
rest of the codebase already budgets in (`QUERY_RESULT_MAX_TOKENS`, the pruning
floor), so the trigger and the floor speak the same language.

The Anthropic path is untouched: an exact count beats an estimate, because it
accounts for tool definitions and system-prompt overhead that tiktoken over a
message list cannot see. The estimate is an upgrade to the floor, never a
replacement for the ceiling.

## Tool calls are context too

The first version of the estimator read `part.content`. `ToolCallPart` is the
one part type with no `content` field -- its payload is in `args` -- so every
tool call counted as **zero**. On this codebase those args carry whole file
bodies (`create_new_file(file_path, content)`), so a 120-turn file-writing
session estimated 120 tokens (0.1% of a 200k window) against a true 241,800
(120.9%). The bug this PR exists to fix, still live for exactly the sessions
that need compaction most. Caught in local review, fixed, and covered by a
test that reddens against the pre-fix code.

## Tests

Eight, in `codebase_rag/tests/test_context_count_any_provider.py`:

- a non-Anthropic provider gets a count, and so does keyless Anthropic (the
  early return had two ways to fire, and testing one would leave the other);
- the estimate SCALES with the history, so a stub returning a constant fails;
- the Anthropic exact count still wins, asserted with a sentinel the estimate
  could never produce -- the control against replacing the ceiling;
- a transient remote failure falls back rather than reporting 0;
- an unreadable config still produces a count (found by mutation: deleting
  that write left every other test green);
- a tool call is not free, and a sweep asserting no part type counts as zero.

Every fix line was mutated individually and reddens only its own test.

## Known limits, not fixed here

- The estimate cannot see tool definitions or system-prompt overhead, so it
  runs under the true count. Under-reporting means compaction fires later
  than the percentage reads; it is the safe direction for a mechanism that
  discards data, and the exact count is used wherever it is available.
- Overlapping background refreshes have no generation guard, so an
  out-of-order completion can write a stale count over a newer one. That is
  pre-existing on the Anthropic path and not introduced here; filing
  separately rather than widening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context usage is now estimated consistently across all providers, including sessions without configuration or authentication.
  * Context pruning works reliably when exact provider counts are unavailable.
  * Tool calls and supported message content types are included in token estimates.
  * Exact token counts continue to be used when available.
  * Token estimation no longer blocks the interactive interface during context refreshes.
  * Cancelled refreshes return promptly, and background estimation no longer delays application shutdown.
  * Overlapping refreshes now use only the latest conversation history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->