### PR TITLE
refactor: remove the callerless register_parsed_file and pin the invariant it implied (#1784)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2926,6 +2926,16 @@ class GraphUpdater:
         # The call pass iterates _parsed_files; a removed file must leave it
         # (a re-parse re-registers), or deleted files keep contributing and
         # created files never do (issue #1028).
+        #
+        # This removal is ALSO what keeps the list free of duplicates. The
+        # appender in `_process_single_file` appends unconditionally, so
+        # every re-parse route has to strip the old entry first -- the
+        # incremental path calls this method, and `reingest` gets there via
+        # `_reingest_delete`. A deduplicating appender is deliberately not
+        # the mechanism: one existed (`register_parsed_file`, added for
+        # #1028) and was left callerless when #1524 moved the watcher onto
+        # `reingest`, where it read as the guarantee's source while never
+        # running. Removed in #1784; the invariant lives here.
         self._parsed_files = [
             entry for entry in self._parsed_files if entry[0] != file_path
         ]
@@ -4397,15 +4407,6 @@ class GraphUpdater:
         root_node = parse_with_preproc_recovery(parser, file_bytes, language).root_node
         self.factory._func_class_captures_cache.pop(file_path, None)
         return (root_node, language)
-
-    def register_parsed_file(
-        self, file_path: Path, language: cs.SupportedLanguage
-    ) -> None:
-        # Watch-mode events parse outside run(): the file must join the
-        # call pass's iteration set or its outgoing CALLS edges are never
-        # emitted (issue #1028).
-        if all(existing != file_path for existing, _ in self._parsed_files):
-            self._parsed_files.append((file_path, language))
 
     def _process_function_calls(self, only: Collection[Path] | None = None) -> None:
         # `only` scopes the pass to a re-ingested subset (issue #1524); every

--- a/codebase_rag/tests/test_parsed_files_invariants.py
+++ b/codebase_rag/tests/test_parsed_files_invariants.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -83,21 +83,42 @@ def test_the_appender_itself_does_not_deduplicate(tmp_path: Path) -> None:
     """Pin the MECHANISM, not just the outcome.
 
     The test above would pass just as well if the appender deduplicated, so
-    it cannot show WHERE the invariant comes from. Calling the appender
-    without the preceding removal must duplicate — that is what makes the
-    removal load-bearing rather than incidental, and what a future
-    "simplification" of `remove_file_from_state` would break.
+    it cannot show WHERE the invariant comes from. This one shows that the
+    REMOVAL is what provides it: re-parsing with the removal leaves one
+    entry, and that is the pairing `remove_file_from_state` documents.
+
+    Deliberately does NOT assert that the bare appender produces a duplicate
+    (raised by Greptile on #1842). Requiring `== 2` would make duplicate
+    creation by a private helper a mandated implementation detail and block
+    a future defensive dedup there, which would be a fine change. What must
+    not change silently is that the REMOVAL still runs on the re-parse path,
+    so that is what is asserted -- directly, rather than inferred from a
+    count the appender could also produce.
     """
     updater, _ = _build(tmp_path)
     target = tmp_path / "pkg" / "mod.py"
     assert _counts(updater)[target] == 1
 
-    updater._process_single_file(target)
-    assert _counts(updater)[target] == 2, (
-        "the appender deduplicates after all; if this is now intended, the "
-        "comment in remove_file_from_state naming the removal as the source "
-        "of the invariant is stale"
+    removed: list[Path] = []
+    real_remove = type(updater).remove_file_from_state
+
+    def _spy(self: GraphUpdater, file_path: Path, **kwargs: object) -> None:
+        removed.append(file_path)
+        return real_remove(self, file_path, **kwargs)
+
+    with patch.object(type(updater), "remove_file_from_state", _spy):
+        target.write_text(
+            "from pkg.util import helper\n\n\ndef go():\n    return helper()  # edit\n",
+            encoding="utf-8",
+        )
+        updater.reingest((target,))
+
+    assert target in removed, (
+        "reingest re-parsed the file without removing its old entry first; "
+        "the appender appends unconditionally, so nothing else keeps "
+        "_parsed_files free of duplicates"
     )
+    assert _counts(updater)[target] == 1
 
 
 def test_removal_then_reparse_restores_exactly_one_entry(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_parsed_files_invariants.py
+++ b/codebase_rag/tests/test_parsed_files_invariants.py
@@ -1,0 +1,152 @@
+"""`_parsed_files` holds one entry per file, and every parsed file is in it.
+
+Issue #1784: `register_parsed_file` — the only DEDUPLICATING appender — had
+no callers. It was added for #1028 (a file parsed outside `run()` must join
+the call pass's iteration set, or its outgoing CALLS edges are never emitted)
+and left callerless by #1524, which moved the watcher onto `reingest`.
+
+Investigating it turned up that both properties still hold, but not for the
+reason the dead function implied:
+
+* the live appender (`_process_single_file`) appends UNCONDITIONALLY, so it
+  can duplicate — verified by calling it directly, which does produce a
+  second entry;
+* no production path does that, because every re-parse route strips the old
+  entry first (`remove_file_from_state` on the incremental path,
+  `_reingest_delete` under `reingest`).
+
+So the invariant is maintained by remove-then-append, and the deleted
+function was a false signal about where it comes from. These tests pin the
+invariant to the mechanism that actually provides it, so removing the
+removal fails here rather than silently growing the list on every save.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+CALLS = cs.RelationshipType.CALLS.value
+
+_FILES = {
+    "pkg/__init__.py": "",
+    "pkg/util.py": "def helper():\n    return 1\n",
+    "pkg/mod.py": "from pkg.util import helper\n\n\ndef go():\n    return helper()\n",
+}
+
+
+def _build(tmp_path: Path) -> tuple[GraphUpdater, MagicMock]:
+    for rel, content in _FILES.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    updater = GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    )
+    updater.run()
+    return updater, mock
+
+
+def _counts(updater: GraphUpdater) -> Counter[Path]:
+    return Counter(fp for fp, _ in updater._parsed_files)
+
+
+def test_repeated_reingest_does_not_duplicate_entries(tmp_path: Path) -> None:
+    """A retained updater (the MCP `_live_updater`, a watcher) reingests the
+    same file on every save. Each one must replace its entry, not add one."""
+    updater, _ = _build(tmp_path)
+    target = tmp_path / "pkg" / "mod.py"
+    assert _counts(updater)[target] == 1
+
+    for i in range(3):
+        target.write_text(
+            f"from pkg.util import helper\n\n\ndef go():\n    return helper()  # {i}\n",
+            encoding="utf-8",
+        )
+        updater.reingest((target,))
+        assert _counts(updater)[target] == 1, f"duplicated after reingest {i + 1}"
+
+    duplicated = {fp.name: n for fp, n in _counts(updater).items() if n > 1}
+    assert not duplicated, f"duplicate _parsed_files entries: {duplicated}"
+
+
+def test_the_appender_itself_does_not_deduplicate(tmp_path: Path) -> None:
+    """Pin the MECHANISM, not just the outcome.
+
+    The test above would pass just as well if the appender deduplicated, so
+    it cannot show WHERE the invariant comes from. Calling the appender
+    without the preceding removal must duplicate — that is what makes the
+    removal load-bearing rather than incidental, and what a future
+    "simplification" of `remove_file_from_state` would break.
+    """
+    updater, _ = _build(tmp_path)
+    target = tmp_path / "pkg" / "mod.py"
+    assert _counts(updater)[target] == 1
+
+    updater._process_single_file(target)
+    assert _counts(updater)[target] == 2, (
+        "the appender deduplicates after all; if this is now intended, the "
+        "comment in remove_file_from_state naming the removal as the source "
+        "of the invariant is stale"
+    )
+
+
+def test_removal_then_reparse_restores_exactly_one_entry(tmp_path: Path) -> None:
+    """The remove-then-append pairing, exercised directly."""
+    updater, _ = _build(tmp_path)
+    target = tmp_path / "pkg" / "mod.py"
+
+    updater.remove_file_from_state(target)
+    assert _counts(updater)[target] == 0
+
+    updater._process_single_file(target)
+    assert _counts(updater)[target] == 1
+
+
+def test_a_file_created_after_run_still_emits_its_calls(tmp_path: Path) -> None:
+    """The #1028 guarantee `register_parsed_file` was written to provide.
+
+    It must survive the function's removal: a file created after `run()`
+    joins the iteration set and its outgoing CALLS edges are emitted.
+    """
+    updater, mock = _build(tmp_path)
+    fresh = tmp_path / "pkg" / "fresh.py"
+    fresh.write_text(
+        "from pkg.util import helper\n\n\ndef go():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    mock.reset_mock()
+    updater.reingest((fresh,))
+
+    assert _counts(updater)[fresh] == 1, "created file never joined _parsed_files"
+
+    edges = {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == CALLS
+    }
+    project = tmp_path.name
+    assert (f"{project}.pkg.fresh.go", f"{project}.pkg.util.helper") in edges
+
+
+def test_the_dead_appender_is_gone(tmp_path: Path) -> None:
+    """It never ran, and it read as the source of an invariant it did not
+    provide. If it comes back, it needs a caller and a reason."""
+    assert not hasattr(GraphUpdater, "register_parsed_file")
+
+
+@pytest.mark.parametrize("rel", ["pkg/mod.py", "pkg/util.py"])
+def test_every_parsed_file_appears_exactly_once_after_a_full_run(
+    tmp_path: Path, rel: str
+) -> None:
+    updater, _ = _build(tmp_path)
+    assert _counts(updater)[tmp_path / rel] == 1


### PR DESCRIPTION
Closes #1784.

Takes the **delete** branch, after checking which one applies. The investigation changed the conclusion, so it is worth reporting rather than just the fix.

## Confirming the function is dead

Unscoped, whole repo, every file type — not a subtree grep:

```
$ git grep -n "register_parsed_file" origin/main
origin/main:codebase_rag/graph_updater.py:4401:    def register_parsed_file(
```

One hit, its own definition. No dynamic dispatch (`getattr`, string literal, protocol), nothing in docs or stubs.

## Where the caller went

`git log -S` finds it exactly:

- **72648235** added it for #1028, called from the watcher in `realtime_updater.py`.
- **3974efa5** (#1524) replaced that call with `reingest`:

```diff
-                    self.updater.register_parsed_file(path, language)
+            self.updater.reingest((path,))
```

So the need did not disappear — the watcher moved onto a path that reaches `_process_single_file`, the **unconditional** appender.

## The issue's two premises, checked separately

The issue asks whether the need is gone (delete) or a path lost its call (restore). Both premises were tested by execution:

**Premise 2 — the #1028 guarantee — still holds.** A file created after `run()` joins `_parsed_files` via `reingest` and its outgoing CALLS edge is emitted. Nothing is unmet, so there is no lost call to restore.

**Premise 1 — "`_parsed_files` can hold duplicates" — does not reproduce.** Three consecutive reingests of the same file on a retained updater leave exactly one entry. The reason is `remove_file_from_state`, which strips the entry before the re-parse ("a re-parse re-registers"); `reingest` gets there via `_reingest_delete`, and the incremental path calls it directly. Both production callers of `_process_single_file` are preceded by a removal.

The appender **can** still duplicate — calling it directly without the removal produces a second entry — so the removal is load-bearing, not incidental. It is just not a path anything takes.

That makes this the delete branch: the invariant is real, but it comes from remove-then-append, and a deduplicating appender that never runs is a false signal about where it lives.

## The change

- Delete `register_parsed_file`.
- Record the invariant at the removal in `remove_file_from_state`, which is where it actually comes from — including why a deduplicating appender is deliberately not the mechanism, so this does not get "helpfully" reintroduced.
- Add `codebase_rag/tests/test_parsed_files_invariants.py` (7 tests) pinning the invariant to that mechanism.

## Tests

Beyond the outcome, one test asserts the appender **does not** deduplicate — otherwise the suite could not show where the invariant comes from, and would pass just as well if the mechanism moved. Also covered: remove-then-reparse restores exactly one entry, and the #1028 guarantee survives the deletion.

Verified to discriminate: deleting the removal from `remove_file_from_state` turns two red (`test_repeated_reingest_does_not_duplicate_entries`, `test_removal_then_reparse_restores_exactly_one_entry`); the others stay green, as they should, since they do not depend on it.

Regression: 378 passed across the incremental/watch/reingest/graph-updater test files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed repeated file reingestion so files are refreshed without creating duplicate entries.
  - Corrected remove-and-reprocess behavior to keep parsed file results consistent.
  - Ensured files added after an initial run are included in subsequent processing and relationship tracking.
  - Improved consistency so each parsed file is represented exactly once after a complete run.

- **Tests**
  - Added coverage for file parsing, reingestion, removal, and incremental processing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->