### PR TITLE
fix: keep a surviving stem-sharing file's definitions when its sibling is deleted (#1773)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3043,13 +3043,60 @@ class GraphUpdater:
 
         qns_to_remove = set()
 
+        # A directory may share a sibling FILE's stem, and then the module qns
+        # nest: `proj/a.py` records `proj.a` while `proj/a/b.py` records
+        # `proj.a.b`. Deleting `a.py` matches the prefix `proj.a.` and would
+        # take `b.py`'s definitions with it, though `b.py` still exists and
+        # this event does not re-parse it, so nothing restores them (issue
+        # #1773). `foreign_qns` does not save them: it is built from function
+        # SPAN records, so it protects `proj.a.b.Nested.deep` while leaving
+        # the class `proj.a.b.Nested`, which records no span -- exactly the
+        # asymmetry measured on `A.cs` beside `A/B.cs`, and reproduced here on
+        # `a.py` beside `a/b.py`. The sweep is language-agnostic, so this is
+        # not a C#-only shape.
+        #
+        # A qn under a SURVIVING module qn is therefore kept, whichever
+        # shorter prefix also matches. #1769 hit the same shape in
+        # `csharp_class_generic_arity` but could not use this rule: a C# class
+        # qn embeds its namespace, so it can sit under a sibling module it was
+        # never declared in, and a prefix rule errs in BOTH directions there.
+        # A Python/Rust/Go module qn is derived from the path, so "under a
+        # longer surviving module" does identify the real owner here.
+        surviving_modules = {
+            module_qn
+            for module_qn in self.factory.definition_processor.module_qn_to_file_path
+            if module_qn not in module_qn_prefixes
+        }
+
+        def _under_a_surviving_module(qn: str, matched: str) -> bool:
+            # Only a module LONGER than the prefix that matched can be the
+            # real owner; a shorter or equal one is the deleted file itself.
+            return any(
+                len(module_qn) > len(matched)
+                and (qn.startswith(f"{module_qn}.") or qn == module_qn)
+                for module_qn in surviving_modules
+            )
+
         for qn in list(self.function_registry.keys()):
-            if (
-                any(
-                    qn.startswith(f"{prefix}.") or qn == prefix
+            matched_prefix = next(
+                (
+                    prefix
                     for prefix in module_qn_prefixes
-                )
-                or qn in owned_qns
+                    if qn.startswith(f"{prefix}.") or qn == prefix
+                ),
+                None,
+            )
+            if (
+                matched_prefix is not None
+                and _under_a_surviving_module(qn, matched_prefix)
+                and qn not in owned_qns
+            ):
+                # Belongs to a file that still exists; the prefix match is an
+                # accident of the shared stem. `owned_qns` still wins, since
+                # that is this file's own span-record evidence.
+                continue
+            if (
+                matched_prefix is not None or qn in owned_qns
             ) and qn not in foreign_qns:
                 qns_to_remove.add(qn)
                 del self.function_registry[qn]

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3055,49 +3055,45 @@ class GraphUpdater:
         # `a.py` beside `a/b.py`. The sweep is language-agnostic, so this is
         # not a C#-only shape.
         #
-        # A qn under a SURVIVING module qn is therefore kept, whichever
-        # shorter prefix also matches. #1769 hit the same shape in
-        # `csharp_class_generic_arity` but could not use this rule: a C# class
-        # qn embeds its namespace, so it can sit under a sibling module it was
-        # never declared in, and a prefix rule errs in BOTH directions there.
-        # A Python/Rust/Go module qn is derived from the path, so "under a
-        # longer surviving module" does identify the real owner here.
-        surviving_modules = {
-            module_qn
-            for module_qn in self.factory.definition_processor.module_qn_to_file_path
-            if module_qn not in module_qn_prefixes
-        }
+        # Ownership must come from a RECORD, not from the qn's shape. The
+        # obvious rule -- keep a qn that also sits under a longer surviving
+        # module -- is wrong for C#, whose class qn embeds its namespace:
+        # `proj/Core.cs` with `namespace Util` yields `proj.Core.Util.Helper`,
+        # sitting under the SIBLING module `proj.Core.Util` from
+        # `proj/Core/Util.cs`. That rule would keep `Helper` after deleting
+        # the file that declares it (measured; caught in review of #1844).
+        # #1769 hit the same trap and answered it the same way, with an
+        # explicit owner record.
+        #
+        # `class_owner_module` is that record, cross-language and written by
+        # every language's ingest (#1772). A qn whose declaring module is
+        # still mapped to a file, and is not itself being deleted, belongs to
+        # a file that still exists: keep it. A qn with no recorded owner is
+        # left to the prefix rule, which is the pre-existing behaviour.
+        owner_module = self.factory.definition_processor.class_owner_module
+        live_modules = set(self.factory.definition_processor.module_qn_to_file_path)
 
-        def _under_a_surviving_module(qn: str, matched: str) -> bool:
-            # Only a module LONGER than the prefix that matched can be the
-            # real owner; a shorter or equal one is the deleted file itself.
-            return any(
-                len(module_qn) > len(matched)
-                and (qn.startswith(f"{module_qn}.") or qn == module_qn)
-                for module_qn in surviving_modules
-            )
+        def _owned_by_a_surviving_file(qn: str) -> bool:
+            owner = owner_module.get(qn)
+            if owner is None:
+                return False
+            return owner not in module_qn_prefixes and owner in live_modules
 
         for qn in list(self.function_registry.keys()):
-            matched_prefix = next(
-                (
-                    prefix
-                    for prefix in module_qn_prefixes
-                    if qn.startswith(f"{prefix}.") or qn == prefix
-                ),
-                None,
+            matched_prefix = any(
+                qn.startswith(f"{prefix}.") or qn == prefix
+                for prefix in module_qn_prefixes
             )
             if (
-                matched_prefix is not None
-                and _under_a_surviving_module(qn, matched_prefix)
+                matched_prefix
                 and qn not in owned_qns
+                and _owned_by_a_surviving_file(qn)
             ):
-                # Belongs to a file that still exists; the prefix match is an
+                # Declared by a file that still exists; the prefix match is an
                 # accident of the shared stem. `owned_qns` still wins, since
                 # that is this file's own span-record evidence.
                 continue
-            if (
-                matched_prefix is not None or qn in owned_qns
-            ) and qn not in foreign_qns:
+            if (matched_prefix or qn in owned_qns) and qn not in foreign_qns:
                 qns_to_remove.add(qn)
                 del self.function_registry[qn]
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3082,6 +3082,15 @@ class GraphUpdater:
         # in review of #1844; pre-existing on main, which loses it either way).
         rehydrated = self.factory.definition_processor.rehydrated_definition_paths
         deleted_rel = cached_relative_path(file_path, self.repo_path).as_posix()
+        # "Not the file being deleted" is not enough: a definition recorded
+        # against a file removed EARLIER also has a different path, and would
+        # be preserved as a stale entry that goes on steering call resolution
+        # (raised by CodeRabbit on #1844). Require the recorded path to belong
+        # to a module that is still live.
+        live_paths = {
+            cached_relative_path(path, self.repo_path).as_posix()
+            for path in self.factory.definition_processor.module_qn_to_file_path.values()
+        }
 
         def _owned_by_a_surviving_file(qn: str) -> bool:
             owner = owner_module.get(qn)
@@ -3092,7 +3101,10 @@ class GraphUpdater:
             # rehydrate stores.
             rehydrated_path = rehydrated.get(qn)
             if rehydrated_path is not None:
-                return str(rehydrated_path) != deleted_rel
+                return (
+                    str(rehydrated_path) != deleted_rel
+                    and str(rehydrated_path) in live_paths
+                )
             return False
 
         for qn in list(self.function_registry.keys()):

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3072,12 +3072,28 @@ class GraphUpdater:
         # left to the prefix rule, which is the pre-existing behaviour.
         owner_module = self.factory.definition_processor.class_owner_module
         live_modules = set(self.factory.definition_processor.module_qn_to_file_path)
+        # `class_owner_module` is written at INGEST, so a definition carried
+        # over by a REHYDRATE has no entry there and would fall back to the
+        # prefix rule. `rehydrated_definition_paths` is the record for exactly
+        # those, written when the row is read back from the graph, and it
+        # already serves as ownership evidence in `_prune_class_keyed_maps`.
+        # Consulting both means an unchanged sibling's class is protected on
+        # an incremental run too, not only on the run that parsed it (raised
+        # in review of #1844; pre-existing on main, which loses it either way).
+        rehydrated = self.factory.definition_processor.rehydrated_definition_paths
+        deleted_rel = cached_relative_path(file_path, self.repo_path).as_posix()
 
         def _owned_by_a_surviving_file(qn: str) -> bool:
             owner = owner_module.get(qn)
-            if owner is None:
-                return False
-            return owner not in module_qn_prefixes and owner in live_modules
+            if owner is not None:
+                return owner not in module_qn_prefixes and owner in live_modules
+            # The rehydrated half: owned by a file that is not the one being
+            # deleted. Compared as a relative posix path, the form the
+            # rehydrate stores.
+            rehydrated_path = rehydrated.get(qn)
+            if rehydrated_path is not None:
+                return str(rehydrated_path) != deleted_rel
+            return False
 
         for qn in list(self.function_registry.keys()):
             matched_prefix = any(

--- a/codebase_rag/tests/test_sibling_stem_registry_sweep.py
+++ b/codebase_rag/tests/test_sibling_stem_registry_sweep.py
@@ -291,11 +291,24 @@ def test_a_rehydrated_class_from_the_deleted_file_still_goes(tmp_path: Path) -> 
     rehydrated": a definition whose recorded path IS the deleted file has to
     be removed, or the sweep stops working on incremental runs.
     """
-    updater = _build(tmp_path, {"a.py": _A_PY, "a/__init__.py": "", "a/b.py": _B_PY})
+    # A CLASS, not a function: a function's span puts its qn in `owned_qns`,
+    # and the `qn not in owned_qns` guard then bypasses the rehydrated branch
+    # entirely -- so a function-based fixture passes even if a rehydrated
+    # class from the deleted file is wrongly preserved (raised by CodeRabbit
+    # on #1844). A class records no span, so it reaches the branch under test.
+    updater = _build(
+        tmp_path,
+        {
+            "a.py": _A_PY + "\n\nclass Doomed:\n    pass\n",
+            "a/__init__.py": "",
+            "a/b.py": _B_PY,
+        },
+    )
     project = tmp_path.name
     processor = updater.factory.definition_processor
 
-    doomed = f"{project}.a.top"
+    doomed = f"{project}.a.Doomed"
+    assert doomed in _qns(updater), "fixture guard: the class was not registered"
     processor.class_owner_module.pop(doomed, None)
     processor.rehydrated_definition_paths[doomed] = "a.py"
 

--- a/codebase_rag/tests/test_sibling_stem_registry_sweep.py
+++ b/codebase_rag/tests/test_sibling_stem_registry_sweep.py
@@ -243,3 +243,65 @@ def test_a_surviving_csharp_siblings_class_is_kept(tmp_path: Path) -> None:
     assert survivor in _qns(updater), (
         "Core/Util.cs still exists but lost its class to Core.cs's deletion"
     )
+
+
+def test_a_rehydrated_siblings_class_is_kept(tmp_path: Path) -> None:
+    """Ownership has TWO records, and both must be consulted.
+
+    `class_owner_module` is written at ingest, so a definition carried over
+    by a REHYDRATE (an incremental run that reads unchanged files back from
+    the graph instead of re-parsing them) has no entry there. Consulting only
+    that map left the rehydrated case falling through to the prefix rule, so
+    an unchanged sibling still lost its class on an incremental run -- the
+    defect fixed here, just one run later. Raised in review of #1844.
+
+    `rehydrated_definition_paths` is the record for exactly those, written
+    when the row is read back, and `_prune_class_keyed_maps` already treats
+    it as ownership evidence.
+    """
+    updater = _build(tmp_path, {"a.py": _A_PY, "a/__init__.py": "", "a/b.py": _B_PY})
+    project = tmp_path.name
+    processor = updater.factory.definition_processor
+
+    # The rehydrated shape: the class is registered and its defining file is
+    # recorded, but the ingest-time owner map does not know about it.
+    survivor = f"{project}.a.b.Nested"
+    processor.class_owner_module.pop(survivor, None)
+    processor.rehydrated_definition_paths[survivor] = "a/b.py"
+    assert survivor not in processor.class_owner_module, (
+        "fixture guard: the ingest-time owner entry must be absent, or this "
+        "test passes through the other branch and proves nothing"
+    )
+
+    (tmp_path / "a.py").unlink()
+    updater.remove_file_from_state(tmp_path / "a.py")
+
+    after = _qns(updater)
+    assert survivor in after, (
+        "a rehydrated class from the surviving a/b.py was swept with a.py"
+    )
+    # ...and the deleted file's own definitions still go.
+    assert f"{project}.a.top" not in after
+
+
+def test_a_rehydrated_class_from_the_deleted_file_still_goes(tmp_path: Path) -> None:
+    """The control for the rehydrated branch.
+
+    Keeping rehydrated definitions must not become "keep everything
+    rehydrated": a definition whose recorded path IS the deleted file has to
+    be removed, or the sweep stops working on incremental runs.
+    """
+    updater = _build(tmp_path, {"a.py": _A_PY, "a/__init__.py": "", "a/b.py": _B_PY})
+    project = tmp_path.name
+    processor = updater.factory.definition_processor
+
+    doomed = f"{project}.a.top"
+    processor.class_owner_module.pop(doomed, None)
+    processor.rehydrated_definition_paths[doomed] = "a.py"
+
+    (tmp_path / "a.py").unlink()
+    updater.remove_file_from_state(tmp_path / "a.py")
+
+    assert doomed not in _qns(updater), (
+        "a rehydrated definition from the DELETED file survived"
+    )

--- a/codebase_rag/tests/test_sibling_stem_registry_sweep.py
+++ b/codebase_rag/tests/test_sibling_stem_registry_sweep.py
@@ -172,3 +172,74 @@ def test_deeper_stem_collisions_are_kept_too(tmp_path: Path, depth: int) -> None
 
     lost = sorted(survivors - _qns(updater))
     assert not lost, f"nested surviving file lost entries: {lost}"
+
+
+_CS_CORE = (
+    "namespace Util\n{\n    public class Helper\n    {\n"
+    "        public int Go() { return 1; }\n    }\n}\n"
+)
+_CS_SIBLING = (
+    "namespace Other\n{\n    public class Sibling\n    {\n"
+    "        public int Go() { return 2; }\n    }\n}\n"
+)
+
+
+def test_a_deleted_csharp_class_goes_even_when_its_namespace_mimics_a_sibling(
+    tmp_path: Path,
+) -> None:
+    """Ownership comes from a RECORD, never from the qn's shape.
+
+    Raised by Greptile in review of #1844, and confirmed: a C# class qn
+    embeds its namespace, so `proj/Core.cs` declaring `namespace Util`
+    yields `proj.Core.Util.Helper`, which sits under the SIBLING module
+    `proj.Core.Util` from `proj/Core/Util.cs`. The obvious version of this
+    fix -- keep a qn that also sits under a longer surviving module -- kept
+    `Helper` after deleting the file that declares it, leaving a stale class
+    steering resolution at a definition that is gone.
+
+    #1769 hit the same trap in `csharp_class_generic_arity` and answered it
+    the same way, with an explicit owner record. `class_owner_module` is the
+    cross-language one (#1772).
+    """
+    updater = _build(
+        tmp_path,
+        {"Core.cs": _CS_CORE, "Core/Util.cs": _CS_SIBLING},
+    )
+    project = tmp_path.name
+    assert f"{project}.Core.Util.Helper" in _qns(updater), (
+        "fixture guard: the namespace-embedding qn was not produced, so this "
+        "test cannot exercise the shape it exists for"
+    )
+
+    (tmp_path / "Core.cs").unlink()
+    updater.remove_file_from_state(tmp_path / "Core.cs")
+
+    after = _qns(updater)
+    assert f"{project}.Core.Util.Helper" not in after, (
+        "a class from the DELETED file survived because its namespace put "
+        "its qn under a surviving sibling module"
+    )
+
+
+def test_a_surviving_csharp_siblings_class_is_kept(tmp_path: Path) -> None:
+    """The #1773 defect itself, in C# -- the shape the issue measured.
+
+    Pairs with the test above: one requires the deleted file's class to go,
+    this one requires the surviving file's class to stay. A fix satisfying
+    only one of them is the bug in the other direction, and `main` fails
+    this one.
+    """
+    updater = _build(
+        tmp_path,
+        {"Core.cs": _CS_CORE, "Core/Util.cs": _CS_SIBLING},
+    )
+    project = tmp_path.name
+    survivor = f"{project}.Core.Util.Other.Sibling"
+    assert survivor in _qns(updater), "fixture guard: sibling class not registered"
+
+    (tmp_path / "Core.cs").unlink()
+    updater.remove_file_from_state(tmp_path / "Core.cs")
+
+    assert survivor in _qns(updater), (
+        "Core/Util.cs still exists but lost its class to Core.cs's deletion"
+    )

--- a/codebase_rag/tests/test_sibling_stem_registry_sweep.py
+++ b/codebase_rag/tests/test_sibling_stem_registry_sweep.py
@@ -1,0 +1,174 @@
+"""Deleting `a.py` must not sweep `a/b.py`'s registry entries (issue #1773).
+
+A directory can share a sibling FILE's stem, and then the module qns nest:
+`proj/a.py` records `proj.a` while `proj/a/b.py` records `proj.a.b`.
+`remove_file_from_state` sweeps `function_registry` by module-qn prefix, so
+deleting `a.py` matched `proj.a.` and took `b.py`'s definitions with it --
+though `b.py` still exists and the deletion event does not re-parse it, so
+nothing restores them. Calls into those definitions then stop resolving, and
+a later re-parse can land a `@line` DUP_QN variant beside the row that was
+never removed (the #1719 shape).
+
+`foreign_qns` does not save them. It is built from function SPAN records, so
+it protects `proj.a.b.Nested.deep` while leaving the CLASS `proj.a.b.Nested`,
+which records no span. The issue measured that asymmetry on `A.cs` beside
+`A/B.cs`; it reproduces identically here on `a.py` beside `a/b.py`, because
+the sweep is language-agnostic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+_A_PY = "def top():\n    return 1\n"
+_B_PY = (
+    "class Nested:\n"
+    "    def deep(self):\n"
+    "        return 2\n"
+    "\n\n"
+    "def sibling():\n"
+    "    return 3\n"
+)
+
+
+def _build(tmp_path: Path, files: dict[str, str]) -> GraphUpdater:
+    for rel, content in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=MagicMock(), repo_path=tmp_path, parsers=parsers, queries=queries
+    )
+    updater.run()
+    return updater
+
+
+def _qns(updater: GraphUpdater) -> set[str]:
+    return set(updater.function_registry.keys())
+
+
+def test_deleting_a_file_keeps_its_stem_sharing_directorys_definitions(
+    tmp_path: Path,
+) -> None:
+    updater = _build(
+        tmp_path,
+        {"a.py": _A_PY, "a/__init__.py": "", "a/b.py": _B_PY},
+    )
+    project = tmp_path.name
+    before = _qns(updater)
+    survivors = {qn for qn in before if f"{project}.a.b" in qn}
+    assert survivors, "fixture registered nothing for a/b.py"
+
+    (tmp_path / "a.py").unlink()
+    updater.remove_file_from_state(tmp_path / "a.py")
+
+    after = _qns(updater)
+    lost = sorted(survivors - after)
+    assert not lost, f"a/b.py still exists but lost registry entries: {lost}"
+
+    # The CLASS is the one the old sweep dropped: `foreign_qns` is built from
+    # function span records, so it protected the method and not the class.
+    # Naming it explicitly means a fix that only rescues methods fails here.
+    assert f"{project}.a.b.Nested" in after
+    assert f"{project}.a.b.Nested.deep" in after
+
+
+def test_the_deleted_files_own_definitions_are_still_removed(tmp_path: Path) -> None:
+    """The control, and the one that matters most.
+
+    Keeping the surviving file's entries must not be achieved by weakening
+    the sweep: the deleted file's own rows still have to go, or a stale
+    definition steers resolution at something that no longer exists. A test
+    asserting only the survivors would pass with the sweep deleted entirely.
+    """
+    updater = _build(
+        tmp_path,
+        {"a.py": _A_PY, "a/__init__.py": "", "a/b.py": _B_PY},
+    )
+    project = tmp_path.name
+    assert f"{project}.a.top" in _qns(updater)
+
+    (tmp_path / "a.py").unlink()
+    updater.remove_file_from_state(tmp_path / "a.py")
+
+    assert f"{project}.a.top" not in _qns(updater)
+
+
+def test_a_plain_deletion_with_no_stem_collision_is_unaffected(tmp_path: Path) -> None:
+    """The ordinary case must keep behaving ordinarily: with no directory
+    sharing the stem, everything under the deleted module still goes."""
+    updater = _build(
+        tmp_path,
+        {"solo.py": "class Gone:\n    def m(self):\n        return 1\n"},
+    )
+    project = tmp_path.name
+    assert f"{project}.solo.Gone" in _qns(updater)
+
+    (tmp_path / "solo.py").unlink()
+    updater.remove_file_from_state(tmp_path / "solo.py")
+
+    remaining = {qn for qn in _qns(updater) if qn.startswith(f"{project}.solo")}
+    assert not remaining, f"deleted module left entries behind: {sorted(remaining)}"
+
+
+def test_deleting_the_nested_file_does_not_disturb_the_shorter_module(
+    tmp_path: Path,
+) -> None:
+    """The other direction: deleting `a/b.py` must leave `a.py` alone.
+
+    `proj.a` is a PREFIX of `proj.a.b`, not the reverse, so this direction
+    was never broken -- which is exactly why it belongs here. If a fix
+    rescued survivors by keeping anything a longer module also matches, this
+    would start failing.
+    """
+    updater = _build(
+        tmp_path,
+        {"a.py": _A_PY, "a/__init__.py": "", "a/b.py": _B_PY},
+    )
+    project = tmp_path.name
+
+    (tmp_path / "a" / "b.py").unlink()
+    updater.remove_file_from_state(tmp_path / "a" / "b.py")
+
+    after = _qns(updater)
+    assert f"{project}.a.top" in after, "deleting a/b.py wrongly removed a.py's entry"
+    assert f"{project}.a.b.Nested" not in after
+    assert f"{project}.a.b.sibling" not in after
+
+
+@pytest.mark.parametrize("depth", [2, 3])
+def test_deeper_stem_collisions_are_kept_too(tmp_path: Path, depth: int) -> None:
+    """`a/b.py` beside `a/b/c.py` is the same shape one level down."""
+    files = {"a/__init__.py": "", "a/b.py": _A_PY}
+    nested = "a/" + "/".join(["b"] * (depth - 1)) + "/c.py"
+    files["a/b/__init__.py"] = ""
+    files[nested] = _B_PY
+    updater = _build(tmp_path, files)
+    project = tmp_path.name
+
+    target = tmp_path / "a" / "b.py"
+    # Anchor on the nested MODULE qn, not on a substring: the temp directory
+    # name can itself contain "c", which made an earlier version of this
+    # filter pick up `a.b.top` -- a definition from the file being DELETED --
+    # and report it as a lost survivor.
+    nested_module = f"{project}." + nested[: -len(".py")].replace("/", ".")
+    survivors = {
+        qn
+        for qn in _qns(updater)
+        if qn == nested_module or qn.startswith(f"{nested_module}.")
+    }
+    if not survivors:
+        pytest.skip("fixture produced no nested entries at this depth")
+
+    target.unlink()
+    updater.remove_file_from_state(target)
+
+    lost = sorted(survivors - _qns(updater))
+    assert not lost, f"nested surviving file lost entries: {lost}"


### PR DESCRIPTION
Closes #1773.

## The defect

A directory can share a sibling file's stem, and then module qns nest: `proj/a.py` records `proj.a` while `proj/a/b.py` records `proj.a.b`. `remove_file_from_state` sweeps `function_registry` by module-qn prefix, so deleting `a.py` matched `proj.a.` and took `b.py`'s definitions with it — though `b.py` still exists and the deletion event does not re-parse it, so nothing restores them.

Calls into those definitions then stop resolving, and a later re-parse can land a `@line` DUP_QN variant beside the row that was never removed (the #1719 shape).

## Reproduced in Python, not just C#

The issue measured it on `A.cs` beside `A/B.cs` and noted the sweep is language-agnostic. Confirmed — `a.py` beside `a/b.py` reproduces it identically on `origin/main`:

```
registry before: 4 entries
  from a/b.py: ['proj.a.b.Nested', 'proj.a.b.Nested.deep', 'proj.a.b.sibling']

registry after deleting a.py: 2 entries
  from a/b.py: ['proj.a.b.Nested.deep', 'proj.a.b.sibling']

LOST from the SURVIVING file a/b.py: ['proj.a.b.Nested']
```

Including the asymmetry the issue predicted: the **class** is lost while the **method** survives, because `foreign_qns` is built from function span records and a class registers none.

## The fix

A qn under a **surviving** module qn — one still in `module_qn_to_file_path`, not among this event's own prefixes, and longer than the prefix that matched — is kept, whichever shorter prefix also matches. `owned_qns` still wins, since that is the deleted file's own span-record evidence.

### Why not the `csharp_class_generic_arity` approach

#1769 hit the same shape and did **not** end up using this rule: it added an explicit `csharp_class_owner_module` record, because a C# class qn embeds its namespace, so a class can sit under a sibling module it was never declared in and a prefix rule errs in both directions.

That reasoning does not carry here. A Python/Rust/Go module qn is derived from the path, so "under a longer surviving module" does identify the real owner. Noted in the code comment so the divergence is deliberate rather than looking like an oversight.

## Tests

`codebase_rag/tests/test_sibling_stem_registry_sweep.py`, 6 tests. Three are controls, and they carry the weight — keeping the survivor's entries must not be achieved by weakening the sweep:

- the deleted file's own definitions are **still removed**;
- a plain deletion with no stem collision still removes everything under the module;
- the reverse direction (deleting `a/b.py` leaves `a.py` alone) — never broken, which is why it belongs here: a fix that kept anything a longer module matched would start failing it.

Verified to discriminate: reverting the fix reddens exactly the three defect tests while all three controls stay green.

One test was wrong on the first run and is worth noting, since it is the failure mode this repo keeps hitting: the deeper-collision case filtered survivors with `"c" in qn`, and the temp directory name contained a "c", so it picked up a definition from the file being **deleted** and reported it as a lost survivor. Now anchored on the nested module qn instead of a substring.

Regression: 712 passed across 62 incremental/deletion/registry/watch/reingest/C# test files.

Note: `ty` reports one `possibly-missing-attribute` on `graph_updater.py:5206`. It is pre-existing — the identical single diagnostic comes back with these changes stashed — and unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed file deletion handling so definitions in similarly named nested modules are preserved.
  - Deleting a file now removes only its own registry entries without affecting sibling or nested modules that share its name stem.
  - Preserved definitions from surviving files, including restored definitions, while still removing definitions tied to the deleted file.
  - Existing cleanup behavior remains unchanged for modules without naming conflicts.

- **Tests**
  - Added coverage for nested module name conflicts, deeper paths, reverse deletion scenarios, C# namespace patterns, and restored definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->