### PR TITLE
docs: state both guarantees safe_decode_text provides, and test them (#1811)

### DIFF
--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -266,6 +266,29 @@ def node_site_properties(node: Node) -> PropertyDict:
 
 
 def safe_decode_text(node: ASTNode | TreeSitterNodeProtocol | None) -> str | None:
+    """A node's text as `str`, or `None` when there is no text to decode.
+
+    "safe" covers BOTH failure modes, and both guarantees are real:
+
+    * a null node, or a node whose `text` is null, yields `None` rather than
+      raising `AttributeError`;
+    * undecodable bytes are replaced, never raised. The decode routes through
+      `language_spec.decode_node_text` (`errors="replace"`), so a single bad
+      byte cannot raise `UnicodeDecodeError` here.
+
+    The second half is worth stating rather than leaving to be re-derived.
+    Until #1797 the decode underneath was strict, so "safe" named only the
+    None handling -- and the name read as "this is the decode that handles
+    bad input", which is exactly the assumption that stops people looking.
+    It cost real time on #1797: a bad byte in a Python decorator dropped
+    every definition in the file through this function, in the repo's primary
+    language, because the per-file handler in `graph_updater` catches
+    `UnicodeDecodeError` and abandons the file. With ~550 call sites, a name
+    asserting a guarantee needs to be checkable against the implementation
+    (issue #1811).
+
+    Returns the value as-is via `str()` when `node.text` is not `bytes`.
+    """
     if node is None or (text_bytes := node.text) is None:
         return None
     if isinstance(text_bytes, bytes):

--- a/codebase_rag/tests/test_safe_decode_text_guarantees.py
+++ b/codebase_rag/tests/test_safe_decode_text_guarantees.py
@@ -1,0 +1,109 @@
+"""`safe_decode_text` must provide both guarantees its name asserts (#1811).
+
+The name reads as "this is the decode that handles bad input". Until #1797
+that was half true: "safe" covered only the None handling, and the decode
+underneath was strict. A bad byte in a Python decorator raised
+`UnicodeDecodeError`, the per-file handler in `graph_updater` caught it and
+abandoned the file, and every definition in that file vanished from the graph
+-- in the repo's primary language, through a function whose name said the
+case was handled.
+
+#1797 made the decode total. #1811 is about keeping the name honest: with
+~550 call sites, a name asserting a guarantee should be checkable against the
+implementation. These tests are that check, so a future strict decode fails
+here rather than silently deleting files' worth of definitions.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.parsers.utils import safe_decode_text
+
+
+class _Node:
+    """Minimal stand-in: `safe_decode_text` reads only `.text`."""
+
+    def __init__(self, text: object) -> None:
+        self.text = text
+
+
+# A bad byte in a decorator -- the exact shape that motivated #1797.
+_BAD_DECORATOR = b"@dec\xffrator"
+
+
+def test_a_strict_decode_would_raise_on_this_input() -> None:
+    """Calibrate the instrument first.
+
+    Every "does not raise" assertion below is evidence only if the input can
+    actually break a strict decode. Without this, a weakened fixture would
+    make the suite pass for the wrong reason.
+    """
+    with pytest.raises(UnicodeDecodeError):
+        _BAD_DECORATOR.decode("utf-8")
+
+
+def test_undecodable_bytes_are_replaced_not_raised() -> None:
+    """The guarantee the name implied but did not provide before #1797."""
+    result = safe_decode_text(_Node(_BAD_DECORATOR))
+    assert result is not None
+    assert result.startswith("@dec")
+    assert result.endswith("rator")
+    # U+FFFD in place of the bad byte: the identifier is visibly mangled and
+    # the rest of the file stays indexable.
+    assert "�" in result
+
+
+def test_wholly_invalid_bytes_still_decode() -> None:
+    assert safe_decode_text(_Node(b"\xff\xfe\x00invalid")) is not None
+
+
+def test_a_null_node_yields_none() -> None:
+    """The guarantee "safe" originally named."""
+    assert safe_decode_text(None) is None
+
+
+def test_a_node_with_null_text_yields_none() -> None:
+    assert safe_decode_text(_Node(None)) is None
+
+
+def test_valid_utf8_is_unchanged() -> None:
+    """The replacement decode must not disturb ordinary input."""
+    assert safe_decode_text(_Node(b"ordinary_name")) == "ordinary_name"
+    assert safe_decode_text(_Node("café".encode())) == "café"
+
+
+def test_non_bytes_text_is_stringified() -> None:
+    assert safe_decode_text(_Node(123)) == "123"
+
+
+def test_the_decode_routes_through_the_shared_helper() -> None:
+    """Pin the mechanism, not just the outcome.
+
+    The assertions above would also pass if this function grew its own
+    `errors="replace"` call. Several passes decode node text independently
+    and each abandons the file on its own, so the requirement is that they
+    all route through one helper -- fixing one and leaving the rest losing
+    data on the same input is what #1797 was.
+    """
+    from codebase_rag.parsers import utils
+
+    called: list[bytes] = []
+    real = utils.decode_node_text
+
+    def spy(raw: bytes) -> str:
+        called.append(raw)
+        return real(raw)
+
+    # The decode is memoised, so use bytes no earlier test has decoded.
+    unique = b"unique_for_the_spy_\xff"
+    utils._cached_decode_bytes.cache_clear()
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(utils, "decode_node_text", spy)
+    try:
+        assert safe_decode_text(_Node(unique)) is not None
+    finally:
+        monkey.undo()
+        utils._cached_decode_bytes.cache_clear()
+
+    assert called == [unique], "decode did not route through decode_node_text"


### PR DESCRIPTION
Closes #1811.

## The problem

`safe_decode_text` has ~550 call sites and a name that reads as "this is the decode that handles bad input". Until #1797 that was only half true: "safe" covered the None handling, while the decode underneath was strict and raised `UnicodeDecodeError` on any undecodable byte.

The issue records what that cost: on #1797 the extractors and the call pass were probed and fixed, and the fix declared complete — while a bad byte in a **Python decorator** still dropped every definition in the file, through this function, in the repo's primary language. `safe_decode_text` was not probed because its name said the case was already handled.

## The fix, per the issue's second option

The issue offers a rename (`decode_text_or_none`) or keeping the name and documenting both guarantees. Taking the second, on the owner's call.

It is now the accurate one: since #1797 the decode routes through `language_spec.decode_node_text` (`errors="replace"`), so both the None case and the undecodable-bytes case really are handled. `decode_text_or_none` would arguably *understate* it — the encoding guarantee is real, and a name mentioning only the None handling implies nothing about it. Keeping the name also leaves ~550 call sites and every in-flight branch untouched.

The issue's actual point is that **a name asserting a guarantee should be checkable against the implementation**. A docstring alone does not achieve that — it can drift from the code silently, which is how the original trap was set. So this adds tests that hold the code to what the docstring claims.

## Verified before writing it down

Both guarantees were confirmed by execution rather than by reading, since a docstring asserting a guarantee the code does not provide is exactly the defect being fixed:

| input | result |
|---|---|
| `None` | `None` |
| node with `text=None` | `None` |
| `b"@dec\xffrator"` | `'@dec�rator'`, no raise |
| `b"\xff\xfe\x00invalid"` | decoded, no raise |
| valid UTF-8 | unchanged |

With a control confirming a strict decode *does* raise on the same input, so "no raise" is evidence of the fix rather than of a weak fixture.

## Tests

`codebase_rag/tests/test_safe_decode_text_guarantees.py`, 8 tests, including:

- a **calibration** test asserting the bad bytes would break a strict decode, so every "does not raise" below it means something;
- both guarantees, separately;
- that valid UTF-8 is undisturbed by the replacement decode;
- that the decode **routes through the shared helper** rather than growing its own `errors="replace"`. Several passes decode node text independently and each abandons the file on its own; fixing one and leaving the rest losing data on the same input is what #1797 was.

Verified to discriminate: restoring the pre-#1797 strict decode turns exactly three red — both guarantee tests and the mechanism test — while the None-handling tests and the calibration stay green.

Regression: 768 passed across the parser/utils/definition/extraction test files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified text-decoding behavior for null values, invalid byte sequences, valid UTF-8, and non-byte inputs.
  - Documented replacement decoding and related failure-handling guarantees.

- **Tests**
  - Added coverage confirming malformed bytes are safely replaced rather than raising errors.
  - Verified null handling, valid UTF-8 preservation, non-byte conversion, and use of the shared decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->