### PR TITLE
fix: key the incomplete-run marker per run so a concurrent clear cannot remove it (#1709)

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -134,6 +134,11 @@ KEY_PROJECT_NAME = "project_name"
 # The incomplete-run marker's phase (#1705 review): whether the run it records
 # had reached its first graph write when the marker was last updated.
 KEY_WRITING = "writing"
+# Identifies ONE run's incomplete-run marker. Two registries can index the
+# same project concurrently (the ingestor lock is per instance), and a marker
+# keyed only by project let the second run's clear delete the first run's
+# marker (issue #1709).
+KEY_RUN_ID = "run_id"
 # ast-grep finding node properties (issue #413)
 KEY_MESSAGE = "message"
 KEY_SNIPPET = "snippet"

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -115,8 +115,17 @@ CYPHER_RECOVER_PROJECT_INCOMPLETE = (
 # forever after an upgrade (raised in review of #1850). Cleared alongside this
 # run's own marker on a successful completion, since a run that completes for
 # the project has established the graph is whole.
+#
+# Phase-guarded for the ROLLING DEPLOYMENT case: during an upgrade an
+# old-version process can still be writing under a legacy marker, and a
+# new-version run completing for the same project would otherwise delete the
+# protection for a graph that IS being written (#1850 review). A legacy
+# marker with no `writing` property coalesces to true and is left alone, so
+# the pre-phase markers this was written for stay put until a run can prove
+# they are stale -- fail-closed, which is the safe direction here.
 CYPHER_CLEAR_LEGACY_PROJECT_INCOMPLETE = (
-    "MATCH (m:IncompleteRun {project: $project_name}) WHERE m.run_id IS NULL DELETE m"
+    "MATCH (m:IncompleteRun {project: $project_name}) "
+    "WHERE m.run_id IS NULL AND coalesce(m.writing, true) = false DELETE m"
 )
 # "Is ANY run outstanding": the read was already a boolean question, so it
 # generalises without changing its callers' meaning. `writing` is true if ANY

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -75,14 +75,35 @@ CYPHER_PROJECT_ROOT_PATH = (
 # marker another process left at `writing=true` over a graph it had started to
 # change, or that process's abort would clear a guard it does not own (#1705
 # review). Ownership of the DELETE is the remaining half, tracked in #1709.
+# One marker node PER RUN, not per project (issue #1709). The ingestor lock is
+# per registry instance, so two registries can index the same project at once;
+# with a single node per project, the second run's clear deleted the first
+# run's marker and a partial graph looked complete to a fresh process.
 CYPHER_MARK_PROJECT_INCOMPLETE = (
-    "MERGE (m:IncompleteRun {project: $project_name}) "
+    "MERGE (m:IncompleteRun {project: $project_name, run_id: $run_id}) "
     "SET m.run_incomplete = true, "
     "m.writing = coalesce(m.writing, false) OR $writing"
 )
+# Deletes only THIS run's marker, so a concurrent run's marker outlives it.
 CYPHER_CLEAR_PROJECT_INCOMPLETE = (
+    "MATCH (m:IncompleteRun {project: $project_name, run_id: $run_id}) DELETE m"
+)
+# RECOVERY: clears every outstanding marker for the project, whichever run
+# wrote it. Deliberately not run-scoped -- its whole purpose is to clear a
+# marker some OTHER run stranded (a run that stopped before its first graph
+# write and could not, or did not live to, clear its own). A run-scoped
+# delete matches nothing there, and the project stays blocked until someone
+# runs a full update. Guarded by the caller on `writing=false` for EVERY
+# outstanding marker, so no run that has begun writing can be cleared this
+# way (issue #1709).
+CYPHER_RECOVER_PROJECT_INCOMPLETE = (
     "MATCH (m:IncompleteRun {project: $project_name}) DELETE m"
 )
+# "Is ANY run outstanding": the read was already a boolean question, so it
+# generalises without changing its callers' meaning. `writing` is true if ANY
+# outstanding run has begun writing, which is the conservative reading -- a
+# recoverable `writing=false` state requires every outstanding run to be
+# read-only still.
 CYPHER_PROJECT_IS_INCOMPLETE = (
     "MATCH (m:IncompleteRun {project: $project_name}) "
     "RETURN coalesce(m.run_incomplete, false) AS run_incomplete, "

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -96,8 +96,27 @@ CYPHER_CLEAR_PROJECT_INCOMPLETE = (
 # runs a full update. Guarded by the caller on `writing=false` for EVERY
 # outstanding marker, so no run that has begun writing can be cleared this
 # way (issue #1709).
+# Deletes only markers that are STILL read-only at delete time. The caller
+# reads the phase and then acts on it, and between those a concurrent run can
+# promote its own marker to `writing=true` -- an unconditional delete would
+# then remove a marker protecting a graph that IS being written (raised in
+# review of #1850). Re-checking the phase inside the delete closes that
+# window: the predicate is evaluated against the row as it is now, not as the
+# caller last saw it. A legacy marker with no `writing` property reads as
+# writing, exactly as `CYPHER_PROJECT_IS_INCOMPLETE` coalesces it, so it stays
+# fail-closed here too.
 CYPHER_RECOVER_PROJECT_INCOMPLETE = (
-    "MATCH (m:IncompleteRun {project: $project_name}) DELETE m"
+    "MATCH (m:IncompleteRun {project: $project_name}) "
+    "WHERE coalesce(m.writing, true) = false DELETE m"
+)
+# A marker written before run ids existed has no `run_id` property, so the
+# run-scoped clear can never match it while the read -- which matches on
+# project alone -- still sees it. Without this the project would stay blocked
+# forever after an upgrade (raised in review of #1850). Cleared alongside this
+# run's own marker on a successful completion, since a run that completes for
+# the project has established the graph is whole.
+CYPHER_CLEAR_LEGACY_PROJECT_INCOMPLETE = (
+    "MATCH (m:IncompleteRun {project: $project_name}) WHERE m.run_id IS NULL DELETE m"
 )
 # "Is ANY run outstanding": the read was already a boolean question, so it
 # generalises without changing its callers' meaning. `writing` is true if ANY

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -2,6 +2,7 @@ import asyncio
 import itertools
 import json
 import sys
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 
@@ -111,6 +112,14 @@ class MCPToolsRegistry:
         # an unrelated marker-less failure earned, whenever some recoverable
         # marker happens to be pending at guard time (#1705 review).
         self._flag_from_failed_clear: str | None = None
+        # This registry's identity in the durable marker. The ingestor lock is
+        # per INSTANCE, so two registries can index the same project at once;
+        # a marker keyed only by project meant the second run's clear deleted
+        # the first run's marker, and a partial graph then looked complete to
+        # a fresh process (issue #1709). Per registry rather than per call
+        # because the instance lock already serialises this registry's own
+        # runs, so its own marker can never overlap itself.
+        self._run_id: str = uuid.uuid4().hex
 
         self.parsers, self.queries = load_parsers()
 
@@ -1066,7 +1075,14 @@ class MCPToolsRegistry:
         degrades this guard back to the old in-process behaviour and only the
         log would show it.
         """
-        params: dict[str, PropertyValue] = {cs.KEY_PROJECT_NAME: project_name}
+        # Both the mark and the clear carry this registry's run id, so a
+        # clear removes only the marker this registry wrote (issue #1709).
+        # The READ deliberately does not: it asks whether ANY run is
+        # outstanding, which is the same boolean question it always asked.
+        params: dict[str, PropertyValue] = {
+            cs.KEY_PROJECT_NAME: project_name,
+            cs.KEY_RUN_ID: self._run_id,
+        }
         if incomplete:
             query = cq.CYPHER_MARK_PROJECT_INCOMPLETE
             params[cs.KEY_WRITING] = writing
@@ -1078,6 +1094,32 @@ class MCPToolsRegistry:
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_FAILED.format(
                     project=project_name, incomplete=incomplete, error=error
+                )
+            )
+            return False
+        return True
+
+    def _recover_stranded_markers(self, project_name: str) -> bool:
+        """Clear EVERY outstanding marker for the project, not just this run's.
+
+        The ordinary clear is run-scoped so a concurrent run's marker outlives
+        it (issue #1709). Recovery is the opposite case by definition: it
+        clears a marker some OTHER run stranded, so a run-scoped delete would
+        match nothing and leave the project blocked until a full update.
+
+        Safe only because the caller has already established that EVERY
+        outstanding marker says `writing=false` -- the graph is as those runs
+        found it. Returns whether the write reached the store.
+        """
+        try:
+            self.ingestor.execute_write(
+                cq.CYPHER_RECOVER_PROJECT_INCOMPLETE,
+                {cs.KEY_PROJECT_NAME: project_name},
+            )
+        except Exception as error:  # noqa: BLE001 -- same contract as _persist_incomplete
+            logger.warning(
+                lg.MCP_INCOMPLETE_MARKER_FAILED.format(
+                    project=project_name, incomplete=False, error=error
                 )
             )
             return False
@@ -1253,7 +1295,7 @@ class MCPToolsRegistry:
             # a marker from before the phase existed stays fail-closed.
             if row.get("writing", True):
                 return True
-            if not self._persist_incomplete(project_name, False):
+            if not self._recover_stranded_markers(project_name):
                 # Could not clear it. The store refused a write, so the run
                 # that would follow could not mark itself either; refuse now
                 # and let the next attempt retry.

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1090,17 +1090,6 @@ class MCPToolsRegistry:
             query = cq.CYPHER_CLEAR_PROJECT_INCOMPLETE
         try:
             self.ingestor.execute_write(query, params)
-            if not incomplete:
-                # A marker written before run ids existed has no `run_id`, so
-                # the run-scoped clear above cannot match it while the read
-                # still sees it -- the project would stay blocked forever
-                # after an upgrade (#1850 review). A run completing for this
-                # project has established the graph is whole, so clearing the
-                # legacy marker here is the same statement its own clear makes.
-                self.ingestor.execute_write(
-                    cq.CYPHER_CLEAR_LEGACY_PROJECT_INCOMPLETE,
-                    {cs.KEY_PROJECT_NAME: project_name},
-                )
         except Exception as error:  # noqa: BLE001 -- see docstring
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_FAILED.format(
@@ -1108,6 +1097,31 @@ class MCPToolsRegistry:
                 )
             )
             return False
+        if not incomplete:
+            # A marker written before run ids existed has no `run_id`, so the
+            # run-scoped clear above cannot match it while the read still sees
+            # it -- the project would stay blocked forever after an upgrade
+            # (#1850 review). A run completing for this project has
+            # established the graph is whole, so clearing the legacy marker is
+            # the same statement its own clear makes.
+            #
+            # BEST EFFORT, and deliberately outside the try above: this run's
+            # own clear has already succeeded by here, so the run IS complete.
+            # Letting a failure in optional compatibility cleanup return False
+            # reported a completed operation as incomplete and raised the flag
+            # for a graph that is whole (#1850 review, second finding). The
+            # legacy marker simply stays for the next run to clear.
+            try:
+                self.ingestor.execute_write(
+                    cq.CYPHER_CLEAR_LEGACY_PROJECT_INCOMPLETE,
+                    {cs.KEY_PROJECT_NAME: project_name},
+                )
+            except Exception as error:  # noqa: BLE001 -- best effort, see above
+                logger.warning(
+                    lg.MCP_INCOMPLETE_MARKER_FAILED.format(
+                        project=project_name, incomplete=False, error=error
+                    )
+                )
         return True
 
     def _recover_stranded_markers(self, project_name: str) -> bool:

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1116,7 +1116,7 @@ class MCPToolsRegistry:
                     cq.CYPHER_CLEAR_LEGACY_PROJECT_INCOMPLETE,
                     {cs.KEY_PROJECT_NAME: project_name},
                 )
-            except Exception as error:  # noqa: BLE001 -- best effort, see above
+            except Exception as error:  # noqa: BLE001 -- best effort; see above
                 logger.warning(
                     lg.MCP_INCOMPLETE_MARKER_FAILED.format(
                         project=project_name, incomplete=False, error=error

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1277,6 +1277,29 @@ class MCPToolsRegistry:
             return None
         return cs.MCP_INCOMPLETE_MARKER_STUCK.format(project=project_name)
 
+    def _marker_rows(self, project_name: str) -> list[dict] | None:
+        """Outstanding marker rows for the project, or None if unreadable.
+
+        Split out so the post-recovery re-check reads the same way the first
+        read does; `None` means the store could not answer, which every
+        caller must treat as "refuse" rather than "nothing outstanding".
+        """
+        try:
+            return list(
+                self.ingestor.fetch_all(
+                    cq.CYPHER_PROJECT_IS_INCOMPLETE,
+                    {cs.KEY_PROJECT_NAME: project_name},
+                )
+                or []
+            )
+        except Exception as error:  # noqa: BLE001 -- same contract as the caller
+            logger.warning(
+                lg.MCP_INCOMPLETE_MARKER_UNREADABLE.format(
+                    project=project_name, error=error
+                )
+            )
+            return None
+
     def _persisted_incomplete(self, project_name: str) -> bool:
         """Whether a previous process left this project mid-update.
 
@@ -1324,6 +1347,17 @@ class MCPToolsRegistry:
                 # Could not clear it. The store refused a write, so the run
                 # that would follow could not mark itself either; refuse now
                 # and let the next attempt retry.
+                return True
+            # The recovery is CONDITIONAL (it deletes only markers still
+            # read-only), and a write reports no affected-row count, so
+            # "the write succeeded" does not mean "the marker is gone". A run
+            # that promoted its own marker between this method's read and
+            # that delete leaves a row the delete skipped, and returning
+            # False here would let a scoped reingest proceed over a graph
+            # being written (raised by CodeRabbit on #1850). Re-read and
+            # refuse if anything is still outstanding.
+            remaining = self._marker_rows(project_name)
+            if remaining is None or remaining:
                 return True
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_RECOVERED.format(project=project_name)

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -1090,6 +1090,17 @@ class MCPToolsRegistry:
             query = cq.CYPHER_CLEAR_PROJECT_INCOMPLETE
         try:
             self.ingestor.execute_write(query, params)
+            if not incomplete:
+                # A marker written before run ids existed has no `run_id`, so
+                # the run-scoped clear above cannot match it while the read
+                # still sees it -- the project would stay blocked forever
+                # after an upgrade (#1850 review). A run completing for this
+                # project has established the graph is whole, so clearing the
+                # legacy marker here is the same statement its own clear makes.
+                self.ingestor.execute_write(
+                    cq.CYPHER_CLEAR_LEGACY_PROJECT_INCOMPLETE,
+                    {cs.KEY_PROJECT_NAME: project_name},
+                )
         except Exception as error:  # noqa: BLE001 -- see docstring
             logger.warning(
                 lg.MCP_INCOMPLETE_MARKER_FAILED.format(

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -922,16 +922,30 @@ class TestIncompleteMarkerSurvivesTheProcess:
                         (params or {}).get(cs.KEY_WRITING, True)
                     )
             elif "DELETE m" in query:
-                if "run_id" in query:
+                if "m.run_id IS NULL" in query:
+                    # The LEGACY clear: markers written before run ids
+                    # existed. The fake models those as the sentinel run id
+                    # "" (see the mark branch, which records whatever the
+                    # params carry).
+                    remaining = runs.get(name, set())
+                    remaining.discard("")
+                    if remaining:
+                        return
+                elif "run_id" in query:
                     # The ordinary clear: only THIS run's marker. The project
                     # reads clear once every outstanding run's marker is gone.
                     remaining = runs.get(name, set())
                     remaining.discard(run_id)
                     if remaining:
                         return
-                # RECOVERY (no run_id in the query): clears every outstanding
-                # marker, which is the point of that path -- it exists to
-                # clear a marker some other run stranded.
+                elif "coalesce(m.writing, true) = false" in query:
+                    # RECOVERY, and it deletes only markers that are STILL
+                    # read-only. The phase is per project in this fake, so a
+                    # promoted phase blocks the whole delete -- which is the
+                    # property under test: a concurrent run that began
+                    # writing must not have its marker recovered away.
+                    if writing.get(name, True):
+                        return
                 runs.pop(name, None)
                 store.pop(name, None)
                 writing.pop(name, None)
@@ -1058,6 +1072,96 @@ class TestIncompleteMarkerSurvivesTheProcess:
         refused = await fresh.reingest(["a.py"])
         assert "failed part way" in refused.get("error", ""), (
             f"expected the incomplete-run refusal; got {refused}"
+        )
+
+    async def test_a_legacy_marker_is_cleared_by_a_completing_run(
+        self, temp_project_root: Path
+    ) -> None:
+        """Markers written before run ids must not wedge the project (#1850).
+
+        A marker from before this change has no `run_id` property. The read
+        matches on project alone and still sees it; the run-scoped clear
+        matches on `run_id` and can never delete it. Recovery reaches only
+        `writing=false` markers, so a legacy marker with `writing=true` (or
+        absent, which coalesces to true) was unreachable by every path and
+        the project stayed blocked forever after an upgrade.
+        """
+        from codebase_rag import cypher_queries as cq
+
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # A legacy marker: modelled as the sentinel empty run id, and left in
+        # the writing phase so neither recovery nor a run-scoped clear can
+        # touch it.
+        ingestor.execute_write(
+            cq.CYPHER_MARK_PROJECT_INCOMPLETE,
+            {cs.KEY_PROJECT_NAME: project, cs.KEY_RUN_ID: "", cs.KEY_WRITING: True},
+        )
+        assert registry._persisted_incomplete(project) is True, (
+            "fixture guard: the legacy marker must read as incomplete"
+        )
+
+        # A run completes for this project: its clear lifts its own marker
+        # and the legacy one with it.
+        assert registry._require_marker(project) is None
+        assert registry._require_marker_cleared(project) is None
+
+        assert registry._persisted_incomplete(project) is False, (
+            "a legacy marker survived a completed run, so the project stays "
+            "blocked with no path that can clear it"
+        )
+
+    async def test_recovery_leaves_a_marker_that_began_writing(
+        self, temp_project_root: Path
+    ) -> None:
+        """A promoted phase must stop the marker being recovered away.
+
+        MEASURED LIMIT, stated so the greenness is not read as coverage: this
+        test passes through the PHASE READ in `_persisted_incomplete`, which
+        returns before recovery is called at all (instrumented: recovery runs
+        0 times here). So it does NOT exercise the re-check inside
+        `CYPHER_RECOVER_PROJECT_INCOMPLETE`, and removing that re-check leaves
+        this test green.
+
+        The re-check is still right, and it is defence in depth against a real
+        TOCTOU window: `_persisted_incomplete` reads the phase and then
+        deletes, and a concurrent run can promote its own marker in between --
+        an unconditional delete would then remove a marker protecting a graph
+        that IS being written. That window needs two markers with DIFFERENT
+        phases, which this fake cannot express: its phase is per project, not
+        per marker. Widening the fake to per-marker phases would make it
+        testable and is the right follow-up if this line is ever load-bearing.
+
+        What this test does cover is the outer property, which is worth having
+        on its own: a project whose marker has been promoted to writing still
+        reads incomplete to a fresh process.
+        """
+        ingestor = self._store()
+        stranding = self._registry(temp_project_root, ingestor)
+        writer = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(stranding)
+        _mark_indexed(writer)
+
+        # A read-only run strands its marker.
+        assert stranding._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert stranding._require_marker_cleared(project) is not None
+        ingestor._failing.discard("clear")
+
+        # A concurrent run promotes the phase to writing before recovery acts.
+        assert writer._require_writing(project) is None
+        assert ingestor._writing_store.get(project) is True, (
+            "fixture guard: the phase must be promoted, or recovery is "
+            "entitled to clear and this test proves nothing"
+        )
+
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        assert fresh._persisted_incomplete(project) is True, (
+            "recovery cleared a marker belonging to a run that had begun "
+            "writing; a scoped reingest would trust a partial graph"
         )
 
     async def test_a_runs_own_clear_still_lifts_its_own_marker(

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -885,7 +885,12 @@ class TestIncompleteMarkerSurvivesTheProcess:
         # The marker's phase, kept beside the marker itself so the existing
         # `store[name] is True` assertions keep their meaning. Absent reads as
         # writing, exactly as the production query's `coalesce` does.
-        writing: dict[str, bool] = {}
+        # PER MARKER, keyed (project, run_id), because production stores the
+        # phase on the marker node. A per-project phase cannot express two
+        # concurrent runs at different phases -- and it silently raised a
+        # legacy marker's phase when an unrelated run marked itself writing,
+        # which is behaviour production does not have (#1850 review).
+        writing: dict[tuple[str, str], bool] = {}
         ingestor = MagicMock()
 
         # A plain dict, never an attribute on the MagicMock: `getattr` on a
@@ -918,17 +923,26 @@ class TestIncompleteMarkerSurvivesTheProcess:
                     store[name] = True
                     # Monotonic, as the production MERGE is: a later mark can
                     # raise the phase to writing but never lower it.
-                    writing[name] = writing.get(name, False) or bool(
-                        (params or {}).get(cs.KEY_WRITING, True)
-                    )
+                    writing[(name, run_id)] = writing.get(
+                        (name, run_id), False
+                    ) or bool((params or {}).get(cs.KEY_WRITING, True))
             elif "DELETE m" in query:
                 if "m.run_id IS NULL" in query:
                     # The LEGACY clear: markers written before run ids
                     # existed. The fake models those as the sentinel run id
                     # "" (see the mark branch, which records whatever the
-                    # params carry).
+                    # params carry). Phase-guarded exactly as production is --
+                    # a legacy marker whose run is still WRITING belongs to an
+                    # old-version process mid-write during a rolling upgrade
+                    # and must not be cleared. A fake that ignored the phase
+                    # would pass tests on behaviour production does not have.
+                    if writing.get((name, ""), True):
+                        return
                     remaining = runs.get(name, set())
                     remaining.discard("")
+                    writing.pop((name, ""), None)
+                    if remaining:
+                        return
                     if remaining:
                         return
                 elif "run_id" in query:
@@ -936,6 +950,7 @@ class TestIncompleteMarkerSurvivesTheProcess:
                     # reads clear once every outstanding run's marker is gone.
                     remaining = runs.get(name, set())
                     remaining.discard(run_id)
+                    writing.pop((name, run_id), None)
                     if remaining:
                         return
                 elif "coalesce(m.writing, true) = false" in query:
@@ -944,11 +959,20 @@ class TestIncompleteMarkerSurvivesTheProcess:
                     # promoted phase blocks the whole delete -- which is the
                     # property under test: a concurrent run that began
                     # writing must not have its marker recovered away.
-                    if writing.get(name, True):
+                    still_writing = {
+                        r for r in runs.get(name, set()) if writing.get((name, r), True)
+                    }
+                    if still_writing:
+                        # Production's WHERE clause deletes the read-only ones
+                        # and leaves the rest; the project stays incomplete.
+                        for r in runs.get(name, set()) - still_writing:
+                            writing.pop((name, r), None)
+                        runs[name] = still_writing
                         return
+                for r in runs.get(name, set()):
+                    writing.pop((name, r), None)
                 runs.pop(name, None)
                 store.pop(name, None)
-                writing.pop(name, None)
 
         def _read(query: str, params: dict | None = None) -> list[dict]:
             if "run_incomplete" not in query:
@@ -961,7 +985,10 @@ class TestIncompleteMarkerSurvivesTheProcess:
             # reads rows[0] would pass against a canned false and fail here.
             if not store.get(name):
                 return []
-            return [{"run_incomplete": True, "writing": writing.get(name, True)}]
+            any_writing = any(
+                writing.get((name, r), True) for r in runs.get(name, {""})
+            )
+            return [{"run_incomplete": True, "writing": any_writing}]
 
         def _delete_project(name: str) -> None:
             # Models CYPHER_DELETE_PROJECT: it detaches the Project and
@@ -973,7 +1000,35 @@ class TestIncompleteMarkerSurvivesTheProcess:
         ingestor.fetch_all.side_effect = _read
         ingestor.delete_project.side_effect = _delete_project
         ingestor._marker_store = store
-        ingestor._writing_store = writing
+
+        # Existing tests ask "is THIS PROJECT writing", which is now a view
+        # over the per-marker phases: true when any outstanding run is.
+        class _WritingView:
+            @staticmethod
+            def get(name: str, default: object = None) -> object:
+                marks = runs.get(name) or ({""} if store.get(name) else set())
+                if not marks:
+                    return default
+                return any(writing.get((name, r), True) for r in marks)
+
+            @staticmethod
+            def __setitem__(name: str, value: bool) -> None:
+                # Tests that plant a marker straight into `_marker_store`
+                # set the phase the same way. Record it against every known
+                # run for the project, and against the legacy sentinel when
+                # the marker was injected without one.
+                for r in runs.get(name) or {""}:
+                    writing[(name, r)] = value
+
+            @staticmethod
+            def pop(name: str, default: object = None) -> object:
+                for r in list(runs.get(name) or {""}):
+                    writing.pop((name, r), None)
+                return default
+
+        ingestor._writing_store = _WritingView()
+        ingestor._writing_by_marker = writing
+        ingestor._marker_runs = runs
         ingestor._failing = failing
         return ingestor
 
@@ -1092,16 +1147,21 @@ class TestIncompleteMarkerSurvivesTheProcess:
         registry = self._registry(temp_project_root, ingestor)
         project = _mark_indexed(registry)
 
-        # A legacy marker: modelled as the sentinel empty run id, and left in
-        # the writing phase so neither recovery nor a run-scoped clear can
-        # touch it.
+        # A legacy marker: modelled as the sentinel empty run id. Left in the
+        # READ-ONLY phase, which is the shape a stale pre-upgrade marker has
+        # once its run is gone -- a `writing=true` legacy marker belongs to an
+        # old-version process that may still be mid-write, and the phase guard
+        # deliberately leaves that one alone (see the sibling test below).
         ingestor.execute_write(
             cq.CYPHER_MARK_PROJECT_INCOMPLETE,
-            {cs.KEY_PROJECT_NAME: project, cs.KEY_RUN_ID: "", cs.KEY_WRITING: True},
+            {cs.KEY_PROJECT_NAME: project, cs.KEY_RUN_ID: "", cs.KEY_WRITING: False},
         )
-        assert registry._persisted_incomplete(project) is True, (
-            "fixture guard: the legacy marker must read as incomplete"
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the legacy marker must be in the store"
         )
+        # Deliberately NOT read through `_persisted_incomplete` here: that
+        # call RECOVERS a read-only marker as a side effect, so it would
+        # clear the very thing under test before the clear below runs.
 
         # A run completes for this project: its clear lifts its own marker
         # and the legacy one with it.
@@ -1113,30 +1173,102 @@ class TestIncompleteMarkerSurvivesTheProcess:
             "blocked with no path that can clear it"
         )
 
+    async def test_a_writing_legacy_marker_is_left_alone(
+        self, temp_project_root: Path
+    ) -> None:
+        """The rolling-deployment case (#1850 review).
+
+        During an upgrade an old-version process can still be WRITING under a
+        legacy marker. A new-version run completing for the same project must
+        not delete that protection, or a later failure in the old process
+        leaves partial data with nothing recording it.
+
+        The pair matters: the sibling test requires a stale read-only legacy
+        marker to be cleared (or an upgraded project is blocked forever), and
+        this one requires a writing legacy marker to survive. A fix
+        satisfying only one is the bug in the other direction.
+        """
+        from codebase_rag import cypher_queries as cq
+
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        # An old-version process, mid-write, under a legacy marker.
+        ingestor.execute_write(
+            cq.CYPHER_MARK_PROJECT_INCOMPLETE,
+            {cs.KEY_PROJECT_NAME: project, cs.KEY_RUN_ID: "", cs.KEY_WRITING: True},
+        )
+        assert registry._persisted_incomplete(project) is True
+
+        # A new-version run completes for the same project.
+        assert registry._require_marker(project) is None
+        assert registry._require_marker_cleared(project) is None
+
+        assert registry._persisted_incomplete(project) is True, (
+            "a completing new-version run deleted the protection for an "
+            "old-version process that was still writing; a later failure "
+            "there would leave partial data with nothing recording it"
+        )
+
+    async def test_recovery_deletes_only_the_read_only_markers(
+        self, temp_project_root: Path
+    ) -> None:
+        """Recovery re-checks the phase AT DELETE TIME (#1850 review).
+
+        `_persisted_incomplete` reads the phase and then deletes, and a
+        concurrent run can promote its own marker in between -- an
+        unconditional delete would remove a marker protecting a graph that IS
+        being written. The re-check makes the delete act on the rows as they
+        are now, not as the caller last saw them.
+
+        Reaching it needs a marker set where the read still proceeds (the
+        first row it sees is read-only) while another marker is writing, so
+        the phase must be per MARKER. It is: the store models it that way
+        precisely so this case is expressible.
+        """
+        ingestor = self._store()
+        stranding = self._registry(temp_project_root, ingestor)
+        writer = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(stranding)
+        _mark_indexed(writer)
+
+        # One read-only marker (recoverable) and one writing marker.
+        assert stranding._require_marker(project, writing=False) is None
+        assert writer._require_marker(project, writing=True) is None
+        assert ingestor._writing_by_marker[(project, stranding._run_id)] is False
+        assert ingestor._writing_by_marker[(project, writer._run_id)] is True
+
+        # Recovery runs. It may clear the read-only marker; it must NOT clear
+        # the writing one, so the project still reads incomplete.
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        fresh._recover_stranded_markers(project)
+
+        assert (project, writer._run_id) in ingestor._writing_by_marker or (
+            writer._run_id in ingestor._marker_runs.get(project, set())
+        ), "recovery deleted a marker belonging to a run that was WRITING"
+        assert ingestor._marker_store.get(project) is True, (
+            "recovery cleared the project though a writing run is outstanding; "
+            "a scoped reingest would trust a graph being written"
+        )
+
     async def test_recovery_leaves_a_marker_that_began_writing(
         self, temp_project_root: Path
     ) -> None:
         """A promoted phase must stop the marker being recovered away.
 
-        MEASURED LIMIT, stated so the greenness is not read as coverage: this
-        test passes through the PHASE READ in `_persisted_incomplete`, which
-        returns before recovery is called at all (instrumented: recovery runs
-        0 times here). So it does NOT exercise the re-check inside
-        `CYPHER_RECOVER_PROJECT_INCOMPLETE`, and removing that re-check leaves
-        this test green.
+        Covers the OUTER property: a project whose marker has been promoted
+        to writing still reads incomplete to a fresh process. It stops at the
+        phase READ in `_persisted_incomplete`, which returns before recovery
+        is called, so it does not reach the re-check inside
+        `CYPHER_RECOVER_PROJECT_INCOMPLETE`.
 
-        The re-check is still right, and it is defence in depth against a real
-        TOCTOU window: `_persisted_incomplete` reads the phase and then
-        deletes, and a concurrent run can promote its own marker in between --
-        an unconditional delete would then remove a marker protecting a graph
-        that IS being written. That window needs two markers with DIFFERENT
-        phases, which this fake cannot express: its phase is per project, not
-        per marker. Widening the fake to per-marker phases would make it
-        testable and is the right follow-up if this line is ever load-bearing.
-
-        What this test does cover is the outer property, which is worth having
-        on its own: a project whose marker has been promoted to writing still
-        reads incomplete to a fresh process.
+        That re-check is covered by
+        `test_recovery_deletes_only_the_read_only_markers`, which needs a
+        marker set where the read still proceeds while another marker is
+        writing -- expressible only because the store models the phase per
+        MARKER rather than per project.
         """
         ingestor = self._store()
         stranding = self._registry(temp_project_root, ingestor)

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1253,6 +1253,54 @@ class TestIncompleteMarkerSurvivesTheProcess:
             "a scoped reingest would trust a graph being written"
         )
 
+    async def test_recovery_rechecks_before_reporting_the_project_clear(
+        self, temp_project_root: Path
+    ) -> None:
+        """A conditional delete plus a write with no row count (#1850 review).
+
+        Recovery deletes only markers still read-only, and `execute_write`
+        reports no affected-row count, so "the write succeeded" does not mean
+        "the marker is gone". A run that promotes its own marker between this
+        method's READ and that DELETE leaves a row the delete skipped, and
+        reporting the project clear then lets a scoped reingest proceed over a
+        graph being written.
+
+        The interleaving is forced rather than hoped for: the concurrent mark
+        is issued from inside the recovery call, which is the only way to land
+        it in that window deterministically.
+        """
+        ingestor = self._store()
+        stranding = self._registry(temp_project_root, ingestor)
+        writer = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(stranding)
+        _mark_indexed(writer)
+
+        # Only a read-only marker exists when the read happens.
+        assert stranding._require_marker(project, writing=False) is None
+
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+
+        real = fresh._recover_stranded_markers
+
+        def _racing(name: str) -> bool:
+            # The concurrent writer promotes its marker inside the window.
+            writer._require_marker(project, writing=True)
+            return real(name)
+
+        fresh._recover_stranded_markers = _racing  # type: ignore[method-assign]
+        verdict = fresh._persisted_incomplete(project)
+        fresh._recover_stranded_markers = real  # type: ignore[method-assign]
+
+        assert ingestor._marker_store.get(project) is True, (
+            "fixture guard: the writing marker must survive the conditional "
+            "delete, or the race under test did not occur"
+        )
+        assert verdict is True, (
+            "the project was reported clear while a writing marker remained; "
+            "a scoped reingest would hydrate from a graph being written"
+        )
+
     async def test_recovery_leaves_a_marker_that_began_writing(
         self, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -880,6 +880,8 @@ class TestIncompleteMarkerSurvivesTheProcess:
         having happened.
         """
         store: dict[str, bool] = {}
+        # {project: {run_id, ...}} -- the outstanding runs behind `store`.
+        runs: dict[str, set[str]] = {}
         # The marker's phase, kept beside the marker itself so the existing
         # `store[name] is True` assertions keep their meaning. Absent reads as
         # writing, exactly as the production query's `coalesce` does.
@@ -903,8 +905,16 @@ class TestIncompleteMarkerSurvivesTheProcess:
             # the code is supposed to answer: with a branch keyed only on
             # "SET m.run_incomplete", reverting MERGE to MATCH left every
             # test green (#1705 review).
+            # The marker node is keyed by (project, run_id) in production
+            # (issue #1709), so the fake keys its per-run set the same way. A
+            # fake keyed only by project cannot express "B's clear leaves A's
+            # marker", which is the whole behaviour under test -- it would
+            # answer the question the code is supposed to answer, exactly as
+            # the MERGE-vs-MATCH note above records.
+            run_id = str((params or {}).get(cs.KEY_RUN_ID, ""))
             if "SET m.run_incomplete" in query:
                 if query.lstrip().startswith("MERGE") or name in store:
+                    runs.setdefault(name, set()).add(run_id)
                     store[name] = True
                     # Monotonic, as the production MERGE is: a later mark can
                     # raise the phase to writing but never lower it.
@@ -912,6 +922,17 @@ class TestIncompleteMarkerSurvivesTheProcess:
                         (params or {}).get(cs.KEY_WRITING, True)
                     )
             elif "DELETE m" in query:
+                if "run_id" in query:
+                    # The ordinary clear: only THIS run's marker. The project
+                    # reads clear once every outstanding run's marker is gone.
+                    remaining = runs.get(name, set())
+                    remaining.discard(run_id)
+                    if remaining:
+                        return
+                # RECOVERY (no run_id in the query): clears every outstanding
+                # marker, which is the point of that path -- it exists to
+                # clear a marker some other run stranded.
+                runs.pop(name, None)
                 store.pop(name, None)
                 writing.pop(name, None)
 
@@ -992,6 +1013,103 @@ class TestIncompleteMarkerSurvivesTheProcess:
         assert "failed part way" in refused.get("error", ""), (
             "a fresh registry hydrated a scoped updater from the partial "
             f"graph left by a crashed update; got {refused}"
+        )
+
+    async def test_a_concurrent_runs_clear_cannot_remove_another_runs_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """The overlap race (#1709), found by CodeRabbit on #1705.
+
+        `_ingestor_lock` is per INSTANCE, so two registries can index the same
+        project at once. With one marker node per project they interleaved:
+
+            1. A marks the project and starts mutating
+            2. B marks it -- a no-op, the node already exists
+            3. B finishes and CLEARS the marker
+            4. A fails part way
+
+        The graph then held A's partial data with no marker, and a fresh
+        process treated it as complete. Markers are now keyed per run, so B's
+        clear removes only B's.
+        """
+        ingestor = self._store()
+        first = self._registry(temp_project_root, ingestor)
+        second = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(first)
+        _mark_indexed(second)
+        assert first._run_id != second._run_id, (
+            "fixture guard: two registries must have distinct run ids, or "
+            "this test cannot tell per-run markers from per-project ones"
+        )
+
+        assert first._require_marker(project) is None
+        assert second._require_marker(project) is None
+        assert second._require_marker_cleared(project) is None
+
+        assert first._persisted_incomplete(project) is True, (
+            "the concurrent run's clear removed this run's marker; A's "
+            "partial graph would look complete to a fresh process"
+        )
+
+        # A fresh process must still refuse, which is the consequence that
+        # matters: the marker exists precisely to survive one.
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        refused = await fresh.reingest(["a.py"])
+        assert "failed part way" in refused.get("error", ""), (
+            f"expected the incomplete-run refusal; got {refused}"
+        )
+
+    async def test_a_runs_own_clear_still_lifts_its_own_marker(
+        self, temp_project_root: Path
+    ) -> None:
+        """The control.
+
+        Making a clear run-scoped must not stop a run clearing what it wrote,
+        or every completed run would leave its marker behind and block the
+        next one -- a fix that satisfies the overlap test while wedging the
+        ordinary path.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        assert registry._require_marker(project) is None
+        assert registry._persisted_incomplete(project) is True
+        assert registry._require_marker_cleared(project) is None
+        assert registry._persisted_incomplete(project) is False, (
+            "a run could not clear the marker it wrote itself"
+        )
+
+    async def test_recovery_clears_a_marker_stranded_by_another_run(
+        self, temp_project_root: Path
+    ) -> None:
+        """Recovery is deliberately NOT run-scoped, and that is load-bearing.
+
+        Its whole purpose is to clear a marker some OTHER run stranded -- one
+        that stopped before its first graph write and could not clear its own.
+        A run-scoped delete matches nothing there, and the project stays
+        blocked until someone runs a full update. Three existing tests cover
+        the paths; this states the property directly so the reason survives.
+        """
+        ingestor = self._store()
+        stranding = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(stranding)
+
+        # A read-only run marks itself, then fails to clear.
+        assert stranding._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert stranding._require_marker_cleared(project) is not None
+        ingestor._failing.discard("clear")
+        assert ingestor._marker_store.get(project) is True
+
+        # A DIFFERENT registry, with a different run id, recovers it.
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+        assert fresh._run_id != stranding._run_id, "fixture guard: distinct runs"
+        assert fresh._persisted_incomplete(project) is False, (
+            "a fresh process could not clear a `writing=false` marker another "
+            "run stranded, so the project stays blocked until a full update"
         )
 
     async def test_a_completed_update_lifts_the_refusal_for_a_fresh_registry(
@@ -2249,15 +2367,18 @@ class TestIncompleteMarkerInvariant:
             "fixture guard: `before_write` must have promoted the marker"
         )
 
-        # Another process finishes a full update and clears the marker.
+        # Another process finishes a full update. Before #1709 its clear
+        # removed THIS registry's marker too -- one node per project -- which
+        # is what made the attribution the deciding factor here. Markers are
+        # now per run, so the other process clears only its own and this
+        # registry's marker survives.
         other = self._registry(temp_project_root, ingestor)
         _mark_indexed(other)
         with patch("codebase_rag.mcp.tools.GraphUpdater"):
             assert "Error" not in await other.update_repository()
-        assert registry._persisted_incomplete(project) is False, (
-            "fixture guard: the other process must have cleared the durable "
-            "marker, or _persisted_incomplete refuses on its own and the "
-            "attribution is never the deciding factor"
+        assert registry._persisted_incomplete(project) is True, (
+            "the other process's clear removed this registry's marker; that "
+            "is the #1709 race, and per-run markers exist to stop it"
         )
 
         registry._live_updater = None
@@ -2273,9 +2394,11 @@ class TestIncompleteMarkerInvariant:
             f"(#1705 review): {hydrations}"
         )
         assert "error" in result, (
-            "another process's marker clear healed a flag earned by THIS "
-            "process's mutating failure, so a scoped reingest ran over the "
-            f"partial graph it left: {result}"
+            "a scoped reingest ran over the partial graph THIS process's "
+            "mutating failure left. Before #1709 the way in was the other "
+            "process's clear removing this marker and a stale attribution "
+            "then healing the flag; with per-run markers the durable marker "
+            f"survives and refuses on its own. Either way it must refuse: {result}"
         )
 
     @pytest.mark.parametrize(

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1344,6 +1344,102 @@ class TestIncompleteMarkerSurvivesTheProcess:
             "writing; a scoped reingest would trust a partial graph"
         )
 
+    async def test_a_failed_legacy_cleanup_does_not_fail_a_completed_run(
+        self, temp_project_root: Path
+    ) -> None:
+        """The legacy cleanup is best effort (#1850 review).
+
+        This run's own clear has already succeeded by the time it runs, so
+        the run IS complete. Letting a failure in optional compatibility
+        cleanup propagate reported a completed operation as incomplete and
+        raised the flag for a graph that is whole. The legacy marker simply
+        waits for the next run.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        assert registry._require_marker(project) is None
+
+        # Fail only the LEGACY delete, leaving this run's own clear working.
+        real_write = ingestor.execute_write.side_effect
+
+        def _fail_legacy(query: str, params: dict | None = None) -> None:
+            if "m.run_id IS NULL" in query:
+                raise RuntimeError("legacy cleanup refused")
+            return real_write(query, params)
+
+        ingestor.execute_write.side_effect = _fail_legacy
+        stuck = registry._require_marker_cleared(project)
+        ingestor.execute_write.side_effect = real_write
+
+        assert stuck is None, (
+            "a failure in optional legacy cleanup reported a COMPLETED run as "
+            f"incomplete: {stuck}"
+        )
+        assert registry._graph_incomplete is False, (
+            "the flag was raised for a graph that is whole"
+        )
+
+    async def test_an_unreadable_store_refuses_rather_than_reporting_clear(
+        self, temp_project_root: Path
+    ) -> None:
+        """ "I cannot tell" and "nothing outstanding" are different answers.
+
+        Both the first marker read and the post-recovery re-check treat an
+        unreadable store as "refuse": acting on a graph whose state is
+        unknown is what the guard exists to prevent, and a full update
+        recovers either way.
+        """
+        ingestor = self._store()
+        registry = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(registry)
+
+        ingestor._failing.add("read")
+        try:
+            assert registry._persisted_incomplete(project) is True, (
+                "an unreadable marker store was reported as nothing outstanding"
+            )
+            assert registry._marker_rows(project) is None, (
+                "an unreadable store must be distinguishable from an empty one"
+            )
+        finally:
+            ingestor._failing.discard("read")
+
+    async def test_a_failed_recovery_write_refuses(
+        self, temp_project_root: Path
+    ) -> None:
+        """If the store refuses the recovery write, the run that would follow
+        could not mark itself either, so refuse now and let the next attempt
+        retry."""
+        ingestor = self._store()
+        stranding = self._registry(temp_project_root, ingestor)
+        project = _mark_indexed(stranding)
+
+        assert stranding._require_marker(project, writing=False) is None
+        ingestor._failing.add("clear")
+        assert stranding._require_marker_cleared(project) is not None
+        ingestor._failing.discard("clear")
+
+        fresh = self._registry(temp_project_root, ingestor)
+        _mark_indexed(fresh)
+
+        real_write = ingestor.execute_write.side_effect
+
+        def _fail_recovery(query: str, params: dict | None = None) -> None:
+            if "coalesce(m.writing, true) = false" in query:
+                raise RuntimeError("recovery write refused")
+            return real_write(query, params)
+
+        ingestor.execute_write.side_effect = _fail_recovery
+        assert fresh._recover_stranded_markers(project) is False
+        verdict = fresh._persisted_incomplete(project)
+        ingestor.execute_write.side_effect = real_write
+
+        assert verdict is True, (
+            "a store that refused the recovery write was reported as clear"
+        )
+
     async def test_a_runs_own_clear_still_lifts_its_own_marker(
         self, temp_project_root: Path
     ) -> None:


### PR DESCRIPTION
Closes #1709.

## The race

`_ingestor_lock` is per **instance**, so two registries can index or update the same project concurrently. The durable marker was one node per project (`MERGE (m:IncompleteRun {project: $project_name})`), so an overlapping pair interleaved:

1. A marks the project and starts mutating
2. B marks it — a no-op, the node already exists
3. B finishes and **clears the marker**
4. A fails part way

Reproduced on `main`:

```
1. A marked:            {'proj': True}
2. B marked (no-op):    {'proj': True}
3. B cleared:           {}
4. A failed. fresh registry sees persisted_incomplete=False
```

A's partial graph then looks complete to a fresh process — the exact failure the marker exists to prevent.

## The fix: per-run markers

Taking the issue's preferred option over a cross-instance lock. Each marker node is keyed `(project, run_id)`, and a clear removes only the run's own. The read is unchanged in meaning — it already asked a boolean question, which now generalises to "is **any** run outstanding".

The run id is per **registry**, not per call: the instance lock already serialises one registry's own runs, so its marker can never overlap itself.

## Recovery is deliberately not run-scoped

Making the clear run-scoped broke three existing tests, and they were right to break. `_persisted_incomplete` recovers a stranded `writing=false` marker — one a run left behind when it stopped before its first graph write and could not clear its own. That path exists *specifically* to clear **another** run's marker, so a run-scoped delete matches nothing and the project stays blocked until someone runs a full update.

So there are two deletes, and the asymmetry is the point:

| | scope | why |
|---|---|---|
| `CYPHER_CLEAR_PROJECT_INCOMPLETE` | this run | a concurrent run's marker must outlive it |
| `CYPHER_RECOVER_PROJECT_INCOMPLETE` | every run | its purpose is clearing what another run stranded |

Recovery stays safe because the caller has already established that every outstanding marker says `writing=false`.

## The test fake had to change too

`_store()` keyed its marker dict by project name alone, so it **could not express** "B's clear leaves A's marker" — the behaviour under test. Left as it was, my probe measured the fake rather than the code and reported the fix as not working. It now models per-run markers and the unscoped recovery delete, in the same spirit as its existing MERGE-vs-MATCH note from the #1705 review.

## One existing test's premise is now obsolete

`test_another_process_clearing_the_marker_cannot_heal_a_mutating_failure` asserted, as a fixture guard, that another process's clear removes this registry's marker. That **is** the #1709 race, so the guard now asserts the opposite and says why. Its real assertion — the reingest must be refused — is unchanged and still passes, now for a stronger reason: the durable marker survives and refuses on its own rather than depending on the attribution.

Verified that edit kept its teeth: restoring the per-project clear reddens it along with the new overlap test.

## Tests

- the overlap race (the regression the issue asks for), ending with a fresh registry still refusing;
- **control**: a run's own clear still lifts its own marker — otherwise every completed run leaves its marker behind and blocks the next one;
- **control**: recovery still clears a marker stranded by a *different* run.

Both error directions verified by mutation: restoring the per-project clear reddens the overlap test; making recovery run-scoped reddens all three stranded-marker tests plus `test_a_recovery_does_not_clear_a_flag_it_cannot_explain`.

Regression: 93 in the MCP file, 600 across 22 MCP/reingest/marker/delta files.

Note: `test_mcp_startup_key_validation.py` has 2 failures, pre-existing and unrelated (identical with these changes stashed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of concurrent indexing runs so one run cannot clear another run’s incomplete-status marker.
  - Project protection now remains active while any indexing run is still in progress.
  - Added safe recovery for stranded markers, clearing only markers confirmed to be recoverable.
  - Runs can clear their own status without affecting other active or failed runs.
  - Added cleanup for compatible markers created by older versions without disrupting active runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->