### PR TITLE
fix: select Cypher prompt graph-algorithm guidance by backend (#1813)

### DIFF
--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -131,7 +131,7 @@ This deployment is Neo4j. Answer algorithmic questions (paths, cycles, reachabil
 - **Reachability / paths**: a bounded variable-length pattern, e.g. `MATCH p = (a)-[:CALLS*1..6]->(b)`, with `LIMIT`.
 - **Shortest path**: `shortestPath((a)-[:CALLS*1..10]->(b))`, which is built in.
 - **Cycles**: a bounded pattern returning to its start, e.g. `MATCH p = (a)-[:CALLS*1..6]->(a)`.
-- **Ranking / "most called"**: aggregate instead of a centrality procedure, e.g. `MATCH (:Function)-[r:CALLS]->(f:Function) RETURN f.qualified_name AS name, count(r) AS callers ORDER BY callers DESC LIMIT 10`.
+- **Ranking / "most called"**: aggregate instead of a centrality procedure, e.g. `MATCH (c:Function)-[r:CALLS]->(f:Function) WHERE f.qualified_name STARTS WITH '<project>.' AND c.qualified_name STARTS WITH '<project>.' RETURN f.qualified_name AS name, count(r) AS callers ORDER BY callers DESC LIMIT 10`. Restrict EVERY alias the aggregate counts over, not only the one you return: an unrestricted end makes the total span projects you did not ask about.
 - **Existence of an edge**: prefer the bare pattern predicate `WHERE (a)-[:CALLS]->(b)` or `WHERE EXISTS { (a)-[:CALLS]->(b) }`, which is the GQL-conformant spelling.
 
 **2c. When Cypher Can't Answer**

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from loguru import logger
 
+from .config import settings
 from .cypher_queries import (
     CYPHER_EXAMPLE_CLASS_METHODS,
     CYPHER_EXAMPLE_CODE_SMELLS,
@@ -19,6 +20,7 @@ from .cypher_queries import (
     CYPHER_EXAMPLE_SECURITY_ISSUES,
     CYPHER_EXAMPLE_TASKS,
 )
+from .graph_dialects import DIALECT_MEMGRAPH
 from .schema_builder import GRAPH_SCHEMA_DEFINITION
 from .tools.tool_descriptions import AgenticToolName
 from .types_defs import ToolNames
@@ -57,7 +59,14 @@ def extract_tool_names(tools: list["Tool"]) -> ToolNames:
     )
 
 
-CYPHER_QUERY_RULES = """**2. Critical Cypher Query Rules**
+# Section 2 is engine-neutral; the algorithm catalogue below is not.
+# MAGE procedures (nxalg.*, wcc.*, pagerank.*, path.expand, ...) exist only
+# on Memgraph. Neo4j 5 has none of them: the nearest equivalents are GDS
+# (a different call shape, needing a projected graph) and APOC, and both
+# are separately installed plugins that cannot be assumed present -- so a
+# non-Memgraph backend gets no catalogue and leans on the bounded Cypher
+# section 2 already specifies in full (issue #1813).
+_CYPHER_QUERY_RULES_TEMPLATE = """**2. Critical Cypher Query Rules**
 
 - **ALWAYS Return Specific Properties with Aliases**: Do NOT return whole nodes (e.g., `RETURN n`). You MUST return specific properties with clear aliases (e.g., `RETURN n.name AS name`).
 - **Use `STARTS WITH` for Paths**: When matching paths, always use `STARTS WITH` for robustness (e.g., `WHERE n.path STARTS WITH 'workflows/src'`). Do not use `=`.
@@ -66,8 +75,17 @@ CYPHER_QUERY_RULES = """**2. Critical Cypher Query Rules**
 - **Querying Lists**: To check if a list property (like `decorators`) contains an item, use the `ANY` or `IN` clause (e.g., `WHERE 'flow' IN n.decorators`).
 - **Match the asked-about relationship explicitly and RETURN it**: For questions about callers, callees, usage, or dependencies, match the specific edge (e.g., `(caller)-[r:CALLS]->(callee)`) and include `type(r) AS relationship` in the RETURN clause. A bare node list is ambiguous — the file that *defines* or *imports* a function is not a *caller* of it, and the consumer can only tell them apart if the relationship type is in the results.
 - **Prefer multi-label matches over guessing one label**: When the node kind is uncertain, match `(n:Function|Method)` (or `(n:Function|Method|Class)`) instead of a single label — a wrong single label silently returns nothing. Leave the *other* end of a relationship pattern unlabeled when any node kind is a valid answer (e.g., module-level code also has `CALLS` edges).
-- **NEVER use unbounded variable-length paths**: Patterns like `[:CALLS*]`, `[*]`, `[:CALLS*1..]` enumerate every path in the graph and exhaust memory. Always cap with an upper bound, e.g. `[:CALLS*1..6]`. If you genuinely need unbounded reachability, use a MAGE procedure (see Section 2b) instead of variable-length Cypher.
+- **NEVER use unbounded variable-length paths**: Patterns like `[:CALLS*]`, `[*]`, `[:CALLS*1..]` enumerate every path in the graph and exhaust memory. Always cap with an upper bound, e.g. `[:CALLS*1..6]`.@@UNBOUNDED_REACHABILITY@@
+"""
 
+_UNBOUNDED_REACHABILITY_SLOT = "@@UNBOUNDED_REACHABILITY@@"
+
+_MAGE_UNBOUNDED_REACHABILITY = (
+    " If you genuinely need unbounded reachability, use a MAGE procedure"
+    " (see Section 2b) instead of variable-length Cypher."
+)
+
+_MAGE_SECTIONS = """
 **2b. Graph Algorithm Procedures (MAGE)**
 
 For algorithmic questions (longest/shortest paths, cycles, recursion clusters, centrality, communities, reachability), prefer calling a MAGE procedure over writing variable-length Cypher. Cypher path patterns enumerate all matches with no memoization, so they OOM on cyclic graphs; MAGE procedures run real graph algorithms in bounded memory.
@@ -97,20 +115,66 @@ If a question cannot be expressed as a bounded Cypher pattern or as a single MAG
 - "longest call chain" → `CALL nxalg.strongly_connected_components() YIELD components RETURN components` (let the orchestrator post-process), or use `CALL path.expand` with a generous but finite `maxHops`.
 - "find a deeply-nested call site" → use a bounded depth such as `[:CALLS*1..10]` with `ORDER BY ... LIMIT 1`."""
 
+# Section 2b's MAGE note recommends `EXISTS((a)-[:CALLS]->(b))`. That form
+# is NOT removed in Neo4j 5 -- `exists(<pattern>)` is a current predicate
+# function there, documented with `exists((p)-[:ACTED_IN]->())` as its own
+# example; what v5 replaced is the PROPERTY overload `exists(prop)`, by
+# `prop IS NOT NULL`. So this section states a PREFERENCE for the
+# GQL-conformant `EXISTS { ... }` rather than a false removal claim --
+# shipping a wrong "X was removed" is the same defect class as the MAGE
+# catalogue this split exists to stop serving.
+_NEO4J_SECTIONS = """
+**2b. Graph Algorithms**
 
-def build_graph_schema_and_rules() -> str:
-    return f"""You are an expert AI assistant for analyzing codebases using a **hybrid retrieval system**: a **Memgraph knowledge graph** for structural queries and a **semantic code search engine** for intent-based discovery.
+This deployment is Neo4j. Answer algorithmic questions (paths, cycles, reachability, ranking) with the bounded Cypher of section 2, and do NOT call graph-algorithm procedures: Memgraph's MAGE catalogue (`nxalg.*`, `wcc.*`, `pagerank.*`, `path.expand`, ...) does not exist here, and the Neo4j equivalents live in the GDS and APOC plugins, which may not be installed.
+
+- **Reachability / paths**: a bounded variable-length pattern, e.g. `MATCH p = (a)-[:CALLS*1..6]->(b)`, with `LIMIT`.
+- **Shortest path**: `shortestPath((a)-[:CALLS*1..10]->(b))`, which is built in.
+- **Cycles**: a bounded pattern returning to its start, e.g. `MATCH p = (a)-[:CALLS*1..6]->(a)`.
+- **Ranking / "most called"**: aggregate instead of a centrality procedure, e.g. `MATCH (:Function)-[r:CALLS]->(f:Function) RETURN f.qualified_name AS name, count(r) AS callers ORDER BY callers DESC LIMIT 10`.
+- **Existence of an edge**: prefer the bare pattern predicate `WHERE (a)-[:CALLS]->(b)` or `WHERE EXISTS { (a)-[:CALLS]->(b) }`, which is the GQL-conformant spelling.
+
+**2c. When Cypher Can't Answer**
+
+If a question cannot be expressed as a bounded Cypher pattern (e.g., "longest call chain in a graph with cycles"), return your best bounded approximation rather than an unbounded path query -- for example a bounded `[:CALLS*1..10]` with `ORDER BY ... LIMIT 1` -- and let the orchestrator post-process."""
+
+
+def _is_memgraph(backend: str | None = None) -> bool:
+    """Whether the configured graph store is Memgraph.
+
+    Read at call time rather than import time: a test or an embedding host may
+    set GRAPH_BACKEND after this module is first imported, and a prompt frozen
+    at import would keep advertising the wrong engine's procedures.
+    """
+    if backend is None:
+        backend = settings.GRAPH_BACKEND
+    return backend == DIALECT_MEMGRAPH
+
+
+def build_cypher_query_rules(backend: str | None = None) -> str:
+    """Section 2 plus the algorithm guidance the configured backend supports."""
+    memgraph = _is_memgraph(backend)
+    # str.replace, not str.format: the rules text carries literal braces
+    # (`{name: 'VatManager'}`, `EXISTS { ... }`) that str.format reads as
+    # fields and rejects. That is what backed this split out of #1590.
+    body = _CYPHER_QUERY_RULES_TEMPLATE.replace(
+        _UNBOUNDED_REACHABILITY_SLOT,
+        _MAGE_UNBOUNDED_REACHABILITY if memgraph else "",
+    )
+    return body + (_MAGE_SECTIONS if memgraph else _NEO4J_SECTIONS)
+
+
+def build_graph_schema_and_rules(backend: str | None = None) -> str:
+    engine = "Memgraph" if _is_memgraph(backend) else "Neo4j"
+    return f"""You are an expert AI assistant for analyzing codebases using a **hybrid retrieval system**: a **{engine} knowledge graph** for structural queries and a **semantic code search engine** for intent-based discovery.
 
 **1. Graph Schema Definition**
 The database contains information about a codebase, structured with the following nodes and relationships.
 
 {GRAPH_SCHEMA_DEFINITION}
 
-{CYPHER_QUERY_RULES}
+{build_cypher_query_rules(backend)}
 """
-
-
-GRAPH_SCHEMA_AND_RULES = build_graph_schema_and_rules()
 
 
 def _format_active_projects_block(active_projects: list[str] | None) -> str:
@@ -331,7 +395,7 @@ def build_cypher_system_prompt(active_projects: list[str] | None = None) -> str:
     return f"""
 You are an expert translator that converts natural language questions about code structure into precise Neo4j Cypher queries.
 
-{GRAPH_SCHEMA_AND_RULES}
+{build_graph_schema_and_rules()}
 {_format_cypher_project_scope(active_projects)}
 **3. Query Optimization Rules**
 
@@ -407,7 +471,7 @@ def build_local_cypher_system_prompt(active_projects: list[str] | None = None) -
     return f"""
 You are a Neo4j Cypher query generator. You ONLY respond with a valid Cypher query. Do not add explanations or markdown.
 
-{GRAPH_SCHEMA_AND_RULES}
+{build_graph_schema_and_rules()}
 {_format_cypher_project_scope(active_projects)}
 **CRITICAL RULES FOR QUERY GENERATION:**
 1.  **NO `UNION`**: Never use the `UNION` clause. Generate a single, simple `MATCH` query.

--- a/codebase_rag/tests/test_cypher_prompt_backend.py
+++ b/codebase_rag/tests/test_cypher_prompt_backend.py
@@ -160,3 +160,32 @@ def test_generated_neo4j_prompt_passes_the_read_only_guard() -> None:
     # can reject at all on the same run.
     with pytest.raises(Exception):
         _validate_call_procedures("CALL gds.pageRank.stream('g') YIELD nodeId")
+
+
+def test_the_neo4j_ranking_example_restricts_every_aggregated_alias() -> None:
+    """An aggregate example must scope BOTH ends of the relationship.
+
+    Raised by Greptile on #1839. The finding as filed attributed the refusal
+    to the pattern predicates this section recommends, which does not hold --
+    varying only the predicate never changes `requires_project_evidence`'s
+    verdict, and its own property-comparison control is refused too. Scoped
+    aggregates are refused on `main` regardless, by design (#1494: a count
+    exposes a MAGNITUDE spanning every indexed project).
+
+    What DID hold is smaller and real: the example named an unrestricted
+    caller alias, so its total would span projects the caller never asked
+    about. That is a bad example independently of any validator, since the
+    prompt teaches the shape the model then emits.
+    """
+    rules = prompts.build_cypher_query_rules(DIALECT_NEO4J)
+    ranking = next(
+        frag for frag in re.findall(r"`([^`]+)`", rules) if "count(r)" in frag
+    )
+    # Every alias the aggregate ranges over is prefix-restricted, not only
+    # the projected one.
+    aliases = set(re.findall(r"\((\w+):Function\)", ranking))
+    assert aliases, "fixture matched no aliases; the loop below would be vacuous"
+    for alias in aliases:
+        assert f"{alias}.qualified_name STARTS WITH" in ranking, (
+            f"alias {alias!r} is aggregated but never restricted: {ranking}"
+        )

--- a/codebase_rag/tests/test_cypher_prompt_backend.py
+++ b/codebase_rag/tests/test_cypher_prompt_backend.py
@@ -157,8 +157,13 @@ def test_generated_neo4j_prompt_passes_the_read_only_guard() -> None:
         _validate_call_procedures(fragment)
 
     # Known-positive: a zero above means "nothing rejected" only if the guard
-    # can reject at all on the same run.
-    with pytest.raises(Exception):
+    # can reject at all on the same run. Pinned to the exact exception and to
+    # the procedure name in its message -- a bare `Exception` would also be
+    # satisfied by a TypeError from a mistyped call, which is the guard NOT
+    # running (python:S5958).
+    from codebase_rag.exceptions import LLMGenerationError
+
+    with pytest.raises(LLMGenerationError, match="gds.pageRank.stream"):
         _validate_call_procedures("CALL gds.pageRank.stream('g') YIELD nodeId")
 
 

--- a/codebase_rag/tests/test_cypher_prompt_backend.py
+++ b/codebase_rag/tests/test_cypher_prompt_backend.py
@@ -1,0 +1,162 @@
+"""The Cypher-generation prompt must match the configured backend (issue #1813).
+
+Sections 2b/2c hard-coded Memgraph's MAGE catalogue (`nxalg.*`, `wcc.*`,
+`pagerank.*`, `path.expand`, ...). None of those exist in Neo4j 5, which
+#1590 added support for: the nearest equivalents are GDS (a different call
+shape, needing a projected graph) and APOC, both separately installed plugins
+that cannot be assumed present. A Neo4j deployment was being told to call
+procedures that are not there.
+
+Only query GENERATION is affected -- indexing works on both engines.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from codebase_rag import prompts
+from codebase_rag.graph_dialects import DIALECT_MEMGRAPH, DIALECT_NEO4J
+
+# The catalogue RECOMMENDS a procedure as `CALL <name>(...)`. The Neo4j
+# section also NAMES the MAGE families in its do-not-use warning, so a bare
+# "is 'nxalg' in the text" check cannot tell a recommendation from a warning
+# -- it reports the fixed prompt as broken. Match the call form instead.
+_CALL_RE = re.compile(r"CALL\s+([A-Za-z_][\w.]*)\s*\(")
+
+
+def _recommended_procedures(backend: str) -> set[str]:
+    return set(_CALL_RE.findall(prompts.build_cypher_query_rules(backend)))
+
+
+def test_neo4j_prompt_recommends_no_graph_procedures() -> None:
+    """The defect: MAGE procedures offered to an engine that has none."""
+    assert _recommended_procedures(DIALECT_NEO4J) == set()
+
+
+def test_memgraph_prompt_keeps_the_mage_catalogue() -> None:
+    """The control. Asserting only the Neo4j side would pass just as well if
+    the catalogue were deleted for everyone, which would be a regression for
+    the default backend rather than a fix."""
+    procedures = _recommended_procedures(DIALECT_MEMGRAPH)
+    assert "nxalg.strongly_connected_components" in procedures
+    assert "pagerank.get" in procedures
+    assert "path.expand" in procedures
+    # The catalogue is ~23 entries; a couple surviving would mean it was
+    # gutted rather than kept.
+    assert len(procedures) > 15
+
+
+def test_neo4j_prompt_offers_builtin_alternatives() -> None:
+    """Removing the catalogue must not leave algorithmic questions unanswered:
+    the Neo4j section has to say what to use instead, or the model falls back
+    to the unbounded paths section 2 forbids."""
+    rules = prompts.build_cypher_query_rules(DIALECT_NEO4J)
+    assert "shortestPath(" in rules
+    assert "[:CALLS*1..6]" in rules
+    assert "MAGE catalogue" in rules, "must say why, not just omit"
+
+
+def test_neo4j_prompt_prefers_the_gql_exists_spelling() -> None:
+    """The Neo4j section must offer `EXISTS { ... }` and must not justify it
+    with a false removal claim.
+
+    An earlier version of this test asserted that Neo4j 5 "removed" the
+    `exists(<pattern>)` function form. It did not: `exists(input)` is a
+    current predicate function in the v5 manual, documented with
+    `exists((p)-[:ACTED_IN]->())` as its own example. What v5 replaced is the
+    PROPERTY overload `exists(prop)`, by `prop IS NOT NULL` -- a different
+    thing. Shipping a wrong "X was removed" to the model is the same defect
+    class as the MAGE catalogue this split exists to stop serving, so the
+    prompt states a preference and this test holds it to that.
+    """
+    rules = prompts.build_cypher_query_rules(DIALECT_NEO4J)
+    assert "EXISTS { (a)-[:CALLS]->(b) }" in rules
+    assert "(a)-[:CALLS]->(b)" in rules  # the bare pattern predicate
+    # No removal/deprecation claim about exists() may reach the model.
+    for match in re.finditer(r"exists", rules, re.IGNORECASE):
+        window = rules[max(0, match.start() - 120) : match.end() + 120]
+        assert "removed" not in window.lower(), (
+            f"prompt claims exists() was removed: {window!r}"
+        )
+        assert "deprecated" not in window.lower(), (
+            f"prompt claims exists() was deprecated: {window!r}"
+        )
+
+
+def test_only_memgraph_gets_the_mage_pointer_in_section_two() -> None:
+    """Section 2's unbounded-paths bullet pointed at 'a MAGE procedure (see
+    Section 2b)'. On Neo4j that names a section that no longer offers one."""
+    assert "use a MAGE procedure" in prompts.build_cypher_query_rules(DIALECT_MEMGRAPH)
+    assert "use a MAGE procedure" not in prompts.build_cypher_query_rules(DIALECT_NEO4J)
+
+
+@pytest.mark.parametrize(
+    ("backend", "engine"), [(DIALECT_MEMGRAPH, "Memgraph"), (DIALECT_NEO4J, "Neo4j")]
+)
+def test_prompt_names_the_configured_engine(backend: str, engine: str) -> None:
+    """The preamble called the store 'a Memgraph knowledge graph' regardless
+    of backend."""
+    assert f"**{engine} knowledge graph**" in prompts.build_graph_schema_and_rules(
+        backend
+    )
+
+
+@pytest.mark.parametrize("backend", [DIALECT_MEMGRAPH, DIALECT_NEO4J])
+def test_shared_rules_survive_on_both_backends(backend: str) -> None:
+    """Section 2 is engine-neutral and must not be lost by the split."""
+    rules = prompts.build_cypher_query_rules(backend)
+    assert "**2. Critical Cypher Query Rules**" in rules
+    assert "NEVER use unbounded variable-length paths" in rules
+    assert "ALWAYS Return Specific Properties with Aliases" in rules
+    # No placeholder may reach the model.
+    assert prompts._UNBOUNDED_REACHABILITY_SLOT not in rules
+
+
+@pytest.mark.parametrize("backend", [DIALECT_MEMGRAPH, DIALECT_NEO4J])
+def test_literal_braces_survive_the_substitution(backend: str) -> None:
+    """The reason this split was backed out of #1590: the rules text contains
+    literal braces (`{name: 'VatManager'}`, `EXISTS { ... }`) that str.format
+    reads as replacement fields and rejects. The substitution must be a plain
+    replace, and these examples must reach the model intact."""
+    full = prompts.build_graph_schema_and_rules(backend)
+    assert "{name: 'VatManager'}" in full
+
+
+def test_backend_is_read_at_call_time_not_import_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prompt frozen at import keeps advertising the engine that was
+    configured when the module first loaded. `prompts` is imported long before
+    a test or embedding host can set GRAPH_BACKEND."""
+    monkeypatch.setattr(prompts.settings, "GRAPH_BACKEND", DIALECT_NEO4J)
+    assert _recommended_procedures(None) == set()  # type: ignore[arg-type]
+
+    monkeypatch.setattr(prompts.settings, "GRAPH_BACKEND", DIALECT_MEMGRAPH)
+    assert "nxalg.simple_cycles" in _recommended_procedures(None)  # type: ignore[arg-type]
+
+
+def test_generated_neo4j_prompt_passes_the_read_only_guard() -> None:
+    """End-to-end: no Cypher the Neo4j prompt suggests may be rejected by the
+    procedure allowlist. The allowlist is deliberately NOT widened to admit
+    `gds.`/`apoc.` -- the prompt recommends no procedures on Neo4j, so the
+    mismatch the issue describes is unreachable rather than merely tolerated,
+    and loosening a security control to permit calls nothing suggests would
+    be the wrong trade."""
+    from codebase_rag.services.llm import _validate_call_procedures
+
+    rules = prompts.build_cypher_query_rules(DIALECT_NEO4J)
+    fragments = [
+        frag
+        for frag in re.findall(r"`([^`]+)`", rules)
+        if re.search(r"\b(MATCH|CALL|WHERE|RETURN)\b", frag)
+    ]
+    assert fragments, "fixture found no Cypher; the loop below would be vacuous"
+    for fragment in fragments:
+        _validate_call_procedures(fragment)
+
+    # Known-positive: a zero above means "nothing rejected" only if the guard
+    # can reject at all on the same run.
+    with pytest.raises(Exception):
+        _validate_call_procedures("CALL gds.pageRank.stream('g') YIELD nodeId")


### PR DESCRIPTION
Closes #1813.

## The defect

`codebase_rag/prompts.py` hard-codes Memgraph's MAGE catalogue in prompt sections 2b/2c — ~23 procedures (`nxalg.*`, `wcc.*`, `pagerank.*`, `graph_util.*`, `path.expand`, ...). Neo4j support arrived in #1590, and **none of those exist in Neo4j 5**. The nearest equivalents live in GDS (a different call shape, needing a projected graph) and APOC, both separately installed plugins that cannot be assumed present. A Neo4j deployment was being told to call procedures that are not there.

Only query *generation* is affected; indexing works on both engines.

## The change

Section 2 is engine-neutral and stays shared. Sections 2b/2c are selected by `settings.GRAPH_BACKEND`, along with the preamble's engine name (`prompts.py:60` said "a **Memgraph** knowledge graph" regardless of backend) and section 2's closing pointer at "a MAGE procedure (see Section 2b)", which named a section that no longer offers one.

For a non-Memgraph backend the catalogue is **omitted rather than translated**, as the issue suggests: naming GDS/APOC procedures that may not be installed would reproduce the bug with different names. The Neo4j section instead says what to use without plugins — bounded patterns, built-in `shortestPath()`, aggregation for ranking, `EXISTS { ... }` — and names MAGE only to say it is unavailable, so the model does not fall back to the unbounded paths section 2 forbids.

Selection happens **at call time**, not import time: `prompts` is imported long before a test or embedding host can set `GRAPH_BACKEND`, and a frozen prompt would keep advertising the wrong engine.

### Why `str.replace` and not `str.format`

The issue notes this split was attempted during #1590 and backed out. Reproduced: the rules text contains literal braces (`{name: 'VatManager'}`, `EXISTS { ... }`) that `str.format` reads as replacement fields — it raises `KeyError: 'name'`. The substitution is a sentinel plus `str.replace`, and a test asserts the literal braces reach the model intact on both backends.

### `CYPHER_ALLOWED_PROCEDURE_PREFIXES` deliberately not widened

The issue notes the read-only guard would reject a legitimate `gds.`/`apoc.` call. Left alone on purpose: the Neo4j prompt now recommends no procedures at all, so the mismatch is unreachable rather than tolerated, and loosening a deny-by-default security allowlist to admit calls nothing suggests is the wrong trade. Verified all 10 Cypher fragments in the Neo4j prompt pass `_validate_call_procedures`, with a known-positive confirming the guard still rejects `gds.pageRank`. Happy to add the parallel set if you would rather.

## Tests

`codebase_rag/tests/test_cypher_prompt_backend.py`, 13 tests. Verified to discriminate with two mutants:

- **API present but selection disabled** → 5 Neo4j-behaviour tests red, 8 structural controls green. This is the case a bare "does the new function exist" failure cannot distinguish from a real fix.
- **Catalogue dropped for every backend** (the over-correction) → the Memgraph control goes red. A suite asserting only the Neo4j side would have waved this through.

Two assertions were initially non-discriminating because they substring-matched text appearing in the prompt's own *do-not-use* warning (`nxalg`, `exists((`) — they reported the fixed prompt as broken. Both now match the recommendation form (`CALL <proc>(`) rather than the mention.

Regression: 511 passed across the prompt/llm/cypher/config/dialect/schema test files.

## Review correction

The local review caught a **false claim I had written into the prompt**: that Neo4j 5 removed the `exists(<pattern>)` function form. It did not — `exists(input)` is a current predicate function in the v5 manual, documented with `exists((p)-[:ACTED_IN]->())` as its own example. What v5 replaced is the *property* overload `exists(prop)`, by `prop IS NOT NULL`. I had conflated the two overloads.

Verified against the Neo4j 5 manual directly and corrected: the prompt now states a preference for the GQL-conformant `EXISTS { ... }` with no removal claim. Shipping a wrong "X was removed" is the same defect class this PR exists to remove. The test that asserted the false claim would have become vacuous once the text changed, so it was rewritten to forbid any removal/deprecation claim about `exists()` reaching the model, and re-validated against a mutant that reintroduces it.

## Out of scope

`prompts.py:178` (`_format_active_projects_block`) still hard-codes "This **Memgraph** database may contain multiple indexed projects." It reaches the agent orchestrator prompt, not the Cypher prompt, so it is a separate surface with the same defect class — worth its own issue rather than widening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Cypher query guidance now adapts automatically to the configured graph database.
  - Neo4j prompts provide built-in alternatives and appropriate `EXISTS` syntax without recommending Memgraph-specific procedures.
  - Memgraph prompts continue to include relevant MAGE procedure guidance.
  - Generated prompts clearly identify the selected graph database while preserving shared query rules.

- **Bug Fixes**
  - Improved backend-specific prompt generation and compatibility with read-only query safeguards.
  - Neo4j ranking examples now apply the required filtering consistently to aggregated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->