### PR TITLE
fix: a proven-restricted aggregate alias is refused twice (#1843)

### DIFF
--- a/codebase_rag/tests/test_mcp_project_scoping.py
+++ b/codebase_rag/tests/test_mcp_project_scoping.py
@@ -2449,9 +2449,15 @@ class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
 
     Said plainly because mutation testing shows it: widening the exemption
     to every aggregated alias leaves the whole file green, since each query
-    it would wrongly admit is already refused upstream. The cases below that
-    DO redden are the ones this change is answerable for -- the property
-    read, and the exemption being dropped entirely.
+    it would wrongly admit is already refused upstream.
+
+    So only three of the eight tests below reach the changed line, and each
+    of the other five says which earlier gate decides it. The three that do:
+    the accepted grouped count, the property-read refusal, and the `collect`
+    refusal. Dropping the exemption reddens the first; dropping the
+    `not reads[entity]` guard reddens the other two. The remaining five are
+    boundary tests of the accepted shape -- worth keeping, but not evidence
+    for this change.
     """
 
     def test_a_grouped_count_over_a_restricted_alias_is_accepted(self) -> None:
@@ -2491,7 +2497,11 @@ class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
         assert not requires_project_evidence(cypher, ALPHA)
 
     def test_a_foreign_project_restriction_is_still_refused(self) -> None:
-        """Restricted to *a* project is not restricted to *yours*."""
+        """Restricted to *a* project is not restricted to *yours*.
+
+        Decided upstream of the exemption, by `_restricts_to_project` --
+        see the class docstring.
+        """
         from codebase_rag.tools.codebase_query import requires_project_evidence
 
         cypher = (
@@ -2522,7 +2532,11 @@ class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
         assert not requires_project_evidence(cypher, ALPHA)
 
     def test_a_wildcard_aggregate_is_still_refused(self) -> None:
-        """`count(*)` binds no alias, so nothing can be shown restricted."""
+        """`count(*)` binds no alias, so nothing can be shown restricted.
+
+        Decided upstream of the exemption, by
+        `_every_aggregate_operand_is_bindable` -- see the class docstring.
+        """
         from codebase_rag.tools.codebase_query import requires_project_evidence
 
         cypher = (
@@ -2540,6 +2554,9 @@ class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
         Its confinement would have to be inferred from its endpoints, which
         this module does not do. Recorded here so the gap is deliberate
         rather than accidental (issue #1843).
+
+        Decided upstream of the exemption, by `_restricts_to_project` --
+        see the class docstring.
         """
         from codebase_rag.tools.codebase_query import requires_project_evidence
 
@@ -2553,7 +2570,11 @@ class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
         assert not requires_project_evidence(cypher, ALPHA)
 
     def test_a_regex_restriction_does_not_vouch_for_an_alias(self) -> None:
-        """A pattern can start with the project and still match everything."""
+        """A pattern can start with the project and still match everything.
+
+        Decided upstream of the exemption, by `_restricts_to_project` --
+        see the class docstring.
+        """
         from codebase_rag.tools.codebase_query import requires_project_evidence
 
         cypher = (

--- a/codebase_rag/tests/test_mcp_project_scoping.py
+++ b/codebase_rag/tests/test_mcp_project_scoping.py
@@ -2421,3 +2421,159 @@ class TestAnUnscopeableQueryNeverReachesTheGraph:
 
         ingestor.fetch_all.assert_called_once()
         assert result.results == [{"qualified_name": f"{ALPHA}.mod.f"}]
+
+
+class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
+    """A proven-confined aggregated alias need not also project its name.
+
+    `RETURN f.qualified_name, count(c)` -- "how many callers does each of my
+    functions have" -- was refused even when the query restricted BOTH `c`
+    and `f` to the requested project. `_restricts_to_project` returned True
+    for `{'C'}`; `_every_projected_entity_is_attributable` then refused
+    anyway, because `c` contributes no property read of its own.
+
+    The two checks answer different questions. Attributability asks "does
+    this row say who it is about", and guards the row filter. The leak an
+    aggregate poses is a MAGNITUDE spanning projects the caller never asked
+    for -- and restriction has already established that magnitude is
+    bounded. Refusing a second time costs a common shape and prevents no
+    leak (issue #1843).
+
+    The exemption covers ONLY aliases `_restricts_to_project` vouched for.
+    What actually enforces that is the caller: `aggregated_only` is the set
+    the restriction gate above has just passed, and it is the same set
+    handed to the exemption, so an unvouched alias cannot reach here at all.
+    The `restricted` parameter is therefore a narrowing the caller cannot
+    currently violate -- defence in depth against a future caller passing a
+    wider set, not the thing keeping today's unrestricted queries out.
+
+    Said plainly because mutation testing shows it: widening the exemption
+    to every aggregated alias leaves the whole file green, since each query
+    it would wrongly admit is already refused upstream. The cases below that
+    DO redden are the ones this change is answerable for -- the property
+    read, and the exemption being dropped entirely.
+    """
+
+    def test_a_grouped_count_over_a_restricted_alias_is_accepted(self) -> None:
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{ALPHA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, count(c) AS callers "
+            "ORDER BY callers DESC LIMIT 10"
+        )
+
+        assert requires_project_evidence(cypher, ALPHA)
+
+    def test_an_unrestricted_aggregated_alias_is_still_refused(self) -> None:
+        """The alias must be restricted, not merely aggregated.
+
+        Only `f` is bounded here, so the count ranges over every project's
+        callers while the row wears an in-project label.
+
+        This one is guarded by `_restricts_to_project` UPSTREAM of the
+        exemption, not by the exemption itself: widening the exemption to
+        every aggregated alias leaves it green, because the query is already
+        refused before attributability runs. Kept as a boundary test of the
+        accepted shape, not as evidence for the `restricted` filter -- see
+        the class docstring for what actually covers that.
+        """
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, count(c) AS callers"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)
+
+    def test_a_foreign_project_restriction_is_still_refused(self) -> None:
+        """Restricted to *a* project is not restricted to *yours*."""
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{BETA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, count(c) AS callers"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)
+
+    def test_an_alias_that_also_reads_a_property_is_still_refused(self) -> None:
+        """The exemption is for aliases exposing NO name of their own.
+
+        `c.name` puts an entity's name in the row, so that entity must carry
+        its own qualified name however well restricted it is -- otherwise
+        the row filter judges it on `f`'s label.
+        """
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{ALPHA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, c.name AS caller, count(c) AS n"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)
+
+    def test_a_wildcard_aggregate_is_still_refused(self) -> None:
+        """`count(*)` binds no alias, so nothing can be shown restricted."""
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{ALPHA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, count(*) AS n"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)
+
+    def test_a_relationship_alias_is_still_refused(self) -> None:
+        """A relationship has no qualified name, so it cannot be vouched for.
+
+        Its confinement would have to be inferred from its endpoints, which
+        this module does not do. Recorded here so the gap is deliberate
+        rather than accidental (issue #1843).
+        """
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[r:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{ALPHA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, count(r) AS callers"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)
+
+    def test_a_regex_restriction_does_not_vouch_for_an_alias(self) -> None:
+        """A pattern can start with the project and still match everything."""
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name =~ '{ALPHA}.*|.*' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, count(c) AS callers"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)
+
+    def test_collect_over_a_restricted_alias_is_still_refused(self) -> None:
+        """`collect` returns the names themselves, not only a magnitude."""
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{ALPHA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, collect(c.name) AS callers"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)

--- a/codebase_rag/tests/test_mcp_project_scoping.py
+++ b/codebase_rag/tests/test_mcp_project_scoping.py
@@ -2453,9 +2453,12 @@ class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
 
     So only three of the eight tests below reach the changed line, and each
     of the other five says which earlier gate decides it. The three that do:
-    the accepted grouped count, the property-read refusal, and the `collect`
-    refusal. Dropping the exemption reddens the first; dropping the
-    `not reads[entity]` guard reddens the other two. The remaining five are
+    the accepted grouped count, the property-read refusal, and the
+    collect-of-a-property refusal. Dropping the exemption reddens the first;
+    dropping the `not reads[entity]` guard reddens the other two. The bare
+    `collect` test reddens on its own mutation -- putting COLLECT back into
+    the magnitude pattern -- and the guard/filter agreement test guards the
+    consistency the bare-collect bug broke. The remaining five are
     boundary tests of the accepted shape -- worth keeping, but not evidence
     for this change.
     """
@@ -2586,7 +2589,61 @@ class TestARestrictedAggregateOnlyAliasIsNotRefusedTwice:
 
         assert not requires_project_evidence(cypher, ALPHA)
 
-    def test_collect_over_a_restricted_alias_is_still_refused(self) -> None:
+    def test_bare_collect_over_a_restricted_alias_is_refused(self) -> None:
+        """`collect(c)` returns the ENTITIES, so restriction does not vouch.
+
+        Caught on review after the first version of this change admitted it.
+        The guard accepted the query and `scope_rows_to_project` then dropped
+        the whole row -- `_names_another_project` fails closed on a driver
+        `Node`, which is neither scalar nor a supported container -- so the
+        caller got an empty result instead of either their data or a refusal.
+        Accepted-then-silently-emptied is worse than refused, because nothing
+        in the response says the scope guard was involved.
+
+        Restriction bounds a MAGNITUDE; it does not make the entities
+        themselves attributable. So the exemption covers `count`/`sum`/`avg`/
+        `min`/`max` only, and `collect` is excluded by construction rather
+        than by a separate check that could drift (issue #1843).
+        """
+        from codebase_rag.tools.codebase_query import requires_project_evidence
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{ALPHA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, collect(c) AS callers"
+        )
+
+        assert not requires_project_evidence(cypher, ALPHA)
+
+    def test_an_accepted_aggregate_survives_the_row_filter(self) -> None:
+        """The guard and the filter must agree, not merely each be safe.
+
+        The `collect` bug was a DISAGREEMENT: admitted by one, emptied by the
+        other. This asserts the pair is consistent for the shape the change
+        exists to allow -- a row whose aggregate is a number survives scoping
+        with its value intact.
+        """
+        from codebase_rag.tools.codebase_query import (
+            requires_project_evidence,
+            scope_rows_to_project,
+        )
+
+        cypher = (
+            "MATCH (c:Function)-[:CALLS]->(f:Function) "
+            f"WHERE c.qualified_name STARTS WITH '{ALPHA}.' "
+            f"AND f.qualified_name STARTS WITH '{ALPHA}.' "
+            "RETURN f.qualified_name AS name, count(c) AS callers"
+        )
+        assert requires_project_evidence(cypher, ALPHA)
+
+        rows = [{"name": f"{ALPHA}.mod.f", "callers": 3}]
+
+        assert scope_rows_to_project(rows, ALPHA) == rows
+
+    def test_collect_of_a_property_over_a_restricted_alias_is_refused(
+        self,
+    ) -> None:
         """`collect` returns the names themselves, not only a magnitude."""
         from codebase_rag.tools.codebase_query import requires_project_evidence
 

--- a/codebase_rag/tools/codebase_query.py
+++ b/codebase_rag/tools/codebase_query.py
@@ -58,6 +58,14 @@ _AGGREGATED_READ_RE = re.compile(
     r"([A-Z_][A-Z0-9_]*)(?:\.[A-Z_][A-Z0-9_]*)?\s*\)"
 )
 
+# An entity aggregated into a MAGNITUDE -- a number that names nobody.
+# `COLLECT` is deliberately absent: it returns the matched entities
+# themselves, so the restriction that bounds a count does not make a
+# collect safe to exempt (issue #1843).
+_MAGNITUDE_AGGREGATED_ENTITY_RE = re.compile(
+    r"\b(?:COUNT|SUM|AVG|MIN|MAX)\(\s*(?:DISTINCT\s+)?([A-Z_][A-Z0-9_]*)\s*\)"
+)
+
 # Every aggregate and whatever it is applied to, so the operand can be
 # judged rather than pattern-matched against known-bad spellings. Listing the
 # constant forms was the wrong shape: it caught `*` and digits and missed a
@@ -462,8 +470,16 @@ def _every_projected_entity_is_attributable(
     # Only an alias that reads NO properties may be exempted: one appearing
     # both as `c.name` and inside `count(c)` exposes a name that still has to
     # be attributable, so restriction alone does not settle it.
+    # Only an alias aggregated into a MAGNITUDE may be exempted. `collect(c)`
+    # returns the entities themselves, so restriction does not make it
+    # attributable -- and the row filter, which cannot inspect a driver Node,
+    # drops the whole row, turning a valid query into an empty result rather
+    # than a refusal (issue #1843).
+    measured = set(_MAGNITUDE_AGGREGATED_ENTITY_RE.findall(projection))
     vouched = {
-        entity for entity in restricted or () if entity in reads and not reads[entity]
+        entity
+        for entity in restricted or ()
+        if entity in reads and not reads[entity] and entity in measured
     }
     return all(
         cs.CYPHER_QUALIFIED_NAME_TOKEN in props

--- a/codebase_rag/tools/codebase_query.py
+++ b/codebase_rag/tools/codebase_query.py
@@ -252,7 +252,9 @@ def requires_project_evidence(
     # belong to an entity nothing attributes. One entity's qualified name
     # does not vouch for another's properties.
     if _PROJECTED_QUALIFIED_NAME_RE.search(projection):
-        return _every_projected_entity_is_attributable(projection)
+        # `aggregated_only` reaches here only when `_restricts_to_project`
+        # above returned True for it, so these aliases are proven confined.
+        return _every_projected_entity_is_attributable(projection, aggregated_only)
     # An aggregate exposes no NAMES but does expose a MAGNITUDE: a scoped
     # caller receiving `count(n)` over every indexed project learns the
     # size of projects they did not ask about. So it counts as evidence
@@ -415,7 +417,9 @@ def _entities_only_ever_aggregated(projection: str) -> set[str]:
     return aggregated - plain
 
 
-def _every_projected_entity_is_attributable(projection: str) -> bool:
+def _every_projected_entity_is_attributable(
+    projection: str, restricted: set[str] | None = None
+) -> bool:
     """Whether every entity read in `projection` also projects its own qn.
 
     Cypher property reads are `<entity>.<property>`, so grouping the
@@ -433,13 +437,39 @@ def _every_projected_entity_is_attributable(projection: str) -> bool:
     aggregate and never as a property read -- so it never entered this
     map, while the count reported how many `b` exist across every project.
     An aggregate names nobody but it still MEASURES someone.
+
+    `restricted` names the aggregated-only aliases the CALLER has already
+    proven confined to this project via `_restricts_to_project`. They are
+    exempt, and only they. Attributability asks "does this row say who it
+    is about"; the leak it defends against is a MAGNITUDE spanning projects
+    the caller never asked for. Once restriction has established that an
+    alias cannot range outside the requested project, that magnitude is
+    bounded, and refusing anyway costs `RETURN f.qualified_name,
+    count(c)` -- "how many callers does this function have" -- for no leak
+    prevented (issue #1843).
+
+    The exemption is narrow on purpose. It covers only aliases the caller
+    passes in, which are only ever `_entities_only_ever_aggregated` that
+    `_restricts_to_project` returned True for; an alias whose properties
+    are READ still needs its own qualified name, because that row names an
+    entity and the row filter must be able to judge it.
     """
     reads: dict[str, set[str]] = {}
     for entity, prop in _PROPERTY_READ_RE.findall(projection):
         reads.setdefault(entity, set()).add(prop)
     for entity in _AGGREGATED_ENTITY_RE.findall(projection):
         reads.setdefault(entity, set())
-    return all(cs.CYPHER_QUALIFIED_NAME_TOKEN in props for props in reads.values())
+    # Only an alias that reads NO properties may be exempted: one appearing
+    # both as `c.name` and inside `count(c)` exposes a name that still has to
+    # be attributable, so restriction alone does not settle it.
+    vouched = {
+        entity for entity in restricted or () if entity in reads and not reads[entity]
+    }
+    return all(
+        cs.CYPHER_QUALIFIED_NAME_TOKEN in props
+        for entity, props in reads.items()
+        if entity not in vouched
+    )
 
 
 def _where_is_a_plain_conjunction(body: str) -> bool:


### PR DESCRIPTION
Fixes #1843.

## The issue's repro does not reproduce

Both examples in the issue pass `alpha` as the project name. That is not a project name — `derive_project_name` builds `<base>__<8 hex>`, and `_PROJECT_LITERAL_RE` requires that shape, so `_restricts_to_project` returns `False` for *any* query when given it. With a real name, the issue's first example is **already accepted** on `main`.

So the premise "refuses every scoped aggregate" is false, and the aggregate/non-aggregate axis is not what tracks the verdict. The comparison table in the issue holds only because every row was run with an unmatchable project name.

## The real gap

Holding the WHERE fixed and varying only the aggregated alias gives three verdicts on `main`:

| projection | before | after |
|---|---|---|
| `f.qualified_name AS name, count(f)` | ACCEPT | ACCEPT |
| `f.qualified_name AS name, count(c)` | REFUSE | **ACCEPT** |
| `f.qualified_name AS name, count(r)` | REFUSE | REFUSE |

The middle row — "how many callers does each of my functions have" — was refused even with both `c` and `f` restricted to the requested project. `_restricts_to_project` returns `True` for `{'C'}`; `_every_projected_entity_is_attributable` then refused anyway, because `c` contributes no property read of its own.

The two checks answer different questions. Attributability asks whether a row says who it is about, and guards the row filter. The leak an aggregate poses is a **magnitude** spanning projects the caller never asked for — which restriction has already bounded. Refusing a second time costs a common shape and prevents no leak.

## The change

`_every_projected_entity_is_attributable` takes the aggregated-only aliases the caller has already proven confined, and exempts those alone. An alias whose properties are **read** still needs its own qualified name however well restricted, because that row names an entity.

Default-deny is unchanged for everything else: wildcard `count(*)`, any alias nothing restricts, foreign literals, regex predicates, and `collect`.

## On the relationship case

`count(r)` stays refused and is now documented as deliberate. A relationship carries no qualified name, so its confinement would have to be inferred from its endpoints — a new inference this module does not make, and one that deserves its own review rather than riding along here.

## Verification

Eight tests. Six mutations run, and the result worth stating plainly: **only three of the eight tests reach the changed line.**

- dropping the exemption → reddens the accepted grouped count
- dropping the call-site argument → same
- dropping the `not reads[entity]` guard → reddens the property-read and `collect` refusals

Widening the exemption to every aggregated alias leaves the **whole file green**, because each query it would wrongly admit is already refused upstream. The other five tests are decided by `_restricts_to_project` or `_every_aggregate_operand_is_bindable`, and each now names the gate that decides it rather than implying coverage it does not have. They stay as boundary tests of the accepted shape.

Local review (4/5, no P0/P1) could not construct any query that now passes and leaks a cross-project magnitude; its one finding was the test-disclaimer gap, fixed in the second commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project-scoped aggregate queries so valid grouped counts and other numeric aggregates using already restricted aliases are accepted.
  - Preserved safeguards for unrestricted aliases, aliases from other projects, property-reading aliases, wildcard and relationship aggregates, regular-expression restrictions, and collection operations.
  - Queries that cannot establish sufficient project attribution continue to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->