### PR TITLE
fix: a successful marker clear settles only the project that owns the flag (#1774)

### DIFF
--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1251,15 +1251,25 @@ class MCPToolsRegistry:
         Also syncs the in-process flag to the durable state, so this process
         and the next agree. Returns None on success, or the failure message.
         """
+        flag_before = self._graph_incomplete
         cleared = self._persist_incomplete(project_name, False)
         if not cleared:
-            if not self._graph_incomplete:
-                self._incomplete_owner = project_name
             self._graph_incomplete = True
             # Attribute the flag to this project's stranded marker, so the
             # recovery in `_hydrate_reingest_updater` heals only the flag it
-            # explains.
-            self._flag_from_failed_clear = project_name
+            # explains -- but ONLY when this failure is what raised it.
+            #
+            # An already-set flag belongs to whatever failure set it, and
+            # claiming it here hands this project recovery authority over
+            # someone else's damage: A fails leaving the flag up, B's clear
+            # then fails and claims the attribution, and when B's marker later
+            # recovers, `recoverable_here` is satisfied and B clears the latch
+            # A owns (caught in review of #1846). Same rule as the ownership
+            # claim below and as `_abandon_before_writing`, which already
+            # guards its attribution with `if not flag_before`.
+            if not flag_before:
+                self._incomplete_owner = project_name
+                self._flag_from_failed_clear = project_name
             return cs.MCP_INCOMPLETE_MARKER_STUCK.format(project=project_name)
 
         # A successful clear settles only the damage THIS project owns.

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -806,12 +806,19 @@ class MCPToolsRegistry:
         # those definitions over what is left. After a completed delete the
         # project is gone and the not-indexed guard takes over.
         self._live_updater = None
+        # Claim ownership ONLY when raising the flag from clean. An
+        # already-set flag records damage an earlier failure found, and
+        # claiming it here would let this operation's own successful clear
+        # settle someone else's -- which is the #1774 defect arriving from
+        # the other side: a failed WIPE leaves owner=None, and an unrelated
+        # delete/index/update would overwrite that with its own project and
+        # then clear it (caught in review of #1846). Read before the raise,
+        # since the raise is what makes it look owned.
+        if not self._graph_incomplete:
+            self._incomplete_owner = project_name
         self._graph_incomplete = True
         # Not a stranded marker: this flag must not be healed by one.
         self._flag_from_failed_clear = None
-        # This operation's own project owns the flag, so its own successful
-        # clear may settle it; an unrelated project's may not (issue #1774).
-        self._incomplete_owner = project_name
         # Invariant (a). Nothing has been touched yet, so refusing costs
         # nothing; proceeding would leave a half-removed graph a fresh
         # registry cannot tell from a completed delete.
@@ -893,12 +900,19 @@ class MCPToolsRegistry:
         # resolve against the retained updater's definitions or against
         # whatever partial graph a failure left behind.
         self._live_updater = None
+        # Claim ownership ONLY when raising the flag from clean. An
+        # already-set flag records damage an earlier failure found, and
+        # claiming it here would let this operation's own successful clear
+        # settle someone else's -- which is the #1774 defect arriving from
+        # the other side: a failed WIPE leaves owner=None, and an unrelated
+        # delete/index/update would overwrite that with its own project and
+        # then clear it (caught in review of #1846). Read before the raise,
+        # since the raise is what makes it look owned.
+        if not self._graph_incomplete:
+            self._incomplete_owner = project_name
         self._graph_incomplete = True
         # Not a stranded marker: this flag must not be healed by one.
         self._flag_from_failed_clear = None
-        # This operation's own project owns the flag, so its own successful
-        # clear may settle it; an unrelated project's may not (issue #1774).
-        self._incomplete_owner = project_name
         # Persisted BEFORE the delete, and on a node the delete cannot reach:
         # this path removes the Project and rebuilds it, so a marker stored on
         # the Project would be destroyed by the very operation whose failure it
@@ -992,12 +1006,19 @@ class MCPToolsRegistry:
         # reingest refuse until an update completes, since hydrating from
         # the partial graph would be no better.
         self._live_updater = None
+        # Claim ownership ONLY when raising the flag from clean. An
+        # already-set flag records damage an earlier failure found, and
+        # claiming it here would let this operation's own successful clear
+        # settle someone else's -- which is the #1774 defect arriving from
+        # the other side: a failed WIPE leaves owner=None, and an unrelated
+        # delete/index/update would overwrite that with its own project and
+        # then clear it (caught in review of #1846). Read before the raise,
+        # since the raise is what makes it look owned.
+        if not self._graph_incomplete:
+            self._incomplete_owner = project_name
         self._graph_incomplete = True
         # Not a stranded marker: this flag must not be healed by one.
         self._flag_from_failed_clear = None
-        # This operation's own project owns the flag, so its own successful
-        # clear may settle it; an unrelated project's may not (issue #1774).
-        self._incomplete_owner = project_name
         # The marker goes down BEFORE ensure_constraints, not after.
         # `ensure_constraints` runs `_migrate_legacy_path_keys`, which drops
         # constraints and can run purge queries -- autocommitted, destructive
@@ -1232,8 +1253,9 @@ class MCPToolsRegistry:
         """
         cleared = self._persist_incomplete(project_name, False)
         if not cleared:
+            if not self._graph_incomplete:
+                self._incomplete_owner = project_name
             self._graph_incomplete = True
-            self._incomplete_owner = project_name
             # Attribute the flag to this project's stranded marker, so the
             # recovery in `_hydrate_reingest_updater` heals only the flag it
             # explains.
@@ -1513,6 +1535,9 @@ class MCPToolsRegistry:
             # mid-run as "nothing changed" and clear a marker that is
             # protecting a partial graph.
             mutated = self._reingest_mutated(updater, exc)
+            # Read before the branch below raises the flag, so ownership is
+            # claimed only when this failure is what set it (#1846 review).
+            flag_before_mutation = self._graph_incomplete
             if mutated:
                 self._live_updater = None
                 self._graph_incomplete = True
@@ -1527,10 +1552,12 @@ class MCPToolsRegistry:
                 # and let a scoped reingest run over the partial graph this
                 # very branch left (#1705 review, final round).
                 #
-                # Owned by this project: the damage is this project's and its
-                # own clear may settle it (issue #1774).
+                # Owned by this project, but only if no earlier failure
+                # already owns the flag -- claiming another owner's would let
+                # this project's clear settle it (#1846 review).
                 self._flag_from_failed_clear = None
-                self._incomplete_owner = project_name
+                if not flag_before_mutation:
+                    self._incomplete_owner = project_name
             elif marked_here is not None:
                 # Nothing was written, so the marker this call created is a
                 # lie about a run that changed nothing and must come off.
@@ -1718,6 +1745,8 @@ class MCPToolsRegistry:
             # or write reuses a partial graph (issue #1525).
             logger.warning(lg.MCP_DELTA_FAILED.format(error=e))
             self._live_updater = None
+            # Read before the raise below, for the same reason.
+            flag_before_delta = self._graph_incomplete
             self._graph_incomplete = True
             # Not a stranded marker: this flag must not be healed by one.
             # This path invalidates precisely BECAUSE a subtree may have been
@@ -1728,9 +1757,11 @@ class MCPToolsRegistry:
             # Added on the rebase: this site landed on main (#1525) after the
             # attribution was written, so it had no way to know about it.
             self._flag_from_failed_clear = None
-            # Owned by this project (issue #1774): the subtree that may be
-            # missing is this project's, so its own clear may settle it.
-            self._incomplete_owner = derive_project_name(root)
+            # Owned by this project (issue #1774), unless an earlier failure
+            # already owns the flag -- see the guard at the delete/index/update
+            # sites for why claiming another owner's is unsafe (#1846 review).
+            if not flag_before_delta:
+                self._incomplete_owner = derive_project_name(root)
             return "\n\n" + cs.MCP_DELTA_ERROR.format(error=e)
         return (
             "\n\n"

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -111,6 +111,22 @@ class MCPToolsRegistry:
         # an unrelated marker-less failure earned, whenever some recoverable
         # marker happens to be pending at guard time (#1705 review).
         self._flag_from_failed_clear: str | None = None
+        # WHICH project's damage `_graph_incomplete` records, when a marker
+        # does not say. The flag is registry-wide but every writer of it is
+        # project-scoped, so a successful clear for project B discarded a
+        # flag project A earned (issue #1774): `_require_marker_cleared` set
+        # it from one project's result with `self._graph_incomplete = not
+        # cleared`. The durable marker cannot cover that case, being per
+        # project -- a wipe that dies before the graph is gone writes no
+        # marker for A at all, leaving this flag the only record that A is
+        # partial, and an unrelated delete erased it.
+        #
+        # `None` means "spans every project, or owner unknown", which is what
+        # a WIPE leaves: no single project's clear may settle it. A named
+        # project means an operation on THAT project raised it and its own
+        # clear is entitled to settle it -- which is what keeps
+        # delete/index/update working, since each clears the flag it raised.
+        self._incomplete_owner: str | None = None
 
         self.parsers, self.queries = load_parsers()
 
@@ -793,6 +809,9 @@ class MCPToolsRegistry:
         self._graph_incomplete = True
         # Not a stranded marker: this flag must not be healed by one.
         self._flag_from_failed_clear = None
+        # This operation's own project owns the flag, so its own successful
+        # clear may settle it; an unrelated project's may not (issue #1774).
+        self._incomplete_owner = project_name
         # Invariant (a). Nothing has been touched yet, so refusing costs
         # nothing; proceeding would leave a half-removed graph a fresh
         # registry cannot tell from a completed delete.
@@ -834,6 +853,11 @@ class MCPToolsRegistry:
                 self._graph_incomplete = True
                 # Not a stranded marker: this flag must not be healed by one.
                 self._flag_from_failed_clear = None
+                # A wipe spans EVERY project and writes no marker, so its
+                # damage is attributable to none of them and no single
+                # project's clear may settle it (issue #1774). The success
+                # path below clears the flag itself.
+                self._incomplete_owner = None
                 await asyncio.to_thread(self.ingestor.clean_database)
                 await asyncio.to_thread(clear_all_embeddings)
                 self._graph_incomplete = False
@@ -872,6 +896,9 @@ class MCPToolsRegistry:
         self._graph_incomplete = True
         # Not a stranded marker: this flag must not be healed by one.
         self._flag_from_failed_clear = None
+        # This operation's own project owns the flag, so its own successful
+        # clear may settle it; an unrelated project's may not (issue #1774).
+        self._incomplete_owner = project_name
         # Persisted BEFORE the delete, and on a node the delete cannot reach:
         # this path removes the Project and rebuilds it, so a marker stored on
         # the Project would be destroyed by the very operation whose failure it
@@ -968,6 +995,9 @@ class MCPToolsRegistry:
         self._graph_incomplete = True
         # Not a stranded marker: this flag must not be healed by one.
         self._flag_from_failed_clear = None
+        # This operation's own project owns the flag, so its own successful
+        # clear may settle it; an unrelated project's may not (issue #1774).
+        self._incomplete_owner = project_name
         # The marker goes down BEFORE ensure_constraints, not after.
         # `ensure_constraints` runs `_migrate_legacy_path_keys`, which drops
         # constraints and can run purge queries -- autocommitted, destructive
@@ -1201,14 +1231,30 @@ class MCPToolsRegistry:
         and the next agree. Returns None on success, or the failure message.
         """
         cleared = self._persist_incomplete(project_name, False)
-        self._graph_incomplete = not cleared
-        # Attribute the flag to this project's stranded marker (or drop a
-        # stale attribution when the clear succeeded), so the recovery in
-        # `_hydrate_reingest_updater` heals only the flag it explains.
-        self._flag_from_failed_clear = project_name if not cleared else None
-        if cleared:
-            return None
-        return cs.MCP_INCOMPLETE_MARKER_STUCK.format(project=project_name)
+        if not cleared:
+            self._graph_incomplete = True
+            self._incomplete_owner = project_name
+            # Attribute the flag to this project's stranded marker, so the
+            # recovery in `_hydrate_reingest_updater` heals only the flag it
+            # explains.
+            self._flag_from_failed_clear = project_name
+            return cs.MCP_INCOMPLETE_MARKER_STUCK.format(project=project_name)
+
+        # A successful clear settles only the damage THIS project owns.
+        # `self._graph_incomplete = not cleared` settled everything, so a
+        # clean clear for project B discarded a flag project A earned from a
+        # failure that wrote no marker -- and the durable marker cannot cover
+        # that, being per project (issue #1774).
+        #
+        # An unowned flag (`None`) is a WIPE's: it spans every project, no
+        # single project's clear may settle it, and the wipe's own success
+        # path clears it inline. A flag owned by another project stands until
+        # that project's own operation settles it.
+        if self._incomplete_owner == project_name or not self._graph_incomplete:
+            self._graph_incomplete = False
+            self._incomplete_owner = None
+        self._flag_from_failed_clear = None
+        return None
 
     def _persisted_incomplete(self, project_name: str) -> bool:
         """Whether a previous process left this project mid-update.
@@ -1480,7 +1526,11 @@ class MCPToolsRegistry:
                 # clear would then satisfy `recoverable_here`, heal the flag,
                 # and let a scoped reingest run over the partial graph this
                 # very branch left (#1705 review, final round).
+                #
+                # Owned by this project: the damage is this project's and its
+                # own clear may settle it (issue #1774).
                 self._flag_from_failed_clear = None
+                self._incomplete_owner = project_name
             elif marked_here is not None:
                 # Nothing was written, so the marker this call created is a
                 # lie about a run that changed nothing and must come off.
@@ -1678,6 +1728,9 @@ class MCPToolsRegistry:
             # Added on the rebase: this site landed on main (#1525) after the
             # attribution was written, so it had no way to know about it.
             self._flag_from_failed_clear = None
+            # Owned by this project (issue #1774): the subtree that may be
+            # missing is this project's, so its own clear may settle it.
+            self._incomplete_owner = derive_project_name(root)
             return "\n\n" + cs.MCP_DELTA_ERROR.format(error=e)
         return (
             "\n\n"

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1285,7 +1285,16 @@ class MCPToolsRegistry:
         if self._incomplete_owner == project_name or not self._graph_incomplete:
             self._graph_incomplete = False
             self._incomplete_owner = None
-        self._flag_from_failed_clear = None
+        # The attribution is scoped the same way, and for the mirror reason.
+        # Dropping it unconditionally discarded ANOTHER project's licence to
+        # heal itself: A's failed clear strands a recoverable `writing=false`
+        # marker and attributes the flag to A, then B's clean clear wiped that
+        # attribution and A's own later reingest could no longer recover --
+        # refused forever though its graph was untouched (raised by CodeRabbit
+        # on #1846). Fails closed rather than open, but it wedges a project
+        # that has nothing wrong with it.
+        if self._flag_from_failed_clear == project_name:
+            self._flag_from_failed_clear = None
         return None
 
     def _persisted_incomplete(self, project_name: str) -> bool:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1185,6 +1185,50 @@ class TestIncompleteMarkerSurvivesTheProcess:
             "A could not heal its own recoverable marker"
         )
 
+    async def test_any_projects_clear_cannot_settle_a_failed_wipe(
+        self, temp_project_root: Path
+    ) -> None:
+        """Issue #1820's reproduction, pinned explicitly.
+
+        That issue is a third face of the same overloaded `None` this PR is
+        about, and it falls out of the ownership rule rather than needing its
+        own change -- but "falls out" is worth an assertion, or a later
+        refactor can quietly take it away again while the two tests above
+        stay green.
+
+        A failed wipe leaves the flag up with no owner (it spans every
+        project and writes no marker), so the in-process flag is the only
+        record the graph is partial. Before the rule, the next successful
+        clear for ANY project settled it and reads proceeded against a
+        half-wiped graph.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        _mark_indexed(registry)
+
+        ingestor.clean_database.side_effect = RuntimeError("wipe died")
+        assert "Error" in await registry.wipe_database(confirm=True)
+        ingestor.clean_database.side_effect = None
+        assert registry._graph_incomplete is True
+        assert registry._incomplete_owner is None, (
+            "fixture guard: a wipe spans every project, so it owns none"
+        )
+
+        # A clear for a project entirely unrelated to the wipe.
+        assert registry._require_marker("any-project", writing=False) is None
+        assert registry._require_marker_cleared("any-project") is None
+
+        assert registry._graph_incomplete is True, (
+            "an unrelated project's clear settled the flag a failed wipe "
+            "earned; reads would proceed against a half-wiped graph (#1820)"
+        )
+
+        _mark_indexed(registry)
+        refused = await registry.reingest(["a.py"])
+        assert "failed part way" in refused.get("error", ""), (
+            f"expected the incomplete-run refusal; got {refused}"
+        )
+
     async def test_a_projects_own_clear_still_settles_its_own_flag(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1039,6 +1039,53 @@ class TestIncompleteMarkerSurvivesTheProcess:
             f"expected the incomplete-run refusal; got {refused}"
         )
 
+    async def test_deleting_an_unrelated_project_cannot_settle_a_wipes_flag(
+        self, temp_project_root: Path
+    ) -> None:
+        """Through the PUBLIC path, which is what the helper-level test missed.
+
+        Raised by Greptile on #1846 and confirmed. The sibling test drives
+        `_require_marker_cleared('project-B')` directly, so it never sees
+        `_delete_project_sync` RAISE the flag for its own project first --
+        overwriting the wipe's `owner=None` with `B` -- and then legitimately
+        settle what it now appears to own. Measured before the fix:
+
+            after failed wipe:  flag=True  owner=None
+            after delete of B:  flag=False owner=None
+            reingest of A: ACCEPTED over a partial graph
+
+        The rule is that an operation claims ownership only when it raises
+        the flag FROM CLEAN; an already-set flag belongs to whatever failure
+        set it. Same rule `_abandon_before_writing` already applied to the
+        attribution.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        ingestor.clean_database.side_effect = RuntimeError("wipe died")
+        assert "Error" in await registry.wipe_database(confirm=True)
+        ingestor.clean_database.side_effect = None
+        assert registry._graph_incomplete is True, "fixture guard: wipe must flag"
+        assert registry._incomplete_owner is None, (
+            "fixture guard: a wipe spans every project, so it owns none"
+        )
+
+        ingestor.list_projects.return_value = [project, "B"]
+        result = await registry.delete_project("B")
+        assert result.get("success") is True, f"fixture guard: delete failed; {result}"
+
+        assert registry._graph_incomplete is True, (
+            "deleting an unrelated project settled the flag a failed wipe "
+            "earned; the next reingest would run over a partially wiped graph"
+        )
+
+        _mark_indexed(registry)
+        refused = await registry.reingest(["a.py"])
+        assert "failed part way" in refused.get("error", ""), (
+            f"expected the incomplete-run refusal; got {refused}"
+        )
+
     async def test_a_projects_own_clear_still_settles_its_own_flag(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1139,6 +1139,52 @@ class TestIncompleteMarkerSurvivesTheProcess:
             "B's marker recovery cleared the latch A owns"
         )
 
+    async def test_a_clean_clear_keeps_another_projects_licence_to_heal(
+        self, temp_project_root: Path
+    ) -> None:
+        """The mirror of the attribution rule, and it fails CLOSED (#1846).
+
+        `_flag_from_failed_clear` is a project's licence to heal itself: A's
+        failed clear strands a recoverable `writing=false` marker and records
+        that the flag is A's to lift once the marker recovers. Dropping the
+        attribution unconditionally on any successful clear meant B's clean
+        clear discarded it, and A's own later reingest could no longer
+        recover -- refused forever though its graph was untouched.
+
+        Harmless compared with the other direction (a wrongly ALLOWED
+        reingest), but it wedges a project with nothing wrong with it, and
+        both directions come from the same unscoped assignment.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # A's clear fails, leaving a recoverable marker attributed to A.
+        assert registry._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert registry._require_marker_cleared(project) is not None
+        ingestor._failing.discard("clear")
+        assert registry._flag_from_failed_clear == project, (
+            "fixture guard: A's failed clear must attribute the flag to A"
+        )
+
+        # B completes and clears its own marker.
+        assert registry._require_marker("B", writing=False) is None
+        assert registry._require_marker_cleared("B") is None
+
+        assert registry._flag_from_failed_clear == project, (
+            "B's clean clear discarded A's licence to heal itself; A's own "
+            "reingest would be refused though its graph was never touched"
+        )
+
+        # And A can still recover: its marker is `writing=false`.
+        registry._live_updater = None
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            registry._hydrate_reingest_updater(project)
+        assert registry._graph_incomplete is False, (
+            "A could not heal its own recoverable marker"
+        )
+
     async def test_a_projects_own_clear_still_settles_its_own_flag(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -994,6 +994,94 @@ class TestIncompleteMarkerSurvivesTheProcess:
             f"graph left by a crashed update; got {refused}"
         )
 
+    async def test_an_unrelated_projects_clear_cannot_settle_a_wipes_flag(
+        self, temp_project_root: Path
+    ) -> None:
+        """A successful clear settles only what it owns (#1774).
+
+        `_graph_incomplete` is registry-wide while every writer of it is
+        project-scoped, so `self._graph_incomplete = not cleared` let project
+        B's clean clear discard a flag project A earned.
+
+        The durable marker does not cover this. It is per project, so
+        `_persisted_incomplete(A)` correctly returns False: a wipe that dies
+        before the graph is gone writes no marker for A at all, leaving the
+        in-process flag the ONLY record that A is partial.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        _mark_indexed(registry)
+
+        # A wipe that fails part way: flag up, no marker written anywhere.
+        ingestor.clean_database.side_effect = RuntimeError("wipe died")
+        assert "Error" in await registry.wipe_database(confirm=True)
+        ingestor.clean_database.side_effect = None
+
+        assert registry._graph_incomplete is True, "fixture guard: wipe must flag"
+        assert not ingestor._marker_store, (
+            "fixture guard: the wipe must write NO marker, or the durable "
+            "check would refuse on its own and this proves nothing"
+        )
+
+        # An unrelated project B completes and clears its own marker.
+        assert registry._require_marker("project-B") is None
+        assert registry._require_marker_cleared("project-B") is None
+
+        assert registry._graph_incomplete is True, (
+            "an unrelated project's successful clear discarded the flag the "
+            "failed wipe earned; the next reingest would run over a partial graph"
+        )
+
+        # And the refusal it protects still fires.
+        _mark_indexed(registry)
+        refused = await registry.reingest(["a.py"])
+        assert "failed part way" in refused.get("error", ""), (
+            f"expected the incomplete-run refusal; got {refused}"
+        )
+
+    async def test_a_projects_own_clear_still_settles_its_own_flag(
+        self, temp_project_root: Path
+    ) -> None:
+        """The control, and the one that constrains the fix.
+
+        Making the flag harder to clear must not break the operations that
+        legitimately clear the flag they raised: delete, index and update
+        each set it before their first write and settle it on success. A fix
+        that simply refused every clear would satisfy the test above while
+        wedging all three.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        _mark_indexed(registry)
+
+        with patch("codebase_rag.mcp.tools.GraphUpdater"):
+            assert "Error" not in await registry.update_repository()
+
+        assert registry._graph_incomplete is False, (
+            "a completed update must clear the flag it raised for its own project"
+        )
+        assert registry._incomplete_owner is None
+
+    async def test_a_delete_still_settles_the_flag_it_raised(
+        self, temp_project_root: Path
+    ) -> None:
+        """Second control, on a different owner-setting path.
+
+        `_delete_project_sync` raises the flag for its own project and
+        settles it via its own `_require_marker_cleared`. Pinning only the
+        update path would leave the delete and index paths free to regress.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+        ingestor.list_projects.return_value = [project, "other"]
+
+        result = await registry.delete_project(project)
+        assert result.get("success") is True, result
+        assert registry._graph_incomplete is False, (
+            "a completed delete must settle the flag it raised"
+        )
+
     async def test_a_completed_update_lifts_the_refusal_for_a_fresh_registry(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1086,6 +1086,59 @@ class TestIncompleteMarkerSurvivesTheProcess:
             f"expected the incomplete-run refusal; got {refused}"
         )
 
+    async def test_a_failed_clear_cannot_claim_another_projects_flag(
+        self, temp_project_root: Path
+    ) -> None:
+        """Recovery authority follows ownership too (#1846 review, third round).
+
+        The ownership field was guarded but `_flag_from_failed_clear` was not,
+        and it is what grants the heal in `_hydrate_reingest_updater`
+        (`recoverable_here = _flag_from_failed_clear == project_name`). So:
+
+            1. A fails leaving the flag up, owner=None (a failed wipe)
+            2. B's marker clear FAILS and claims the attribution
+            3. B's marker later recovers -> B heals the latch A owns
+
+        Measured before the fix: step 3 left `flag=False`, and B's scoped
+        reingest proceeded over A's partial graph.
+
+        The rule is the same one the ownership claim uses: an already-set flag
+        belongs to whatever failure set it.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        ingestor.clean_database.side_effect = RuntimeError("wipe died")
+        assert "Error" in await registry.wipe_database(confirm=True)
+        ingestor.clean_database.side_effect = None
+        assert registry._graph_incomplete is True, "fixture guard: wipe must flag"
+        assert registry._flag_from_failed_clear is None, (
+            "fixture guard: a wipe strands no marker, so nothing is attributed"
+        )
+
+        # B strands a marker of its own: its clear fails.
+        assert registry._require_marker("B", writing=False) is None
+        ingestor._failing.add("clear")
+        assert registry._require_marker_cleared("B") is not None, (
+            "fixture guard: the clear was expected to fail"
+        )
+        ingestor._failing.discard("clear")
+
+        assert registry._flag_from_failed_clear is None, (
+            "B's failed clear claimed recovery authority over the flag A owns"
+        )
+
+        # B's marker recovers. The heal must not fire on A's flag.
+        ingestor._marker_store.pop("B", None)
+        registry._live_updater = None
+        ingestor.list_projects.return_value = [project, "B"]
+        with pytest.raises(ValueError, match="failed part way"):
+            registry._hydrate_reingest_updater("B")
+        assert registry._graph_incomplete is True, (
+            "B's marker recovery cleared the latch A owns"
+        )
+
     async def test_a_projects_own_clear_still_settles_its_own_flag(
         self, temp_project_root: Path
     ) -> None:


### PR DESCRIPTION
Closes #1774.

## The defect

`_graph_incomplete` is a single registry-wide boolean, but `_require_marker_cleared` set it from **one project's** clear result:

```python
cleared = self._persist_incomplete(project_name, False)
self._graph_incomplete = not cleared
```

So a *successful* clear for project B discarded a flag project A earned. Reproduced on unmodified `main`:

```
after a marker-less failure:  flag=True
after B's successful clear:   flag=False
=> DEFECT REPRODUCES: B's clear discarded A's flag
```

The durable marker cannot cover this. It is per project, so `_persisted_incomplete(A)` correctly returns False: a wipe that dies before the graph is gone writes no marker for A at all, leaving the in-process flag the **only** record that A is partial.

## The fix, and why not the simpler one

The issue offers "per project, or conditional on `project_name` matching whatever raised it". The obvious reading — treat an unattributed (`None`) flag as unsettleable — **breaks three working paths**, and I confirmed that by trying it first:

```
FAILED test_delete_project_drops_the_retained_updater
```

`delete_project`, `index_repository` and `update_repository` each raise the flag before their first write with `_flag_from_failed_clear = None` ("Not a stranded marker: this flag must not be healed by one") and then settle it via their own `_require_marker_cleared` on success. So `None` does not mean "marker-less failure"; it also means "an operation is in flight and will clear its own flag".

The distinguishing fact is *which project the damage belongs to*, and no existing field carries it. So this adds `_incomplete_owner`, set at every one of the six sites that raise the flag:

- the four project-scoped paths (delete, index, update, reingest-mutated, delta) record their own project;
- the **wipe** records `None`, because it spans every project, writes no marker, and no single project's clear may settle it. Its own success path clears the flag inline.

A clear then settles the flag only when this project owns it. Same shape as #1769's `csharp_class_owner_module`, and as `_abandon_before_writing`, which already restores `flag_before` rather than clearing unconditionally.

## Tests

- the defect: an unrelated project's successful clear cannot settle a failed wipe's flag, and the reingest refusal it protects still fires;
- **two controls**, which are what constrain the fix: a completed `update_repository` still settles the flag it raised, and a completed `delete_project` does too. A fix that simply refused every clear would satisfy the defect test while wedging all three paths — which is exactly the failure my first attempt produced.

The controls cover two different owner-setting sites deliberately: pinning only the update path would leave delete and index free to regress.

Verified to discriminate: restoring the unconditional settle reddens the defect test alone; both controls stay green.

Regression: the full `test_mcp_update_and_search.py` passes (93), including the existing `TestIncompleteMarkerInvariant` suite that pins invariants (a), (b) and (c); 600 passed across 22 MCP/reingest/marker/delta files.

Note: `test_mcp_startup_key_validation.py` has 2 failures. They are pre-existing — the identical two come back with these changes stashed — and unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery tracking for incomplete project operations.
  - Prevented successful operations on one project from incorrectly clearing an unresolved failure from another project.
  - Preserved safeguards that block scoped reingestion while a prior operation remains incomplete.
  - Ensured project-specific recovery actions can clear their own incomplete status without affecting other projects.
  - Improved consistency across repeated project updates, deletions, marker-clearing attempts, and failed recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->