### PR TITLE
docs: state what the single-file prune guard is actually protecting (#1776)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -5193,13 +5193,26 @@ class GraphUpdater:
             # rows never runs for them.
             #
             # #1775 fixed that misrooting: `repo_path` is now the project
-            # root whenever an ancestor holds the hash cache. THE GUARD IS
-            # STILL REQUIRED, and for a reason the misrooting only obscured
-            # -- a run that walked one file cannot distinguish "this module
-            # was deleted" from "this module was not visited", whatever it
-            # is rooted at. Correct rooting makes the over-deletion rarer,
-            # not impossible, and a genuinely deleted sibling is swept on a
-            # run that never looked at it.
+            # root whenever an ancestor holds the hash cache or a `.git`.
+            #
+            # That removes the MEASURED cause of #1756 rather than the guard's
+            # justification. Two things were checked while looking at #1776:
+            #
+            # * the path test now agrees with disk truth -- on a correctly
+            #   rooted single-file run, surviving siblings survive and only a
+            #   genuinely absent path is selected;
+            # * `packages_now` is NOT a partial-walk artefact either, because
+            #   `identify_structure` rglobs the whole of `repo_path`
+            #   independently of which FILES are parsed. An earlier version of
+            #   this comment claimed the opposite; a test written to pin that
+            #   claim failed, which is how the error was found.
+            #
+            # So the guard is now conservative rather than load-bearing, and
+            # narrowing it is #1776. It is kept because "conservative" is the
+            # right default for a whole-project delete, and because the
+            # premise above is worth re-measuring against a live database
+            # before acting on it -- these observations come from the
+            # emulated store, which models fewer node kinds than production.
             logger.info(ls.PRUNE_SKIPPED_SINGLE_FILE)
             # The two sweeps below still run. Unlike the path-keyed loop they
             # take no path and no project: each deletes only nodes with zero

--- a/codebase_rag/tests/test_single_file_project_root.py
+++ b/codebase_rag/tests/test_single_file_project_root.py
@@ -430,3 +430,61 @@ def test_a_single_file_run_still_updates_an_existing_cache(
         "the next update would re-parse what this run already applied"
     )
     assert set(after) == set(before), "the run dropped a sibling's cache entry"
+
+
+def test_a_single_file_run_still_sees_every_directory(
+    tmp_path: Path, parsers_and_queries: tuple[dict, dict]
+) -> None:
+    """`packages_now` is NOT a partial-walk artefact (#1776).
+
+    Written expecting the opposite, and it failed -- recorded here because
+    the refuted version is the load-bearing part.
+
+    `_prune_orphan_nodes` consults `packages_now` for Folder and Package,
+    deleting a `Package` whose path is `not in` that set. The obvious worry
+    is that a single-file run populates it from its target's chain only, so
+    every other directory would look like it had stopped being a package.
+
+    It does not. `identify_structure` `rglob`s the whole of `repo_path`
+    independently of which FILES are parsed, so the directory set is
+    complete on a single-file run too -- which, since #1775, means complete
+    relative to the real project root.
+
+    So the kind test is not an obstacle to narrowing the prune guard, and
+    #1776's "recoverable with a narrower condition" reading holds for
+    Package as well as for File and Module.
+    """
+    root = tmp_path / "nested"
+    _tree(root)
+    (root / "other").mkdir()
+    (root / "other" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "other" / "mod.py").write_text("z = 3\n", encoding="utf-8")
+    parsers, queries = parsers_and_queries
+
+    def walked(repo_path: Path) -> set[str]:
+        up = GraphUpdater(
+            ingestor=MagicMock(),
+            repo_path=repo_path,
+            parsers=parsers,
+            queries=queries,
+            project_name="nested",
+        )
+        up.run()
+        return {
+            rel.as_posix()
+            for rel, qn in up.factory.structure_processor.structural_elements.items()
+            if qn
+        }
+
+    by_full = walked(root)
+    by_single = walked(root / "pkg" / "module_a.py")
+
+    assert "other" in by_full, (
+        "fixture guard: the full build must see the unrelated package, or "
+        "the comparison below measures nothing"
+    )
+    assert by_single == by_full, (
+        "a single-file run's directory set diverged from a full build's "
+        f"({by_single} vs {by_full}); the prune's Folder/Package kind test "
+        "would then delete directories the run merely did not visit"
+    )

--- a/codebase_rag/tests/test_single_file_project_root.py
+++ b/codebase_rag/tests/test_single_file_project_root.py
@@ -469,6 +469,20 @@ def test_a_single_file_run_still_sees_every_directory(
             queries=queries,
             project_name="nested",
         )
+        # The comparison below is only the one this test NAMES if the
+        # single-file leg is rooted at the project root. Nothing in `_tree`
+        # writes a `.git` or a cache, so that rooting holds solely because
+        # the full-build leg runs first and writes the cache as a side
+        # effect. Run the legs in the other order and the single-file leg
+        # roots at `pkg` and sees `{'.'}`, and the assertion fails for a
+        # reason that has nothing to do with parse scoping.
+        #
+        # An ordering dependency no assertion states is exactly the shape
+        # that makes a test stop measuring what it claims, so state it.
+        assert up.repo_path.resolve() == root.resolve(), (
+            "fixture guard: this leg must be rooted at the project root, or "
+            f"the directory sets are not comparable: {up.repo_path}"
+        )
         up.run()
         return {
             rel.as_posix()

--- a/codebase_rag/tests/test_single_file_project_root.py
+++ b/codebase_rag/tests/test_single_file_project_root.py
@@ -461,7 +461,7 @@ def test_a_single_file_run_still_sees_every_directory(
     (root / "other" / "mod.py").write_text("z = 3\n", encoding="utf-8")
     parsers, queries = parsers_and_queries
 
-    def walked(repo_path: Path) -> set[str]:
+    def discovered_package_paths(repo_path: Path) -> set[str]:
         up = GraphUpdater(
             ingestor=MagicMock(),
             repo_path=repo_path,
@@ -490,8 +490,8 @@ def test_a_single_file_run_still_sees_every_directory(
             if qn
         }
 
-    by_full = walked(root)
-    by_single = walked(root / "pkg" / "module_a.py")
+    by_full = discovered_package_paths(root)
+    by_single = discovered_package_paths(root / "pkg" / "module_a.py")
 
     assert "other" in by_full, (
         "fixture guard: the full build must see the unrelated package, or "


### PR DESCRIPTION
Part of #1776. Comments and tests only — no behaviour change.

## What this is

#1776 asks whether the #1756 single-file prune guard can be narrowed now that #1775 roots such runs correctly. Investigating that turned up a **false claim in the guard's own comment**, which I had written on #1775 and which would have misled the next person to read it.

## The claim, and its refutation

The comment said the guard is required because "a run that walked one file cannot distinguish 'this module was deleted' from 'this module was not visited', **whatever it is rooted at**".

I believed the Folder/Package half of that specifically: `stale_kind` consults `packages_now`, built from `structural_elements`, and deletes a `Package` whose path is `not in` that set — so a partial walk looked like it would delete every unvisited package.

I wrote that belief as a test so it could be checked, and **the test failed**:

```
assert 'other' not in {'.', 'other', 'pkg'}
```

`identify_structure` does a full `rglob` of `repo_path`, independent of which *files* are parsed:

```python
directories = {self.repo_path}
for path in self.repo_path.rglob(cs.GLOB_ALL):
    if path.is_dir() and not should_skip_path(...):
        directories.add(path)
```

So `packages_now` is fully populated on a single-file run too — and since #1775, populated relative to the real project root.

## What the guard is actually protecting

Both halves are clear:

- the **path test** agrees with disk truth: on a correctly-rooted single-file run, surviving siblings survive and only a genuinely absent path is selected;
- the **kind test** is not an obstacle either, per the above.

So the guard is now **conservative rather than load-bearing**. The comment says that, says which observations came from the emulated store, and defers the narrowing to #1776 rather than claiming the guard is removable. "Conservative" remains the right default for a whole-project delete.

## Changes

- `_prune_orphan_nodes`: the guard comment now states what was measured, including that an earlier version of it was wrong and how that was found.
- `test_a_single_file_run_still_sees_every_directory`: pins that `structural_elements` is not parse-scoped. Named and documented as the *refuted* form of my guess, because that is the load-bearing part — if it ever becomes parse-scoped, narrowing the guard stops being safe and this goes red.

## Verification

The test discriminates: mutating `run()` to filter `structural_elements` to the target's ancestor chain reddens it with the intended message.

Local review raised one P2 which is fixed here: the directory-set comparison was only meaningful because the full-build leg runs first and writes the hash cache as a side effect, rooting the single-file leg correctly. Nothing asserted that. Reversing the leg order made the assertion fail for an unrelated reason. There is now an explicit fixture guard, verified by reversing the order — it fails with the rooting diagnostic rather than a confusing set mismatch.

An ordering dependency no assertion states is the same shape as a fixture that cannot fail, which is the defect class #1859 is about.

Suite: 33 passed across the two affected files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming that single-file and full-project runs discover the same directory structure.
  - Verified that valid project directories remain preserved during single-file processing.

- **Documentation**
  - Clarified the rationale and current limitations behind conservative pruning behavior for single-file runs.
  - Documented considerations for future refinement of this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->