### PR TITLE
fix: read the durable incomplete-run marker on the structural-delta path too (#1783)

### DIFF
--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1663,7 +1663,18 @@ class MCPToolsRegistry:
                 self.ingestor.fetch_all,
                 updater.project_name,
                 relative,
-                lambda: updater.reingest(changed, deleted=deleted),
+                # Invariant (a), second half: the marks above say
+                # `writing=False`, and `reingest` starts deleting after its
+                # read-only prologue. Without advancing the phase there, a
+                # crash mid-delete left a partial graph that a fresh registry
+                # reads as recoverable, CLEARS, and hydrates as complete
+                # (raised by CodeRabbit on #1845). Same callback
+                # `_reingest_sync` passes for the same reason.
+                lambda: updater.reingest(
+                    changed,
+                    deleted=deleted,
+                    before_write=lambda: self._begin_writing_or_refuse(project_name),
+                ),
                 repo_root=root,
             )
         except (ValueError, ReingestAborted) as e:

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1637,10 +1637,25 @@ class MCPToolsRegistry:
             # would durably wedge the project (caught in review of #1845).
             # `_reingest_sync` pairs the same mark with a clear via
             # `marked_here`; this tracks it the same way.
+            #
+            # BOTH branches mark. The retained-updater branch reaches the same
+            # mutating `reingest` below, so leaving it unmarked meant a crash
+            # mid-delta left a partially rebuilt graph that a fresh process
+            # could not tell from a complete one (raised in review of #1845).
+            # That is the fifth-path gap `_reingest_sync` closed in the #1705
+            # review, round 6, arriving on this path too. `writing=False`
+            # because the updater's prologue is read-only; the phase advances
+            # at its first delete.
+            project_name = derive_project_name(root)
             if self._live_updater is not None:
                 updater = self._live_updater
+                if (
+                    refusal := self._require_marker(project_name, writing=False)
+                ) is not None:
+                    raise RuntimeError(refusal)
+                marked_here = project_name
             else:
-                marked_here = derive_project_name(root)
+                marked_here = project_name
                 updater = self._hydrate_reingest_updater(marked_here)
             deleted = [p for p in relative if not (root / p).exists()]
             changed = [p for p in relative if p not in deleted]

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1670,6 +1670,14 @@ class MCPToolsRegistry:
             # Raised before any graph change (validation, an abort while the
             # paths are split): the graph is whole and the updater reusable.
             logger.warning(lg.MCP_DELTA_FAILED.format(error=e))
+            # ...so the marker this call took must come off, or a graph that
+            # was never touched goes on refusing every later scoped reingest
+            # (raised by CodeRabbit on #1845). `_abandon_before_writing` is
+            # the same helper `_reingest_sync` uses for its own no-write
+            # aborts: it lifts the marker and leaves the attribution to
+            # whichever failure owns it.
+            if marked_here is not None:
+                self._abandon_before_writing(marked_here)
             return "\n\n" + cs.MCP_DELTA_ERROR.format(error=e)
         except Exception as e:
             # The re-ingest may have deleted a subtree it never rebuilt: the

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1369,39 +1369,6 @@ class MCPToolsRegistry:
         self._live_updater = updater
         return updater
 
-    def _updater_for_reingest(self) -> GraphUpdater:
-        updater = self._live_updater
-        if updater is None:
-            # A scoped re-ingest completes a graph; it cannot stand in for
-            # the first index. After delete_project or wipe_database the
-            # project is gone, and hydrating from nothing would leave every
-            # unrelated definition missing.
-            project_name = derive_project_name(Path(self.project_root))
-            if self._graph_incomplete:
-                raise ValueError(
-                    cs.MCP_REINGEST_AFTER_FAILED_RUN.format(project=project_name)
-                )
-            if project_name not in self.ingestor.list_projects():
-                raise ValueError(
-                    cs.MCP_REINGEST_NEEDS_INDEX.format(project=project_name)
-                )
-            self.ingestor.ensure_constraints()
-            # The same exclusion set the index and update paths use, or an
-            # agent-named path under a CLI-excluded directory would be
-            # indexed here and kept by every later update.
-            exclude_paths, unignore_paths = self._ignore_sets()
-            updater = GraphUpdater(
-                ingestor=self.ingestor,
-                repo_path=Path(self.project_root),
-                parsers=self.parsers,
-                queries=self.queries,
-                unignore_paths=unignore_paths,
-                exclude_paths=exclude_paths,
-                project_name=project_name,
-            )
-            self._live_updater = updater
-        return updater
-
     def _reingest_sync(
         self, paths: list[str], deleted: list[str]
     ) -> ReingestToolResult:
@@ -1647,7 +1614,24 @@ class MCPToolsRegistry:
                 derive_project_name(root) not in self.ingestor.list_projects()
             ):
                 return ""
-            updater = self._updater_for_reingest()
+            # The marker-reading hydration, not `_updater_for_reingest`
+            # (issue #1783). That helper guards on `_graph_incomplete` alone,
+            # which lives on the registry and dies with the process: after a
+            # crash or an MCP restart it is False because nothing in THIS
+            # process failed, so the guard passes and hydrates from a graph a
+            # previous run left partial. `_hydrate_reingest_updater` reads the
+            # persisted marker as well, which is what survives the process
+            # that earned it (#1679).
+            #
+            # #1705 rebuilt the scoped-reingest call site onto this helper but
+            # not this one, which the #1546 stack added after that branch was
+            # written -- so the two paths refused and proceeded in the same
+            # registry state, and neither call site showed it.
+            updater = (
+                self._live_updater
+                if self._live_updater is not None
+                else self._hydrate_reingest_updater(derive_project_name(root))
+            )
             deleted = [p for p in relative if not (root / p).exists()]
             changed = [p for p in relative if p not in deleted]
             delta = sd.observe(

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1609,6 +1609,9 @@ class MCPToolsRegistry:
         """
         root = Path(self.project_root)
         relative = sd.normalise_paths(paths, root)
+        # Set when the hydration below marks the run, so the success path can
+        # lift that marker (invariant b) -- see the comment at the call.
+        marked_here: str | None = None
         try:
             if self._live_updater is None and (
                 derive_project_name(root) not in self.ingestor.list_projects()
@@ -1627,11 +1630,18 @@ class MCPToolsRegistry:
             # not this one, which the #1546 stack added after that branch was
             # written -- so the two paths refused and proceeded in the same
             # registry state, and neither call site showed it.
-            updater = (
-                self._live_updater
-                if self._live_updater is not None
-                else self._hydrate_reingest_updater(derive_project_name(root))
-            )
+            #
+            # Invariant (b) comes with it: that helper MARKS before its
+            # destructive migration, so a completed delta has to lift the
+            # marker or every later run refuses on it -- a successful delta
+            # would durably wedge the project (caught in review of #1845).
+            # `_reingest_sync` pairs the same mark with a clear via
+            # `marked_here`; this tracks it the same way.
+            if self._live_updater is not None:
+                updater = self._live_updater
+            else:
+                marked_here = derive_project_name(root)
+                updater = self._hydrate_reingest_updater(marked_here)
             deleted = [p for p in relative if not (root / p).exists()]
             changed = [p for p in relative if p not in deleted]
             delta = sd.observe(
@@ -1663,6 +1673,14 @@ class MCPToolsRegistry:
             # attribution was written, so it had no way to know about it.
             self._flag_from_failed_clear = None
             return "\n\n" + cs.MCP_DELTA_ERROR.format(error=e)
+        if marked_here is not None:
+            # Invariant (b): the hydration marked before its constraint
+            # migration, so a completed delta must lift it. A failed clear is
+            # reported in place of the delta rather than silently retained --
+            # this method never raises, so the message is the only channel.
+            if (stuck := self._require_marker_cleared(marked_here)) is not None:
+                logger.warning(lg.MCP_DELTA_FAILED.format(error=stuck))
+                return "\n\n" + cs.MCP_DELTA_ERROR.format(error=stuck)
         return (
             "\n\n"
             + cs.MCP_DELTA_HEADER

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1167,6 +1167,40 @@ class TestIncompleteMarkerSurvivesTheProcess:
             "process could not tell the partial graph from a complete one"
         )
 
+    async def test_a_delta_whose_marker_clear_fails_reports_it(
+        self, temp_project_root: Path
+    ) -> None:
+        """A stuck clear is a retryable failure, not a silent success.
+
+        The delta itself succeeded but its marker could not be lifted, so the
+        project is still durably marked and every later run will refuse. This
+        method never raises -- it reports in place of the delta -- so the
+        message is the only channel that can say so. Reporting the delta as
+        clean here would leave the caller with a wedged project and no
+        indication why (the same shape #1705 fixed on the reingest path).
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = MagicMock(
+                reparsed=(), affected=(), removed=(), elapsed_ms=0.1
+            )
+            updater_cls.return_value.project_name = project
+            with patch("codebase_rag.mcp.tools.sd.observe", return_value=""):
+                ingestor._failing.add("clear")
+                result = registry._delta_after_write(["a.py"])
+                ingestor._failing.discard("clear")
+
+        assert "Structural delta unavailable" in result, (
+            f"a stuck marker clear was reported as a clean delta; got {result!r}"
+        )
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the clear was expected to fail and leave the marker"
+        )
+
     async def test_a_completed_update_lifts_the_refusal_for_a_fresh_registry(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1186,6 +1186,53 @@ class TestIncompleteMarkerSurvivesTheProcess:
             "the retained-branch delta left its own marker behind"
         )
 
+    async def test_a_delta_aborted_before_writing_lifts_its_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """A no-write abort must not leave the project blocked (#1845 review).
+
+        `reingest` can raise `ReingestAborted` during its READ-ONLY prologue.
+        The graph is whole then -- the handler's own comment says so -- but
+        the marker this call took stayed, so every later scoped reingest
+        refused a graph that was never touched, in this process and in any
+        fresh one.
+
+        Pairs with `test_a_failed_structural_delta_keeps_its_marker`: that one
+        requires the marker to SURVIVE a failure that may have mutated. The
+        distinction is exactly whether the graph was touched, which is what
+        `_abandon_before_writing` exists to express.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.project_name = project
+            with patch(
+                "codebase_rag.mcp.tools.sd.observe",
+                side_effect=ReingestAborted("aborted in the prologue"),
+            ):
+                result = registry._delta_after_write(["a.py"])
+
+        assert "unavailable" in result, f"fixture guard: expected the abort; {result!r}"
+        assert ingestor._marker_store.get(project) is not True, (
+            "a delta aborted BEFORE any graph change left its marker behind; "
+            "the project refuses every later reingest though nothing was written"
+        )
+
+        # End to end: a fresh process must not inherit the refusal.
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = MagicMock(
+                reparsed=(), affected=(), removed=(), skipped=(), elapsed_ms=0.1
+            )
+            after = await fresh.reingest(["a.py"])
+        assert "failed part way" not in after.get("error", ""), (
+            f"a fresh registry inherited a marker from a no-write abort; {after}"
+        )
+
     async def test_a_failed_structural_delta_keeps_its_marker(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1137,6 +1137,55 @@ class TestIncompleteMarkerSurvivesTheProcess:
             f"a fresh registry refused after a SUCCESSFUL delta; got {after}"
         )
 
+    async def test_a_delta_through_a_retained_updater_is_marked_too(
+        self, temp_project_root: Path
+    ) -> None:
+        """BOTH delta branches mark, not only the hydrating one (#1845 review).
+
+        The retained-updater branch reaches the same mutating `reingest`, so
+        leaving it unmarked meant a crash mid-delta left a partially rebuilt
+        graph that a fresh process could not tell from a complete one. Same
+        fifth-path gap `_reingest_sync` closed in the #1705 review, round 6.
+
+        Observed through the marker store DURING the delta -- after it, a
+        successful run has cleared its own marker, so the end state looks
+        identical whether or not one was ever taken.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+
+        retained = MagicMock()
+        retained.project_name = project
+        retained.reingest.return_value = MagicMock(
+            reparsed=(), affected=(), removed=(), elapsed_ms=0.1
+        )
+        registry._live_updater = retained
+        assert registry._live_updater is not None, "fixture guard: retained branch"
+
+        marked_during: list[bool] = []
+
+        def _observe(*_args: object, **_kwargs: object) -> str:
+            # Called inside `sd.observe`, i.e. while the delta is running.
+            marked_during.append(ingestor._marker_store.get(project) is True)
+            return ""
+
+        with patch("codebase_rag.mcp.tools.sd.observe", side_effect=_observe):
+            result = registry._delta_after_write(["a.py"])
+
+        assert "unavailable" not in result, (
+            f"fixture guard: the delta must succeed; got {result!r}"
+        )
+        assert marked_during == [True], (
+            "a delta through the RETAINED updater mutated the graph with no "
+            "durable marker; a crash mid-delta would leave a partial graph "
+            "indistinguishable from a complete one"
+        )
+        assert ingestor._marker_store.get(project) is not True, (
+            "the retained-branch delta left its own marker behind"
+        )
+
     async def test_a_failed_structural_delta_keeps_its_marker(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1088,6 +1088,85 @@ class TestIncompleteMarkerSurvivesTheProcess:
         """
         assert not hasattr(MCPToolsRegistry, "_updater_for_reingest")
 
+    async def test_a_successful_structural_delta_lifts_its_own_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """Invariant (b) on the structural-delta path (#1845 review).
+
+        Routing this path through `_hydrate_reingest_updater` (#1783) brings
+        its MARK with it: that helper marks before its constraint migration.
+        Without a matching clear a SUCCESSFUL delta left the project durably
+        marked, and every later run -- delta or scoped reingest, in this
+        process or a fresh one -- refused on a marker no failure earned.
+
+        The delta must genuinely succeed here: on the failure path a retained
+        marker is correct, so a test whose delta errored would pass against
+        the bug.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = MagicMock(
+                reparsed=(), affected=(), removed=(), elapsed_ms=0.1
+            )
+            updater_cls.return_value.project_name = project
+            with patch("codebase_rag.mcp.tools.sd.observe", return_value=""):
+                result = registry._delta_after_write(["a.py"])
+
+        assert "unavailable" not in result, (
+            f"fixture guard: the delta FAILED, so a retained marker is "
+            f"correct and this test cannot see the defect; got {result!r}"
+        )
+        assert ingestor._marker_store.get(project) is not True, (
+            "a successful structural delta left its own marker set; every "
+            "later run would refuse on it"
+        )
+
+        # The consequence, end to end: a fresh process must not refuse.
+        second = self._registry(temp_project_root, ingestor)
+        _mark_indexed(second)
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.reingest.return_value = MagicMock(
+                reparsed=(), affected=(), removed=(), skipped=(), elapsed_ms=0.1
+            )
+            after = await second.reingest(["a.py"])
+        assert "failed part way" not in after.get("error", ""), (
+            f"a fresh registry refused after a SUCCESSFUL delta; got {after}"
+        )
+
+    async def test_a_failed_structural_delta_keeps_its_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """The control for the clear above.
+
+        The marker must come off only on SUCCESS. A delta that fails after
+        mutating may have left a subtree deleted and not rebuilt, and that is
+        exactly what the marker exists to record -- so a fix that simply
+        always cleared would satisfy the test above while discarding the
+        protection.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.project_name = project
+            with patch(
+                "codebase_rag.mcp.tools.sd.observe",
+                side_effect=RuntimeError("delta died mid-write"),
+            ):
+                result = registry._delta_after_write(["a.py"])
+
+        assert "unavailable" in result, f"fixture guard: expected failure; {result!r}"
+        assert ingestor._marker_store.get(project) is True, (
+            "a delta that failed after mutating dropped its marker; a fresh "
+            "process could not tell the partial graph from a complete one"
+        )
+
     async def test_a_completed_update_lifts_the_refusal_for_a_fresh_registry(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1233,6 +1233,57 @@ class TestIncompleteMarkerSurvivesTheProcess:
             f"a fresh registry inherited a marker from a no-write abort; {after}"
         )
 
+    async def test_a_delta_advances_the_phase_before_mutating(
+        self, temp_project_root: Path
+    ) -> None:
+        """Invariant (a), second half, on the delta path (#1845 review).
+
+        Both delta branches mark with `writing=False`, and `reingest` starts
+        deleting after its read-only prologue. Without advancing the phase
+        there, a crash mid-delete left a partial graph that a fresh registry
+        reads as recoverable, CLEARS, and hydrates as complete -- worse than
+        no marker, because the recovery path actively removes the protection.
+
+        Asserts the phase as seen from `before_write`, i.e. at the moment the
+        updater is about to issue its first delete.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+
+        phase_at_write: list[bool] = []
+
+        def _reingest(*_a: object, before_write: object = None, **_k: object) -> object:
+            # PRODUCTION must supply the callback. An earlier version of this
+            # test called it unconditionally when present, which passes
+            # whether or not the delta path passes one -- it observed the stub
+            # rather than the code, and stayed green with `before_write`
+            # removed from the call site.
+            assert callable(before_write), (
+                "the delta path did not pass a before_write callback, so the "
+                "marker stays writing=False through the deletes"
+            )
+            before_write()
+            phase_at_write.append(ingestor._writing_store.get(project) is True)
+            return MagicMock(reparsed=(), affected=(), removed=(), elapsed_ms=0.1)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.project_name = project
+            updater_cls.return_value.reingest.side_effect = _reingest
+            with patch(
+                "codebase_rag.mcp.tools.sd.observe",
+                side_effect=lambda *a, **k: (
+                    (a[3]() if len(a) > 3 else k["run"]()) and ""
+                ),
+            ):
+                result = registry._delta_after_write(["a.py"])
+
+        assert phase_at_write == [True], (
+            "the delta began deleting with its marker still saying "
+            f"writing=False; a crash there is recoverable-looking: {result!r}"
+        )
+
     async def test_a_failed_structural_delta_keeps_its_marker(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -994,6 +994,100 @@ class TestIncompleteMarkerSurvivesTheProcess:
             f"graph left by a crashed update; got {refused}"
         )
 
+    async def test_a_fresh_registry_refuses_the_structural_delta_after_a_crash(
+        self, temp_project_root: Path
+    ) -> None:
+        """The structural-delta path needs the same durable check (#1783).
+
+        `_updater_for_reingest` guards on the in-process flag alone and never
+        reads the persisted marker, so after a crash or an MCP restart it
+        passes -- `_graph_incomplete` is False because nothing in THIS
+        process failed -- and hydrates from the partial graph.
+
+        The sibling test above covers `_reingest_sync`, which #1705 rebuilt
+        as `_hydrate_reingest_updater` (the marker-reading version). The
+        structural-delta call site was added by the #1546 stack after that
+        branch was written, so it kept the flag-only helper. Same registry,
+        same state, opposite answers -- and invisible from either call site,
+        since each looks correct alone.
+
+        Driven through `_delta_after_write`, the real caller, rather than the
+        helper: the defect is which helper that path REACHES, so calling the
+        helper directly would assert the fix on the wrong subject.
+        """
+        ingestor = self._store()
+        first = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(first)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            updater_cls.return_value.run.side_effect = RuntimeError("update died")
+            assert "Error" in await first.update_repository()
+
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the failed update left no persisted marker, so a "
+            "fresh process has nothing to read and this proves nothing"
+        )
+
+        second = self._registry(temp_project_root, ingestor)
+        _mark_indexed(second)
+        assert second._graph_incomplete is False, (
+            "fixture guard: the new registry must NOT carry the in-process "
+            "flag, or this test cannot tell the persisted marker apart from it"
+        )
+
+        # `_delta_after_write` never raises -- it reports in place of the
+        # delta -- so the refusal shows up in the returned text.
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            result = second._delta_after_write(["a.py"])
+            hydrated = updater_cls.called
+
+        assert not hydrated, (
+            "the structural-delta path built an updater over the partial "
+            "graph left by a crashed update; it must refuse like the scoped "
+            "reingest path does"
+        )
+        assert "failed part way" in result, (
+            f"expected the incomplete-run refusal in the delta text; got {result!r}"
+        )
+
+    async def test_a_completed_update_lets_the_structural_delta_through(
+        self, temp_project_root: Path
+    ) -> None:
+        """The control.
+
+        Without it the fix is indistinguishable from one that refuses every
+        structural delta forever, which also satisfies the test above.
+        """
+        ingestor = self._store()
+        first = self._registry(temp_project_root, ingestor)
+        _mark_indexed(first)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            assert "Error" not in await first.update_repository()
+
+        second = self._registry(temp_project_root, ingestor)
+        _mark_indexed(second)
+
+        (temp_project_root / "a.py").write_text("x = 1\n", encoding="utf-8")
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as updater_cls:
+            second._delta_after_write(["a.py"])
+            assert updater_cls.called, (
+                "a clean store must still let the structural delta hydrate"
+            )
+
+    async def test_the_flag_only_hydration_helper_is_gone(self) -> None:
+        """Both reingest paths now read the durable marker (#1783).
+
+        `_updater_for_reingest` guarded on `_graph_incomplete` alone. With
+        its last caller routed through `_hydrate_reingest_updater` it has
+        none, and a flag-only hydration helper left sitting beside the
+        marker-reading one is how this defect came back once already: the
+        #1546 stack picked the wrong one because both existed and looked
+        interchangeable. If it returns it needs a caller and a reason.
+        """
+        assert not hasattr(MCPToolsRegistry, "_updater_for_reingest")
+
     async def test_a_completed_update_lifts_the_refusal_for_a_fresh_registry(
         self, temp_project_root: Path
     ) -> None:


### PR DESCRIPTION
Closes #1783.

Now reachable: #1705 merged on 2026-09-07, so `_hydrate_reingest_updater` is on `main` and the two paths genuinely disagree.

## The defect

`_updater_for_reingest` guards on `_graph_incomplete` alone and never reads the durable incomplete-run marker. That flag lives on the registry, so it dies with the process: after a crash or an MCP restart it is `False` because nothing in *this* process failed, the guard passes, and the updater hydrates from a graph a previous run left partial — treating its missing definitions as authoritative (#1679).

#1705 rebuilt the scoped-reingest call site as `_hydrate_reingest_updater`, which reads the persisted marker as well. It did not touch the structural-delta call site, which the #1546 stack added after that branch was written. Same registry, same state, opposite answers — and invisible from either call site, since each looks correct alone.

## Red before green

The defect test fails on unmodified `main`:

```
>       assert not hydrated, (
E       assert not True
FAILED ... test_a_fresh_registry_refuses_the_structural_delta_after_a_crash
```

A crashed `update_repository` leaves the marker set; a **second registry** over the same store (what a restarted server has, sharing the store but not the flag) then runs `_delta_after_write`, and on `main` it builds an updater over the partial graph.

## The change

Route the structural-delta path through `_hydrate_reingest_updater`, as the issue prescribes.

That left `_updater_for_reingest` with **no callers**, so it is removed. Leaving a flag-only hydration helper beside the marker-reading one is how this defect arrived in the first place: the #1546 stack picked the wrong one because both existed and looked interchangeable. Directly the #1784 shape, on the same day — a dead helper that reads as a live guarantee.

## Tests

Driven through `_delta_after_write`, the real caller, not the helper: the defect is *which helper that path reaches*, so calling the helper directly would assert the fix on the wrong subject.

- a fresh registry refuses the structural delta after a crashed update (red before, green after);
- **the control** — a completed update still lets the structural delta hydrate. Without it the fix is indistinguishable from one that refuses every structural delta forever, which also satisfies the first test;
- a guard that `_updater_for_reingest` stays gone.

Full file: 93 passed, including the existing `TestIncompleteMarkerInvariant` suite that pins invariants (a), (b) and (c).

Regression: 600 passed across 22 MCP/reingest/marker/delta test files.

Note: `test_mcp_startup_key_validation.py` has 2 failures. They are pre-existing — the identical two come back with these changes stashed — and unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery after interrupted or crashed updates by detecting persisted incomplete-update status.
  - Prevented structural-delta processing from proceeding against incomplete graph data.
  - Ensured processing continues normally after successfully completed updates.
  - Updated incomplete status before the first structural-delta mutation.
  - Structural-delta processing now clears its incomplete-update status after success, reports cleanup failures, and releases markers when processing stops before writing.
  - Ensured incomplete status is retained when delta processing fails.

- **Tests**
  - Added regression coverage for update recovery, marker lifecycle, mutation timing, and cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->