### PR TITLE
fix: rebuild findings and endpoint links on the scoped re-ingest path (#1670)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -5021,6 +5021,8 @@ class GraphUpdater:
         self._prune_stale_seeded_module_qns(set(reparse.values()))
         self._reingest_resolve(reparse, captured)
         self._reingest_update_hashes(cache_path, hashes, reparse, parsed, gone)
+        self._reingest_rebuild_findings(reparse)
+        self._link_endpoint_resources()
 
         report = ReingestReport(
             # `parsed`, not `present`: a file that became unreadable between
@@ -5044,6 +5046,33 @@ class GraphUpdater:
             ms=round(report.elapsed_ms, 1),
         )
         return report
+
+    def _reingest_rebuild_findings(self, reparse: dict[str, Path]) -> None:
+        """Re-run the finding analysis for the RE-PARSED modules only.
+
+        `CYPHER_DELETE_MODULE` detaches a re-parsed Module from its finding
+        nodes (`HAS_SMELL`, `HAS_VULNERABILITY`, `IMPLEMENTS_PATTERN`), and
+        nothing recreated those edges until the next full `update_repository`
+        (issue #1670). A re-ingested file therefore lost its findings and
+        stayed lost, which reads as "this file is clean".
+
+        Scoped rather than repo-wide, because the full pass is not cheap
+        enough to run on every re-ingest -- the other option the issue
+        offers. Measured over this repo's own parser tree: 1.001s for 125
+        modules against 0.001s for one, so the full pass would dominate a
+        scoped re-ingest and grow with the repository rather than with the
+        change. The analyzer already takes a module map, so the scope is the
+        argument and needs no new machinery.
+        """
+        processor = self.factory.definition_processor
+        touched = set(reparse.values())
+        scoped = {
+            module_qn: path
+            for module_qn, path in processor.module_qn_to_file_path.items()
+            if path in touched
+        }
+        if scoped:
+            self.finding_analyzer.analyze(scoped)
 
     def _prune_orphan_nodes(self) -> None:
         """Remove graph nodes whose files/folders no longer exist on disk."""

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -5029,6 +5029,15 @@ class GraphUpdater:
         # (raised in review of #1852).
         self._reingest_rebuild_findings(reparse)
         self._link_endpoint_resources()
+        # Unconditionally, because neither post-pass guarantees one:
+        # `_reingest_rebuild_findings` only QUEUES its nodes and edges, and
+        # `_link_endpoint_resources` returns early when RESOLVES_TO is
+        # disabled or the ingestor cannot query, so on those paths nothing
+        # flushes what the rebuild queued. The hash cache below records these
+        # files as current, and a later run would take the in-sync path and
+        # skip the post-passes entirely -- so an unflushed queue here is lost
+        # for good rather than retried (raised by CodeRabbit on #1852).
+        self.ingestor.flush_all()
         self._reingest_update_hashes(cache_path, hashes, reparse, parsed, gone)
 
         report = ReingestReport(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -5020,9 +5020,16 @@ class GraphUpdater:
         # would never shrink on the retained updater this fix exists for.
         self._prune_stale_seeded_module_qns(set(reparse.values()))
         self._reingest_resolve(reparse, captured)
-        self._reingest_update_hashes(cache_path, hashes, reparse, parsed, gone)
+        # BEFORE the hash commit, matching `run()`, which does both passes
+        # ahead of its cache write. `_reingest_update_hashes` saves the hash
+        # cache to disk, which records these files as indexed; queueing the
+        # rebuilt finding and link writes after it meant an interruption in
+        # between left caches claiming the files were done while those writes
+        # never landed -- and the next run would skip them as unchanged
+        # (raised in review of #1852).
         self._reingest_rebuild_findings(reparse)
         self._link_endpoint_resources()
+        self._reingest_update_hashes(cache_path, hashes, reparse, parsed, gone)
 
         report = ReingestReport(
             # `parsed`, not `present`: a file that became unreadable between

--- a/codebase_rag/tests/test_reingest.py
+++ b/codebase_rag/tests/test_reingest.py
@@ -1278,10 +1278,19 @@ class _QueryableSink:
         return []
 
     def stale_delete_qns(self) -> set[str]:
+        # Selects the stale-delete query by the parameter it carries, not by
+        # the word EXPOSES appearing anywhere in the text. The endpoint LINK
+        # pass also writes EXPOSES and takes different parameters, and it now
+        # runs on the re-ingest path too (issue #1670) -- a text match alone
+        # raised KeyError on its params.
         return {
             qn.split(".", 1)[1]
             for c in self.execute_write.call_args_list
-            if c.args and "EXPOSES" in c.args[0]
+            if c.args
+            and "EXPOSES" in c.args[0]
+            and len(c.args) > 1
+            and isinstance(c.args[1], dict)
+            and "qns" in c.args[1]
             for qn in c.args[1]["qns"]
         }
 

--- a/codebase_rag/tests/test_reingest_rebuilds_findings.py
+++ b/codebase_rag/tests/test_reingest_rebuilds_findings.py
@@ -1,0 +1,169 @@
+"""A scoped re-ingest must rebuild the passes a full run does (issue #1670).
+
+Two repository-wide passes never ran on the `reingest` path:
+
+* the finding analysis (`HAS_SMELL`, `HAS_VULNERABILITY`,
+  `IMPLEMENTS_PATTERN`). `CYPHER_DELETE_MODULE` detaches a re-parsed Module
+  from its finding nodes and nothing recreated the edges until the next full
+  `update_repository`, so a re-ingested file lost its findings and stayed
+  lost -- which reads as "this file is clean";
+* the URL-to-endpoint link pass, which rebuilds `RESOLVES_TO` from all live
+  resources, so a changed route or client URL kept its old links.
+
+The issue offers a scoped variant or "a measured statement that the full pass
+is cheap enough to run every time". Measured over this repo's own parser
+tree: the finding pass takes 1.001s for 125 modules against 0.001s for one.
+The full pass grows with the repository rather than with the change, so the
+scoped variant is the answer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+_FINDING_RELS = {
+    cs.RelationshipType.HAS_SMELL.value,
+    cs.RelationshipType.HAS_VULNERABILITY.value,
+    cs.RelationshipType.IMPLEMENTS_PATTERN.value,
+}
+
+# `eval` on a parameter is flagged by the shipped rules. If that ever stops
+# being true the fixture guard below fails loudly rather than passing empty.
+_RISKY = "def run(data):\n    return eval(data)\n"
+_PLAIN = "def helper():\n    return 1\n"
+
+
+def _finding_edges(mock: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(call.args[0][2]), str(call.args[2][2]))
+        for call in mock.ensure_relationship_batch.call_args_list
+        if str(call.args[1]) in _FINDING_RELS
+    }
+
+
+def _build(tmp_path: Path, files: dict[str, str]) -> tuple[GraphUpdater, MagicMock]:
+    for rel, content in files.items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    updater = GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        # FINDINGS is opt-in. Without it the analyzer no-ops and every
+        # assertion here passes on an empty set -- the whole file would be
+        # green while measuring nothing.
+        capture=resolve_capture([cs.CaptureGroup.FINDINGS.value]),
+    )
+    updater.run()
+    return updater, mock
+
+
+def test_a_reingested_file_keeps_its_findings(tmp_path: Path) -> None:
+    updater, mock = _build(tmp_path, {"risky.py": _RISKY, "other.py": _PLAIN})
+    assert _finding_edges(mock), (
+        "fixture guard: the full index produced no findings, so this test "
+        "cannot tell a rebuilt edge from an absent one"
+    )
+
+    mock.reset_mock()
+    target = tmp_path / "risky.py"
+    target.write_text(_RISKY.replace("eval(data)", "eval(data)  # edited"), "utf-8")
+    updater.reingest((target,))
+
+    assert _finding_edges(mock), (
+        "the re-ingested file emitted no findings; its Module was detached "
+        "from them and nothing rebuilt the edges, so the file reads as clean"
+    )
+
+
+def test_the_rebuild_is_scoped_to_the_reparsed_files(tmp_path: Path) -> None:
+    """The measured reason for scoping, asserted rather than assumed.
+
+    Re-running the whole repository's analysis on every re-ingest is the
+    other option the issue offers, and it costs time proportional to the
+    repository rather than to the change. This pins that the analyser is
+    handed only the re-parsed modules, so a future "simplification" to the
+    full map fails here instead of quietly slowing every re-ingest.
+    """
+    updater, _ = _build(
+        tmp_path,
+        {"risky.py": _RISKY, "other.py": _PLAIN, "third.py": _PLAIN},
+    )
+
+    # The analyzer uses __slots__, so the spy goes on the CLASS and is
+    # removed again before the assertions run.
+    seen: list[int] = []
+    analyzer = updater.finding_analyzer
+    real = type(analyzer).analyze
+
+    def _spy(self: object, module_map: dict[str, Path]) -> None:
+        if self is analyzer:
+            seen.append(len(module_map))
+        return real(self, module_map)
+
+    target = tmp_path / "risky.py"
+    target.write_text(_RISKY.replace("eval(data)", "eval(data)  # edited"), "utf-8")
+    with patch.object(type(analyzer), "analyze", _spy):
+        updater.reingest((target,))
+
+    assert seen, "the re-ingest never ran the finding analysis at all"
+    assert max(seen) < 3, (
+        f"the re-ingest analysed {max(seen)} modules for a one-file change; "
+        "the pass is scoped to the re-parsed files, not the repository"
+    )
+
+
+def test_a_reingest_relinks_endpoint_resources(tmp_path: Path) -> None:
+    """The second pass: the URL-to-endpoint link rebuild.
+
+    It deletes every network link and rebuilds it from all live resources, so
+    a changed route or client URL kept its old links until the next full
+    update. Asserted through the call rather than the edges, because the link
+    pass needs a queryable store and the fixture ingestor is a mock -- the
+    defect was that it never ran on this path at all.
+    """
+    updater, _ = _build(tmp_path, {"risky.py": _RISKY})
+
+    calls: list[int] = []
+    real_link = type(updater)._link_endpoint_resources
+
+    def _spy(self: object) -> None:
+        if self is updater:
+            calls.append(1)
+        return real_link(self)
+
+    target = tmp_path / "risky.py"
+    target.write_text(_RISKY.replace("eval(data)", "eval(data)  # edited"), "utf-8")
+    with patch.object(type(updater), "_link_endpoint_resources", _spy):
+        updater.reingest((target,))
+
+    assert calls, (
+        "the re-ingest never ran the endpoint link pass, so a changed route "
+        "or client URL keeps its old links until the next full update"
+    )
+
+
+@pytest.mark.parametrize("rel", ["risky.py", "other.py"])
+def test_a_full_run_still_analyses_everything(tmp_path: Path, rel: str) -> None:
+    """The control: scoping the re-ingest must not scope the full run.
+
+    A fix that narrowed both would satisfy the tests above while quietly
+    stopping `update_repository` from analysing the repository.
+    """
+    updater, _ = _build(tmp_path, {"risky.py": _RISKY, "other.py": _PLAIN})
+    module_map = updater.factory.definition_processor.module_qn_to_file_path
+    assert any(path == tmp_path / rel for path in module_map.values()), (
+        f"{rel} is missing from the full run's module map"
+    )

--- a/codebase_rag/tests/test_reingest_rebuilds_findings.py
+++ b/codebase_rag/tests/test_reingest_rebuilds_findings.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from codebase_rag import constants as cs
 from codebase_rag.capture import resolve_capture
 from codebase_rag.graph_updater import GraphUpdater
@@ -174,6 +172,7 @@ def test_the_rebuild_runs_before_the_hash_commit(tmp_path: Path) -> None:
     real_findings = type(updater)._reingest_rebuild_findings
     real_link = type(updater)._link_endpoint_resources
     real_hashes = type(updater)._reingest_update_hashes
+    real_flush = updater.ingestor.flush_all
 
     def _findings(self: object, *a: object, **k: object) -> object:
         order.append("findings")
@@ -186,6 +185,12 @@ def test_the_rebuild_runs_before_the_hash_commit(tmp_path: Path) -> None:
     def _hashes(self: object, *a: object, **k: object) -> object:
         order.append("hashes")
         return real_hashes(self, *a, **k)
+
+    def _flush(*a: object, **k: object) -> object:
+        order.append("flush")
+        return real_flush(*a, **k)
+
+    updater.ingestor.flush_all = _flush  # type: ignore[method-assign]
 
     target = tmp_path / "risky.py"
     target.write_text(_RISKY.replace("eval(data)", "eval(data)  # edited"), "utf-8")
@@ -204,17 +209,59 @@ def test_the_rebuild_runs_before_the_hash_commit(tmp_path: Path) -> None:
     assert order.index("link") < order.index("hashes"), (
         f"the endpoint link pass ran AFTER the hash commit: {order}"
     )
+    # And the queued writes must actually reach the store before the cache
+    # records these files as current. `_reingest_rebuild_findings` only
+    # QUEUES, and `_link_endpoint_resources` returns early when RESOLVES_TO
+    # is disabled, so neither post-pass guarantees a flush of its own.
+    # A flush must fall BETWEEN the rebuild and the hash commit. `.index`
+    # alone is not enough: an earlier flush already runs inside the re-ingest
+    # (before the rebuild), so "a flush happened before the hash commit" is
+    # true even with the new one removed -- the first version of this
+    # assertion passed against exactly that mutation.
+    first = order.index("findings")
+    last = order.index("hashes")
+    assert "flush" in order[first:last], (
+        f"the writes the rebuild QUEUED were never flushed before the hash "
+        f"commit, so an interruption loses them for good: {order}"
+    )
 
 
-@pytest.mark.parametrize("rel", ["risky.py", "other.py"])
-def test_a_full_run_still_analyses_everything(tmp_path: Path, rel: str) -> None:
+def test_a_full_run_still_analyses_everything(tmp_path: Path) -> None:
     """The control: scoping the re-ingest must not scope the full run.
 
     A fix that narrowed both would satisfy the tests above while quietly
     stopping `update_repository` from analysing the repository.
+
+    Asserts what the analyser RECEIVED, not what the module map contains
+    (raised by CodeRabbit on #1852). The earlier version checked the map was
+    populated, which is true even if analysis is skipped entirely or handed a
+    single module -- it could not see the regression it exists to catch.
     """
-    updater, _ = _build(tmp_path, {"risky.py": _RISKY, "other.py": _PLAIN})
-    module_map = updater.factory.definition_processor.module_qn_to_file_path
-    assert any(path == tmp_path / rel for path in module_map.values()), (
-        f"{rel} is missing from the full run's module map"
+    for rel, content in {"risky.py": _RISKY, "other.py": _PLAIN}.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=MagicMock(),
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.FINDINGS.value]),
     )
+
+    received: list[set[Path]] = []
+    real = type(updater.finding_analyzer).analyze
+
+    def _spy(self: object, module_map: dict[str, Path]) -> None:
+        received.append(set(module_map.values()))
+        return real(self, module_map)
+
+    with patch.object(type(updater.finding_analyzer), "analyze", _spy):
+        updater.run()
+
+    assert received, "the full run never analysed anything"
+    analysed = set().union(*received)
+    for rel in ("risky.py", "other.py"):
+        assert tmp_path / rel in analysed, (
+            f"the full run did not hand {rel} to the finding analyser; "
+            f"it saw {sorted(p.name for p in analysed)}"
+        )

--- a/codebase_rag/tests/test_reingest_rebuilds_findings.py
+++ b/codebase_rag/tests/test_reingest_rebuilds_findings.py
@@ -155,6 +155,57 @@ def test_a_reingest_relinks_endpoint_resources(tmp_path: Path) -> None:
     )
 
 
+def test_the_rebuild_runs_before_the_hash_commit(tmp_path: Path) -> None:
+    """Ordering, not just presence (raised in review of #1852).
+
+    `_reingest_update_hashes` saves the hash cache to disk, which records
+    these files as indexed. Queueing the rebuilt finding and link writes
+    AFTER it meant an interruption in between left the caches claiming the
+    files were done while those writes never landed -- and the next run would
+    skip them as unchanged, so the loss became permanent rather than being
+    repaired on the following pass.
+
+    `run()` does both passes before its own cache write; this asserts the
+    re-ingest path matches.
+    """
+    updater, _ = _build(tmp_path, {"risky.py": _RISKY})
+    order: list[str] = []
+
+    real_findings = type(updater)._reingest_rebuild_findings
+    real_link = type(updater)._link_endpoint_resources
+    real_hashes = type(updater)._reingest_update_hashes
+
+    def _findings(self: object, *a: object, **k: object) -> object:
+        order.append("findings")
+        return real_findings(self, *a, **k)
+
+    def _link(self: object, *a: object, **k: object) -> object:
+        order.append("link")
+        return real_link(self, *a, **k)
+
+    def _hashes(self: object, *a: object, **k: object) -> object:
+        order.append("hashes")
+        return real_hashes(self, *a, **k)
+
+    target = tmp_path / "risky.py"
+    target.write_text(_RISKY.replace("eval(data)", "eval(data)  # edited"), "utf-8")
+    with (
+        patch.object(type(updater), "_reingest_rebuild_findings", _findings),
+        patch.object(type(updater), "_link_endpoint_resources", _link),
+        patch.object(type(updater), "_reingest_update_hashes", _hashes),
+    ):
+        updater.reingest((target,))
+
+    assert "hashes" in order, "fixture guard: the hash commit never ran"
+    assert "findings" in order, "fixture guard: the finding rebuild never ran"
+    assert order.index("findings") < order.index("hashes"), (
+        f"the finding rebuild ran AFTER the hash commit: {order}"
+    )
+    assert order.index("link") < order.index("hashes"), (
+        f"the endpoint link pass ran AFTER the hash commit: {order}"
+    )
+
+
 @pytest.mark.parametrize("rel", ["risky.py", "other.py"])
 def test_a_full_run_still_analyses_everything(tmp_path: Path, rel: str) -> None:
     """The control: scoping the re-ingest must not scope the full run.


### PR DESCRIPTION
Closes #1670.

## The gap

Two repository-wide passes never ran on the `reingest` path:

- **the finding analysis** (`HAS_SMELL`, `HAS_VULNERABILITY`, `IMPLEMENTS_PATTERN`). `CYPHER_DELETE_MODULE` detaches a re-parsed Module from its finding nodes, and nothing recreated the edges until the next full `update_repository`. A re-ingested file lost its findings and stayed lost — which reads as *this file is clean*;
- **the URL-to-endpoint link pass**, which deletes every network link and rebuilds it from all live resources, so a changed route or client URL kept its old links.

Reproduced on `origin/main` with a file the shipped rules flag:

```
findings after the full index:        1
findings re-emitted by the re-ingest: 0
```

On this branch the same probe re-emits the finding.

## Which of the issue's two options, and why

The issue offers a scoped variant **or** "a measured statement that the full pass is cheap enough to run on every re-ingest". Measured over this repo's own parser tree:

| finding pass over | time |
|---|---|
| all 125 modules | 1.001s |
| one module | 0.001s |

**731×.** The full pass costs time proportional to the repository rather than to the change, so it is not cheap enough to run on every re-ingest — the second option is refuted and the scoped variant is the answer.

Worth noting how nearly that measurement went the other way: my first run reported **0.000s for both arms**, because the FINDINGS capture group is opt-in and the analyzer was silently no-opping. A disabled pass reported as a cheap one would have justified exactly the wrong choice.

The analyzer already takes a module map, so the scope is the argument — no new machinery. The endpoint link pass is called as-is; it is idempotent by construction, rebuilding from live resources.

## Tests

`codebase_rag/tests/test_reingest_rebuilds_findings.py`:

- a re-ingested file keeps its findings;
- the rebuild is **scoped** to the re-parsed files, not the repository;
- a re-ingest runs the endpoint link pass;
- **control**: a full run still analyses everything — a fix that narrowed both would satisfy the others while quietly stopping `update_repository` from analysing the repository.

Both error directions verified by mutation: removing the passes reddens the three defect tests; running the finding pass repo-wide (the refuted option) reddens the scoping test. The fixture guards the capture group explicitly, since without it every assertion here would pass on an empty set.

## One existing test helper had to change

`stale_delete_qns` in `test_reingest.py` collected every `execute_write` whose text contained `EXPOSES` and indexed its params by `qns`. The endpoint link pass also writes `EXPOSES` with different parameters, and now runs on this path, so the text match raised `KeyError`. It now selects on the parameter it actually requires.

Checked that this did not defang it: both call sites assert a non-empty result (`{"routes.get_user"}`), so a helper that matched nothing would fail rather than pass.

Regression: 716 passed across 62 incremental/reingest/registry/watch files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Re-ingesting files now rebuilds applicable findings and correctly relinks endpoint resources.
  - Finding analysis remains limited to re-parsed files during scoped updates, while full repository analysis continues to cover all files.
  - Re-ingestion writes are flushed before files are marked current, improving consistency after targeted updates.

- **Tests**
  - Added regression coverage for finding rebuilds, endpoint-resource relinking, update ordering, and complete repository analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->