### PR TITLE
test: add a fixture-coverage assertion so a vacuous empty-result test fails (#1859)

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -9,7 +9,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-from collections.abc import Callable, Generator, Iterator
+from collections.abc import Generator, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, Self
@@ -891,7 +891,7 @@ def pytest_runtest_call(item: pytest.Item) -> Iterator[None]:
         pytest.skip(str(excinfo[1]))
 
 
-def _assert_fixture_covers(covered: set[str], required: set[str], *, what: str) -> None:
+def assert_fixture_covers(covered: set[str], required: set[str], *, what: str) -> None:
     """Fail unless a fixture supplies every input the predicate under test reads.
 
     The defect this exists for (#1859): a test asserting that a filter
@@ -925,10 +925,3 @@ def _assert_fixture_covers(covered: set[str], required: set[str], *, what: str) 
         "fixture supplies none of its inputs (#1859). Add the missing "
         "values, or the test passes whatever the code does."
     )
-
-
-@pytest.fixture
-def assert_fixture_covers() -> Callable[..., None]:
-    """`_assert_fixture_covers` as a fixture, which is how this suite shares
-    helpers -- no test file imports from `conftest` directly."""
-    return _assert_fixture_covers

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -919,9 +919,19 @@ def assert_fixture_covers(covered: set[str], required: set[str], *, what: str) -
         what: named in the failure, e.g. "the all-concluded rollup".
     """
     missing = required - covered
+    # Two diagnoses, because they are different bugs. A fixture supplying
+    # NONE of the inputs makes the empty result vacuous outright; one
+    # supplying some makes it merely unreliable -- the filter may be
+    # examining the present values correctly and simply never seeing the
+    # absent ones. Saying "none" for the partial case is a false diagnosis
+    # that sends the reader looking for the wrong thing (#1862 review).
+    reason = (
+        "the fixture supplies none of its inputs"
+        if not covered & required
+        else "the fixture does not supply all of them"
+    )
     assert not missing, (
-        f"{what} does not cover {sorted(missing)}, so any assertion that the "
-        "filter returned nothing holds for the trivial reason that the "
-        "fixture supplies none of its inputs (#1859). Add the missing "
-        "values, or the test passes whatever the code does."
+        f"{what} does not cover {sorted(missing)}, so an assertion that the "
+        f"filter returned nothing proves little: {reason} (#1859). Add the "
+        "missing values, or the test passes whatever the code does."
     )

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -9,7 +9,7 @@ import stat
 import subprocess
 import sys
 import tempfile
-from collections.abc import Generator, Iterator
+from collections.abc import Callable, Generator, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, Self
@@ -889,3 +889,46 @@ def pytest_runtest_call(item: pytest.Item) -> Iterator[None]:
     excinfo = getattr(outcome, "excinfo", None)
     if excinfo is not None and isinstance(excinfo[1], NodeOracleUnavailable):
         pytest.skip(str(excinfo[1]))
+
+
+def _assert_fixture_covers(covered: set[str], required: set[str], *, what: str) -> None:
+    """Fail unless a fixture supplies every input the predicate under test reads.
+
+    The defect this exists for (#1859): a test asserting that a filter
+    returned NOTHING passes vacuously when the fixture contains none of the
+    values that filter inspects. Measured on `REAL_ROLLUP_ALL_CONCLUDED`,
+    which held two checks that were not members of `AGGREGATED_JOBS` -- so
+    "the aggregate is absent although every dependency concluded" was reached
+    because the rollup held no dependency at all. Flipping every conclusion
+    to unfinished left all 105 tests green.
+
+    An empty result and an empty INPUT read identically from the assertion's
+    side, and only one of them is evidence. This makes the fixture's adequacy
+    a checked precondition rather than a property nobody states.
+
+    Deliberately narrow. It cannot detect the sibling case where the fixture
+    is well-formed but every row is pinned at the one value that drives the
+    branch -- there the inputs are present and only varying them shows the
+    problem. That half stays a review convention (assert the verdict
+    CHANGES), because no assertion inside one test can observe what another
+    test failed to vary.
+
+    Args:
+        covered: the required values the fixture actually supplies.
+        required: every value the predicate under test reads.
+        what: named in the failure, e.g. "the all-concluded rollup".
+    """
+    missing = required - covered
+    assert not missing, (
+        f"{what} does not cover {sorted(missing)}, so any assertion that the "
+        "filter returned nothing holds for the trivial reason that the "
+        "fixture supplies none of its inputs (#1859). Add the missing "
+        "values, or the test passes whatever the code does."
+    )
+
+
+@pytest.fixture
+def assert_fixture_covers() -> Callable[..., None]:
+    """`_assert_fixture_covers` as a fixture, which is how this suite shares
+    helpers -- no test file imports from `conftest` directly."""
+    return _assert_fixture_covers

--- a/codebase_rag/tests/test_fixture_coverage_helper.py
+++ b/codebase_rag/tests/test_fixture_coverage_helper.py
@@ -1,0 +1,122 @@
+"""`assert_fixture_covers` makes a fixture's adequacy a checked precondition.
+
+The defect it exists for (#1859): a test asserting that a filter returned
+NOTHING passes vacuously when the fixture holds none of the values that
+filter inspects. The assertion cannot tell "the filter correctly found
+nothing" from "the filter was handed nothing to look at", and only the first
+is evidence.
+
+Measured instance, on `REAL_ROLLUP_ALL_CONCLUDED` in `test_pr_gate_check.py`:
+the fixture held `CodeQL` and `Analyze (actions)`, neither a member of
+`AGGREGATED_JOBS`, so the "every dependency concluded" branch was reached
+because the rollup contained no dependency. Flipping every conclusion to
+unfinished left all 105 tests green.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+Covers = Callable[..., None]
+
+
+def test_a_complete_fixture_passes(assert_fixture_covers: Covers) -> None:
+    assert_fixture_covers({"a", "b"}, {"a", "b"}, what="the rollup")
+
+
+def test_a_superset_passes(assert_fixture_covers: Covers) -> None:
+    """Extra values are not a defect.
+
+    A fixture may legitimately hold non-inputs alongside the real ones --
+    indeed it should, so it exercises the filter's DISCRIMINATION rather
+    than only its positive path.
+    """
+    assert_fixture_covers({"a", "b", "unrelated"}, {"a", "b"}, what="the rollup")
+
+
+def test_a_missing_input_fails_and_names_it(assert_fixture_covers: Covers) -> None:
+    """The helper must be able to fail, and say which value is absent.
+
+    A guard that cannot produce a failure is the same defect one level up,
+    so this is the test that makes the others mean anything.
+    """
+    with pytest.raises(AssertionError) as excinfo:
+        assert_fixture_covers({"a"}, {"a", "b"}, what="the rollup")
+
+    message = str(excinfo.value)
+    assert "'b'" in message, "the failure must name the missing value"
+    assert "the rollup" in message, "the failure must name the fixture"
+
+
+def test_an_empty_fixture_fails(assert_fixture_covers: Covers) -> None:
+    """The exact measured shape: a fixture supplying none of the inputs."""
+    with pytest.raises(AssertionError):
+        assert_fixture_covers(set(), {"a", "b"}, what="the all-concluded rollup")
+
+
+def test_requiring_nothing_passes(assert_fixture_covers: Covers) -> None:
+    """A predicate that reads no named inputs cannot be under-covered.
+
+    Pinned so the helper is not mistaken for a general vacuity detector: it
+    checks one specific precondition and says nothing about tests that do
+    not have named inputs.
+    """
+    assert_fixture_covers(set(), set(), what="the rollup")
+
+
+def test_the_measured_instance_would_have_been_caught(
+    assert_fixture_covers: Covers,
+) -> None:
+    """The helper against the real defect that motivated it (#1859).
+
+    `REAL_ROLLUP_ALL_CONCLUDED` held `CodeQL` and `Analyze (actions)`. Neither
+    is an `AGGREGATED_JOBS` member, so `absent_context_reason` reached its
+    "every dependency concluded" branch with no dependency present, and four
+    tests named for the concluded state passed with every conclusion blanked.
+
+    Reproduced here against the real `AGGREGATED_JOBS` rather than invented
+    strings, so this goes red if that tuple ever changes in a way that makes
+    the example stop demonstrating the point.
+    """
+    from scripts.check_pr_gated import AGGREGATED_JOBS, aggregated_job_for
+
+    defective = ["CodeQL", "Analyze (actions)"]
+    covered = {
+        job for name in defective if (job := aggregated_job_for(name)) is not None
+    }
+
+    assert covered == set(), (
+        "the historical fixture is expected to cover NO aggregated job; if "
+        "it now covers one, this example no longer shows the defect"
+    )
+    with pytest.raises(AssertionError, match="#1859"):
+        assert_fixture_covers(
+            covered, set(AGGREGATED_JOBS), what="the all-concluded rollup"
+        )
+
+
+def test_a_corrected_fixture_passes_the_same_check(
+    assert_fixture_covers: Covers,
+) -> None:
+    """The other direction, so the test above is not satisfied by a helper
+    that simply always raises."""
+    from scripts.check_pr_gated import AGGREGATED_JOBS, aggregated_job_for
+
+    corrected = [
+        "CodeQL",
+        "Analyze (actions)",
+        "Lint & Format",
+        "Type Check",
+        "Unit Tests (ubuntu-latest, py3.13)",
+        "Integration Tests (ubuntu-latest)",
+        "Binary Smoke Test",
+    ]
+    covered = {
+        job for name in corrected if (job := aggregated_job_for(name)) is not None
+    }
+
+    assert_fixture_covers(
+        covered, set(AGGREGATED_JOBS), what="the all-concluded rollup"
+    )

--- a/codebase_rag/tests/test_fixture_coverage_helper.py
+++ b/codebase_rag/tests/test_fixture_coverage_helper.py
@@ -15,18 +15,16 @@ unfinished left all 105 tests green.
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 import pytest
 
-Covers = Callable[..., None]
+from codebase_rag.tests.conftest import assert_fixture_covers
 
 
-def test_a_complete_fixture_passes(assert_fixture_covers: Covers) -> None:
+def test_a_complete_fixture_passes() -> None:
     assert_fixture_covers({"a", "b"}, {"a", "b"}, what="the rollup")
 
 
-def test_a_superset_passes(assert_fixture_covers: Covers) -> None:
+def test_a_superset_passes() -> None:
     """Extra values are not a defect.
 
     A fixture may legitimately hold non-inputs alongside the real ones --
@@ -36,7 +34,7 @@ def test_a_superset_passes(assert_fixture_covers: Covers) -> None:
     assert_fixture_covers({"a", "b", "unrelated"}, {"a", "b"}, what="the rollup")
 
 
-def test_a_missing_input_fails_and_names_it(assert_fixture_covers: Covers) -> None:
+def test_a_missing_input_fails_and_names_it() -> None:
     """The helper must be able to fail, and say which value is absent.
 
     A guard that cannot produce a failure is the same defect one level up,
@@ -50,13 +48,13 @@ def test_a_missing_input_fails_and_names_it(assert_fixture_covers: Covers) -> No
     assert "the rollup" in message, "the failure must name the fixture"
 
 
-def test_an_empty_fixture_fails(assert_fixture_covers: Covers) -> None:
+def test_an_empty_fixture_fails() -> None:
     """The exact measured shape: a fixture supplying none of the inputs."""
     with pytest.raises(AssertionError):
         assert_fixture_covers(set(), {"a", "b"}, what="the all-concluded rollup")
 
 
-def test_requiring_nothing_passes(assert_fixture_covers: Covers) -> None:
+def test_requiring_nothing_passes() -> None:
     """A predicate that reads no named inputs cannot be under-covered.
 
     Pinned so the helper is not mistaken for a general vacuity detector: it
@@ -66,9 +64,7 @@ def test_requiring_nothing_passes(assert_fixture_covers: Covers) -> None:
     assert_fixture_covers(set(), set(), what="the rollup")
 
 
-def test_the_measured_instance_would_have_been_caught(
-    assert_fixture_covers: Covers,
-) -> None:
+def test_the_measured_instance_would_have_been_caught() -> None:
     """The helper against the real defect that motivated it (#1859).
 
     `REAL_ROLLUP_ALL_CONCLUDED` held `CodeQL` and `Analyze (actions)`. Neither
@@ -91,15 +87,22 @@ def test_the_measured_instance_would_have_been_caught(
         "the historical fixture is expected to cover NO aggregated job; if "
         "it now covers one, this example no longer shows the defect"
     )
-    with pytest.raises(AssertionError, match="#1859"):
+    with pytest.raises(AssertionError, match="does not cover") as excinfo:
         assert_fixture_covers(
             covered, set(AGGREGATED_JOBS), what="the all-concluded rollup"
         )
 
+    # Matched on the behavioural phrase rather than the issue number: an
+    # issue reference in a message is documentation, so pinning it reddens
+    # this test on a pure rewording that changes nothing.
+    for job in AGGREGATED_JOBS:
+        assert job in str(excinfo.value), (
+            f"the failure must name every uncovered dependency; {job!r} is "
+            "missing, so a reader cannot fix the fixture from the message"
+        )
 
-def test_a_corrected_fixture_passes_the_same_check(
-    assert_fixture_covers: Covers,
-) -> None:
+
+def test_a_corrected_fixture_passes_the_same_check() -> None:
     """The other direction, so the test above is not satisfied by a helper
     that simply always raises."""
     from scripts.check_pr_gated import AGGREGATED_JOBS, aggregated_job_for

--- a/codebase_rag/tests/test_fixture_coverage_helper.py
+++ b/codebase_rag/tests/test_fixture_coverage_helper.py
@@ -126,22 +126,39 @@ def test_the_measured_instance_would_have_been_caught() -> None:
 
 def test_a_corrected_fixture_passes_the_same_check() -> None:
     """The other direction, so the test above is not satisfied by a helper
-    that simply always raises."""
+    that simply always raises.
+
+    The corrected rollup is DERIVED from `AGGREGATED_JOBS` rather than typed
+    out. A hardcoded list is a second fixture with the same defect as the
+    first: it silently stops covering the predicate the moment the tuple
+    grows, and this one grows -- it went from five entries to eight while
+    this PR was open, because `all-checks-pass` declares more dependencies in
+    `needs:` than were listed.
+
+    The matrix suffix is appended to one entry so the derived rollup also
+    exercises `aggregated_job_for`'s `name (` matching rather than only its
+    exact-match arm.
+    """
     from scripts.check_pr_gated import AGGREGATED_JOBS, aggregated_job_for
 
     corrected = [
+        # Non-dependencies, kept so the fixture exercises the filter's
+        # discrimination rather than only its positive path.
         "CodeQL",
         "Analyze (actions)",
-        "Lint & Format",
-        "Type Check",
-        "Unit Tests (ubuntu-latest, py3.13)",
-        "Integration Tests (ubuntu-latest)",
-        "Binary Smoke Test",
+        *(
+            f"{job} (ubuntu-latest)" if job == "Integration Tests" else job
+            for job in AGGREGATED_JOBS
+        ),
     ]
     covered = {
         job for name in corrected if (job := aggregated_job_for(name)) is not None
     }
 
+    assert covered == set(AGGREGATED_JOBS), (
+        "fixture guard: the derived rollup must cover every aggregated job, "
+        f"or this test asserts nothing; missing {set(AGGREGATED_JOBS) - covered}"
+    )
     assert_fixture_covers(
         covered, set(AGGREGATED_JOBS), what="the all-concluded rollup"
     )

--- a/codebase_rag/tests/test_fixture_coverage_helper.py
+++ b/codebase_rag/tests/test_fixture_coverage_helper.py
@@ -54,6 +54,28 @@ def test_an_empty_fixture_fails() -> None:
         assert_fixture_covers(set(), {"a", "b"}, what="the all-concluded rollup")
 
 
+def test_partial_and_total_gaps_are_diagnosed_differently() -> None:
+    """They are different bugs and need different messages (#1862 review).
+
+    A fixture supplying NONE of the inputs makes the empty result vacuous
+    outright. One supplying some makes it merely unreliable -- the filter may
+    be examining the present values correctly and simply never seeing the
+    absent ones. An earlier version said "none of its inputs" for both, which
+    is a false diagnosis on the partial case and sends the reader looking for
+    the wrong thing.
+    """
+    with pytest.raises(AssertionError) as total:
+        assert_fixture_covers(set(), {"a", "b"}, what="the rollup")
+    with pytest.raises(AssertionError) as partial:
+        assert_fixture_covers({"a"}, {"a", "b"}, what="the rollup")
+
+    assert "supplies none of its inputs" in str(total.value)
+    assert "supplies none of its inputs" not in str(partial.value), (
+        "a fixture covering SOME inputs was reported as covering none"
+    )
+    assert "does not supply all of them" in str(partial.value)
+
+
 def test_requiring_nothing_passes() -> None:
     """A predicate that reads no named inputs cannot be under-covered.
 

--- a/codebase_rag/tests/test_fixture_coverage_helper.py
+++ b/codebase_rag/tests/test_fixture_coverage_helper.py
@@ -64,10 +64,11 @@ def test_partial_and_total_gaps_are_diagnosed_differently() -> None:
     is a false diagnosis on the partial case and sends the reader looking for
     the wrong thing.
     """
+    required = {"a", "b"}
     with pytest.raises(AssertionError) as total:
-        assert_fixture_covers(set(), {"a", "b"}, what="the rollup")
+        assert_fixture_covers(set(), required, what="the rollup")
     with pytest.raises(AssertionError) as partial:
-        assert_fixture_covers({"a"}, {"a", "b"}, what="the rollup")
+        assert_fixture_covers({"a"}, required, what="the rollup")
 
     assert "supplies none of its inputs" in str(total.value)
     assert "supplies none of its inputs" not in str(partial.value), (
@@ -109,10 +110,12 @@ def test_the_measured_instance_would_have_been_caught() -> None:
         "the historical fixture is expected to cover NO aggregated job; if "
         "it now covers one, this example no longer shows the defect"
     )
+    # `set(...)` is built outside the block so only ONE call inside it can
+    # raise; otherwise a failure in the argument construction would be
+    # indistinguishable from the assertion under test (Sonar S5778).
+    required = set(AGGREGATED_JOBS)
     with pytest.raises(AssertionError, match="does not cover") as excinfo:
-        assert_fixture_covers(
-            covered, set(AGGREGATED_JOBS), what="the all-concluded rollup"
-        )
+        assert_fixture_covers(covered, required, what="the all-concluded rollup")
 
     # Matched on the behavioural phrase rather than the issue number: an
     # issue reference in a message is documentation, so pinning it reddens


### PR DESCRIPTION
Closes #1859.

## The defect class

A test asserting that a filter returned **nothing** passes vacuously when the fixture holds none of the values that filter inspects. From the assertion's side, "the filter correctly found nothing" and "the filter was handed nothing to look at" are identical, and only the first is evidence.

Measured instance, on `REAL_ROLLUP_ALL_CONCLUDED`:

```python
REAL_ROLLUP_ALL_CONCLUDED = [
    {"__typename": "CheckRun", "name": "CodeQL", "conclusion": "SKIPPED"},
    {"__typename": "CheckRun", "name": "Analyze (actions)", "conclusion": "SUCCESS"},
]
```

Neither is an `AGGREGATED_JOBS` member, so `absent_context_reason` reached its "every dependency concluded" branch because the rollup held **no dependency at all**. Blanking every `conclusion` left `105 passed`.

## What this adds

`assert_fixture_covers(covered, required, *, what)` in `conftest.py`, plus a test file exercising both directions.

It is deliberately narrow, and the issue is right that only this half is mechanisable. It **cannot** detect the sibling case where a fixture is well-formed but every row is pinned at the one value that drives the branch — there the inputs are present and only varying them shows the problem. That stays a review convention, because no assertion inside one test can observe what another test failed to vary.

## Why it is not the "correct sweep nothing calls" shape (#1784)

It has no production caller yet, which is the pattern this repo has been bitten by. The difference is that it ships with seven tests that drive both directions, including against the real `AGGREGATED_JOBS` rather than invented strings — #1784's defect was code no test drove.

The obvious caller is `test_pr_gate_check.py`, which I have deliberately **not** touched: that exact file is being fixed in #1858, and editing it here would conflict. Worth noting that #1858 guards its corrected fixture with a *comment* ("Every entry here must be a real `AGGREGATED_JOBS` member"), so the executable check remains absent on `main` even after it lands. Wiring it up is a one-line follow-up once that merges.

## Verification

| mutation | reddens |
|---|---|
| `missing = set()` (helper cannot detect a gap) | 3 tests |
| helper always raises | the other 4 |
| add `CodeQL` to `AGGREGATED_JOBS` | the measured-instance test |
| remove the issue number from the message | nothing (correctly) |

That last one is the fix for a review finding: the test originally matched on `"#1859"`, so a pure rewording would have reddened it. It now matches the behavioural phrase and separately asserts every uncovered dependency is named, which is what a reader actually needs to fix their fixture.

## Corrections from local review

Two findings, both mine, both fixed:

- I had exported the helper as a pytest fixture, justified in its docstring by "no test file imports from `conftest` directly". **That claim was false** — 311 files do. My original grep searched `from conftest import` rather than the real module path and I read the empty result as evidence of absence, which is the same absence-vs-never-ran trap the issue is about. The indirection is gone; it is a plain function now.
- The fixture's `Callable[..., None]` annotation erased the signature, so the type checker accepted calls omitting required arguments. Direct import restores the real signature.

Suite: 560 passed, 0 failed across the fixture / gate-check / single-file set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure test fixtures provide all inputs required by the conditions they exercise.
  * Added coverage for complete, incomplete, empty, partial, and corrected fixture scenarios.
  * Improved failure messages to distinguish empty fixtures from partially incomplete fixtures and identify missing inputs.
  * Added regression coverage for cases involving integration jobs with matrix-specific variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->