### PR TITLE
fix: a queued CI run is not a missing one (#1848)

### DIFF
--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -1624,3 +1624,54 @@ class TestAConflictIsNotWhyAContextIsAbsent:
             )
 
             assert "CONFLICT" not in reason.upper()
+
+
+class TestTheAllConcludedFixtureCoversEveryDependency:
+    """The fixture must be able to EXPRESS "all dependencies concluded".
+
+    It previously held `CodeQL` and `Analyze (actions)`, neither an
+    `AGGREGATED_JOBS` member, so four tests asserting that every dependency
+    had concluded were measuring the emptiness of a filter over a rollup
+    containing no dependency at all -- vacuously true. A peer session mutated
+    both entries' `conclusion` to `""` and the whole file stayed green.
+
+    These two guards are the reverse-direction checks the old fixture was
+    structurally incapable of carrying: one fails with the missing names
+    printed if the fixture is ever trimmed, the other requires the verdict to
+    FLIP when a dependency is unfinished (#1848).
+    """
+
+    def test_the_fixture_covers_every_aggregated_job(self) -> None:
+        covered = {
+            check_pr_gated.aggregated_job_for(check_pr_gated.context_name(entry))
+            for entry in REAL_ROLLUP_ALL_CONCLUDED
+        } - {None}
+
+        assert covered == set(AGGREGATED_JOBS), (
+            f"fixture no longer covers: {sorted(set(AGGREGATED_JOBS) - covered)}"
+        )
+
+    def test_one_unfinished_dependency_flips_the_verdict(self) -> None:
+        """The assertion the vacuous fixture could not make.
+
+        If the fixture holds real dependencies, marking one unfinished must
+        move the verdict from "not going to appear" to "has not reported YET".
+        A rollup with no dependencies cannot produce that difference.
+        """
+        concluded = check_pr_gated.absent_context_reason(
+            "All Checks Pass", REAL_ROLLUP_ALL_CONCLUDED, [{"status": "completed"}]
+        )
+        one_running = check_pr_gated.absent_context_reason(
+            "All Checks Pass",
+            [
+                {**entry, "status": "IN_PROGRESS", "conclusion": None}
+                if check_pr_gated.aggregated_job_for(check_pr_gated.context_name(entry))
+                == "Type Check"
+                else entry
+                for entry in REAL_ROLLUP_ALL_CONCLUDED
+            ],
+            [{"status": "completed"}],
+        )
+
+        assert "not going to appear" in concluded
+        assert "has not reported YET" in one_running

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -1810,3 +1810,94 @@ class TestAggregatedJobsCoversEveryDeclaredDependency:
         reason = check_pr_gated.absent_context_reason("All Checks Pass", rollup, [])
 
         assert "still running" in reason
+
+
+class TestTheArmsAreOrderedMostSpecificFirst:
+    """Three review findings on this function were all the same defect.
+
+    A new early-return arm silently steals cases from the arms after it,
+    because the conditions OVERLAP -- a running dependency and an unfinished
+    run are both true at once, and whichever is tested first wins regardless
+    of which is more informative. The three, in the order they were found:
+
+    1. the conflict arm (removed; its premise was false too) swallowed the
+       "every dependency concluded" verdict;
+    2. the empty-rollup arm swallowed the queued-run case;
+    3. the unstarted-run arm then swallowed the running-dependency case --
+       introduced by the fix for (2).
+
+    So this pins the PRECEDENCE rather than any single arm, over inputs where
+    more than one condition holds. A reordering that still satisfies every
+    other test in this file reddens here (#1848).
+    """
+
+    DEP_RUNNING = [
+        {
+            "__typename": "CheckRun",
+            "name": "Unit Tests (ubuntu-latest, py3.12)",
+            "status": "IN_PROGRESS",
+        }
+    ]
+    PR_RUN = {"status": "in_progress", "event": "pull_request"}
+
+    def test_a_running_dependency_outranks_an_unfinished_run(self) -> None:
+        """Both conditions hold; the named dependency is more informative.
+
+        Saying "produced no check entries so far" while a dependency is
+        visibly running is not merely less useful -- it is false.
+        """
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.DEP_RUNNING, [self.PR_RUN]
+        )
+
+        assert "still running" in reason
+        assert "no check entries" not in reason
+
+    def test_the_running_dependency_is_named(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.DEP_RUNNING, [self.PR_RUN]
+        )
+
+        assert "Unit Tests (ubuntu-latest, py3.12)" in reason
+
+    def test_an_unfinished_run_outranks_the_empty_rollup_arm(self) -> None:
+        """Finding 2: an empty rollup is what a queued run looks like."""
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", [], [{"status": "queued", "event": "pull_request"}]
+        )
+
+        assert "not yet started" in reason
+
+    def test_every_overlapping_combination_picks_one_verdict(self) -> None:
+        """The precedence table, as a single assertion over the overlaps.
+
+        Each row has at least two conditions true. Pinning the whole table
+        means a reordering cannot pass by satisfying the rows individually.
+        """
+        concluded = [
+            {
+                "__typename": "CheckRun",
+                "name": job,
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+            for job in AGGREGATED_JOBS
+        ]
+        queued_pr = {"status": "queued", "event": "pull_request"}
+        dispatch = {"status": "queued", "event": "workflow_dispatch"}
+
+        expected = [
+            (self.DEP_RUNNING, [self.PR_RUN], "still running"),
+            (self.DEP_RUNNING, [], "still running"),
+            ([], [queued_pr], "not yet started"),
+            ([], [dispatch], "no check reported at the head at all"),
+            (concluded, [dispatch], "has concluded"),
+            ([], [], "no check reported at the head at all"),
+        ]
+
+        for rollup, runs, marker in expected:
+            reason = check_pr_gated.absent_context_reason(
+                "All Checks Pass", rollup, runs
+            )
+
+            assert marker in reason, f"{marker!r} not in {reason!r}"

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -1130,6 +1130,17 @@ REAL_ROLLUP_ALL_CONCLUDED = [
         "conclusion": "SUCCESS",
     },
     {"__typename": "CheckRun", "name": "Binary Smoke Test", "conclusion": "SUCCESS"},
+    {
+        "__typename": "CheckRun",
+        "name": "Wheel Smoke (unlocked resolution)",
+        "conclusion": "SUCCESS",
+    },
+    {"__typename": "CheckRun", "name": "Go Frontend", "conclusion": "SUCCESS"},
+    {
+        "__typename": "CheckRun",
+        "name": "Sonar Zero Issues Gate",
+        "conclusion": "SUCCESS",
+    },
     {"__typename": "CheckRun", "name": "CodeQL", "conclusion": "SKIPPED"},
     {"__typename": "CheckRun", "name": "Analyze (actions)", "conclusion": "SUCCESS"},
 ]
@@ -1675,3 +1686,127 @@ class TestTheAllConcludedFixtureCoversEveryDependency:
 
         assert "not going to appear" in concluded
         assert "has not reported YET" in one_running
+
+
+class TestAnUnstartedRunOutranksTheEmptyRollupArm:
+    """An empty rollup is exactly what a queued run looks like.
+
+    The empty-rollup arm ran first and returned "no check reported at the head
+    at all", sending the reader to investigate a workflow that had simply not
+    started -- reintroducing, for the emptiest case of all, the defect this
+    change exists to fix. Found on review; the same arm-ordering mistake as the
+    conflict arm removed earlier in this branch (#1848).
+    """
+
+    def test_a_queued_run_with_an_empty_rollup_says_not_yet_started(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", [], [{"status": "queued", "event": "pull_request"}]
+        )
+
+        assert "not yet started" in reason
+
+    def test_an_empty_rollup_with_no_run_still_says_nothing_reported(self) -> None:
+        """The control: with no run at all, the empty-rollup arm is right."""
+        reason = check_pr_gated.absent_context_reason("All Checks Pass", [], [])
+
+        assert "no check reported at the head at all" in reason
+
+
+class TestOnlyAPullRequestRunCreatesThisPrsContexts:
+    """A dispatched run at the same SHA is evidence about itself.
+
+    `workflow_dispatch` and `push` runs report under their own event and
+    contribute no PR check context, so counting one as "the contexts are
+    coming" says wait forever while the pull-request run has already finished.
+    That suppresses the #1582 verdict via an unrelated run (#1848).
+    """
+
+    def test_a_queued_dispatch_run_is_not_evidence_of_pending_contexts(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", [], [{"status": "queued", "event": "workflow_dispatch"}]
+        )
+
+        assert "not yet started" not in reason
+
+    def test_a_dispatch_run_does_not_suppress_the_investigate_verdict(self) -> None:
+        """The case that matters: every dependency concluded, so investigate."""
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": job,
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+            for job in AGGREGATED_JOBS
+        ]
+
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass",
+            rollup,
+            [{"status": "queued", "event": "workflow_dispatch"}],
+        )
+
+        assert "not going to appear" in reason
+
+    def test_a_run_without_an_event_field_is_treated_as_a_pr_run(self) -> None:
+        """Fail in the direction that preserves the old behaviour."""
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", [], [{"status": "queued"}]
+        )
+
+        assert "not yet started" in reason
+
+
+class TestAggregatedJobsCoversEveryDeclaredDependency:
+    """The list must match `all-checks-pass`'s `needs:` block in ci.yml.
+
+    Five of the nine were listed. A head where only a missing one had reported
+    looked like "no dependency reported at all", and a missing one still
+    running was not counted as pending. Found on review (#1848).
+
+    The coupling cannot be removed: the rollup carries display names while
+    `needs:` carries job ids, with no mapping available without parsing the
+    workflow. So it is asserted here instead, against the names the workflow
+    declares.
+    """
+
+    DECLARED_DISPLAY_NAMES = (
+        "Lint & Format",
+        "Type Check",
+        "Unit Tests",
+        "Integration Tests",
+        "Binary Smoke Test",
+        "Wheel Smoke (unlocked resolution)",
+        "Go Frontend",
+        "Sonar Zero Issues Gate",
+    )
+
+    def test_every_declared_dependency_is_aggregated(self) -> None:
+        missing = [
+            name
+            for name in self.DECLARED_DISPLAY_NAMES
+            if check_pr_gated.aggregated_job_for(name) is None
+        ]
+
+        assert not missing, f"not recognised as dependencies: {missing}"
+
+    def test_the_base_install_matrix_cell_resolves_to_unit_tests(self) -> None:
+        """`test-unit-base` needs no entry: the matrix rule covers it."""
+        assert (
+            check_pr_gated.aggregated_job_for("Unit Tests (base install)")
+            == "Unit Tests"
+        )
+
+    def test_a_missing_dependency_still_running_counts_as_pending(self) -> None:
+        """The consequence of the omission, not just the omission."""
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "Go Frontend",
+                "status": "IN_PROGRESS",
+            }
+        ]
+
+        reason = check_pr_gated.absent_context_reason("All Checks Pass", rollup, [])
+
+        assert "still running" in reason

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -1109,7 +1109,27 @@ REAL_ROLLUP_MID_RUN = [
 ]
 
 # The #1582 shape: everything concluded, the aggregate never appeared.
+# Every entry here must be a real `AGGREGATED_JOBS` member, or the fixture
+# cannot express "all of the aggregate's dependencies concluded" -- which is
+# the state these tests are about. The original pair (`CodeQL`,
+# `Analyze (actions)`) are NOT dependencies of `All Checks Pass`, so the tests
+# using it were asserting that every dependency had concluded while the rollup
+# contained none: green on an input the production path never produces. Found
+# when the no-dependency-reported guard was added (#1848).
 REAL_ROLLUP_ALL_CONCLUDED = [
+    {"__typename": "CheckRun", "name": "Lint & Format", "conclusion": "SUCCESS"},
+    {"__typename": "CheckRun", "name": "Type Check", "conclusion": "SUCCESS"},
+    {
+        "__typename": "CheckRun",
+        "name": "Unit Tests (ubuntu-latest, py3.12)",
+        "conclusion": "SUCCESS",
+    },
+    {
+        "__typename": "CheckRun",
+        "name": "Integration Tests (ubuntu-latest)",
+        "conclusion": "SUCCESS",
+    },
+    {"__typename": "CheckRun", "name": "Binary Smoke Test", "conclusion": "SUCCESS"},
     {"__typename": "CheckRun", "name": "CodeQL", "conclusion": "SKIPPED"},
     {"__typename": "CheckRun", "name": "Analyze (actions)", "conclusion": "SUCCESS"},
 ]
@@ -1476,3 +1496,129 @@ class TestTheAbsentMessageClaimsOnlyWhatItExamined:
         reason = check_pr_gated.absent_context_reason("All Checks Pass", rollup)
 
         assert "every check at the head" not in reason
+
+
+class TestAQueuedRunIsNotAMissingOne:
+    """A `queued` CI run contributes no rollup entry, so it read as absent.
+
+    The pending filter finds nothing (there are no dependency entries yet),
+    so the all-concluded fallback fired and reported "not going to appear"
+    about a run that had not started. Worse, with zero dependency entries it
+    asserted they had all concluded -- a claim about an empty set.
+
+    This is the window right after a push, where the tool is most consulted
+    and where the remedy the old message implies -- an empty commit to
+    re-trigger -- moves the head and discards any review anchored to the old
+    SHA. Measured live: a real PR had `ci.yml` at `queued` with only unrelated
+    contexts reported (#1848).
+    """
+
+    UNRELATED = [
+        {
+            "__typename": "CheckRun",
+            "name": "CodeRabbit",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+        }
+    ]
+
+    def test_a_queued_run_reports_as_not_yet_started(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
+        )
+
+        assert "not yet started" in reason
+
+    def test_a_queued_run_does_not_claim_it_will_never_appear(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
+        )
+
+        assert "not going to appear" not in reason
+
+    def test_a_queued_run_warns_against_the_empty_commit(self) -> None:
+        """The destructive remedy is what makes this worth more than tidiness."""
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
+        )
+
+        assert "empty commit" in reason
+
+    def test_no_dependency_reported_does_not_claim_all_concluded(self) -> None:
+        """With no CI run either, the old message asserted an empty set."""
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [], "MERGEABLE"
+        )
+
+        assert "every check it aggregates has concluded" not in reason
+
+    def test_a_concluded_run_still_reports_it_will_not_appear(self) -> None:
+        """The control: the #1582 case must keep saying "investigate"."""
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": job,
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+            for job in AGGREGATED_JOBS
+        ]
+
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", rollup, [{"status": "completed"}], "MERGEABLE"
+        )
+
+        assert "not going to appear" in reason
+
+
+class TestAConflictingBranchNeverRunsAnything:
+    """A conflicting branch runs no PR workflows, so "wait" never terminates.
+
+    GitHub skips PR workflows entirely on a conflicting branch. The rollup
+    then looks exactly like a queued run's -- empty of dependencies -- but the
+    correct advice is the opposite: merge the base in, because nothing will
+    ever run. Measured tonight: a peer chased a "broken workflow" for an hour
+    on a branch whose only problem was a conflict (#1848).
+
+    Checked BEFORE the not-yet-started arm, since a conflicting branch may
+    also carry a stale queued run from before the conflict appeared.
+    """
+
+    UNRELATED = [
+        {
+            "__typename": "CheckRun",
+            "name": "CodeRabbit",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+        }
+    ]
+
+    def test_a_conflicting_branch_is_named_as_the_cause(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [], "CONFLICTING"
+        )
+
+        assert "CONFLICTS" in reason
+
+    def test_a_conflicting_branch_advises_merging_the_base(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [], "CONFLICTING"
+        )
+
+        assert "Merge the base in" in reason
+
+    def test_a_conflict_outranks_a_stale_queued_run(self) -> None:
+        """Both present an empty rollup; only one has terminating advice."""
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "CONFLICTING"
+        )
+
+        assert "CONFLICTS" in reason
+        assert "not yet started" not in reason
+
+    def test_a_mergeable_branch_is_not_blamed_on_a_conflict(self) -> None:
+        reason = check_pr_gated.absent_context_reason(
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
+        )
+
+        assert "CONFLICTS" not in reason

--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -1524,14 +1524,14 @@ class TestAQueuedRunIsNotAMissingOne:
 
     def test_a_queued_run_reports_as_not_yet_started(self) -> None:
         reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}]
         )
 
         assert "not yet started" in reason
 
     def test_a_queued_run_does_not_claim_it_will_never_appear(self) -> None:
         reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}]
         )
 
         assert "not going to appear" not in reason
@@ -1539,7 +1539,7 @@ class TestAQueuedRunIsNotAMissingOne:
     def test_a_queued_run_warns_against_the_empty_commit(self) -> None:
         """The destructive remedy is what makes this worth more than tidiness."""
         reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
+            "All Checks Pass", self.UNRELATED, [{"status": "queued"}]
         )
 
         assert "empty commit" in reason
@@ -1547,7 +1547,7 @@ class TestAQueuedRunIsNotAMissingOne:
     def test_no_dependency_reported_does_not_claim_all_concluded(self) -> None:
         """With no CI run either, the old message asserted an empty set."""
         reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [], "MERGEABLE"
+            "All Checks Pass", self.UNRELATED, []
         )
 
         assert "every check it aggregates has concluded" not in reason
@@ -1565,60 +1565,62 @@ class TestAQueuedRunIsNotAMissingOne:
         ]
 
         reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", rollup, [{"status": "completed"}], "MERGEABLE"
+            "All Checks Pass", rollup, [{"status": "completed"}]
         )
 
         assert "not going to appear" in reason
 
 
-class TestAConflictingBranchNeverRunsAnything:
-    """A conflicting branch runs no PR workflows, so "wait" never terminates.
+class TestAConflictIsNotWhyAContextIsAbsent:
+    """A conflicting branch DOES run PR workflows -- measured, not assumed.
 
-    GitHub skips PR workflows entirely on a conflicting branch. The rollup
-    then looks exactly like a queued run's -- empty of dependencies -- but the
-    correct advice is the opposite: merge the base in, because nothing will
-    ever run. Measured tonight: a peer chased a "broken workflow" for an hour
-    on a branch whose only problem was a conflict (#1848).
+    An earlier version of this change claimed the opposite and returned "the
+    branch CONFLICTS, so the contexts will never arrive". That premise is
+    false: `ci.yml` triggers on plain `pull_request`, which fires on
+    opened/synchronize regardless of mergeability. Verified on two live
+    CONFLICTING PRs of this repo, each carrying a completed successful
+    `ci.yml` run at its head.
 
-    Checked BEFORE the not-yet-started arm, since a conflicting branch may
-    also carry a stale queued run from before the conflict appeared.
+    The arm was also checked FIRST, so on any conflicting branch it swallowed
+    the #1582 verdict this function exists to preserve -- "every dependency
+    concluded and the aggregate never appeared", which must say investigate.
+
+    These tests pin the corrected behaviour: mergeability is not consulted at
+    all, so no conflicting-branch input can suppress a real verdict (#1848).
     """
 
-    UNRELATED = [
-        {
-            "__typename": "CheckRun",
-            "name": "CodeRabbit",
-            "status": "COMPLETED",
-            "conclusion": "SUCCESS",
-        }
-    ]
+    def test_all_concluded_still_says_investigate(self) -> None:
+        """The verdict the removed arm masked, at the state that matters."""
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": job,
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+            for job in AGGREGATED_JOBS
+        ]
 
-    def test_a_conflicting_branch_is_named_as_the_cause(self) -> None:
         reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [], "CONFLICTING"
+            "All Checks Pass", rollup, [{"status": "completed"}]
         )
 
-        assert "CONFLICTS" in reason
+        assert "not going to appear" in reason
 
-    def test_a_conflicting_branch_advises_merging_the_base(self) -> None:
-        reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [], "CONFLICTING"
-        )
+    def test_no_arm_mentions_a_conflict(self) -> None:
+        """Mergeability explains a blocked MERGE, never an absent context."""
+        rollup = [
+            {
+                "__typename": "CheckRun",
+                "name": "CodeRabbit",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            }
+        ]
 
-        assert "Merge the base in" in reason
+        for runs in ([], [{"status": "queued"}], [{"status": "completed"}]):
+            reason = check_pr_gated.absent_context_reason(
+                "All Checks Pass", rollup, runs
+            )
 
-    def test_a_conflict_outranks_a_stale_queued_run(self) -> None:
-        """Both present an empty rollup; only one has terminating advice."""
-        reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "CONFLICTING"
-        )
-
-        assert "CONFLICTS" in reason
-        assert "not yet started" not in reason
-
-    def test_a_mergeable_branch_is_not_blamed_on_a_conflict(self) -> None:
-        reason = check_pr_gated.absent_context_reason(
-            "All Checks Pass", self.UNRELATED, [{"status": "queued"}], "MERGEABLE"
-        )
-
-        assert "CONFLICTS" not in reason
+            assert "CONFLICT" not in reason.upper()

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -231,7 +231,6 @@ def absent_context_reason(
     context: str,
     rollup: list[dict[str, object]],
     ci_runs: list[dict[str, Any]] | None = None,
-    mergeable: str | None = None,
 ) -> str:
     """Why `context` is missing: still coming, never arriving, or no run.
 
@@ -279,18 +278,6 @@ def absent_context_reason(
     # consulted and where the remedy it implies -- an empty commit to
     # re-trigger -- moves the head and discards any review anchored to the
     # old SHA (#1848).
-    # CHECKED BEFORE "not yet started", because a conflicting branch runs no
-    # PR workflows AT ALL. GitHub skips them entirely, so the contexts are not
-    # "coming" -- waiting for them never terminates. A queued run and a
-    # conflicting branch both present an empty rollup and need OPPOSITE advice,
-    # which is the pair a single "not gated" verdict flattens (#1848).
-    if mergeable == "CONFLICTING":
-        return (
-            f"'{context}' is absent because the branch CONFLICTS with its base: "
-            "GitHub runs no PR workflows on a conflicting branch, so the "
-            "contexts will never arrive. Merge the base in -- waiting will not "
-            "help, and re-triggering cannot run anything"
-        )
     unstarted = [
         run
         for run in ci_runs or ()
@@ -608,7 +595,7 @@ def check(pr: str) -> tuple[list[str], list[str]]:
             "--repo",
             REPO,
             "--json",
-            "headRefOid,baseRefName,statusCheckRollup,comments,reviews,mergeable",
+            "headRefOid,baseRefName,statusCheckRollup,comments,reviews",
         )
     )
     if not view:
@@ -658,9 +645,7 @@ def check(pr: str) -> tuple[list[str], list[str]]:
     if missing:
         reasons.append(
             f"required context absent at the head: {missing}; "
-            + absent_context_reason(
-                REQUIRED_CONTEXT, rollup, at_head, str(view.get("mergeable", ""))
-            )
+            + absent_context_reason(REQUIRED_CONTEXT, rollup, at_head)
         )
     else:
         for entry in rollup:

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -45,6 +45,14 @@ from typing import Any
 REPO = "vitali87/code-graph-rag"
 CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
 
+# A CI run in one of these states has not finished, so its check contexts are
+# still coming. `queued` is the one that matters: it contributes no rollup
+# entry at all, which is indistinguishable from "never ran" without this
+# (#1848).
+CI_RUN_UNFINISHED_STATUSES = frozenset(
+    {"queued", "in_progress", "waiting", "pending", "requested"}
+)
+
 # The one context the active ruleset requires on the default branch. It
 # aggregates the jobs below and asserts each result == "success", so a
 # skipped or cancelled job fails it rather than passing silently.
@@ -219,7 +227,12 @@ def aggregated_job_for(name: str) -> str | None:
     return None
 
 
-def absent_context_reason(context: str, rollup: list[dict[str, object]]) -> str:
+def absent_context_reason(
+    context: str,
+    rollup: list[dict[str, object]],
+    ci_runs: list[dict[str, Any]] | None = None,
+    mergeable: str | None = None,
+) -> str:
     """Why `context` is missing: still coming, never arriving, or no run.
 
     "Absent" collapses two states needing opposite responses. `All Checks
@@ -254,6 +267,53 @@ def absent_context_reason(context: str, rollup: list[dict[str, object]]) -> str:
             f"'{context}' has not reported YET: {len(pending)} check(s) at the "
             f"head are still running{named}. This is CI in flight, not a "
             "missing run -- re-check rather than investigate"
+        )
+    # A QUEUED run contributes NO rollup entry at all, so the filter above
+    # finds nothing pending and the fallback below would report "not going to
+    # appear" about a run that has not started. Worse, with zero dependency
+    # entries it asserts they all concluded -- a claim about an empty set.
+    #
+    # The run list already fetched settles it without another API call: a
+    # `queued` or `in_progress` CI run at this head means the contexts are
+    # coming. This is the window right after a push, where the tool is most
+    # consulted and where the remedy it implies -- an empty commit to
+    # re-trigger -- moves the head and discards any review anchored to the
+    # old SHA (#1848).
+    # CHECKED BEFORE "not yet started", because a conflicting branch runs no
+    # PR workflows AT ALL. GitHub skips them entirely, so the contexts are not
+    # "coming" -- waiting for them never terminates. A queued run and a
+    # conflicting branch both present an empty rollup and need OPPOSITE advice,
+    # which is the pair a single "not gated" verdict flattens (#1848).
+    if mergeable == "CONFLICTING":
+        return (
+            f"'{context}' is absent because the branch CONFLICTS with its base: "
+            "GitHub runs no PR workflows on a conflicting branch, so the "
+            "contexts will never arrive. Merge the base in -- waiting will not "
+            "help, and re-triggering cannot run anything"
+        )
+    unstarted = [
+        run
+        for run in ci_runs or ()
+        if str(run.get("status", "")) in CI_RUN_UNFINISHED_STATUSES
+    ]
+    if unstarted:
+        statuses = sorted({str(run.get("status", "")) for run in unstarted})
+        return (
+            f"'{context}' has not reported YET: the CI run at the head is "
+            f"{', '.join(statuses)} and has produced no check entries so far. "
+            "This is CI not yet started, not a missing run -- re-check rather "
+            "than investigate, and do NOT push an empty commit (it moves the "
+            "head and discards any review anchored to it)"
+        )
+    # Only reachable with at least one CONCLUDED dependency entry, or with no
+    # CI run at all -- and the caller reports the latter separately. Without
+    # this guard the sentence below claims every dependency concluded when
+    # none was ever seen.
+    if not any(aggregated_job_for(context_name(entry)) for entry in rollup):
+        return (
+            f"'{context}' is absent and NO check it aggregates reported at the "
+            "head at all, so whether it is coming cannot be told from the "
+            "rollup -- check whether CI ran for this head"
         )
     # "every check" would overclaim: `pending` above counts only the entries
     # this aggregate DEPENDS on, so an unrelated pending check (CodeRabbit,
@@ -548,7 +608,7 @@ def check(pr: str) -> tuple[list[str], list[str]]:
             "--repo",
             REPO,
             "--json",
-            "headRefOid,baseRefName,statusCheckRollup,comments,reviews",
+            "headRefOid,baseRefName,statusCheckRollup,comments,reviews,mergeable",
         )
     )
     if not view:
@@ -598,7 +658,9 @@ def check(pr: str) -> tuple[list[str], list[str]]:
     if missing:
         reasons.append(
             f"required context absent at the head: {missing}; "
-            + absent_context_reason(REQUIRED_CONTEXT, rollup)
+            + absent_context_reason(
+                REQUIRED_CONTEXT, rollup, at_head, str(view.get("mergeable", ""))
+            )
         )
     else:
         for entry in rollup:

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -252,36 +252,67 @@ def absent_context_reason(
     rollup: list[dict[str, object]],
     ci_runs: list[dict[str, Any]] | None = None,
 ) -> str:
-    """Why `context` is missing: still coming, never arriving, or no run.
+    """Why `context` is missing: still running, not yet started, or absent.
 
-    "Absent" collapses two states needing opposite responses. `All Checks
-    Pass` is an aggregate that reports only once its dependencies finish,
-    so it is legitimately missing for the whole run -- yet the same
-    sentence covers the #1582 case, where every job concluded and the
-    aggregate never appeared. One says wait, the other says investigate,
-    and the reassuring reading is the one a reader defaults to (#1827).
+    "Absent" collapses states that need opposite responses. `All Checks Pass`
+    is an aggregate that reports only once its dependencies finish, so it is
+    legitimately missing for a whole run -- yet the same sentence covered the
+    #1582 case, where every job concluded and the aggregate never appeared.
+    One says wait, the other says investigate, and the reassuring reading is
+    the one a reader defaults to (#1827).
 
-    The three are separable from the rollup already fetched, so this costs
-    no extra API call. Measured on #1547: 20 unconcluded entries alongside
-    a passing `CI Ran At Head`, reported as though nothing had run.
+    EVERY FACT IS GATHERED BEFORE ANY ARM RUNS, and the arms are ordered
+    most-specific first. Three separate review findings on this function were
+    all the same defect -- a new early-return arm silently stealing cases from
+    the arms after it -- because the conditions OVERLAP: a running dependency
+    and an unfinished run are both true at once, and whichever was tested
+    first won regardless of which was more informative. Computing the facts
+    up front makes the overlap visible instead of implicit in the order
+    (#1848).
+
+    The three facts, and why each is ordered where it is:
+
+    * `pending` -- a dependency of the aggregate is unfinished. The MOST
+      specific, because it names the job the reader is waiting for.
+    * `unstarted` -- a `pull_request` CI run exists but has produced no
+      contexts. Less specific: it says the run is coming without saying what.
+      Only a pull-request run counts; a `workflow_dispatch` or `push` run at
+      the same SHA reports under its own event and creates none of this PR's
+      contexts, so it is evidence about itself.
+    * neither -- then either no dependency ever reported, or all of them
+      concluded and the aggregate genuinely never arrived (#1582).
     """
-    # An unfinished run is checked FIRST, because an empty rollup is exactly
-    # what a queued run looks like -- the contexts have not been created yet.
-    # Returning "no check reported at all" here sent the reader to investigate
-    # a workflow that simply had not started, which is the defect this change
-    # exists to fix; putting the empty-rollup arm first reintroduced it for the
-    # emptiest case of all (#1848).
-    # Only a PULL_REQUEST run creates this PR's check contexts. A
-    # `workflow_dispatch` or `push` run at the same SHA reports under its own
-    # event and contributes no PR context, so counting it as "the contexts are
-    # coming" says wait forever while the pull-request run has already
-    # finished -- the #1582 verdict suppressed by an unrelated run (#1848).
+    # Only the jobs the aggregate WAITS ON can explain its absence. Any
+    # unfinished entry used to count, so a single unrelated pending check --
+    # CodeRabbit is pending on nearly every PR here -- flipped the verdict
+    # from "investigate" to "wait" while every dependency had concluded.
+    pending = [
+        entry
+        for entry in rollup
+        if not entry_finished(entry) and aggregated_job_for(context_name(entry))
+    ]
     unstarted = [
         run
         for run in ci_runs or ()
         if str(run.get("status", "")) in CI_RUN_UNFINISHED_STATUSES
         and str(run.get("event", "pull_request")) in CI_RUN_PR_EVENTS
     ]
+    any_dependency_reported = any(
+        aggregated_job_for(context_name(entry)) for entry in rollup
+    )
+
+    # MOST SPECIFIC: a named dependency is still running.
+    if pending:
+        names = sorted(name for name in map(context_name, pending) if name)
+        shown = ", ".join(names[:3]) + ("..." if len(names) > 3 else "")
+        named = f" ({shown})" if names else ""
+        return (
+            f"'{context}' has not reported YET: {len(pending)} check(s) at the "
+            f"head are still running{named}. This is CI in flight, not a "
+            "missing run -- re-check rather than investigate"
+        )
+    # The run exists but has created no contexts yet. Checked after `pending`
+    # so a running dependency is named rather than described as "no entries".
     if unstarted:
         statuses = sorted({str(run.get("status", "")) for run in unstarted})
         return (
@@ -293,41 +324,17 @@ def absent_context_reason(
         )
     if not rollup:
         return f"no check reported at the head at all, so '{context}' cannot appear"
-    # Only the jobs the aggregate WAITS ON can explain its absence. Any
-    # unfinished entry used to count, so a single unrelated pending check --
-    # CodeRabbit is pending on nearly every PR here -- flipped the verdict
-    # from "investigate" to "wait" while every dependency had concluded.
-    # That is the #1582 case reported as its opposite, which is the exact
-    # confusion this function exists to remove.
-    pending = [
-        entry
-        for entry in rollup
-        if not entry_finished(entry) and aggregated_job_for(context_name(entry))
-    ]
-    if pending:
-        names = sorted(name for name in map(context_name, pending) if name)
-        shown = ", ".join(names[:3]) + ("..." if len(names) > 3 else "")
-        named = f" ({shown})" if names else ""
-        return (
-            f"'{context}' has not reported YET: {len(pending)} check(s) at the "
-            f"head are still running{named}. This is CI in flight, not a "
-            "missing run -- re-check rather than investigate"
-        )
-    # Only reachable with at least one CONCLUDED dependency entry, or with no
-    # CI run at all -- and the caller reports the latter separately. Without
-    # this guard the sentence below claims every dependency concluded when
-    # none was ever seen.
-    if not any(aggregated_job_for(context_name(entry)) for entry in rollup):
+    # Without this guard the sentence below claims every dependency concluded
+    # when none was ever seen -- a claim about an empty set.
+    if not any_dependency_reported:
         return (
             f"'{context}' is absent and NO check it aggregates reported at the "
             "head at all, so whether it is coming cannot be told from the "
             "rollup -- check whether CI ran for this head"
         )
-    # "every check" would overclaim: `pending` above counts only the entries
-    # this aggregate DEPENDS on, so an unrelated pending check (CodeRabbit,
-    # say) is deliberately excluded and may still be running. Say what was
-    # actually examined, or the message asserts something the filter never
-    # looked at (#1827).
+    # "every check" would overclaim: `pending` counts only the entries this
+    # aggregate DEPENDS on, so an unrelated pending check is deliberately
+    # excluded and may still be running. Say what was actually examined.
     return (
         f"'{context}' is absent although every check it aggregates has "
         "concluded, so it is not going to appear"

--- a/scripts/check_pr_gated.py
+++ b/scripts/check_pr_gated.py
@@ -53,17 +53,37 @@ CI_RUN_UNFINISHED_STATUSES = frozenset(
     {"queued", "in_progress", "waiting", "pending", "requested"}
 )
 
+# The events whose runs create a PR's check contexts. `workflow_dispatch` and
+# `push` runs can sit at the same head SHA and report under their own event,
+# so they are evidence about themselves, not about this PR (#1848). Defaulted
+# to `pull_request` when absent, so a response without the field behaves as
+# before rather than silently dropping every run.
+CI_RUN_PR_EVENTS = frozenset({"pull_request", "pull_request_target"})
+
 # The one context the active ruleset requires on the default branch. It
 # aggregates the jobs below and asserts each result == "success", so a
 # skipped or cancelled job fails it rather than passing silently.
 REQUIRED_CONTEXT = "All Checks Pass"
 
+# Every job `all-checks-pass` declares in `needs:`, by DISPLAY name -- the
+# rollup carries names, not job ids. Five were listed and four were missing,
+# so a head where only a missing one had reported looked like "no dependency
+# reported at all" (#1848). `Unit Tests (base install)` needs no entry of its
+# own: the matrix rule matches it under `Unit Tests`.
+#
+# This list must stay in step with ci.yml's `needs:` block. It cannot be
+# derived at runtime -- the rollup gives display names and `needs:` gives job
+# ids, with no mapping available without parsing the workflow -- so the
+# coupling is real and worth stating rather than hiding.
 AGGREGATED_JOBS = (
     "Lint & Format",
     "Type Check",
     "Unit Tests",
     "Integration Tests",
     "Binary Smoke Test",
+    "Wheel Smoke (unlocked resolution)",
+    "Go Frontend",
+    "Sonar Zero Issues Gate",
 )
 
 # A review artifact must POSITIVELY carry a verdict. The alternative --
@@ -245,6 +265,32 @@ def absent_context_reason(
     no extra API call. Measured on #1547: 20 unconcluded entries alongside
     a passing `CI Ran At Head`, reported as though nothing had run.
     """
+    # An unfinished run is checked FIRST, because an empty rollup is exactly
+    # what a queued run looks like -- the contexts have not been created yet.
+    # Returning "no check reported at all" here sent the reader to investigate
+    # a workflow that simply had not started, which is the defect this change
+    # exists to fix; putting the empty-rollup arm first reintroduced it for the
+    # emptiest case of all (#1848).
+    # Only a PULL_REQUEST run creates this PR's check contexts. A
+    # `workflow_dispatch` or `push` run at the same SHA reports under its own
+    # event and contributes no PR context, so counting it as "the contexts are
+    # coming" says wait forever while the pull-request run has already
+    # finished -- the #1582 verdict suppressed by an unrelated run (#1848).
+    unstarted = [
+        run
+        for run in ci_runs or ()
+        if str(run.get("status", "")) in CI_RUN_UNFINISHED_STATUSES
+        and str(run.get("event", "pull_request")) in CI_RUN_PR_EVENTS
+    ]
+    if unstarted:
+        statuses = sorted({str(run.get("status", "")) for run in unstarted})
+        return (
+            f"'{context}' has not reported YET: the CI run at the head is "
+            f"{', '.join(statuses)} and has produced no check entries so far. "
+            "This is CI not yet started, not a missing run -- re-check rather "
+            "than investigate, and do NOT push an empty commit (it moves the "
+            "head and discards any review anchored to it)"
+        )
     if not rollup:
         return f"no check reported at the head at all, so '{context}' cannot appear"
     # Only the jobs the aggregate WAITS ON can explain its absence. Any
@@ -266,31 +312,6 @@ def absent_context_reason(
             f"'{context}' has not reported YET: {len(pending)} check(s) at the "
             f"head are still running{named}. This is CI in flight, not a "
             "missing run -- re-check rather than investigate"
-        )
-    # A QUEUED run contributes NO rollup entry at all, so the filter above
-    # finds nothing pending and the fallback below would report "not going to
-    # appear" about a run that has not started. Worse, with zero dependency
-    # entries it asserts they all concluded -- a claim about an empty set.
-    #
-    # The run list already fetched settles it without another API call: a
-    # `queued` or `in_progress` CI run at this head means the contexts are
-    # coming. This is the window right after a push, where the tool is most
-    # consulted and where the remedy it implies -- an empty commit to
-    # re-trigger -- moves the head and discards any review anchored to the
-    # old SHA (#1848).
-    unstarted = [
-        run
-        for run in ci_runs or ()
-        if str(run.get("status", "")) in CI_RUN_UNFINISHED_STATUSES
-    ]
-    if unstarted:
-        statuses = sorted({str(run.get("status", "")) for run in unstarted})
-        return (
-            f"'{context}' has not reported YET: the CI run at the head is "
-            f"{', '.join(statuses)} and has produced no check entries so far. "
-            "This is CI not yet started, not a missing run -- re-check rather "
-            "than investigate, and do NOT push an empty commit (it moves the "
-            "head and discards any review anchored to it)"
         )
     # Only reachable with at least one CONCLUDED dependency entry, or with no
     # CI run at all -- and the caller reports the latter separately. Without


### PR DESCRIPTION
Fixes #1848.

## The defect

A `queued` CI run contributes **no** rollup entry. The pending filter therefore finds nothing, and the all-concluded fallback reported "not going to appear" about a run that had not started. With zero dependency entries it also asserted they had all concluded — a claim about an empty set.

Reproduced live before fixing: a real PR carried `ci.yml` at `queued` with only unrelated contexts reported.

This matters because of *when* it is wrong. It is the window right after a push, where the tool is most consulted, and the remedy the old message implies — an empty commit to re-trigger CI — moves the PR head and discards any bot review anchored to the old SHA. I nearly did exactly that earlier tonight.

## The change

Two new arms, both from data already fetched, so neither costs an extra request:

- **Not yet started.** A `queued`/`in_progress`/`waiting`/`pending`/`requested` CI run at the head means the contexts are coming. Says so, and warns explicitly against the empty commit.
- **No dependency reported at all.** Without this, the all-concluded sentence claims every dependency concluded when none was ever seen.

The status set matches the Actions API's `status` enum; real runs on this repo report lowercase, so the comparison is deliberately case-sensitive. `action_required` is correctly absent — those runs report `status: completed`.

## An arm I added and removed

I first added a conflicting-branch arm on the premise that GitHub runs no PR workflows on a conflicting branch. **That premise is false**, and the local review caught it:

```
#1835  mergeable=CONFLICTING  ci.yml runs at head: 1
#1833  mergeable=CONFLICTING  ci.yml runs at head: 1
```

`ci.yml` triggers on plain `pull_request`, which fires on opened/synchronize regardless of mergeability. A conflict blocks the merge, not the workflow. I had inferred the claim from a peer session's report of a branch with no CI run; the actual cause there was `ci.yml`'s `branches: [main, master, develop]` filter — a PR based on a feature branch runs nothing, and that PR's mergeability was `UNKNOWN`.

The arm was also checked first with no other condition, so on any conflicting branch it swallowed the #1582 verdict this function exists to preserve. The control test could not catch that, because it pinned `mergeable=MERGEABLE`.

Removed, with two tests pinning the corrected behaviour: an all-concluded rollup still says investigate, and no input produces a conflict message.

## A fixture that could not express its own claim

`REAL_ROLLUP_ALL_CONCLUDED` held `CodeQL` and `Analyze (actions)` — neither an `AGGREGATED_JOBS` member. Three existing tests used it to assert "every dependency concluded" against a rollup containing **no dependencies at all**: green on an input the production path cannot produce. The new guard surfaced it. The fixture now holds all five real dependencies, and those three tests exercise the path they name.

## Verification

112 tests pass in the gate's own file, lint clean, and the tool runs correctly against live PRs. Four mutations, each red on its predicted test — ignoring the queued run, dropping `queued` from the status set, dropping the no-dependency guard, and reinstating the removed conflict arm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request gate messages for queued, pending, or in-progress CI runs.
  - Prevented incomplete or empty rollups from being reported as fully concluded.
  - Corrected missing-check explanations by distinguishing active, completed, and not-yet-started dependencies.
  - Prevented unrelated manually triggered or push-based runs from affecting pull request status.
  - Added recognition for additional required frontend, security, quality, and package validation checks.

- **Tests**
  - Added coverage for queued, completed, unfinished, empty-rollup, matrix, and dependency-precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Both halves share one root cause

They read as unrelated fixes — an arm removed, a fixture corrected — but they are the same defect at two levels, and it is worth naming because it is the reason the change is bigger than the issue.

**A green that is insensitive to the thing under test.**

- The fixture supplied *none* of the dependency filter's inputs, so "every dependency concluded" was vacuously true. A peer blanked every `conclusion` in the original two-entry fixture and the whole file stayed green.
- The conflict arm's control supplied the arm's input but pinned it at `MERGEABLE`, the one value that guaranteed the arm never fired. So it could not distinguish "the arm is correct" from "the arm never ran".

In both cases the test passes, the mutation survives, and nothing is measuring what the name claims. The guards added here are the reverse-direction checks each case was missing: the coverage assertion fails with the missing names printed, and the flip assertion requires a verdict *change* that a dependency-free rollup cannot produce.

Verified on this branch that the guard reddens for the right reason rather than incidentally: every fixture entry resolves as intended under `aggregated_job_for`'s exact-or-`" ("` rule —

```
'Lint & Format'                      -> 'Lint & Format'
'Type Check'                         -> 'Type Check'
'Unit Tests (ubuntu-latest, py3.12)' -> 'Unit Tests'
'Integration Tests (ubuntu-latest)'  -> 'Integration Tests'
'Binary Smoke Test'                  -> 'Binary Smoke Test'
'CodeQL'                             -> None
'Analyze (actions)'                  -> None
```

— and all seven names are verbatim from a live rollup on this repo, so a matrix name silently failing the rule (which would redden the guard for a reason unrelated to coverage) is ruled out. The last two are kept deliberately: they are the non-dependency case, so the fixture exercises both directions of `aggregated_job_for` rather than only the positive one.
