### PR TITLE
test: use the shared fixture-coverage helper in test_pr_gate_check (#1863)

### DIFF
--- a/codebase_rag/tests/test_pr_gate_check.py
+++ b/codebase_rag/tests/test_pr_gate_check.py
@@ -28,6 +28,7 @@ import json
 
 import pytest
 
+from codebase_rag.tests.conftest import assert_fixture_covers
 from scripts import check_pr_gated
 from scripts.check_pr_gated import (
     AGGREGATED_JOBS,
@@ -1654,12 +1655,18 @@ class TestTheAllConcludedFixtureCoversEveryDependency:
 
     def test_the_fixture_covers_every_aggregated_job(self) -> None:
         covered = {
-            check_pr_gated.aggregated_job_for(check_pr_gated.context_name(entry))
+            job
             for entry in REAL_ROLLUP_ALL_CONCLUDED
-        } - {None}
+            if (
+                job := check_pr_gated.aggregated_job_for(
+                    check_pr_gated.context_name(entry)
+                )
+            )
+            is not None
+        }
 
-        assert covered == set(AGGREGATED_JOBS), (
-            f"fixture no longer covers: {sorted(set(AGGREGATED_JOBS) - covered)}"
+        assert_fixture_covers(
+            covered, set(AGGREGATED_JOBS), what="the all-concluded rollup"
         )
 
     def test_one_unfinished_dependency_flips_the_verdict(self) -> None:


### PR DESCRIPTION
Fixes #1863. Agreed follow-up to #1862, which added the helper.

## The change

`test_the_fixture_covers_every_aggregated_job` swaps its inline assertion for `assert_fixture_covers`:

```python
assert_fixture_covers(
    covered, set(AGGREGATED_JOBS), what="the all-concluded rollup"
)
```

One spelling instead of two, and it picks up the helper's two-way diagnosis. "Supplies none of its inputs" and "does not supply all of them" are different bugs — vacuous outright versus merely unreliable, where the filter may be reading correctly what is present and never seeing what is absent. Calling the second case "none" sends the reader after the wrong thing.

## Not closing a gap

The property was already enforced. The inline guard reddened when an entry was dropped, and it earned its keep in #1858 — widening `AGGREGATED_JOBS` from five to nine made it fail immediately with the three missing names.

## Verification, and a correction worth recording

Reddened it both ways and read the **assertion output**:

```
drop one dependency   -> the all-concluded rollup does not cover ['Go Frontend']
drop all but one      -> ... does not cover ['Binary Smoke Test', 'Go Frontend', ...]
```

My first pass at that check grepped the file for the message text and matched the *source line* of the old assertion, so it reported both cases as producing the identical message — and I briefly concluded the helper's diagnosis split was broken. It is not; calling it directly with `({'A','B'}, {'A','B','C'})` and `(set(), {'A','B','C'})` gives the two distinct messages correctly.

That is the same adjacent-predicate mistake this whole family of fixes has been about: I searched the file instead of the failure, and got a result that looked like a measurement. Recorded because a check that cannot see the thing it is checking for is exactly the defect class #1859 names, and I walked into it while verifying the fix for it.

## Import

By module path (`from codebase_rag.tests.conftest import assert_fixture_covers`), matching `test_fixture_coverage_helper.py` and the 311 other files that import conftest that way — the spelling a `from conftest import` grep misses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved aggregate-fixture coverage validation.
  * Retained checks ensuring every declared aggregated job is represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->