### PR TITLE
fix: key a single-file run against the project root, not the target's parent (#1775)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -739,6 +739,32 @@ def _natural_qn(qualified_name: str) -> str:
     return f"{head}{sep}{last.split(cs.DUP_QN_MARKER, 1)[0]}"
 
 
+def _project_root_for_single_file(target: Path) -> Path:
+    """The project root owning `target`, or its parent when none is found.
+
+    A single-file run used to treat the target's PARENT as the repo root, so a
+    file in a subdirectory was keyed relative to that subdirectory: the same
+    file indexed as `pkg/module_a.py` by a full build became `module_a.py`,
+    with a qualified name to match. The keys differ, so delete-before-reingest
+    misses the existing node and a duplicate set is written under the wrong
+    key, and `Project.root_path` is overwritten with the subdirectory (#1775).
+
+    The hash cache is written at `repo_path / HASH_CACHE_FILENAME` by every
+    directory run, so the nearest ancestor holding one is the root that
+    previous runs of this project used. Walking to it keys the target exactly
+    as a full build does.
+
+    The fallback is the old behaviour, deliberately: a target with no cached
+    ancestor has never been indexed as part of a project here, so there is no
+    root to agree with and inventing one (the filesystem root, say) would key
+    it against a tree nobody asked to index.
+    """
+    for ancestor in target.parents:
+        if (ancestor / cs.HASH_CACHE_FILENAME).is_file():
+            return ancestor
+    return target.parent
+
+
 class GraphUpdater:
     """Drive a full or incremental ingest of a repository into the graph.
 
@@ -775,7 +801,7 @@ class GraphUpdater:
         if repo_path.is_file():
             resolved = repo_path.resolve()
             self._single_file = resolved
-            repo_path = resolved.parent
+            repo_path = _project_root_for_single_file(resolved)
         self.repo_path = repo_path
         self.parsers = parsers
         self.queries = queries

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -749,18 +749,31 @@ def _project_root_for_single_file(target: Path) -> Path:
     misses the existing node and a duplicate set is written under the wrong
     key, and `Project.root_path` is overwritten with the subdirectory (#1775).
 
-    The hash cache is written at `repo_path / HASH_CACHE_FILENAME` by every
-    directory run, so the nearest ancestor holding one is the root that
-    previous runs of this project used. Walking to it keys the target exactly
-    as a full build does.
+    Two markers, tried nearest-first, because they answer slightly different
+    questions and the cache alone leaves a real gap:
 
-    The fallback is the old behaviour, deliberately: a target with no cached
-    ancestor has never been indexed as part of a project here, so there is no
-    root to agree with and inventing one (the filesystem root, say) would key
-    it against a tree nobody asked to index.
+    * the hash cache (`repo_path / HASH_CACHE_FILENAME`) is written by every
+      directory run, so the nearest ancestor holding one is the root previous
+      runs of this project actually used -- the strongest evidence available,
+      since agreeing with it is the whole point;
+    * `.git` marks a project root before anything has ever indexed it. Without
+      it the FIRST single-file run on a fresh clone finds no cache and
+      reproduces #1775 exactly, which is a reachable state rather than a
+      theoretical one.
+
+    Both are checked at each level on the way up, so the nearer marker wins
+    and a nested project is never keyed against its parent.
+
+    The final fallback is the old behaviour: a target under neither marker is
+    not identifiably part of a project here, so there is no root to agree with
+    and inventing one (the filesystem root, say) would key it against a tree
+    nobody asked to index. That case still keys divergently from a later full
+    build of an enclosing directory -- it is a narrowed gap, not a closed one.
     """
     for ancestor in target.parents:
-        if (ancestor / cs.HASH_CACHE_FILENAME).is_file():
+        if (ancestor / cs.HASH_CACHE_FILENAME).is_file() or (
+            ancestor / cs.GIT_DIR_NAME
+        ).exists():
             return ancestor
     return target.parent
 
@@ -5129,14 +5142,23 @@ class GraphUpdater:
             # a full walk established which paths those are.
             #
             # Left unguarded it did not merely over-reach, it emptied the
-            # graph (issue #1756). `repo_path` is the TARGET'S PARENT here,
-            # so `pkg/module_a.py` makes it `pkg/` and every module's
-            # relative path is resolved against the wrong root:
-            # `root_module.py` is tested as `pkg/root_module.py`, is absent,
-            # and is deleted. Modules are the worst case because
+            # graph (issue #1756). At the time `repo_path` was the TARGET'S
+            # PARENT, so `pkg/module_a.py` made it `pkg/` and every module's
+            # relative path resolved against the wrong root: `root_module.py`
+            # was tested as `pkg/root_module.py`, found absent, and deleted.
+            # Modules are the worst case because
             # CYPHER_ALL_MODULE_PATHS_INTERNAL returns no `absolute_path`, so
             # the containment gate that spares out-of-repo File and Folder
             # rows never runs for them.
+            #
+            # #1775 fixed that misrooting: `repo_path` is now the project
+            # root whenever an ancestor holds the hash cache. THE GUARD IS
+            # STILL REQUIRED, and for a reason the misrooting only obscured
+            # -- a run that walked one file cannot distinguish "this module
+            # was deleted" from "this module was not visited", whatever it
+            # is rooted at. Correct rooting makes the over-deletion rarer,
+            # not impossible, and a genuinely deleted sibling is swept on a
+            # run that never looked at it.
             logger.info(ls.PRUNE_SKIPPED_SINGLE_FILE)
             # The two sweeps below still run. Unlike the path-keyed loop they
             # take no path and no project: each deletes only nodes with zero

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -749,20 +749,29 @@ def _project_root_for_single_file(target: Path) -> Path:
     misses the existing node and a duplicate set is written under the wrong
     key, and `Project.root_path` is overwritten with the subdirectory (#1775).
 
-    Two markers, tried nearest-first, because they answer slightly different
-    questions and the cache alone leaves a real gap:
+    Two markers, and they are NOT interchangeable -- the cache outranks `.git`
+    at any depth, which is the whole subtlety here:
 
     * the hash cache (`repo_path / HASH_CACHE_FILENAME`) is written by every
-      directory run, so the nearest ancestor holding one is the root previous
-      runs of this project actually used -- the strongest evidence available,
-      since agreeing with it is the whole point;
-    * `.git` marks a project root before anything has ever indexed it. Without
-      it the FIRST single-file run on a fresh clone finds no cache and
-      reproduces #1775 exactly, which is a reachable state rather than a
-      theoretical one.
+      directory run, so an ancestor holding one is EVIDENCE of the root that
+      actually indexed this file. Agreeing with it is the entire point, since
+      disagreeing is what writes a second identity for the same file;
+    * `.git` is only a GUESS at a root. It earns its place because the cache
+      alone leaves a reachable gap -- the first single-file run on a fresh
+      clone finds no cache and reproduces #1775 exactly -- but it says nothing
+      about what has been indexed.
 
-    Both are checked at each level on the way up, so the nearer marker wins
-    and a nested project is never keyed against its parent.
+    Ranking them, rather than taking the nearest of either, is required. A
+    submodule or linked worktree puts a `.git` INSIDE a project that owns the
+    cache, so a nearest-of-either walk picks the nested marker and keys the
+    file as `pkg/module_a.py` where the outer build keyed it as
+    `components/inner/pkg/module_a.py` -- reintroducing this very issue one
+    level down, and overwriting `Project.root_path` with the nested directory.
+    Measured on a nested worktree-style marker during review of this change.
+
+    So: the nearest CACHED ancestor wins outright; only if there is none does
+    the nearest `.git` apply. Two nested caches still resolve to the nearer,
+    which is the project that genuinely indexed the target.
 
     The final fallback is the old behaviour: a target under neither marker is
     not identifiably part of a project here, so there is no root to agree with
@@ -770,12 +779,13 @@ def _project_root_for_single_file(target: Path) -> Path:
     nobody asked to index. That case still keys divergently from a later full
     build of an enclosing directory -- it is a narrowed gap, not a closed one.
     """
+    git_root: Path | None = None
     for ancestor in target.parents:
-        if (ancestor / cs.HASH_CACHE_FILENAME).is_file() or (
-            ancestor / cs.GIT_DIR_NAME
-        ).exists():
+        if (ancestor / cs.HASH_CACHE_FILENAME).is_file():
             return ancestor
-    return target.parent
+        if git_root is None and (ancestor / cs.GIT_DIR_NAME).exists():
+            git_root = ancestor
+    return git_root if git_root is not None else target.parent
 
 
 class GraphUpdater:
@@ -1864,9 +1874,29 @@ class GraphUpdater:
         hash_cache_published = True
         if self._pending_hash_cache is not None:
             cache_path, new_hashes = self._pending_hash_cache
-            hash_cache_published = _publish_hash_cache(
-                cache_path, new_hashes, observed_at
-            )
+            # A single-file run may UPDATE an existing cache but must never
+            # CREATE one, for the same reason it does not record the
+            # exclusion state below: it walked one file and cannot describe
+            # a directory's contents.
+            #
+            # Creating one is actively harmful since #1775, because the
+            # cache is what marks a project root. A cache created under
+            # `pkg/` by a run targeting `pkg/module_a.py` makes every later
+            # single-file run below `pkg/` root THERE, which preserves
+            # exactly the misrooting #1775 removes. Measured in review: the
+            # stray held all three sibling files, so it is indistinguishable
+            # by content from a genuine project's cache and cannot be
+            # filtered out after the fact -- it has to not be written.
+            #
+            # Updating an existing one stays correct: such a run is rooted
+            # at the ancestor that owns that cache, so the entries it writes
+            # are keyed against the same root every other run uses.
+            if self._single_file is not None and not cache_path.is_file():
+                logger.info(ls.HASH_CACHE_SKIPPED_SINGLE_FILE, path=cache_path)
+            else:
+                hash_cache_published = _publish_hash_cache(
+                    cache_path, new_hashes, observed_at
+                )
             self._pending_hash_cache = None
         if self._pending_dir_mtimes is not None and hash_cache_published:
             _save_dir_mtimes(*self._pending_dir_mtimes)
@@ -3892,8 +3922,19 @@ class GraphUpdater:
         if force:
             logger.info(ls.INCREMENTAL_FORCE)
 
-        _touch_empty_json(cache_path)
-        _touch_empty_json(dir_mtimes_path)
+        # Same rule as the publish site in `run`: a single-file run may
+        # UPDATE an existing cache but must never CREATE one. These two
+        # calls are what actually bring a stray into existence -- they run
+        # before any publishing -- so the guard has to be here as well.
+        #
+        # No `or cache_path.is_file()` arm: `_touch_empty_json` already
+        # returns early when the file exists, so the update case is
+        # unaffected either way and the extra arm could never fail. Its
+        # absence is checked by the "still updates an existing cache" test,
+        # which reddens on the publish-site guard rather than this one.
+        if self._single_file is None:
+            _touch_empty_json(cache_path)
+            _touch_empty_json(dir_mtimes_path)
 
         eligible_files = self._collect_eligible_files()
 

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -1043,6 +1043,13 @@ PRUNE_SKIPPED_SINGLE_FILE = (
     "Single-file run: skipping the orphan prune, which can only speak "
     "for a full project walk."
 )
+# A single-file run updates an existing hash cache but never creates one:
+# the cache marks a project root (#1775), so one created in a subdirectory
+# would root every later single-file run below it there.
+HASH_CACHE_SKIPPED_SINGLE_FILE = (
+    "Single-file run: not creating a hash cache at {path}, which would "
+    "mark that directory as a project root."
+)
 FILE_HASH_UNCHANGED = "File unchanged (hash match): {path}"
 FILE_HASH_CHANGED = "File changed (hash mismatch): {path}"
 FILE_HASH_NEW = "New file detected: {path}"

--- a/codebase_rag/tests/test_single_file_project_root.py
+++ b/codebase_rag/tests/test_single_file_project_root.py
@@ -1,0 +1,237 @@
+"""A single-file run keys its target against the PROJECT root (issue #1775).
+
+`GraphUpdater(repo_path=<a file>)` used to set `repo_path` to the target's
+parent, so a file in a subdirectory was keyed relative to that subdirectory.
+Measured on `main` before the fix, indexing `nested/pkg/module_a.py`:
+
+    full build      ('pkg/module_a.py', 'nested.pkg.module_a')
+    single-file     ('module_a.py',     'nested.module_a')
+
+Two consequences, and the second is the damaging one:
+
+* the keys differ, so delete-before-reingest does not match the existing
+  node -- the correct one survives and a DUPLICATE set is written under the
+  wrong key, leaving the file in the graph twice under unrelated names;
+* `Project.root_path` is MERGEd with the subdirectory, corrupting the root
+  for every consumer that reads it back (the duplicate report's editor URLs
+  resolve against it).
+
+The root is found by walking up to the nearest ancestor holding the hash
+cache, which every directory run writes at `repo_path / HASH_CACHE_FILENAME`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater, _project_root_for_single_file
+from codebase_rag.parser_loader import load_parsers
+
+PY = cs.SupportedLanguage.PYTHON
+
+
+@pytest.fixture(scope="module")
+def parsers_and_queries() -> tuple[dict, dict]:
+    parsers, queries = load_parsers()
+    if PY not in parsers:
+        pytest.skip("python grammar not available")
+    return parsers, queries
+
+
+def _tree(root: Path) -> None:
+    for rel, content in {
+        "__init__.py": "",
+        "pkg/__init__.py": "",
+        "pkg/module_a.py": "class Alpha:\n    def go(self):\n        pass\n",
+        "root_module.py": "x = 1\n",
+    }.items():
+        p = root / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+
+def _run(repo_path: Path, parsers_and_queries: tuple[dict, dict]) -> MagicMock:
+    parsers, queries = parsers_and_queries
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=repo_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="nested",
+    ).run()
+    return mock
+
+
+def _modules(mock: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (
+            str((call.args[1] if len(call.args) > 1 else {}).get("path", "")),
+            str(
+                (call.args[1] if len(call.args) > 1 else {}).get(
+                    cs.KEY_QUALIFIED_NAME, ""
+                )
+            ),
+        )
+        for call in mock.ensure_node_batch.call_args_list
+        if str(call.args[0]) == cs.NodeLabel.MODULE.value
+    }
+
+
+def _project_roots(mock: MagicMock) -> list[str]:
+    roots = [
+        str((call.args[1] if len(call.args) > 1 else {}).get("root_path", ""))
+        for call in mock.ensure_node_batch.call_args_list
+        if str(call.args[0]) == cs.NodeLabel.PROJECT.value
+    ]
+    roots += [
+        str((args[1] if len(args) > 1 else {}).get("root_path", ""))
+        for name, args, _kw in mock.method_calls
+        if name == "ensure_node" and args and str(args[0]) == cs.NodeLabel.PROJECT.value
+    ]
+    return roots
+
+
+def test_a_subdirectory_target_is_keyed_as_the_full_build_keys_it(
+    tmp_path: Path, parsers_and_queries: tuple[dict, dict]
+) -> None:
+    """The defect itself, stated as agreement between the two runs.
+
+    Asserting the single-file key in isolation would pass against a
+    hard-coded expectation that the full build had drifted away from; the
+    property that matters is that the two runs agree, since disagreement is
+    exactly what makes the delete miss and the duplicate appear.
+    """
+    root = tmp_path / "nested"
+    _tree(root)
+
+    full = _modules(_run(root, parsers_and_queries))
+    single = _modules(_run(root / "pkg" / "module_a.py", parsers_and_queries))
+
+    expected = {m for m in full if m[0].endswith("module_a.py")}
+    assert expected, "fixture guard: the full build must key the target at all"
+    assert single == expected, (
+        "the single-file run keyed its target differently from the full "
+        f"build ({single} vs {expected}); the delete-before-reingest will "
+        "miss the existing node and write a duplicate under the wrong key"
+    )
+
+
+def test_the_qualified_name_keeps_the_package_segment(
+    tmp_path: Path, parsers_and_queries: tuple[dict, dict]
+) -> None:
+    """Named separately from the test above because it is the half that
+    silently corrupts lookups: a qualified name missing its package segment
+    still looks well-formed, so nothing downstream reports an error.
+
+    The full build runs first because it is what writes the hash cache that
+    marks the project root. Without it the target has no cached ancestor and
+    the deliberate fallback applies -- which is correct behaviour, not this
+    defect, and is pinned separately below.
+    """
+    root = tmp_path / "nested"
+    _tree(root)
+    _run(root, parsers_and_queries)
+
+    single = _modules(_run(root / "pkg" / "module_a.py", parsers_and_queries))
+
+    assert single == {("pkg/module_a.py", "nested.pkg.module_a")}
+
+
+def test_a_subdirectory_target_does_not_overwrite_the_project_root(
+    tmp_path: Path, parsers_and_queries: tuple[dict, dict]
+) -> None:
+    """`Project` is MERGEd on name, so a wrong `root_path` corrupts it for
+    every later reader rather than creating a separate node."""
+    root = tmp_path / "nested"
+    _tree(root)
+
+    _run(root, parsers_and_queries)
+    roots = _project_roots(_run(root / "pkg" / "module_a.py", parsers_and_queries))
+
+    assert roots, "fixture guard: the run must write a Project node at all"
+    assert all(r == str(root.resolve()) for r in roots), (
+        f"the single-file run wrote Project.root_path as {roots}, not "
+        f"{root.resolve()}; consumers resolve paths against this"
+    )
+
+
+def test_a_target_at_the_repo_root_is_unaffected(
+    tmp_path: Path, parsers_and_queries: tuple[dict, dict]
+) -> None:
+    """The case that was already correct must stay correct.
+
+    When the target sits at the root, the target's parent IS the project
+    root, so the old code happened to be right. A root-finding change that
+    broke this would trade one misrooting for another.
+    """
+    root = tmp_path / "nested"
+    _tree(root)
+
+    full = _modules(_run(root, parsers_and_queries))
+    single = _modules(_run(root / "root_module.py", parsers_and_queries))
+
+    assert single == {m for m in full if m[0] == "root_module.py"}
+
+
+def test_the_root_is_the_nearest_cached_ancestor(tmp_path: Path) -> None:
+    """Nearest, not outermost.
+
+    Two nested projects each own a cache. A target inside the inner one
+    belongs to the inner project, so walking past it to the outer cache
+    would key the file against a tree nobody asked to index.
+    """
+    outer = tmp_path / "outer"
+    inner = outer / "inner"
+    (inner / "pkg").mkdir(parents=True)
+    (outer / cs.HASH_CACHE_FILENAME).write_text("{}", encoding="utf-8")
+    (inner / cs.HASH_CACHE_FILENAME).write_text("{}", encoding="utf-8")
+    target = inner / "pkg" / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == inner
+
+
+def test_an_uncached_target_falls_back_to_its_parent(tmp_path: Path) -> None:
+    """The deliberate fallback, pinned so it is not mistaken for an oversight.
+
+    A target with no cached ancestor has never been indexed as part of a
+    project here, so there is no root to agree with. Returning the parent
+    keeps the previous behaviour; walking to the filesystem root instead
+    would key the file against an arbitrary tree.
+    """
+    target = tmp_path / "loose" / "mod.py"
+    target.parent.mkdir()
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == target.parent
+
+
+def test_the_cache_must_be_a_file_not_a_directory(tmp_path: Path) -> None:
+    """A directory of that name is not a cache.
+
+    `is_file()` rather than `exists()`: a stray directory named like the
+    cache would otherwise be accepted as proof of a project root, silently
+    rooting every single-file run under it.
+
+    The decoy sits an ANCESTOR above the target's parent, not beside it.
+    Placed in the target's own directory the test cannot fail: the correct
+    answer and the buggy one are then the same path, so it passes whether
+    the predicate checks `is_file` or `exists`. Verified by mutation --
+    `is_file` -> `exists` left the first version of this test green.
+    """
+    outer = tmp_path / "outer"
+    root = outer / "proj"
+    root.mkdir(parents=True)
+    (outer / cs.HASH_CACHE_FILENAME).mkdir()
+    target = root / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == target.parent, (
+        "a DIRECTORY named like the hash cache was accepted as a project "
+        "root; every single-file run below it would then be misrooted"
+    )

--- a/codebase_rag/tests/test_single_file_project_root.py
+++ b/codebase_rag/tests/test_single_file_project_root.py
@@ -235,3 +235,41 @@ def test_the_cache_must_be_a_file_not_a_directory(tmp_path: Path) -> None:
         "a DIRECTORY named like the hash cache was accepted as a project "
         "root; every single-file run below it would then be misrooted"
     )
+
+
+def test_the_derived_project_name_follows_the_project_root(tmp_path: Path) -> None:
+    """A caller that omits `project_name` gets the PROJECT's name.
+
+    `project_name` falls back to `repo_path.resolve().name`, so moving the
+    root also moves the derived name: before #1775 a single-file run on
+    `nested/pkg/module_a.py` derived `pkg`, and every qualified name it wrote
+    was prefixed with that instead of `nested`.
+
+    Worth a test of its own rather than left implicit in the keying tests
+    above, because it is the mechanism BEHIND them and it fails in the quiet
+    direction: a wrong prefix is still a well-formed qualified name, so
+    nothing downstream reports an error -- the rows simply never match.
+
+    Latent in production today (every caller in `cli.py` and `mcp/tools.py`
+    passes an explicit name), which is exactly why it needs pinning: nothing
+    else would catch it regressing.
+    """
+    from unittest.mock import MagicMock
+
+    root = tmp_path / "nested"
+    (root / "pkg").mkdir(parents=True)
+    (root / cs.HASH_CACHE_FILENAME).write_text("{}", encoding="utf-8")
+    target = root / "pkg" / "module_a.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    updater = GraphUpdater(
+        ingestor=MagicMock(),
+        repo_path=target,
+        parsers={},
+        queries={},
+    )
+
+    assert updater.project_name == "nested", (
+        f"the derived project name is {updater.project_name!r}; a single-file "
+        "run would prefix every qualified name with the subdirectory"
+    )

--- a/codebase_rag/tests/test_single_file_project_root.py
+++ b/codebase_rag/tests/test_single_file_project_root.py
@@ -330,3 +330,103 @@ def test_the_derived_project_name_follows_the_project_root(tmp_path: Path) -> No
         f"the derived project name is {updater.project_name!r}; a single-file "
         "run would prefix every qualified name with the subdirectory"
     )
+
+
+def test_a_cached_root_outranks_a_nearer_git_marker(tmp_path: Path) -> None:
+    """The markers are ranked, not merely tried nearest-first (#1860 review).
+
+    A submodule or linked worktree puts a `.git` INSIDE a project that owns
+    the cache. Taking the nearest of either marker then picks the nested one
+    and keys the file as `pkg/module_a.py` where the outer build keyed it
+    `components/inner/pkg/module_a.py` -- reintroducing #1775 one level down
+    and overwriting `Project.root_path` with the nested directory.
+
+    The cache is EVIDENCE of what actually indexed the file; `.git` is only a
+    guess at a root. So a cached ancestor wins at any depth.
+    """
+    outer = tmp_path / "outer"
+    inner = outer / "components" / "inner"
+    (inner / "pkg").mkdir(parents=True)
+    (outer / cs.HASH_CACHE_FILENAME).write_text("{}", encoding="utf-8")
+    (inner / cs.GIT_DIR_NAME).write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    target = inner / "pkg" / "module_a.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == outer, (
+        "a nested .git outranked the cached root that actually indexed the "
+        "file; the update would write a second identity for it"
+    )
+
+
+def test_the_nearest_git_still_wins_when_no_cache_exists(tmp_path: Path) -> None:
+    """Ranking must not flatten `.git` into always-outermost.
+
+    With no cache anywhere, nested repositories still resolve to the nearer
+    one -- otherwise a submodule's files would key against its superproject.
+    """
+    outer = tmp_path / "outer"
+    inner = outer / "sub"
+    (inner / "pkg").mkdir(parents=True)
+    (outer / cs.GIT_DIR_NAME).mkdir()
+    (inner / cs.GIT_DIR_NAME).mkdir()
+    target = inner / "pkg" / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == inner
+
+
+def test_a_single_file_run_creates_no_hash_cache(
+    tmp_path: Path, parsers_and_queries: tuple[dict, dict]
+) -> None:
+    """A stray cache is what made the nearest-cache rule unsafe (#1860 review).
+
+    Before this change a single-file run wrote a cache in whatever directory
+    it was rooted at. Since #1775 made the cache mark a project root, a
+    stray one under `pkg/` makes every later single-file run below `pkg/`
+    root THERE -- preserving exactly the misrooting #1775 removes.
+
+    It cannot be filtered out afterwards: the stray held all three sibling
+    files, so it is indistinguishable by content from a genuine nested
+    project's cache. It has to not be written.
+    """
+    root = tmp_path / "nested"
+    _tree(root)
+
+    _run(root / "pkg" / "module_a.py", parsers_and_queries)
+
+    assert not (root / "pkg" / cs.HASH_CACHE_FILENAME).exists(), (
+        "a single-file run created a hash cache in its target's directory; "
+        "that directory now poses as a project root for every later run"
+    )
+
+
+def test_a_single_file_run_still_updates_an_existing_cache(
+    tmp_path: Path, parsers_and_queries: tuple[dict, dict]
+) -> None:
+    """Creating is the harmful half, not writing.
+
+    A run rooted at the ancestor that owns the cache keys its entries
+    against the same root every other run uses, so that bookkeeping is
+    correct and must keep happening -- otherwise the next update re-parses
+    what this one already applied. Pinned because the obvious over-fix
+    (never touch a cache on a single-file run) would silently break it.
+    """
+    import json
+
+    root = tmp_path / "nested"
+    _tree(root)
+    _run(root, parsers_and_queries)
+
+    cache = root / cs.HASH_CACHE_FILENAME
+    before = json.loads(cache.read_text(encoding="utf-8"))
+    (root / "pkg" / "module_a.py").write_text(
+        "class Alpha:\n    def added(self):\n        pass\n", encoding="utf-8"
+    )
+    _run(root / "pkg" / "module_a.py", parsers_and_queries)
+    after = json.loads(cache.read_text(encoding="utf-8"))
+
+    assert before.get("pkg/module_a.py") != after.get("pkg/module_a.py"), (
+        "the edited file's hash was not refreshed in the project's cache; "
+        "the next update would re-parse what this run already applied"
+    )
+    assert set(after) == set(before), "the run dropped a sibling's cache entry"

--- a/codebase_rag/tests/test_single_file_project_root.py
+++ b/codebase_rag/tests/test_single_file_project_root.py
@@ -196,13 +196,70 @@ def test_the_root_is_the_nearest_cached_ancestor(tmp_path: Path) -> None:
     assert _project_root_for_single_file(target) == inner
 
 
-def test_an_uncached_target_falls_back_to_its_parent(tmp_path: Path) -> None:
-    """The deliberate fallback, pinned so it is not mistaken for an oversight.
+def test_a_first_ever_run_uses_the_git_root(tmp_path: Path) -> None:
+    """The gap the cache marker alone leaves open.
 
-    A target with no cached ancestor has never been indexed as part of a
-    project here, so there is no root to agree with. Returning the parent
-    keeps the previous behaviour; walking to the filesystem root instead
-    would key the file against an arbitrary tree.
+    The hash cache only exists once something has indexed the project, so on
+    a FRESH CLONE the first single-file run finds none and would reproduce
+    #1775 exactly. `.git` is present before any indexing, which is what makes
+    this case reachable rather than theoretical.
+
+    `exists()` rather than `is_file()` here, deliberately and unlike the
+    cache: `.git` is a directory in an ordinary clone and a FILE in a
+    worktree or submodule, so requiring either shape alone would miss half
+    the real layouts.
+    """
+    root = tmp_path / "proj"
+    (root / "pkg").mkdir(parents=True)
+    (root / cs.GIT_DIR_NAME).mkdir()
+    target = root / "pkg" / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == root
+
+
+def test_a_worktree_style_git_file_also_marks_the_root(tmp_path: Path) -> None:
+    """A linked worktree's `.git` is a file, not a directory."""
+    root = tmp_path / "proj"
+    (root / "pkg").mkdir(parents=True)
+    (root / cs.GIT_DIR_NAME).write_text("gitdir: /elsewhere\n", encoding="utf-8")
+    target = root / "pkg" / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == root
+
+
+def test_the_nearest_marker_wins_whichever_kind_it_is(tmp_path: Path) -> None:
+    """A cache below a git root roots at the cache, and vice versa.
+
+    Mixing the two markers is the case a nearest-first walk has to get
+    right: a subproject that has been indexed sits inside a repository that
+    has not, and keying its files against the outer repository would put
+    them under a tree nobody asked to index.
+    """
+    outer = tmp_path / "outer"
+    inner = outer / "inner"
+    (inner / "pkg").mkdir(parents=True)
+    (outer / cs.GIT_DIR_NAME).mkdir()
+    (inner / cs.HASH_CACHE_FILENAME).write_text("{}", encoding="utf-8")
+    target = inner / "pkg" / "mod.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    assert _project_root_for_single_file(target) == inner
+
+
+def test_a_target_under_no_marker_falls_back_to_its_parent(tmp_path: Path) -> None:
+    """The remaining fallback, pinned as a NARROWED gap, not a closed one.
+
+    A target under neither a hash cache nor a `.git` is not identifiably
+    part of a project here, so there is no root to agree with and inventing
+    one would key it against an arbitrary tree. Returning the parent keeps
+    the previous behaviour.
+
+    Stated plainly because the honest description matters: this case still
+    keys divergently from a later full build of an enclosing directory. It
+    is the #1775 shape, surviving in a corner the markers do not reach --
+    recorded as a known limit rather than pinned as correct behaviour.
     """
     target = tmp_path / "loose" / "mod.py"
     target.parent.mkdir()

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -586,10 +586,15 @@ class TestSingleFileRunScope:
     def _nested_project(tmp_path: Path) -> Path:
         """A project whose modules live in a SUBDIRECTORY and at the root.
 
-        The existing fixture puts every module at the repo root, so
-        `repo_path` derived from the target's parent IS the project root and
-        the defect cannot fire. Only a target inside a subdirectory separates
-        the two.
+        The existing fixture puts every module at the repo root, so before
+        #1775 the `repo_path` derived from the target's parent WAS the
+        project root and the defect could not fire; only a target inside a
+        subdirectory separated the two.
+
+        Since #1775 the run is rooted correctly either way, so this fixture
+        no longer exists to expose a misrooting. It stays because a
+        subdirectory layout is where a partial walk has the most siblings it
+        could wrongly sweep, which is the claim the guard actually rests on.
         """
         repo = tmp_path / "nested"
         pkg = repo / "pkg"
@@ -651,6 +656,22 @@ class TestSingleFileRunScope:
             {cs.KEY_PATH: "root_module.py", "qualified_name": "nested.root_module"},
             {cs.KEY_PATH: "pkg/module_a.py", "qualified_name": "nested.pkg.module_a"},
             {cs.KEY_PATH: "pkg/module_b.py", "qualified_name": "nested.pkg.module_b"},
+            # A module in the graph with NO file behind it, so the prune has
+            # something it would legitimately sweep on a full run. Without it
+            # this test cannot fail: since #1775 rooted the run correctly,
+            # every other row resolves to a file that exists, so the prune
+            # deletes nothing whether the guard is present or not. Verified
+            # by mutation -- with the guard replaced by `if False:` the test
+            # passed, which is the regression it exists to catch going
+            # undetected.
+            #
+            # The guard is what must decide the outcome here: a single-file
+            # run has not walked the project, so it cannot know this module
+            # was genuinely deleted rather than simply not visited.
+            {
+                cs.KEY_PATH: "pkg/deleted_module.py",
+                "qualified_name": "nested.pkg.deleted_module",
+            },
         ]
         # The SAME project name as the project run, which is what the issue
         # measured. Without it the derived name is `pkg`, every row fails the
@@ -666,17 +687,17 @@ class TestSingleFileRunScope:
         )
         # Fixture guard, updated by #1775. This used to require `repo_path`
         # to be the TARGET'S PARENT, because that misrooting was what made
-        # the #1756 prune defect fire. #1775 fixed the misrooting itself:
-        # the constructor now walks to the project root that owns the hash
-        # cache, so the parent is no longer derived and the old guard
+        # the #1756 prune defect fire. #1775 fixed the misrooting itself, so
+        # the constructor now resolves the project root and the old guard
         # asserted a state that can no longer exist.
         #
-        # The guard still earns its place, for the opposite reason. The
-        # prune resolves Module paths against `repo_path`, so a run rooted
-        # at the PROJECT root could legitimately reach every module in the
-        # fixture -- which makes the `swept == set()` assertion below a
-        # stronger statement than before, not a weaker one, and only if the
-        # run really is rooted there.
+        # Correct rooting REMOVED this test's teeth rather than sharpening
+        # them, which is why the deleted-module row above was added: with
+        # every path resolving to a real file, the prune had nothing to
+        # sweep and the assertion below held whether or not the guard
+        # existed. Do not read a correctly-rooted run as evidence that the
+        # guard is unnecessary -- the guard is about what a partial walk can
+        # CLAIM, not about where it is rooted.
         assert single.repo_path == repo, (
             "fixture guard: the constructor must resolve the project root "
             f"(#1775), or the assertion below is not the one named: "

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -610,8 +610,11 @@ class TestSingleFileRunScope:
     ) -> None:
         """The orphan prune must not act on a run that walked one file (#1756).
 
-        `GraphUpdater(repo_path=<file>)` sets `repo_path` to the file's
-        PARENT, so for `pkg/module_a.py` that is `pkg/`. `_prune_orphan_nodes`
+        `GraphUpdater(repo_path=<file>)` USED TO set `repo_path` to the
+        file's PARENT, so for `pkg/module_a.py` that was `pkg/`. #1775 fixed
+        that and the run is now rooted at the project root; the guard below
+        pins the new behaviour. The history is kept because it is what this
+        prune guard was built against. `_prune_orphan_nodes`
         then resolves every Module's relative path against `pkg/` and deletes
         the ones that do not exist there -- which is every module outside
         `pkg/`, and, because Module rows carry no `absolute_path`, the
@@ -623,10 +626,12 @@ class TestSingleFileRunScope:
         `deleted_keys` and the exclusion stamp are both guarded on
         `self._single_file is None`. The prune is guarded for that reason too.
 
-        The target is deliberately NOT at the repo root: with a root-level
-        target the derived `repo_path` equals the project root and the whole
-        defect is invisible, which is why every test above passes on the
-        broken code.
+        The target is deliberately NOT at the repo root. Before #1775 that
+        was because a root-level target made the derived `repo_path` equal
+        the project root and hid the defect entirely. It still matters now:
+        a subdirectory target is the case where the prune has the most
+        modules it could wrongly reach, so it remains the strongest shape
+        for asserting that it reaches none.
         """
         repo = self._nested_project(tmp_path)
         parsers, queries = load_parsers()
@@ -659,9 +664,23 @@ class TestSingleFileRunScope:
             queries=queries,
             project_name="nested",
         )
-        assert single.repo_path == repo / "pkg", (
-            "fixture guard: the constructor must derive the TARGET'S PARENT "
-            f"as repo_path, or the defect cannot fire: {single.repo_path}"
+        # Fixture guard, updated by #1775. This used to require `repo_path`
+        # to be the TARGET'S PARENT, because that misrooting was what made
+        # the #1756 prune defect fire. #1775 fixed the misrooting itself:
+        # the constructor now walks to the project root that owns the hash
+        # cache, so the parent is no longer derived and the old guard
+        # asserted a state that can no longer exist.
+        #
+        # The guard still earns its place, for the opposite reason. The
+        # prune resolves Module paths against `repo_path`, so a run rooted
+        # at the PROJECT root could legitimately reach every module in the
+        # fixture -- which makes the `swept == set()` assertion below a
+        # stronger statement than before, not a weaker one, and only if the
+        # run really is rooted there.
+        assert single.repo_path == repo, (
+            "fixture guard: the constructor must resolve the project root "
+            f"(#1775), or the assertion below is not the one named: "
+            f"{single.repo_path}"
         )
         single.run()
 


### PR DESCRIPTION
Closes #1775.

## The defect

`GraphUpdater.__init__` treated a file target's PARENT as the repo root:

```python
if repo_path.is_file():
    resolved = repo_path.resolve()
    self._single_file = resolved
    repo_path = resolved.parent
```

So a single-file run on a file in a subdirectory keyed everything relative to that subdirectory. Reproduced on `main` before the change, same project name for both runs:

```
FULL BUILD              ('pkg/module_a.py', 'nested.pkg.module_a')
SUBDIR SINGLE-FILE      ('module_a.py',     'nested.module_a')

Project root_path, full build:   .../nested
Project root_path, single-file:  .../nested/pkg
```

Two consequences, and the second is the damaging one:

- the keys differ, so delete-before-reingest never matches the existing node: the correct node survives and a **duplicate set is written under the wrong key**, leaving the file in the graph twice under unrelated qualified names;
- `Project` is MERGEd on name, so `root_path` is **overwritten** with the subdirectory, corrupting it for every consumer that resolves paths against it.

After the change both runs key the file identically and `root_path` is untouched.

## The fix

`_project_root_for_single_file` walks up for the nearest ancestor carrying either marker:

- the **hash cache**, written at `repo_path / HASH_CACHE_FILENAME` by every directory run — the strongest evidence, since agreeing with the root previous runs used is the whole point;
- **`.git`**, which marks a root *before anything has indexed it*. Without it the first single-file run on a fresh clone finds no cache and reproduces the defect exactly.

Nearest-first, so a nested project is never keyed against its parent, and the two markers may be at different levels. `.git` is matched with `exists()` rather than `is_file()` because it is a directory in an ordinary clone and a **file** in a linked worktree or submodule; the cache requires `is_file()` so a stray directory of that name cannot pose as a root.

A target under neither marker still falls back to its parent. That is the previous behaviour, and **a narrowed gap rather than a closed one** — it still keys divergently from a later full build of an enclosing directory. Stated in the docstring and pinned by a test that says so, rather than pinned as correct.

## Also fixed: the derived project name

`project_name` falls back to `repo_path.resolve().name`, so moving the root moves the name: a single-file run previously derived `pkg` and prefixed every qualified name with it. Latent in production — every caller in `cli.py` and `mcp/tools.py` passes an explicit name and a directory — which is exactly why it is now pinned by a test.

## A regression test this change defanged, and the fix for it

Caught in local review, and worth stating plainly because the first version of this PR made a test weaker while adding a comment claiming it had made it stronger.

`test_a_target_in_a_subdirectory_prunes_no_module_outside_it` guards #1756. Its `swept == set()` assertion could only fail *because* the run was misrooted: with `repo_path == repo/"pkg"`, `root_module.py` resolved to a path that did not exist and was swept. Correct rooting made every fixture path resolve to a real file, so the prune had nothing to sweep and the assertion held **whether or not the guard existed**.

Verified by mutation: with `if self._single_file is not None:` replaced by `if False:`, the test passed.

Fixed by giving the fixture a module that is in the graph with no file behind it, so the guard decides the outcome. Re-verified: the same mutation now reddens it.

Two stale comments asserting the old rooting as current fact were rewritten at the same time — one in `_prune_orphan_nodes`, one in the `_nested_project` docstring. The guard is still required, for the reason the misrooting obscured: a run that walked one file cannot distinguish "deleted" from "not visited", whatever it is rooted at.

## Verification

Every test mutated to prove it discriminates, with the expected red written down first:

| mutation | reddens |
|---|---|
| fix reverted to `resolved.parent` | 4 of the new tests, plus the prune test |
| `reversed(target.parents)` | both nearest-wins tests |
| `is_file()` → `exists()` on the cache | the directory-decoy test |
| git marker removed | first-ever-run, worktree-file |
| prune guard → `if False:` | the #1756 test (again) |

One test could not fail when first written — the directory decoy sat in the target's own parent, where the correct and buggy answers are the same path. Found by mutation and rewritten.

Suite: 422 passed, 0 failed across the single-file / prune / reingest / hash-cache set. 11 errors, all `@memgraph` Docker setup (no Docker locally; zero non-Docker errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved single-file indexing to correctly identify the project root, including nested projects, Git worktrees, and cached repositories.
  - Preserved accurate project names, target keys, and qualified names when indexing files individually.
  - Prevented unintended orphan removal during partial indexing while continuing to clean up unrelated orphaned entries.
  - Prevented directories with cache-like names from being treated as project roots.
  - Single-file indexing no longer creates new cache files, while still updating existing caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->