### PR TITLE
fix: count special token spellings as ordinary text

### DIFF
--- a/codebase_rag/tests/test_token_utils.py
+++ b/codebase_rag/tests/test_token_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from codebase_rag.types_defs import ResultRow
 from codebase_rag.utils.token_utils import count_tokens, truncate_results_by_tokens
 
@@ -17,8 +19,32 @@ class TestCountTokens:
         long = count_tokens("hello world this is a longer string with more tokens")
         assert long > short
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "<|endoftext|>",
+            "<|fim_prefix|>",
+            "<|fim_middle|>",
+            "<|fim_suffix|>",
+            "<|endofprompt|>",
+        ],
+    )
+    def test_special_token_spellings_are_ordinary_text(self, text: str) -> None:
+        assert count_tokens(text) > 1
+
 
 class TestTruncateResultsByTokens:
+    def test_special_token_spellings_in_query_results(self) -> None:
+        rows: list[ResultRow] = [
+            {"content": "A source comment mentioning <|endoftext|>"},
+            {"content": "another result"},
+        ]
+        results, tokens, truncated = truncate_results_by_tokens(rows, max_tokens=1)
+
+        assert results == rows[:1]
+        assert tokens > 1
+        assert truncated is True
+
     def test_empty_results(self) -> None:
         results, tokens, truncated = truncate_results_by_tokens([], max_tokens=1000)
         assert results == []

--- a/codebase_rag/utils/token_utils.py
+++ b/codebase_rag/utils/token_utils.py
@@ -17,7 +17,7 @@ def _get_encoding() -> tiktoken.Encoding:
 
 
 def count_tokens(text: str) -> int:
-    return len(_get_encoding().encode(text))
+    return len(_get_encoding().encode_ordinary(text))
 
 
 def truncate_results_by_tokens(


### PR DESCRIPTION
## Summary

- Count literal spellings such as `<|endoftext|>` as ordinary source text. Tiktoken's default `encode()` rejects them, causing query-result truncation or context pruning to raise `ValueError` when retrieved code mentions one.
- Use `encode_ordinary()` and add regression tests for all five special-token spellings in the configured encoding and for truncating a query result containing one.

## Type of Change

- [x] Bug fix

## Related Issues

Found during source review; no associated issue.

## Test Plan

- [x] New tests added
- Targeted token tests: 15 passed with `uv run --frozen --no-sync python -m pytest codebase_rag/tests/test_token_utils.py --noconftest -o addopts= -q`, including a rerun with the locked Tiktoken 0.12.0. Before the fix: 6 failed, 9 passed.
- Targeted `ty check`, repository Ruff hooks, Bandit, and README generation passed. README generation produced no changes.
- Core dependencies were installed from `uv.lock` using wheels only, excluding `pymgclient`. Full unit/integration suites were not run; `--noconftest` avoids unrelated parser/database fixture imports. The full pre-commit type check with locked `ty` 0.0.13 still reports 45 diagnostics, including 34 unresolved imports for optional packages such as PyTorch, libclang, and ast-grep. Heavy semantic-search dependencies were not installed.

## Checklist

- [x] PR title follows Conventional Commits
- [ ] All pre-commit checks pass (full-project type check limitation above)
- [x] No new hardcoded production strings
- [x] No new type ignores, casts, `Any`, or `object` type hints
- [x] No new comments or docstrings

AI assistance: OpenAI Codex helped investigate, implement, review, and test this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added provider-independent token estimates for message histories.
  - Tool payloads and structured argument values are now included in token-cost estimates, improving accuracy for messages containing tool calls.
  - Special token spellings are treated as ordinary text when counting tokens.
- **Bug Fixes**
  - Improved result truncation for content containing special token spellings, ensuring token limits are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->