### PR TITLE
fix: a file parsing to no definitions must retract its stale call sites (#1794)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -4451,8 +4451,22 @@ class GraphUpdater:
                 continue
             if captures_cache is not None and file_path in captures_cache:
                 cached = captures_cache[file_path]
-                if not cached.get(cs.CAPTURE_CALL) and not cached.get(
-                    cs.CAPTURE_FUNCTION
+                # The perf skip (e65d8b08) reads "this file has no call sites
+                # and no functions, so the call walk has nothing to find".
+                # That is only true when the parse produced SOMETHING: a
+                # wholly empty entry means the combined query matched nothing
+                # at all, and a module-level reference (a dispatch dict
+                # holding an imported handler) is a call the walk still has to
+                # emit -- it lives under neither capture.
+                #
+                # This distinction only became reachable when the re-parse
+                # started writing empty entries to keep the cache honest
+                # (#1794). Before that an empty entry could not exist, so the
+                # skip and the emptiness test happened to agree.
+                if (
+                    cached
+                    and not cached.get(cs.CAPTURE_CALL)
+                    and not cached.get(cs.CAPTURE_FUNCTION)
                 ):
                     continue
             self.factory.call_processor.process_calls_in_file(

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -499,7 +499,18 @@ class DefinitionProcessor(
                 if combined_query:
                     cursor = QueryCursor(combined_query)
                     combined_captures = sorted_captures(cursor, root_node)
-            if self._func_class_captures_cache is not None:
+            # An UNAVAILABLE query is not an empty result. `combined_captures`
+            # stays None when the language has no combined query (or building
+            # it raised), and caching {} for that would tell the call walk
+            # "this file has no functions" when the truth is "nobody looked".
+            # Measured: it attributed a call to the MODULE alongside the
+            # correct function-owned edge, so the graph gained a spurious
+            # `proj.pkg.caller CALLS ...` beside `proj.pkg.caller.run CALLS
+            # ...` (Greptile, PR #1833). Absent is the honest state there, and
+            # it is what the reader already falls back on.
+            if self._func_class_captures_cache is not None and (
+                combined_captures is not None
+            ):
                 # Write unconditionally, including the EMPTY entry. The two
                 # truthiness guards this replaces both skipped the write when
                 # the file yielded nothing, which LEFT THE PREVIOUS PARSE'S

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -499,13 +499,29 @@ class DefinitionProcessor(
                 if combined_query:
                     cursor = QueryCursor(combined_query)
                     combined_captures = sorted_captures(cursor, root_node)
-            if self._func_class_captures_cache is not None and combined_captures:
+            if self._func_class_captures_cache is not None:
+                # Write unconditionally, including the EMPTY entry. The two
+                # truthiness guards this replaces both skipped the write when
+                # the file yielded nothing, which LEFT THE PREVIOUS PARSE'S
+                # ENTRY in place -- captures holding nodes from a tree that
+                # has since been discarded.
+                #
+                # A file emptied (or made unparseable) between runs is exactly
+                # that case: its AST cache is correctly refreshed to the empty
+                # tree, but `_process_function_calls` reads these captures, so
+                # it walked the OLD call sites and re-emitted a CALLS edge out
+                # of a function that no longer exists in the source (#1794).
+                # `_load_ast_from_disk` already pops this cache on eviction for
+                # the same reason; the re-parse path has to keep it true too.
+                #
+                # An absent entry and an empty one are not the same thing to
+                # the reader: absent means "not parsed this run, look at the
+                # AST", empty means "parsed, and it has nothing".
                 cache_entry: dict[str, list] = {}
                 for key in (cs.CAPTURE_FUNCTION, cs.CAPTURE_CLASS, cs.CAPTURE_CALL):
-                    if key in combined_captures:
+                    if combined_captures and key in combined_captures:
                         cache_entry[key] = combined_captures[key]
-                if cache_entry:
-                    self._func_class_captures_cache[file_path] = cache_entry
+                self._func_class_captures_cache[file_path] = cache_entry
 
             # A reused updater's second run re-parses this module into a map
             # still holding the first run's spans. The key is (module_qn,

--- a/codebase_rag/tests/test_reingest_empty_file_calls.py
+++ b/codebase_rag/tests/test_reingest_empty_file_calls.py
@@ -147,3 +147,43 @@ def test_a_still_defined_function_keeps_its_calls(tmp_path: Path) -> None:
         "a still-present call was retracted, so the fix over-corrected and "
         "drops live edges on every re-parse"
     )
+
+
+def test_a_module_level_reference_survives_the_re_parse(tmp_path: Path) -> None:
+    """The other half of the fix, which nothing here was pinning.
+
+    Writing empty cache entries made them possible for the first time, and a
+    pre-existing perf skip read "no call captures and no function captures" as
+    "nothing to do". That is true only when the parse produced SOMETHING: a
+    module-level reference -- a dispatch dict holding an imported handler --
+    is a real call edge that lives under NEITHER capture, so an empty entry
+    made the walk skip a file that still had an edge to emit.
+
+    Reverting that guard leaves every other test in this file green; the only
+    thing catching it was `test_src_layout_dispatch_dict_value` in
+    `test_python_source_root_imports.py`, whose name gives no hint that it
+    guards this behaviour, so rewriting that test would silently un-fix this
+    branch (greptile-local, #1794).
+    """
+    _fixture(tmp_path)
+    (tmp_path / "pkg" / "dispatch.py").write_text(
+        "from pkg.util import helper\n\nTABLE = {'h': helper}\n", encoding="utf-8"
+    )
+    updater, store = _built(tmp_path)
+
+    edge = ("proj.pkg.dispatch", "proj.pkg.util.helper")
+    assert edge in _calls(store), (
+        "fixture guard: the module-level reference must be emitted by the "
+        f"initial index, or the re-parse below proves nothing: {sorted(_calls(store))}"
+    )
+
+    # Re-parse the dispatch module itself. Its captures are empty -- the
+    # reference is neither a call site nor a function -- so this is exactly
+    # the file the skip would drop.
+    updater.reingest(["pkg/dispatch.py"])
+    store.flush_all()
+
+    assert edge in _calls(store), (
+        "a module-level reference was dropped by the re-parse: the file's "
+        f"captures are empty, so the call walk skipped it entirely: {sorted(_calls(store))}"
+    )

--- a/codebase_rag/tests/test_reingest_empty_file_calls.py
+++ b/codebase_rag/tests/test_reingest_empty_file_calls.py
@@ -1,0 +1,149 @@
+"""A file that parses to no definitions must retract its old CALLS edges (#1794).
+
+`reingest` deletes a re-parsed file's Module subtree and then re-resolves its
+calls. The re-resolution reads `_func_class_captures_cache`, which was only
+WRITTEN when the new parse produced captures -- so a file emptied between runs
+skipped the write and left the PREVIOUS parse's captures in place. Those
+captures hold nodes from a tree that has since been discarded, so the call
+walk re-emitted an edge out of a function no longer present in the source.
+
+The graph then asserted `proj.pkg.app.run CALLS proj.pkg.util.helper` with
+`run` deleted -- an edge whose source node does not exist. A clean index of
+the same tree emits nothing, so the incremental and batch paths disagreed.
+
+This is the watcher's normal mid-write state: an editor that truncates before
+writing leaves a zero-length file, and a save caught at that instant produced
+exactly this.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+UTIL = "def helper():\n    return 1\n"
+APP = "from pkg.util import helper\n\n\ndef run():\n    return helper()\n"
+
+
+def _fixture(root: Path) -> None:
+    (root / "pkg").mkdir()
+    (root / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "pkg" / "util.py").write_text(UTIL, encoding="utf-8")
+    (root / "pkg" / "app.py").write_text(APP, encoding="utf-8")
+
+
+def _calls(store: _StatefulIngestor) -> set[tuple[str, str]]:
+    return {
+        (str(src), str(dst))
+        for (_sl, src, rel, _tl, dst) in store.edges
+        if rel == "CALLS"
+    }
+
+
+def _built(root: Path) -> tuple[GraphUpdater, _StatefulIngestor]:
+    parsers, queries = load_parsers()
+    if "python" not in {str(k) for k in parsers}:
+        pytest.skip("python parser not available")
+    store = _StatefulIngestor()
+    updater = GraphUpdater(
+        ingestor=store,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run(force=True)
+    store.flush_all()
+    return updater, store
+
+
+@pytest.mark.parametrize(
+    ("new_content", "label"),
+    [
+        ("", "emptied"),
+        ("\x00\xff not python at all \x00", "unparseable"),
+    ],
+    ids=["emptied", "unparseable"],
+)
+def test_a_file_parsing_to_no_definitions_retracts_its_calls(
+    tmp_path: Path, new_content: str, label: str
+) -> None:
+    """Both routes to "no definitions" must retract, not just the empty one.
+
+    Parametrised because the two reach the same state by different paths: an
+    empty file produces no captures at all, while unparseable bytes produce a
+    tree whose captures are empty. A fix guarding only on `content == ""`
+    would pass the first and fail the second.
+    """
+    _fixture(tmp_path)
+    updater, store = _built(tmp_path)
+
+    assert _calls(store) == {("proj.pkg.app.run", "proj.pkg.util.helper")}, (
+        "fixture guard: the initial index must emit the edge that is later "
+        "expected to be retracted, or this test proves nothing"
+    )
+
+    (tmp_path / "pkg" / "app.py").write_text(new_content, encoding="utf-8")
+    updater.reingest(["pkg/app.py"])
+    store.flush_all()
+
+    assert _calls(store) == set(), (
+        f"a {label} file left a CALLS edge out of a function that no longer "
+        f"exists in the source: {sorted(_calls(store))}"
+    )
+
+
+def test_the_incremental_result_matches_a_clean_index(tmp_path: Path) -> None:
+    """The property that actually matters, stated against a real rebuild.
+
+    Asserting an empty set is right here but would not notice a fix that
+    over-retracted. Comparing against a clean index of the same tree pins
+    incremental and batch together whatever the correct answer turns out to
+    be, which is the invariant the issue is really about.
+    """
+    _fixture(tmp_path)
+    updater, store = _built(tmp_path)
+    (tmp_path / "pkg" / "app.py").write_text("", encoding="utf-8")
+    updater.reingest(["pkg/app.py"])
+    store.flush_all()
+
+    clean_root = tmp_path.parent / "clean"
+    clean_root.mkdir()
+    _fixture(clean_root)
+    (clean_root / "pkg" / "app.py").write_text("", encoding="utf-8")
+    _, clean_store = _built(clean_root)
+
+    assert _calls(store) == _calls(clean_store), (
+        "the incremental path and a clean index disagree about CALLS: "
+        f"incremental={sorted(_calls(store))} clean={sorted(_calls(clean_store))}"
+    )
+
+
+def test_a_still_defined_function_keeps_its_calls(tmp_path: Path) -> None:
+    """The control against over-retracting.
+
+    The obvious wrong fix is to drop a re-parsed file's captures and never
+    rewrite them, which retracts every edge rather than only the stale ones.
+    This edit leaves `run` defined and still calling `helper`, so the edge
+    must SURVIVE -- and the issue records that this shape was already handled
+    correctly, so it must stay that way.
+    """
+    _fixture(tmp_path)
+    updater, store = _built(tmp_path)
+
+    (tmp_path / "pkg" / "app.py").write_text(
+        "from pkg.util import helper\n\n\ndef run():\n    return helper() + 1\n",
+        encoding="utf-8",
+    )
+    updater.reingest(["pkg/app.py"])
+    store.flush_all()
+
+    assert _calls(store) == {("proj.pkg.app.run", "proj.pkg.util.helper")}, (
+        "a still-present call was retracted, so the fix over-corrected and "
+        "drops live edges on every re-parse"
+    )

--- a/codebase_rag/tests/test_reingest_empty_file_calls.py
+++ b/codebase_rag/tests/test_reingest_empty_file_calls.py
@@ -187,3 +187,49 @@ def test_a_module_level_reference_survives_the_re_parse(tmp_path: Path) -> None:
         "a module-level reference was dropped by the re-parse: the file's "
         f"captures are empty, so the call walk skipped it entirely: {sorted(_calls(store))}"
     )
+
+
+def test_an_unavailable_query_is_not_cached_as_an_empty_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "Nobody looked" must not be recorded as "there is nothing there".
+
+    `combined_captures` stays None when a language has no combined query, or
+    when building it raised. Writing `{}` for that case told the call walk the
+    file has no functions, and it then attributed a call to the MODULE
+    alongside the correct function-owned edge -- a spurious
+    `proj.pkg.caller CALLS ...` beside `proj.pkg.caller.run CALLS ...`.
+
+    The same absent-vs-empty distinction the fix above depends on, in the
+    opposite direction: there, absent wrongly meant "nothing changed"; here,
+    empty wrongly means "nothing is there". Both are cases of a cache entry
+    that cannot say which question it is answering (Greptile, PR #1833).
+
+    Asserted against the edge set a working combined query produces, so the
+    test states the invariant -- an unavailable query must not CHANGE the
+    answer -- rather than a hardcoded expectation.
+    """
+    from codebase_rag import constants as cs
+    from codebase_rag.parsers import definition_processor as dp
+
+    _fixture(tmp_path)
+    (tmp_path / "pkg" / "caller.py").write_text(
+        "from pkg.util import helper\n\n\ndef run():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    _, with_query = _built(tmp_path)
+    expected = _calls(with_query)
+    assert expected, (
+        "fixture guard: the working-query index must emit at least one call "
+        "edge, or the comparison below is vacuous"
+    )
+
+    monkeypatch.setitem(
+        dp.COMBINED_FUNC_CLASS_IMPORT_QUERIES, cs.SupportedLanguage.PYTHON, None
+    )
+    _, without_query = _built(tmp_path)
+
+    assert _calls(without_query) == expected, (
+        "an unavailable combined query changed the call edges: "
+        f"without={sorted(_calls(without_query))} with={sorted(expected)}"
+    )


### PR DESCRIPTION
Closes #1794.

## The bug

A file whose new content parses to NO definitions (emptied, or unparseable)
kept the `CALLS` edges its now-deleted functions used to emit. The graph
asserted `proj.pkg.app.run CALLS proj.pkg.util.helper` with `run` absent from
the source; a clean index of the same tree emits nothing, so the incremental
and batch paths disagreed.

This is the watcher's normal mid-write state: an editor that truncates before
writing leaves a zero-length file, and a save caught at that instant produced
exactly this.

## Root cause, found by instrumentation rather than reading

My first hypothesis was the inbound-edge restore, and it was wrong. That path
receives zero rows here, and the deletion works correctly:

```
delete_module_subtree('pkg/app.py') CALLS [('proj.pkg.app.run', ...)] -> []
restore called with 0 rows
final CALLS: [('proj.pkg.app.run', 'proj.pkg.util.helper')]
run node present after reingest: []
```

So the edge is deleted and then RE-EMITTED, out of a node that no longer
exists. The AST cache is not the culprit either -- it refreshes to the empty
tree correctly.

The stale input is `_func_class_captures_cache`. Its write was guarded twice:

```python
if self._func_class_captures_cache is not None and combined_captures:
    ...
    if cache_entry:
        self._func_class_captures_cache[file_path] = cache_entry
```

A file yielding nothing fails both guards, so the write is SKIPPED and the
previous parse's entry survives -- captures holding tree-sitter nodes from a
tree that has since been discarded. Measured across the re-parse: `captures
before: calls=1 funcs=1`, `captures after: calls=1 funcs=1`, against an AST
that is now empty. `_process_function_calls` reads those captures and walks
call sites belonging to the discarded tree.

`_load_ast_from_disk` already pops this cache on eviction, with a comment
saying evicted files carry stale captures. The re-parse path needed the same
invariant and did not have it.

## The fix, in two parts

1. **`definition_processor.py`** -- write the entry unconditionally, including
   the empty one. An absent entry and an empty entry mean different things to
   the reader ("not parsed this run, use the AST" vs "parsed, and there is
   nothing in it"), and collapsing them let a stale entry impersonate a fresh
   one.

2. **`graph_updater.py`** -- empty entries did not previously exist, so a perf
   skip reading "no calls and no functions, so nothing to do" now fired for
   files it never used to. A module-level reference (a dispatch dict holding
   an imported handler) is a real edge that lives under NEITHER capture. Found
   by a regression: `test_src_layout_dispatch_dict_value` went red.

## Scope, wider than the issue reports

The local review verified the fix also repairs comment-only, import-only,
whitespace-only, docstring-only and module-data-only edits, and that it holds
for JavaScript and TypeScript as well as Python.

## Tests

`codebase_rag/tests/test_reingest_empty_file_calls.py`, five:

- both leaking shapes, parametrised (empty and unparseable reach the same
  state by different routes; a fix keyed on `content == ""` passes one and
  fails the other);
- incremental output compared against a real clean index of the same tree
  rather than a hardcoded empty set, which pins the two paths together
  whatever the right answer is;
- a control on the third row of the issue's table (`run` still defined, call
  removed) asserting the edge SURVIVES, against the obvious over-correction;
- a module-level reference surviving its own re-parse. That one exists because
  the review found the `graph_updater.py` half was protected only by an
  unrelated src-layout import test, whose name gives no hint it guards this
  branch -- so rewriting it would have silently un-fixed the code.

834 passed across the 60-file affected set. Every fix line mutated
individually and reddens only its own test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved single-file indexing by correctly identifying project context without creating unnecessary project-wide caches.
  - Preserved definitions from unaffected sibling files during incremental cleanup.
  - Fixed stale call relationships after files become empty or unparseable.
  - Preserved valid function and module-level references during re-indexing.
  - Ensured incremental indexing matches clean rebuild results.
  - Prevented unavailable combined queries from being cached as empty results.
  - Ensured scoped re-indexing fully refreshes findings and saved state.

- **Tests**
  - Added regression coverage for empty and unparseable files, retained references, and query caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->