### PR TITLE
fix: find the CI run by head SHA, not in a window of recent runs

### DIFF
--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -24,8 +24,11 @@ The four that bite, and which a naive implementation gets wrong:
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from scripts import check_pr_gated
 from scripts.check_pr_gated import (
     AGGREGATED_JOBS,
     context_name,
@@ -418,3 +421,184 @@ class TestIsRealReview:
         )
 
         assert is_real_review(invented_future_notice, "coderabbitai") is False
+
+
+class TestCiRunsAtHeadIsNotWindowed:
+    """The run lookup must ask by SHA, not page recent runs.
+
+    Measured on PR #1826: its CI run was 36 minutes old, all 40 of the most
+    recent repo runs were newer, and the tool reported a fully green PR as
+    having "no CI run at the head". A windowed lookup turns repo traffic
+    into a false "never ran" verdict, which is the exact confusion this
+    checker exists to remove.
+    """
+
+    HEAD = "8c93429b6e9bc17a61b3096c296cae1a26f1a411"
+
+    CI_PATH = ".github/workflows/ci.yml"
+
+    def _payload(self, *, path: str | None = None) -> str:
+        return json.dumps(
+            {
+                "workflow_runs": [
+                    {
+                        "id": 34416630107,
+                        "name": "CI",
+                        "path": path if path is not None else self.CI_PATH,
+                        "head_sha": self.HEAD,
+                    }
+                ]
+            }
+        )
+
+    def test_the_query_is_scoped_to_the_head_sha(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[tuple[str, ...]] = []
+
+        def fake(*args: str) -> str:
+            seen.append(args)
+            return self._payload()
+
+        monkeypatch.setattr(check_pr_gated, "_gh_stdout_or_empty", fake)
+
+        check_pr_gated.ci_runs_at_head(self.HEAD)
+
+        assert any(f"head_sha={self.HEAD}" in arg for call in seen for arg in call)
+
+    def test_it_does_not_page_recent_runs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `--limit` listing is the bug; it must not be how the answer is got."""
+        seen: list[tuple[str, ...]] = []
+
+        def fake(*args: str) -> str:
+            seen.append(args)
+            return self._payload()
+
+        monkeypatch.setattr(check_pr_gated, "_gh_stdout_or_empty", fake)
+
+        check_pr_gated.ci_runs_at_head(self.HEAD)
+
+        assert not any("--limit" in call for call in seen)
+
+    def test_a_run_older_than_any_window_is_still_found(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            check_pr_gated, "_gh_stdout_or_empty", lambda *a: self._payload()
+        )
+
+        runs = check_pr_gated.ci_runs_at_head(self.HEAD)
+
+        assert [r["id"] for r in runs] == [34416630107]
+
+    def test_a_non_ci_workflow_at_the_same_sha_is_excluded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            check_pr_gated,
+            "_gh_stdout_or_empty",
+            lambda *a: self._payload(path=".github/workflows/codeql.yml"),
+        )
+
+        assert check_pr_gated.ci_runs_at_head(self.HEAD) == []
+
+    def test_an_impostor_workflow_merely_named_ci_is_excluded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A display name is a string any workflow file may declare.
+
+        Matching on it would let a second file called `CI` satisfy the
+        check without running a single test, so the run is identified by
+        the workflow PATH. The repo's own require-ci-at-head workflow
+        matches on path for this reason.
+        """
+        monkeypatch.setattr(
+            check_pr_gated,
+            "_gh_stdout_or_empty",
+            lambda *a: self._payload(path=".github/workflows/not-really-ci.yml"),
+        )
+
+        assert check_pr_gated.ci_runs_at_head(self.HEAD) == []
+
+    def test_a_run_on_a_later_page_is_still_found(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--paginate` concatenates one JSON object per page.
+
+        Decoding only the first would reintroduce the windowing bug at a
+        larger size: a match on page two would read as "no run at head".
+        """
+        page_one = json.dumps(
+            {
+                "workflow_runs": [
+                    {"id": 1, "name": "OSV", "path": ".github/workflows/osv.yml"}
+                ]
+            }
+        )
+        monkeypatch.setattr(
+            check_pr_gated,
+            "_gh_stdout_or_empty",
+            lambda *a: page_one + "\n" + self._payload(),
+        )
+
+        runs = check_pr_gated.ci_runs_at_head(self.HEAD)
+
+        assert [r["id"] for r in runs] == [34416630107]
+
+    def test_an_unreachable_api_reports_no_runs_rather_than_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(check_pr_gated, "_gh_stdout_or_empty", lambda *a: "")
+
+        assert check_pr_gated.ci_runs_at_head(self.HEAD) == []
+
+
+class TestCheckResolvesRunOwnershipWithTheRestField:
+    """`check` must read the run id by the name the REST payload uses.
+
+    `ci_runs_at_head` returns REST `workflow_runs` entries, which carry
+    `id`. The previous lookup returned `gh run list` entries, which carry
+    `databaseId`. Keeping the old name fetches `actions/runs/None`, leaves
+    `owners` empty, and reports "does not resolve to #<pr>" -- trading one
+    false blocker for another. Verified against live PR #1826.
+    """
+
+    def test_ownership_resolves_rather_than_reporting_an_empty_owner_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        head = "f" * 40
+        view = {
+            "headRefOid": head,
+            "baseRefName": "main",
+            "statusCheckRollup": [],
+            "comments": [],
+            "reviews": [],
+        }
+
+        def fake(*args: str) -> str:
+            if args[:2] == ("pr", "view"):
+                return json.dumps(view)
+            if args[0] == "api" and f"head_sha={head}" in " ".join(args):
+                return json.dumps(
+                    {
+                        "workflow_runs": [
+                            {
+                                "id": 555,
+                                "name": "CI",
+                                "path": ".github/workflows/ci.yml",
+                                "head_sha": head,
+                            }
+                        ]
+                    }
+                )
+            if args[0] == "api" and args[1].endswith("/actions/runs/555"):
+                return json.dumps({"pull_requests": [{"number": 1826}]})
+            return ""
+
+        monkeypatch.setattr(check_pr_gated, "_gh_stdout_or_empty", fake)
+
+        reasons = check_pr_gated.check("1826")
+
+        assert not any("does not resolve to" in r for r in reasons)

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -466,6 +466,36 @@ class TestCiRunsAtHeadIsNotWindowed:
 
         assert any(f"head_sha={self.HEAD}" in arg for call in seen for arg in call)
 
+    def test_the_request_paginates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`head_sha` is exact but not unbounded -- it pages at 30 by default.
+
+        Without --paginate a run on a later page reads as "no run at
+        head", which is the windowing bug this fix removes, returning at
+        a larger size. The decoder test cannot catch this: it feeds
+        pre-concatenated pages to a stub, so it covers the parsing but
+        not the flag that makes multiple pages arrive.
+        """
+        seen: list[tuple[str, ...]] = []
+
+        def fake(*args: str) -> str:
+            seen.append(args)
+            return self._payload()
+
+        monkeypatch.setattr(check_pr_gated, "_gh_stdout_or_empty", fake)
+
+        check_pr_gated.ci_runs_at_head(self.HEAD)
+
+        # Assert the ARGUMENT ORDER, not merely that the flag is present.
+        # `gh --paginate api ...` is rejected by gh, and a presence-only
+        # check passes for it -- caught exactly that way while restoring
+        # this flag after a mutation.
+        assert seen, "no gh call was made"
+        call = seen[0]
+        assert call[0] == "api"
+        assert "--paginate" in call
+        assert call.index("--paginate") > call.index("api")
+        assert any("per_page=100" in arg for arg in call)
+
     def test_it_does_not_page_recent_runs(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -652,6 +682,30 @@ class TestCiRunsAtHeadFailsClosedOnMalformedPages:
         body = bodies[label] if raw is None else raw
 
         assert len(self._runs(monkeypatch, body)) == expected
+
+    @pytest.mark.parametrize(
+        "prefix", ["\n", " ", "\t\n ", "\r\n"], ids=["nl", "space", "mixed", "crlf"]
+    )
+    def test_leading_whitespace_does_not_discard_every_page(
+        self, monkeypatch: pytest.MonkeyPatch, prefix: str
+    ) -> None:
+        """`raw_decode` does not tolerate leading whitespace.
+
+        Skipping separators only AFTER a decode means a response that
+        opens with one raises on the first pass and returns nothing,
+        reported as "no CI run exists at the head SHA" -- the very
+        verdict this lookup was rewritten to stop producing falsely.
+        """
+        runs = self._runs(monkeypatch, prefix + self._page())
+
+        assert [r["id"] for r in runs] == [1]
+
+    def test_leading_whitespace_before_multiple_pages_keeps_them_all(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        raw = "\n" + self._page(1) + "\n" + self._page(2)
+
+        assert [r["id"] for r in self._runs(monkeypatch, raw)] == [1, 2]
 
     def test_a_truncated_final_page_keeps_the_pages_already_decoded(
         self, monkeypatch: pytest.MonkeyPatch

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -720,3 +720,50 @@ class TestCiRunsAtHeadFailsClosedOnMalformedPages:
     ) -> None:
         """Guards against an infinite loop when the decoder cannot advance."""
         assert self._runs(monkeypatch, "not json" + self._page()) == []
+
+
+class TestTheTrueNegativeSurvivesTheFix:
+    """Removing the false "no CI run" must not weaken the real one.
+
+    The point of this gate is to refuse a PR whose CI never ran, so a fix
+    aimed at a false negative has to be checked against the true one --
+    otherwise it trades a tool that cries wolf for one that waves
+    everything through.
+    """
+
+    HEAD = "a" * 40
+
+    def test_a_head_with_no_runs_at_all_reports_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            check_pr_gated,
+            "_gh_stdout_or_empty",
+            lambda *a: json.dumps({"total_count": 0, "workflow_runs": []}),
+        )
+
+        assert check_pr_gated.ci_runs_at_head(self.HEAD) == []
+
+    def test_a_head_whose_runs_are_all_other_workflows_reports_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CodeQL and OSV run without CI on a queued head -- a real case.
+
+        Observed on #1847: every other workflow had reported while
+        `ci.yml` was still pending, so the head carried runs but none of
+        them was the one the gate requires.
+        """
+        monkeypatch.setattr(
+            check_pr_gated,
+            "_gh_stdout_or_empty",
+            lambda *a: json.dumps(
+                {
+                    "workflow_runs": [
+                        {"id": 1, "path": ".github/workflows/codeql.yml"},
+                        {"id": 2, "path": ".github/workflows/osv-scanner.yml"},
+                    ]
+                }
+            ),
+        )
+
+        assert check_pr_gated.ci_runs_at_head(self.HEAD) == []

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -602,3 +602,67 @@ class TestCheckResolvesRunOwnershipWithTheRestField:
         reasons = check_pr_gated.check("1826")
 
         assert not any("does not resolve to" in r for r in reasons)
+
+
+class TestCiRunsAtHeadFailsClosedOnMalformedPages:
+    """Malformed paginated output must yield fewer runs, never more.
+
+    Every degradation here reports "no CI run at the head", which blocks
+    a merge. The opposite direction -- inventing a run from unparseable
+    output -- would report a PR gated on evidence that does not exist.
+    """
+
+    CI_PATH = ".github/workflows/ci.yml"
+
+    def _page(self, run_id: int = 1) -> str:
+        return json.dumps({"workflow_runs": [{"id": run_id, "path": self.CI_PATH}]})
+
+    def _runs(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> list[dict]:
+        monkeypatch.setattr(check_pr_gated, "_gh_stdout_or_empty", lambda *a: raw)
+        return check_pr_gated.ci_runs_at_head("a" * 40)
+
+    @pytest.mark.parametrize(
+        "label,raw,expected",
+        [
+            ("empty", "", 0),
+            ("whitespace only", "   \n  ", 0),
+            ("one page", None, 1),
+            ("trailing whitespace", None, 1),
+            ("page is null", None, 1),
+            ("page is a list", None, 1),
+            ("workflow_runs missing", None, 1),
+            ("workflow_runs not a list", None, 1),
+        ],
+    )
+    def test_malformed_output_never_invents_a_run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        label: str,
+        raw: str | None,
+        expected: int,
+    ) -> None:
+        bodies = {
+            "one page": self._page(),
+            "trailing whitespace": self._page() + "\n\n  ",
+            "page is null": "null\n" + self._page(),
+            "page is a list": "[1,2]\n" + self._page(),
+            "workflow_runs missing": '{"total_count":0}' + "\n" + self._page(),
+            "workflow_runs not a list": '{"workflow_runs":"x"}' + "\n" + self._page(),
+        }
+        body = bodies[label] if raw is None else raw
+
+        assert len(self._runs(monkeypatch, body)) == expected
+
+    def test_a_truncated_final_page_keeps_the_pages_already_decoded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A cut-off last page must not discard the complete ones before it."""
+        raw = self._page() + "\n" + '{"workflow_runs":[{"id":2,'
+
+        assert [r["id"] for r in self._runs(monkeypatch, raw)] == [1]
+
+    def test_the_page_loop_terminates_on_unparseable_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Guards against an infinite loop when the decoder cannot advance."""
+        assert self._runs(monkeypatch, "not json" + self._page()) == []

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -315,8 +315,15 @@ def ci_runs_at_head(head: str) -> list[dict[str, Any]]:
     minutes old, every one of the 40 most recent runs was newer, and the
     tool called a fully green PR ungated.
 
-    The `head_sha` parameter is exact and unbounded, so age and repo
-    traffic cannot affect the answer.
+    The `head_sha` parameter is exact, so age and repo traffic cannot
+    affect the answer. It is NOT unbounded -- it pages at 30 by default,
+    which is why this paginates; an unpaginated query would reintroduce
+    the same bug once a SHA carried enough runs.
+
+    The run is identified by workflow PATH rather than display name: a
+    name is a string any workflow file may declare, so a second file
+    named `CI` would satisfy a name check without running a test. The
+    repo's own require-ci-at-head.yml matches on path for this reason.
     """
     raw = _gh_stdout_or_empty(
         "api",

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -43,6 +43,7 @@ import sys
 from typing import Any
 
 REPO = "vitali87/code-graph-rag"
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 
 # The one context the active ruleset requires on the default branch. It
 # aggregates the jobs below and asserts each result == "success", so a
@@ -303,6 +304,47 @@ def _unresolved_thread_count(pr: str) -> tuple[int, str]:
     )
 
 
+def ci_runs_at_head(head: str) -> list[dict[str, Any]]:
+    """The CI runs at exactly `head`, asked of the API by SHA.
+
+    Listing recent runs and filtering client-side cannot answer this: the
+    listing is a fixed-size window over the WHOLE repo, so on a busy repo a
+    run drops out of it while the PR is still open and the PR then reports
+    as having no CI run at all -- the "never ran" verdict, produced by a
+    run that did happen and passed. Measured on #1826: its run was 36
+    minutes old, every one of the 40 most recent runs was newer, and the
+    tool called a fully green PR ungated.
+
+    The `head_sha` parameter is exact and unbounded, so age and repo
+    traffic cannot affect the answer.
+    """
+    raw = _gh_stdout_or_empty(
+        "api",
+        "--paginate",
+        f"repos/{REPO}/actions/runs?head_sha={head}&per_page=100",
+    )
+    runs: list[dict[str, Any]] = []
+    # `--paginate` without `--jq` concatenates one JSON object per page, so
+    # this is a stream of objects rather than one document. `--jq` would
+    # flatten it, but `gh` rejects the `--slurp` needed to rebuild an array
+    # alongside `--jq`, so decode the pages here instead.
+    decoder = json.JSONDecoder()
+    index = 0
+    while index < len(raw):
+        try:
+            page, offset = decoder.raw_decode(raw, index)
+        except ValueError:
+            break
+        if isinstance(page, dict):
+            found = page.get("workflow_runs", [])
+            if isinstance(found, list):
+                runs.extend(r for r in found if isinstance(r, dict))
+        index = offset
+        while index < len(raw) and raw[index].isspace():
+            index += 1
+    return [run for run in runs if str(run.get("path", "")) == CI_WORKFLOW_PATH]
+
+
 def check(pr: str) -> list[str]:
     """Every reason `pr` is not verifiably gated, in order. Empty means gated."""
     reasons: list[str] = []
@@ -335,32 +377,14 @@ def check(pr: str) -> list[str]:
             "so nothing is enforced on this PR regardless of its check list"
         )
 
-    runs = _json_list(
-        _gh_stdout_or_empty(
-            "run",
-            "list",
-            "--repo",
-            REPO,
-            "--workflow",
-            "CI",
-            "--limit",
-            "40",
-            "--json",
-            "headSha,databaseId",
-        )
-    )
-    at_head = [
-        r for r in runs if isinstance(r, dict) and str(r.get("headSha", "")) == head
-    ]
+    at_head = ci_runs_at_head(head)
     if not at_head:
         reasons.append(f"no CI run exists at the head SHA {head[:8]}")
     else:
         owners: set[str] = set()
         for run in at_head:
             detail = _json_dict(
-                _gh_stdout_or_empty(
-                    "api", f"repos/{REPO}/actions/runs/{run.get('databaseId')}"
-                )
+                _gh_stdout_or_empty("api", f"repos/{REPO}/actions/runs/{run.get('id')}")
             )
             owners.update(
                 str(p.get("number"))

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -338,6 +338,14 @@ def ci_runs_at_head(head: str) -> list[dict[str, Any]]:
     decoder = json.JSONDecoder()
     index = 0
     while index < len(raw):
+        # Skip separators BEFORE decoding, not only after. `raw_decode` does
+        # not tolerate leading whitespace, so a response starting with one
+        # would raise on the first pass and return no runs at all -- the
+        # exact false "no CI run at the head" this function exists to remove.
+        while index < len(raw) and raw[index].isspace():
+            index += 1
+        if index >= len(raw):
+            break
         try:
             page, offset = decoder.raw_decode(raw, index)
         except ValueError:
@@ -347,8 +355,6 @@ def ci_runs_at_head(head: str) -> list[dict[str, Any]]:
             if isinstance(found, list):
                 runs.extend(r for r in found if isinstance(r, dict))
         index = offset
-        while index < len(raw) and raw[index].isspace():
-            index += 1
     return [run for run in runs if str(run.get("path", "")) == CI_WORKFLOW_PATH]
 
 

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -338,10 +338,15 @@ def ci_runs_at_head(head: str) -> list[dict[str, Any]]:
     decoder = json.JSONDecoder()
     index = 0
     while index < len(raw):
-        # Skip separators BEFORE decoding, not only after. `raw_decode` does
-        # not tolerate leading whitespace, so a response starting with one
-        # would raise on the first pass and return no runs at all -- the
-        # exact false "no CI run at the head" this function exists to remove.
+        # Skip separators BEFORE decoding, not only after, and do not
+        # reorder these two steps. `raw_decode` does not tolerate leading
+        # whitespace: skipping only after a successful decode means a
+        # response opening with a newline raises on the first pass and
+        # returns no runs at all, reported as "no CI run exists at the head
+        # SHA" -- the exact false verdict this function was rewritten to
+        # stop producing. Trailing-only skipping looks equivalent and is
+        # not; `test_leading_whitespace_does_not_discard_every_page` fails
+        # if these are swapped back.
         while index < len(raw) and raw[index].isspace():
             index += 1
         if index >= len(raw):


### PR DESCRIPTION
## The bug

`scripts/check_pr_gated.py` decided whether a CI run existed at a PR's head by listing the 40 most recent CI runs **repo-wide** and filtering for the head SHA client-side.

That window spans the whole repo, so on a busy evening a run scrolls out of it while its PR is still open. The tool then reports:

```
no CI run exists at the head SHA <sha>
```

for a PR whose CI ran and passed.

## Measured, not theorised

On #1826, whose CI was fully green including `All Checks Pass`:

| | runs at that head |
|---|---|
| 40-run window | **0** |
| `actions/runs?head_sha=` | **7** |

Its run was 36 minutes old and every one of the 40 most recent repo runs was newer. A second session independently reproduced the same shape on #1844 (window 1, actual 7) before it had degraded to zero.

So the window is already discarding most runs per SHA; #1826 is simply the case where it reached zero.

A third instance, found live on a PR belonging to neither of those sessions. #1833 at `636b173c` has a CI run; the 40-run window contains none of it. Running the same tool against the same PR, before and after:

```
main:        PR #1833: NOT verifiably gated -- 2 reason(s)
               - no CI run exists at the head SHA 636b173c
               - 1 unresolved review thread(s)

this branch: PR #1833: NOT verifiably gated -- 1 reason(s)
               - 1 unresolved review thread(s)
```

The false reason disappears and the genuine one remains.

## Blast radius

**The defect is one-directional: it can only produce a false NEGATIVE.** It never reports a PR gated when it is not, so it cannot have let an unverified PR through. It strands ready PRs and wastes reviewer time.

The cost is higher than "wastes time" suggests, though. A false "no CI run exists" on a PR that *is* gated invites the obvious remedy: push an empty commit to re-trigger CI. That moves the head, which **invalidates every bot review anchored to the old SHA**, so the false negative can destroy real review state rather than merely delaying a merge. It stays one-directional and still lets no bad merge through.

The enforcing gate in CI (`require-ci-at-head.yml`) was never affected — it already queries by `head_sha`. This script is the advisory one run by hand before merging, so the cost was agents and humans being misled.

## The fix

Query `actions/runs?head_sha=` instead. Three details, each matching what `require-ci-at-head.yml` already does for the same documented reasons:

- **Paginate.** `head_sha` is exact but *not* unbounded — it pages at 30 by default, so an unpaginated query reintroduces the same bug at a larger size. `gh` rejects `--slurp` alongside `--jq`, so `--paginate` emits one JSON object per page and they are decoded as a stream.
- **Match the workflow PATH, not its display name.** A display name is a string any workflow file may declare, so a second file named `CI` would satisfy a name-only check without running a single test.
- **Read the run id as `id`.** `gh run list` named the same field `databaseId`; carrying that over fetches `actions/runs/None`, empties `owners`, and reports "does not resolve to #<pr>" — trading one false blocker for another.

## Verification

53 tests (was 29). Every protection has a test verified to go red under a mutation of the line it names:

| Mutation | Reddens |
|---|---|
| `head_sha` query → windowed `--limit 40` | the two scoping tests |
| path match → display-name match | both exclusion tests |
| pagination loop → first page only | the later-page test |
| `--paginate` removed | the paginate test |
| `gh api --paginate` → `gh --paginate api` | the paginate test |
| whitespace skip removed | the five whitespace tests |
| `id` → `databaseId` | the ownership test |
| loop `break` → `continue` | hangs until killed |

The last one confirms the loop guard prevents a real infinite hang rather than being defensive decoration.

Malformed paginated output is pinned to fail **closed** — empty body, whitespace-only, `null` page, list page, missing or non-list `workflow_runs`, truncated final page, unparseable output. Every degradation yields fewer runs (blocking a merge), never a fabricated one.

Local review raised one P1 and two P2s, all fixed here: `raw_decode` does not tolerate leading whitespace and the skip ran only after a decode, so a response opening with a newline returned nothing — the exact false verdict being fixed, latent because `gh` emits none today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pull request checks now identify CI runs for the exact commit.
  - CI run detection supports pagination and excludes unrelated or similarly named workflows.
  - Improved validation of CI run ownership and details.
  - Unavailable or malformed API responses are handled safely without falsely reporting missing runs.

- **Tests**
  - Added coverage for pagination, workflow filtering, ownership validation, and malformed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

