### PR TITLE
fix: sweep glosses whose subject a project delete removed (#1828)

### DIFF
--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -991,6 +991,12 @@ PARSER_FINGERPRINT_MISMATCH = (
     "every project in a shared database, not just this one."
 )
 
+GLOSS_PRUNE_FAILED = (
+    "Could not sweep orphaned glosses: {error}. The project delete itself "
+    "succeeded; the orphans are unreachable rather than wrong, and the next "
+    "deliberate project delete sweeps them."
+)
+
 REHYDRATE_QUERY_FAILED = (
     "Could not read persisted definitions from the graph; continuing with "
     "only this run's freshly parsed registry."

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -19,6 +19,8 @@ from codebase_rag.config import load_ignore_patterns
 from codebase_rag.graph_updater import GraphUpdater, ReingestAborted
 from codebase_rag.models import ToolMetadata
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.services import QueryProtocol
+from codebase_rag.services.gloss_cleanup import prune_orphaned_glosses
 from codebase_rag.services.graph_service import MemgraphIngestor
 from codebase_rag.services.llm import CypherGenerator, create_rag_orchestrator
 from codebase_rag.tools import tool_descriptions as td
@@ -828,6 +830,16 @@ class MCPToolsRegistry:
             return DeleteProjectErrorResult(success=False, error=refusal)
         self._cleanup_embeddings_then_begin_writing(project_name)
         self.ingestor.delete_project(project_name)
+        # A Gloss is unreachable from the project-delete traversal by design:
+        # that is what lets it survive an index's delete-then-rebuild, which
+        # deletes and recreates the very symbols it annotates. So the orphan
+        # sweep belongs HERE, on the deliberate delete, and not inside
+        # `delete_project` itself -- `_index_repository_sync` calls that too,
+        # and a sweep there would destroy every gloss on each reindex
+        # (issue #1828; caught in review of #1856). Exactly the rule the
+        # incomplete-run marker follows two lines below.
+        if isinstance(self.ingestor, QueryProtocol):
+            prune_orphaned_glosses(self.ingestor)
         # Invariant (b). The marker sits on its own node so `delete_project`
         # cannot reach it -- which is what lets it survive an index's
         # delete-then-rebuild -- so a deliberate delete must remove it. The

--- a/codebase_rag/services/gloss_cleanup.py
+++ b/codebase_rag/services/gloss_cleanup.py
@@ -30,7 +30,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 from .. import constants as cs
+from .. import logs as lg
 
 if TYPE_CHECKING:
     from . import QueryProtocol
@@ -50,6 +53,25 @@ CYPHER_DELETE_ORPHANED_GLOSSES = (
 )
 
 
-def prune_orphaned_glosses(ingestor: QueryProtocol) -> None:
-    """Delete glosses whose subject is gone, leaving anchored ones intact."""
-    ingestor.execute_write(CYPHER_DELETE_ORPHANED_GLOSSES)
+def prune_orphaned_glosses(ingestor: QueryProtocol) -> bool:
+    """Delete glosses whose subject is gone, leaving anchored ones intact.
+
+    Never raises. The caller runs this AFTER the project delete has already
+    succeeded, and the delete is not undoable: letting a cleanup failure
+    propagate would report a completed deletion as failed, and a retry then
+    short-circuits on `project not found` before reaching this sweep at all,
+    so the orphans would survive indefinitely (raised by CodeRabbit on
+    #1856).
+
+    Returns whether the sweep reached the store, so a caller that can
+    schedule a retry may, and the log records it either way. Leaving the
+    orphans is the mild outcome: they are unreachable rather than wrong, and
+    the next deliberate delete of any project sweeps them -- the predicate is
+    "this gloss has no subject", not "this gloss belonged to that project".
+    """
+    try:
+        ingestor.execute_write(CYPHER_DELETE_ORPHANED_GLOSSES)
+    except Exception as error:  # noqa: BLE001 -- see docstring
+        logger.warning(lg.GLOSS_PRUNE_FAILED.format(error=error))
+        return False
+    return True

--- a/codebase_rag/services/gloss_cleanup.py
+++ b/codebase_rag/services/gloss_cleanup.py
@@ -1,0 +1,55 @@
+"""Removal of Gloss nodes whose subject no longer exists.
+
+A `Gloss` hangs off the symbol it describes via `ANNOTATES`, which
+`CYPHER_DELETE_PROJECT` traverses in neither of its lists (containment, then
+DEFINES/DEFINES_METHOD). Deleting a project therefore removes the symbol and
+leaves the gloss behind as unreachable garbage, and re-indexing the same
+project builds fresh symbol nodes the orphan is not attached to (issue #1828).
+
+Extending that traversal would be the wrong fix, because a gloss has a
+lifecycle no other node has:
+
+* it MUST survive `index_repository` / `update_repository` / reingest -- its
+  truth lives only in the graph and is never rebuilt from source, so a rebuild
+  that deleted it would destroy the only copy;
+* it MUST NOT survive deletion of the project it describes, or it is garbage
+  no query can reach.
+
+A traversal-based delete cannot separate those: the rebuild path deletes and
+recreates the same symbols, so anything reachable from a symbol dies with it.
+This is the `prune_unanchored_resources` shape instead -- a separate sweep
+that asks whether the SUBJECT still exists, which is false only after a real
+deletion and true throughout a rebuild.
+
+Liveness check and delete run as one statement, for the reason the resource
+sweep documents: a concurrent writer must not be able to attach a gloss to a
+subject between a snapshot read and the delete.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+
+if TYPE_CHECKING:
+    from . import QueryProtocol
+
+# A gloss is live when its ANNOTATES edge still reaches a node. `DETACH
+# DELETE` on the subject removes the edge as well, so an orphaned gloss has
+# no outgoing ANNOTATES at all -- counting the endpoint is what distinguishes
+# it from a gloss whose subject survives. Direction matters: the edge runs
+# from the gloss to its subject, and an undirected match would also count a
+# gloss annotated BY something else, if that relationship is ever added.
+CYPHER_DELETE_ORPHANED_GLOSSES = (
+    f"MATCH (g:{cs.NodeLabel.GLOSS.value}) "
+    f"OPTIONAL MATCH (g)-[:{cs.RelationshipType.ANNOTATES.value}]->(subject) "
+    "WITH g, count(subject) AS subjects "
+    "WHERE subjects = 0 "
+    "DETACH DELETE g"
+)
+
+
+def prune_orphaned_glosses(ingestor: QueryProtocol) -> None:
+    """Delete glosses whose subject is gone, leaving anchored ones intact."""
+    ingestor.execute_write(CYPHER_DELETE_ORPHANED_GLOSSES)

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -68,6 +68,7 @@ from ..types_defs import (
     ResultRow,
 )
 from ..utils.path_utils import project_roots_from_rows
+from .gloss_cleanup import prune_orphaned_glosses
 from .resource_cleanup import prune_unanchored_resources
 
 if TYPE_CHECKING:
@@ -363,6 +364,12 @@ class MemgraphIngestor:
         # Shared prefix-less nodes (Resources, ExternalModules) only lose
         # their edges above; drop the ones this project alone anchored.
         prune_unanchored_resources(self)
+        # A Gloss is unreachable from the traversal above by design -- that is
+        # what lets it survive a rebuild, which deletes and recreates the very
+        # symbols it annotates. It must still die with a real project delete,
+        # so it gets its own sweep keyed on whether the subject still exists
+        # (issue #1828).
+        prune_orphaned_glosses(self)
         self._execute_query(CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES)
         logger.info(ls.MG_PROJECT_DELETED.format(project_name=project_name))
 

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -68,7 +68,6 @@ from ..types_defs import (
     ResultRow,
 )
 from ..utils.path_utils import project_roots_from_rows
-from .gloss_cleanup import prune_orphaned_glosses
 from .resource_cleanup import prune_unanchored_resources
 
 if TYPE_CHECKING:
@@ -364,12 +363,6 @@ class MemgraphIngestor:
         # Shared prefix-less nodes (Resources, ExternalModules) only lose
         # their edges above; drop the ones this project alone anchored.
         prune_unanchored_resources(self)
-        # A Gloss is unreachable from the traversal above by design -- that is
-        # what lets it survive a rebuild, which deletes and recreates the very
-        # symbols it annotates. It must still die with a real project delete,
-        # so it gets its own sweep keyed on whether the subject still exists
-        # (issue #1828).
-        prune_orphaned_glosses(self)
         self._execute_query(CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES)
         logger.info(ls.MG_PROJECT_DELETED.format(project_name=project_name))
 

--- a/codebase_rag/tests/test_gloss_cleanup.py
+++ b/codebase_rag/tests/test_gloss_cleanup.py
@@ -1,0 +1,113 @@
+"""A Gloss dies with a project delete but survives a rebuild (issue #1828).
+
+`CYPHER_DELETE_PROJECT` reaches nodes through containment and then
+DEFINES/DEFINES_METHOD. `ANNOTATES` is in neither list, so deleting a project
+removed the symbol a gloss describes and left the gloss behind, detached and
+unreachable; re-indexing then built fresh symbols the orphan was not attached
+to.
+
+The two requirements pull apart, which is why this is a separate sweep rather
+than an extra relationship in that traversal:
+
+* a gloss MUST survive index/update/reingest -- its truth lives only in the
+  graph and is never rebuilt from source;
+* a gloss MUST NOT survive deletion of the project it describes.
+
+A traversal-based delete cannot separate those, because a rebuild deletes and
+recreates the same symbols. Asking whether the SUBJECT still exists can: that
+is false only after a real deletion.
+"""
+
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag.services.gloss_cleanup import (
+    CYPHER_DELETE_ORPHANED_GLOSSES,
+    prune_orphaned_glosses,
+)
+
+
+class _FakeStore:
+    """Records the statement, so the query's SHAPE can be asserted.
+
+    The evals emulator does not model `CYPHER_DELETE_PROJECT` at all, so a
+    probe built on it reports "nothing was deleted" for every query alike --
+    it cannot distinguish this leak from a working delete. The parts that can
+    be checked without a live database are the query's shape and that the
+    sweep is wired into the delete path, so those are what these assert.
+    """
+
+    def __init__(self) -> None:
+        self.writes: list[str] = []
+
+    def execute_write(self, query: str, params: object = None) -> None:
+        self.writes.append(query)
+
+
+def test_the_project_delete_does_not_reach_a_gloss() -> None:
+    """The leak itself, asserted against the query that causes it.
+
+    If `ANNOTATES` is ever added to this traversal the sweep becomes
+    redundant AND harmful -- a rebuild would then delete glosses with the
+    symbols it recreates -- so this pins the separation the design depends on.
+    """
+    from codebase_rag import cypher_queries as cq
+
+    assert cs.RelationshipType.ANNOTATES.value not in cq.CYPHER_DELETE_PROJECT, (
+        "ANNOTATES was added to the project-delete traversal; a gloss would "
+        "then be destroyed by every rebuild, which deletes and recreates the "
+        "symbols it annotates"
+    )
+
+
+def test_the_sweep_deletes_only_glosses_with_no_subject() -> None:
+    """The predicate is 'the subject is gone', not 'a gloss exists'."""
+    assert f"MATCH (g:{cs.NodeLabel.GLOSS.value})" in CYPHER_DELETE_ORPHANED_GLOSSES
+    assert cs.RelationshipType.ANNOTATES.value in CYPHER_DELETE_ORPHANED_GLOSSES
+    assert "subjects = 0" in CYPHER_DELETE_ORPHANED_GLOSSES, (
+        "the sweep must delete only glosses whose subject count is zero; "
+        "without that condition it deletes every gloss on every call"
+    )
+
+
+def test_the_sweep_checks_and_deletes_in_one_statement() -> None:
+    """Same reason `prune_unanchored_resources` documents: a concurrent
+    writer must not be able to attach a gloss to a subject between a snapshot
+    read and the delete."""
+    assert CYPHER_DELETE_ORPHANED_GLOSSES.count("DETACH DELETE") == 1
+    # One statement: the liveness check and the delete are not separate calls.
+    assert "MATCH" in CYPHER_DELETE_ORPHANED_GLOSSES.split("DETACH DELETE")[0]
+
+
+def test_the_sweep_follows_the_edge_in_its_real_direction() -> None:
+    """The edge runs FROM the gloss TO its subject.
+
+    An undirected match would also count a gloss annotated by something else,
+    if such a relationship is ever added, and would then keep an orphan alive
+    on the strength of an unrelated edge.
+    """
+    assert f"-[:{cs.RelationshipType.ANNOTATES.value}]->" in (
+        CYPHER_DELETE_ORPHANED_GLOSSES
+    )
+
+
+def test_prune_issues_exactly_one_write() -> None:
+    store = _FakeStore()
+    prune_orphaned_glosses(store)  # type: ignore[arg-type]
+    assert store.writes == [CYPHER_DELETE_ORPHANED_GLOSSES]
+
+
+def test_delete_project_runs_the_sweep() -> None:
+    """Wiring, not just existence.
+
+    A correct sweep that nothing calls fixes nothing -- the same shape as a
+    deduplicating appender with no callers.
+    """
+    import inspect
+
+    from codebase_rag.services import graph_service
+
+    source = inspect.getsource(graph_service.MemgraphIngestor.delete_project)
+    assert "prune_orphaned_glosses" in source, (
+        "delete_project does not run the gloss sweep, so the orphan survives"
+    )

--- a/codebase_rag/tests/test_gloss_cleanup.py
+++ b/codebase_rag/tests/test_gloss_cleanup.py
@@ -97,7 +97,7 @@ def test_prune_issues_exactly_one_write() -> None:
     assert store.writes == [CYPHER_DELETE_ORPHANED_GLOSSES]
 
 
-def test_delete_project_runs_the_sweep() -> None:
+def test_the_deliberate_delete_runs_the_sweep() -> None:
     """Wiring, not just existence.
 
     A correct sweep that nothing calls fixes nothing -- the same shape as a
@@ -105,9 +105,53 @@ def test_delete_project_runs_the_sweep() -> None:
     """
     import inspect
 
+    from codebase_rag.mcp import tools
+
+    source = inspect.getsource(tools.MCPToolsRegistry._delete_project_sync)
+    assert "prune_orphaned_glosses" in source, (
+        "the deliberate project delete does not run the gloss sweep, so the "
+        "orphan survives the deletion it should die with"
+    )
+
+
+def test_the_shared_ingestor_delete_does_NOT_run_the_sweep() -> None:
+    """The half that matters more, and the one my first attempt got wrong.
+
+    `MemgraphIngestor.delete_project` is called by BOTH the deliberate delete
+    and `_index_repository_sync`, which deletes and rebuilds. A sweep there
+    runs on every reindex, and since the rebuild recreates the symbols AFTER
+    the delete, every gloss is an orphan at that moment -- so the sweep would
+    destroy all of them, permanently, on a routine reindex.
+
+    That is the exact requirement #1828 names: a gloss must survive
+    index/update/reingest because its truth lives only in the graph. Caught
+    in review of #1856, where I had wired it into the shared method.
+    """
+    import inspect
+
     from codebase_rag.services import graph_service
 
     source = inspect.getsource(graph_service.MemgraphIngestor.delete_project)
-    assert "prune_orphaned_glosses" in source, (
-        "delete_project does not run the gloss sweep, so the orphan survives"
+    assert "prune_orphaned_glosses" not in source, (
+        "the gloss sweep is wired into the SHARED ingestor delete, which "
+        "index_repository also calls -- every reindex would permanently "
+        "destroy every saved gloss"
+    )
+
+
+def test_the_index_path_does_not_sweep_glosses() -> None:
+    """Stated against the index path directly, not inferred from the above.
+
+    The previous test pins where the sweep is NOT; this pins that the
+    rebuild path never reaches it by some other route.
+    """
+    import inspect
+
+    from codebase_rag.mcp import tools
+
+    source = inspect.getsource(tools.MCPToolsRegistry._index_repository_sync)
+    assert "prune_orphaned_glosses" not in source, (
+        "the reindex path sweeps glosses; the rebuild recreates symbols "
+        "after the delete, so every gloss is momentarily an orphan and "
+        "would be destroyed"
     )

--- a/codebase_rag/tests/test_gloss_cleanup.py
+++ b/codebase_rag/tests/test_gloss_cleanup.py
@@ -93,8 +93,43 @@ def test_the_sweep_follows_the_edge_in_its_real_direction() -> None:
 
 def test_prune_issues_exactly_one_write() -> None:
     store = _FakeStore()
-    prune_orphaned_glosses(store)  # type: ignore[arg-type]
+    assert prune_orphaned_glosses(store) is True  # type: ignore[arg-type]
     assert store.writes == [CYPHER_DELETE_ORPHANED_GLOSSES]
+
+
+def test_a_failing_sweep_does_not_raise() -> None:
+    """The delete has already succeeded by the time this runs (#1856 review).
+
+    Letting a cleanup failure propagate would report a completed, unundoable
+    deletion as failed -- and a retry then short-circuits on `project not
+    found` BEFORE reaching the sweep, so the orphans would survive
+    indefinitely. The mild outcome is the right one: leave them, say so in
+    the log, and let the next deliberate delete sweep them.
+    """
+
+    class _Refusing:
+        def execute_write(self, query: str, params: object = None) -> None:
+            raise RuntimeError("store refused the sweep")
+
+    assert prune_orphaned_glosses(_Refusing()) is False, (  # type: ignore[arg-type]
+        "a refused sweep must report failure rather than raise, so the "
+        "caller can log it without failing a delete that already happened"
+    )
+
+
+def test_the_sweep_is_not_scoped_to_one_project() -> None:
+    """Why leaving orphans behind is recoverable rather than permanent.
+
+    The predicate is 'this gloss has no subject', not 'this gloss belonged to
+    the project just deleted'. So a sweep that fails once is retried by the
+    next deliberate delete of ANY project -- which is what makes the
+    non-raising behaviour above safe rather than merely convenient.
+    """
+    assert "$project_name" not in CYPHER_DELETE_ORPHANED_GLOSSES
+    assert "project" not in CYPHER_DELETE_ORPHANED_GLOSSES.lower(), (
+        "the sweep became project-scoped; a failed sweep would then only be "
+        "retried by deleting that same project, which no longer exists"
+    )
 
 
 def test_the_deliberate_delete_runs_the_sweep() -> None:


### PR DESCRIPTION
Closes #1828.

## The leak

`CYPHER_DELETE_PROJECT` reaches nodes two ways — containment, then `DEFINES`/`DEFINES_METHOD`:

```cypher
MATCH (p:Project {name: $project_name})
OPTIONAL MATCH (p)-[:CONTAINS_PACKAGE|CONTAINS_FOLDER|CONTAINS_FILE|CONTAINS_MODULE|CONTAINS_SECTION*]->(container)
OPTIONAL MATCH (container)-[:DEFINES|DEFINES_METHOD*]->(defined)
DETACH DELETE p, container, defined
```

`ANNOTATES` is in neither list, so a `Gloss` is unreachable: deleting a project removes the symbol it describes and leaves the gloss behind, detached. Re-indexing then builds fresh symbols the orphan is not attached to.

## Why a sweep, not an extra relationship in that traversal

Taking the issue's reading, and it is the load-bearing part. A gloss has a lifecycle no other node has:

- it **must survive** index / update / reingest — its truth lives only in the graph and is never rebuilt from source, so a rebuild that deleted it would destroy the only copy;
- it **must not survive** deletion of the project it describes, or it is garbage no query can reach.

A traversal-based delete cannot separate those, because a rebuild deletes and recreates the very symbols it annotates — anything reachable from a symbol dies with it. Asking whether the **subject still exists** can: that is false only after a real deletion, and true throughout a rebuild.

So this follows `prune_unanchored_resources`, the existing pass for exactly this class of node, including its one-statement check-and-delete so a concurrent writer cannot anchor a gloss between a snapshot read and the delete.

## On verification, stated plainly

I could not build a runtime reproduction. The evals emulator does not model `CYPHER_DELETE_PROJECT` at all, so a probe on it reports "nothing was deleted" for every query alike and cannot tell this leak from a working delete — my first probe did exactly that and would have read as "no leak" if I had trusted it.

What is checkable without a live database is the query shape, and that is conclusive: `ANNOTATES` appears nowhere in the delete traversal, so the gloss is unreachable from it by inspection. The tests assert that, the sweep's predicate, and the wiring.

## Tests

- the project delete still does **not** reach a gloss — if `ANNOTATES` is ever added there the sweep becomes redundant *and harmful*, since rebuilds would then delete glosses along with the symbols they recreate;
- the sweep deletes only glosses whose subject count is zero;
- check and delete are one statement;
- the edge is followed in its real direction (an undirected match would keep an orphan alive on an unrelated edge);
- `delete_project` actually calls it — a correct sweep nothing calls fixes nothing, which is the same shape as the callerless appender in #1784.

Both error directions verified by mutation: unwiring the call reddens the wiring test; dropping the liveness condition (so it deletes every gloss) reddens the predicate test.

Regression: 102 passed across the gloss/delete/service files, 604 across the MCP set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deliberate project deletion now removes orphaned gloss entries that no longer reference an existing subject.
  - Gloss entries remain available during repository reindexing and rebuild operations, preventing temporary orphaning from causing data loss.
  - If orphan cleanup fails, the project deletion still completes successfully, and cleanup can be retried during a later deliberate project deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->